### PR TITLE
Added missing subspecs for Objective-C

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -212,6 +212,7 @@ target 'NumberTileGame' do
   # but if not, adjust the `:path` accordingly
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'Core',
+    'CxxBridge', # Include this for RN >= 0.47
     'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
     'RCTText',
     'RCTNetwork',


### PR DESCRIPTION
Added missing CxxBridge to React subspecs for Objective-C

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
