### PR TITLE
Replace deprecated View.propTypes by ViewPropTypes

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -102,7 +102,7 @@ The very final step is to create the JavaScript module that defines the interfac
 // ImageView.js
 
 import PropTypes from 'prop-types';
-import { requireNativeComponent, View } from 'react-native';
+import { requireNativeComponent, ViewPropTypes } from 'react-native';
 
 var iface = {
   name: 'ImageView',
@@ -110,7 +110,7 @@ var iface = {
     src: PropTypes.string,
     borderRadius: PropTypes.number,
     resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
-    ...View.propTypes // include the default view properties
+    ...ViewPropTypes // include the default view properties
   },
 };
 


### PR DESCRIPTION
`View.propTypes` are deprecated and not available since RN 0.49.

Replaced with `ViewPropTypes`.