### PR TITLE
Fix Animated.timing() link in Easing

### DIFF
--- a/docs/easing.md
+++ b/docs/easing.md
@@ -4,7 +4,7 @@ title: Easing
 ---
 
 The `Easing` module implements common easing functions. This module is used
-by [Animate.timing()](animate.md#timing) to convey physically
+by [Animated.timing()](animated.md#timing) to convey physically
 believable motion in animations.
 
 You can find a visualization of some common easing functions at

--- a/website/versioned_docs/version-0.43/easing.md
+++ b/website/versioned_docs/version-0.43/easing.md
@@ -5,7 +5,7 @@ original_id: easing
 ---
 
 The `Easing` module implements common easing functions. This module is used
-by [Animate.timing()](animate.md#timing) to convey physically
+by [Animated.timing()](animated.md#timing) to convey physically
 believable motion in animations.
 
 You can find a visualization of some common easing functions at

--- a/website/versioned_docs/version-0.5/easing.md
+++ b/website/versioned_docs/version-0.5/easing.md
@@ -5,7 +5,7 @@ original_id: easing
 ---
 
 The `Easing` module implements common easing functions. This module is used
-by [Animate.timing()](animate.md#timing) to convey physically
+by [Animated.timing()](animated.md#timing) to convey physically
 believable motion in animations.
 
 You can find a visualization of some common easing functions at

--- a/website/versioned_docs/version-0.51/easing.md
+++ b/website/versioned_docs/version-0.51/easing.md
@@ -5,7 +5,7 @@ original_id: easing
 ---
 
 The `Easing` module implements common easing functions. This module is used
-by [Animate.timing()](animate.md#timing) to convey physically
+by [Animated.timing()](animated.md#timing) to convey physically
 believable motion in animations.
 
 You can find a visualization of some common easing functions at


### PR DESCRIPTION
The link to `Animated.timing()` was wrong. 

Also applied to versioned docs.