### PR TITLE
Decrease margin between sidebar and content.

### DIFF
--- a/website/static/css/react-native.css
+++ b/website/static/css/react-native.css
@@ -10,6 +10,16 @@ body {
   background-color: $backgroundColor !important;
 }
 
+@media only screen and (min-width: 1024px) {
+  .mainContainer {
+    margin-left: 20px;
+  }
+}
+
+.docsNavContainer {
+  width: 240px;
+}
+
 .mainContainer h1,
 .mainContainer h2,
 .mainContainer h3,


### PR DESCRIPTION
Due to anchor link fix, margin between sidebar and content container has been increase, from 60px to 100px.

In order to fix this issue, docsNavContainer now have a width of 240px and mainContainer has a margin-left of 20px on screen greater than 1024px.

**Before**
<img width="1280" alt="capture d ecran 2017-12-19 a 21 41 37" src="https://user-images.githubusercontent.com/1331358/34188639-79f33912-e505-11e7-9290-56b6afad4698.png">

**After**
<img width="1280" alt="capture d ecran 2017-12-19 a 21 37 46" src="https://user-images.githubusercontent.com/1331358/34188610-5779491c-e505-11e7-860b-7efb78bdf9c3.png">

#71 and #79 