### PR TITLE
Fix React docs link

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -55,5 +55,5 @@ In a real application, you probably won't be setting state with a timer. You mig
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 
-State works the same way as it does in React, so for more details on handling state, you can look at the [React.Component API](https://facebook.github.io/react/component-api.md).
+State works the same way as it does in React, so for more details on handling state, you can look at the [React.Component API](https://reactjs.org/docs/react-component.html#setstate).
 At this point, you might be annoyed that most of our examples so far use boring default black text. To make things more beautiful, you will have to [learn about Style](style.md).


### PR DESCRIPTION
That one was extremely old—I don't even think it was supported by the old website.
Surprised this has been broken for so long.