### PR TITLE
Update appstate.md with note on Android activities

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -13,7 +13,7 @@ AppState is frequently used to determine the intent and proper behavior when han
 * `background` - The app is running in the background. The user is either:
   * in another app
   * on the home screen
-  * [Android] on another `Activity` (even if it was launched by your app)
+  * [Android] on another `Activity` (even if it was launched by your app)
 * `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
 
 For more information, see [Apple's documentation](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html)

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -10,7 +10,10 @@ AppState is frequently used to determine the intent and proper behavior when han
 ### App States
 
 * `active` - The app is running in the foreground
-* `background` - The app is running in the background. The user is either in another app or on the home screen
+* `background` - The app is running in the background. The user is either:
+  * in another app
+  * on the home screen
+  * [Android] on another `Activity` (even if it was launched by your app)
 * `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
 
 For more information, see [Apple's documentation](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html)


### PR DESCRIPTION
Hello,

On Android, it appears that the AppState becomes [`background`](https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java#L59) when you start a new intent from your app. It is worth mentioning because when you use third-party SDKs that rely on other activities, you'll enter this state. On iOS, the behavior is not the same (AppState stays active).