### PR TITLE
Fix Modal `onRequestClose` attribute required spec table

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -110,9 +110,10 @@ The `supportedOrientations` prop allows the modal to be rotated to any of the sp
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV.
 
-| Type             | Required |
-| ---------------- | -------- |
-| (Platform.isTVOS |          | Platform.OS === 'android') ? PropTypes.func.isRequired : PropTypes.func | No |
+| Type     | Required | Platform                 |
+| -------- | -------- | ------------------------ |
+| function | Yes      | Android, Platform.isTVOS |
+| function | No       | (Others)                 |
 
 ---
 


### PR DESCRIPTION
The `onRequestClose` spec tablet show required by platform correctly.

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
