### PR TITLE
Fixed typo - comment was blocking closing bracket

### DIFF
--- a/website/versioned_docs/version-0.51/actionsheetios.md
+++ b/website/versioned_docs/version-0.51/actionsheetios.md
@@ -48,7 +48,7 @@ ActionSheetIOS.showActionSheetWithOptions({
   cancelButtonIndex: 0,
 },
 (buttonIndex) => {
-  if (buttonIndex === 1) { // destructive action }
+  if (buttonIndex === 1) { /* destructive action */ }
 });
 ```
 


### PR DESCRIPTION
Small issue, but when using `ActionSheetIOS` if you copy the example, you'll run into an issue the way the code is commented. Changed the comment structure so it will work when copied.