### PR TITLE
Add movies.json used in networking tutorial

### DIFF
--- a/website/static/movies.json
+++ b/website/static/movies.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Basics - Networking",
+  "description": "Your app fetched this from a remote endpoint!",
+  "movies": [
+    { "title": "Star Wars", "releaseYear": "1977"},
+    { "title": "Back to the Future", "releaseYear": "1985"},
+    { "title": "The Matrix", "releaseYear": "1999"},
+    { "title": "Inception", "releaseYear": "2010"},
+    { "title": "Interstellar", "releaseYear": "2014"}
+  ]
+}
+


### PR DESCRIPTION
* In [Networking · React Native](https://facebook.github.io/react-native/docs/network.html), access to `https://facebook.github.io/react-native/movies.json` currently returns 404. 
* This PR fixes it by copying `movies.json` from [react\-native/movies\.json at master · facebook/react\-native](https://github.com/facebook/react-native/blob/master/website/src/react-native/movies.json).