### PR TITLE
Fix Controlled Components link on handling-text-input.md

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -39,6 +39,6 @@ AppRegistry.registerComponent('AwesomeProject', () => PizzaTranslator);
 
 In this example, we store `text` in the state, because it changes over time.
 
-There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://facebook.github.io/react/forms.md), or the [reference docs for TextInput](textinput.md).
+There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](textinput.md).
 
 Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](handling-touches.md).


### PR DESCRIPTION
This PR changes the URL in the docs Markdown in order to get the right url for `React Documentation`.

#55
