### PR TITLE
Update description of accessibilityComponentType in accessibility docs

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -87,7 +87,7 @@ Assign this property to a custom function which will be called when someone perf
 
 #### accessibilityComponentType (Android)
 
-In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. For instances, we support ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’ and so on.
+In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. We support 'none', ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’.
 
 ```javascript
 <TouchableWithoutFeedback accessibilityComponentType=”button”


### PR DESCRIPTION
I found the language "and so on" used to describe `accessibilityComponentType` property imprecise as it suggests there are more options than the ones already listed.

Looking at the declaration [ViewAccessiblity.js](https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewAccessibility.js#L33) I've updated the list to be exhaustive. 

This PR is related to https://github.com/facebook/react-native/issues/13740 as it would make the documentation reflect the current level of support for accessibilityComponentType.
