### PR TITLE
Update state.md

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -16,18 +16,18 @@ import { AppRegistry, Text, View } from 'react-native';
 class Blink extends Component {
   constructor(props) {
     super(props);
-    this.state = {showText: true};
+    this.state = {isShowingText: true};
 
     // Toggle the state every second
     setInterval(() => {
       this.setState(previousState => {
-        return { showText: !previousState.showText };
+        return { isShowingText: !previousState.isShowingText };
       });
     }, 1000);
   }
 
   render() {
-    let display = this.state.showText ? this.props.text : ' ';
+    let display = this.state.isShowingText ? this.props.text : ' ';
     return (
       <Text>{display}</Text>
     );


### PR DESCRIPTION
"showText" changed to "isShowingText"
Best practice is to name booleans starting with "is" (or something similar). (And this is the Apple standard.)
This helps avoid confusion.  When someone sees something called "showText", it's easy to mistakenly assume that is a function that shows text.

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
