### PR TITLE
Added `locale` prop to `DaterPickerIOS`

### DIFF
--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -59,6 +59,7 @@ const styles = StyleSheet.create({
 - [`minimumDate`](datepickerios.md#minimumdate)
 - [`minuteInterval`](datepickerios.md#minuteinterval)
 - [`mode`](datepickerios.md#mode)
+- [`locale`](datepickerios.md#locale)
 - [`timeZoneOffsetInMinutes`](datepickerios.md#timezoneoffsetinminutes)
 
 ---
@@ -142,6 +143,16 @@ The date picker mode.
 | enum('date', 'time', 'datetime') | No       |
 
 Example with `mode` set to `date`, `time`, and `datetime`: ![](/react-native/docs/assets/DatePickerIOS/mode.png)
+
+---
+
+### `locale`
+
+The locale for the date picker. Value needs to be a [Locale ID](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html).
+
+| Type         | Required |
+| ------------ | -------- |
+| String       | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.52-RC/datepickerios.md
+++ b/website/versioned_docs/version-0.52-RC/datepickerios.md
@@ -60,6 +60,7 @@ const styles = StyleSheet.create({
 - [`minimumDate`](datepickerios.md#minimumdate)
 - [`minuteInterval`](datepickerios.md#minuteinterval)
 - [`mode`](datepickerios.md#mode)
+- [`locale`](datepickerios.md#locale)
 - [`timeZoneOffsetInMinutes`](datepickerios.md#timezoneoffsetinminutes)
 
 ---
@@ -143,6 +144,16 @@ The date picker mode.
 | enum('date', 'time', 'datetime') | No       |
 
 Example with `mode` set to `date`, `time`, and `datetime`: ![](/react-native/docs/assets/DatePickerIOS/mode.png)
+
+---
+
+### `locale`
+
+The locale for the date picker. Value needs to be a [Locale ID](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html).
+
+| Type         | Required |
+| ------------ | -------- |
+| String       | No       |
 
 ---
 


### PR DESCRIPTION
`DatePickerIOS` has a new prop `locale` in 0.52.0-RC thanks to facebook/react-native@fd9c361; this adds the missing docs for that.