### PR TITLE
Overflow issue in React Native examples (Expo)

### DIFF
--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -118,7 +118,6 @@ function SnackPlayer(md) {
           border: 1px solid rgba(0,0,0,.16);
           border-radius: 4px;
           height: 514px;
-          width: 880px;
         "
       >` +
       '</div>' +


### PR DESCRIPTION
When width is set to 880px, it overflows my viewport.
My screen is 1024px wide.