### PR TITLE
Added BatchedBridge to Podfile in Integration-Doc as it is required for #15049

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -213,6 +213,7 @@ target 'NumberTileGame' do
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'Core',
     'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
+    'BatchedBridge', # Fix for [#15049](https://github.com/facebook/react-native/issues/15049)
     'RCTText',
     'RCTNetwork',
     'RCTWebSocket', # needed for debugging


### PR DESCRIPTION
// If your PR references an existing issue, please add the issue number below:

#15049

In order to get the integration-guide done with already existing iOS-Apps, a specific Pod is required called BatchedBridge. 

See https://github.com/facebook/react-native/issues/15049#issuecomment-316115595