### PR TITLE
Fix 'Release Notes' link on versions page

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -227,11 +227,11 @@ Status bar style
 
 **Constants:**
 
-| Value         | Description                                                         |
-| ------------- | ------------------------------------------------------------------- |
-| default       | Default status bar style (dark for iOS, light for Android)          |
-| light-content | Dark background, white texts and icons                              |
-| dark-content  | Light background, dark texts and icons (requires API>=23 on Android)|
+| Value         | Description                                                          |
+| ------------- | -------------------------------------------------------------------- |
+| default       | Default status bar style (dark for iOS, light for Android)           |
+| light-content | Dark background, white texts and icons                               |
+| dark-content  | Light background, dark texts and icons (requires API>=23 on Android) |
 
 ---
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -22,7 +22,6 @@ export default class HelloWorldApp extends Component {
     );
   }
 }
-
 ```
 
 If you are feeling curious, you can play around with sample code directly in the web simulators. You can also paste it into your `App.js` file to create a real app on your local machine.

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -43,9 +43,7 @@ class VersionItem extends React.Component {
           "https://github.com/facebook/react-native/releases/tag/v" +
           version +
           ".0" +
-          isRC
-            ? "-rc.0"
-            : ""
+          (isRC ? "-rc.0" : "")
         }
       >
         Release Notes

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -51,7 +51,7 @@ class VersionItem extends React.Component {
     );
 
     return (
-      <tr key={"version_" + version}>
+      <tr>
         <th>{versionName}</th>
         <td>{documentationLink}</td>
         <td>{releaseNotesLink}</td>
@@ -100,6 +100,7 @@ class Versions extends React.Component {
               {latestVersions.map(function(version) {
                 return (
                   <VersionItem
+                    key={"version_" + version}
                     version={version}
                     baseUrl={siteConfig.baseUrl}
                     currentVersion={currentVersion}
@@ -119,6 +120,7 @@ class Versions extends React.Component {
               {stableVersions.map(function(version) {
                 return (
                   <VersionItem
+                    key={"version_" + version}
                     version={version}
                     baseUrl={siteConfig.baseUrl}
                     currentVersion={currentVersion}


### PR DESCRIPTION
This fixes a problem with the 'Release Notes' link on the [versions page](https://facebook.github.io/react-native/versions.html).

There was an unwrapped ternary expression:
```JavaScript
<a
  href={
    "https://github.com/facebook/react-native/releases/tag/v" +
    version +
    ".0" +
    isRc
      ? "-rc.0"
      : ""
  }
>
  Release Notes
</a>
```

Which evaluates like:
```JavaScript
("https://github.com/facebook/react-native/releases/tag/v" + version + ".0" + isRc) ? "-rc.0" : ""
```

Making the href attribute always `-rc.0`.

The fix just wraps the ternary statement in brackets, for the intended functionality:

```JavaScript
<a
  href={
    "https://github.com/facebook/react-native/releases/tag/v" +
    version +
    ".0" +
    (isRC ? "-rc.0" : "")
  }
>
  Release Notes
</a>
```

Which, obviously, evaluates like:
```JavaScript
"https://github.com/facebook/react-native/releases/tag/v" + version + ".0" + (isRc ? "-rc.0" : "")
```

I also fixed unique 'key' prop warnings in the same file, by moving the key to the `VersionItem` component itself rather than the `tr` element inside the `VersionItem` component.

Also some Prettier fixes that were nothing to do with me, but couldn't commit without them. 😛 