### PR TITLE
Fix broken link to react native tutorial on jest website

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,7 @@ id: testing
 title: Testing your Changes
 ---
 
-This document is about testing your changes to React Native as a [contributor](contributing.md). If you're interested in testing a React Native app, check out the [React Native Tutorial](http://facebook.github.io/jest/tutorial-react-native.md) on the Jest website.
+This document is about testing your changes to React Native as a [contributor](contributing.md). If you're interested in testing a React Native app, check out the [React Native Tutorial](https://facebook.github.io/jest/docs/en/tutorial-react-native.html) on the Jest website.
 
 The React Native repo has several tests you can run to verify you haven't caused a regression with your PR. These tests are run using [Circle](https://circleci.com/gh/facebook/react-native), a continuous integration system. Circle will automatically annotate pull requests with the test results.
 


### PR DESCRIPTION
Old link:
![image](https://user-images.githubusercontent.com/9313546/33732368-2bc7e3a0-dbeb-11e7-86a9-bcb99d676f73.png)

New link:
![image](https://user-images.githubusercontent.com/9313546/33732417-5a2f864e-dbeb-11e7-9639-9b4186546aa2.png)
