### PR TITLE
Update Image resizeMode=repeat docs

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -249,7 +249,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 * `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-* `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio, unless it is larger than the view, in which case it will be scaled down uniformly.
+* `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio, unless it is larger than the view, in which case it will be scaled down uniformly so that it is contained in the view.
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/docs/image.md
+++ b/docs/image.md
@@ -249,7 +249,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 * `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-* `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio.
+* `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio, unless it is larger than the view, in which case it will be scaled down uniformly.
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/docs/image.md
+++ b/docs/image.md
@@ -249,7 +249,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 * `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-* `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+* `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio.
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |


### PR DESCRIPTION
1. Android implementation pending review: https://github.com/facebook/react-native/pull/17404
2. Current behaviour on iOS (as well as on Android per https://github.com/facebook/react-native/pull/17404) differs from what's documented for an image that's larger than the view.