### PR TITLE
Change require url

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -26,7 +26,7 @@ You can also use the `@2x` and `@3x` suffixes to provide images for different sc
 ...and `button.js` code contains:
 
 ```javascript
-<Image source={require('./assets/check.png')} />
+<Image source={require('./img/check.png')} />
 ```
 
 ...the packager will bundle and serve the image corresponding to device's screen density. For example, `check@2x.png`, will be used on an iPhone 7, while`check@3x.png` will be used on an iPhone 7 Plus or a Nexus 5. If there is no image matching the screen density, the closest best option will be selected.


### PR DESCRIPTION
The @2x and @3x image example showed the file directory containing the `img` directory and the React example source url showed `assets` as the directory.

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
