### PR TITLE
Updated tutorial.md to fix export error

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -13,7 +13,7 @@ In accordance with the ancient traditions of our people, we must first build an 
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text } from 'react-native';
+import { Text } from 'react-native';
 
 export default class HelloWorldApp extends Component {
   render() {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -24,7 +24,7 @@ export default class HelloWorldApp extends Component {
 }
 
 // skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => HelloWorldApp);
+export default App;
 ```
 
 If you are feeling curious, you can play around with sample code directly in the web simulators. You can also paste it into your `App.js` file to create a real app on your local machine.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -23,8 +23,6 @@ export default class HelloWorldApp extends Component {
   }
 }
 
-// skip this line if using Create React Native App
-export default App;
 ```
 
 If you are feeling curious, you can play around with sample code directly in the web simulators. You can also paste it into your `App.js` file to create a real app on your local machine.


### PR DESCRIPTION
As shown in [#17208](https://github.com/facebook/react-native/issues/17208) in facebook/react-native, "`App.js` should not include `AppRegistry.registerComponent('SampleApp', () => App)`;. That is only needed in `index.js.`"

Replace `AppRegistry` with `export default App;`
