### PR TITLE
Added `spaceEvenly` value to `justifyContent`

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -307,9 +307,9 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.
 
-| Type                                                                      | Required |
-| ------------------------------------------------------------------------- | -------- |
-| enum('flex-start', 'flex-end', 'center', 'space-between', 'space-around') | No       |
+| Type                                                                                      | Required |
+| ----------------------------------------------------------------------------------------- | -------- |
+| enum('flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly') | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.52-RC/layout-props.md
+++ b/website/versioned_docs/version-0.52-RC/layout-props.md
@@ -308,9 +308,9 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.
 
-| Type                                                                      | Required |
-| ------------------------------------------------------------------------- | -------- |
-| enum('flex-start', 'flex-end', 'center', 'space-between', 'space-around') | No       |
+| Type                                                                                      | Required |
+| ----------------------------------------------------------------------------------------- | -------- |
+| enum('flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly') | No       |
 
 ---
 


### PR DESCRIPTION
In 0.52.0-RC, value `justifyContent` was added to `spaceEvenly` (facebook/react-native@1050e0b). Update the docs to reflect this. Note that this is already explained in the existing link to Mozilla, so I don't believe we need to add any more detail of what `spaceEvenly` is.