### PR TITLE
Fix hover anchor click.

### DIFF
--- a/website/static/css/react-native.css
+++ b/website/static/css/react-native.css
@@ -188,12 +188,6 @@ p {
   }
 }
 
-@media only screen and (min-width: 1024px) {
-  .docsNavContainer {
-    margin-right: 0;
-  }
-}
-
 .prose h1 {
   padding: 0 0;
 }


### PR DESCRIPTION
Due to `margin-right: 0;` of `.docsNavContainer` `.hash-link` became 'un-clickable' when title parent missed hover.
So `margin-right: 0;` has been removed in order to fix this bug.

**Actual behavior:**
<img width="1280" alt="capture d ecran 2017-12-18 a 21 57 52" src="https://user-images.githubusercontent.com/1331358/34138693-d83967ca-e43e-11e7-83a0-70767b2b8966.png">

**Fixed behavior:**
<img width="1280" alt="capture d ecran 2017-12-18 a 21 58 03" src="https://user-images.githubusercontent.com/1331358/34138696-dd7ef7ae-e43e-11e7-94db-1d0c91f23880.png">


#71
