### PR TITLE
correct 2nd example of Animated.event()

### DIFF
--- a/website/versioned_docs/version-0.51/animated.md
+++ b/website/versioned_docs/version-0.51/animated.md
@@ -489,9 +489,9 @@ then calls `setValue` on the mapped outputs.  e.g.
  ...
  onPanResponderMove: Animated.event([
    null,                // raw event arg ignored
-   {dx: this._panX},    // gestureState arg
+   {dx: this._panX}],   // gestureState arg
 {listener: (event, gestureState) => console.log(event, gestureState)}, // Optional async listener
- ]),
+ ),
 ```
 
 Config is an object that may have the following options:


### PR DESCRIPTION
2nd example of Animated.event() had the arguments incorrectly presented
was:

Animated.event([
   {rawEvent}, 
   {gestureState},
   {listener}
 ])

this correction:

Animated.event([
   {rawEvent}, 
   {gestureState}],
   {listener}
)

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
