### PR TITLE
Remove out of date reference to ResponderEventPlugin.js

### DIFF
--- a/docs/gesture-responder-system.md
+++ b/docs/gesture-responder-system.md
@@ -5,7 +5,7 @@ title: Gesture Responder System
 
 The gesture responder system manages the lifecycle of gestures in your app. A touch can go through several phases as the app determines what the user's intention is. For example, the app needs to determine if the touch is scrolling, sliding on a widget, or tapping. This can even change during the duration of a touch. There can also be multiple simultaneous touches.
 
-The touch responder system is needed to allow components to negotiate these touch interactions without any additional knowledge about their parent or child components. This system is implemented in `ResponderEventPlugin.js`, which contains further details and documentation.
+The touch responder system is needed to allow components to negotiate these touch interactions without any additional knowledge about their parent or child components.
 
 ### Best Practices
 

--- a/website/versioned_docs/version-0.5/gesture-responder-system.md
+++ b/website/versioned_docs/version-0.5/gesture-responder-system.md
@@ -6,7 +6,7 @@ original_id: gesture-responder-system
 
 The gesture responder system manages the lifecycle of gestures in your app. A touch can go through several phases as the app determines what the user's intention is. For example, the app needs to determine if the touch is scrolling, sliding on a widget, or tapping. This can even change during the duration of a touch. There can also be multiple simultaneous touches.
 
-The touch responder system is needed to allow components to negotiate these touch interactions without any additional knowledge about their parent or child components. This system is implemented in `ResponderEventPlugin.js`, which contains further details and documentation.
+The touch responder system is needed to allow components to negotiate these touch interactions without any additional knowledge about their parent or child components.
 
 ### Best Practices
 


### PR DESCRIPTION
The file ResponderEventPlugin.js is nowhere to be found in the source code of react-native although it is referenced by name 33 times in 6 files. ResponderEventPlugin can be found inside of Libraries\Renderer\ReactNativeRenderer-prod.js though.

Having had a look at ReactNativeRenderer-prod.js I realised that there are neither details nor documentation inside of this file. Thus, I would propose to completely remove this sentence.
