### PR TITLE
use local skype icon

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -58,7 +58,7 @@
   {
     "name": "Skype",
     "icon":
-      "http://is1.mzstatic.com/image/thumb/Purple118/v4/9c/86/19/9c861944-900e-2d61-18b5-9250b3840277/source/175x175bb.jpg",
+      "skype.png",
     "linkAppStore":
       "https://itunes.apple.com/us/app/skype-for-iphone/id304878510?mt=8",
     "linkPlayStore":


### PR DESCRIPTION
instead of remote
http://is1.mzstatic.com/image/thumb/Purple118/v4/9c/86/19/9c861944-900e-2d61-18b5-9250b3840277/source/175x175bb.jpg

:shruggie:?

...to avoid:

```
Mixed Content: The page at 'https://facebook.github.io/react-native/' was loaded over HTTPS, but requested an insecure image 'http://is1.mzstatic.com/image/thumb/Purple118/v4/9c/86/19/9c861944-900e-2d61-18b5-9250b3840277/source/175x175bb.jpg'. This content should also be served over HTTPS.
```

