### PR TITLE
Corrected example

### DIFF
--- a/docs/cameraroll.md
+++ b/docs/cameraroll.md
@@ -103,7 +103,7 @@ Loading images:
 _handleButtonPress = () => {
    CameraRoll.getPhotos({
        first: 20,
-       assetType: 'All',
+       assetType: 'Photos',
      })
      .then(r => {
        this.setState({ photos: r.edges });


### PR DESCRIPTION
`assetType='All'` means that videos are also included which might cause a problem since the example only uses the `<Image />` element to display the photos
