### PR TITLE
Add configuration for deploy preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base    = "website"
-  publish = "website/build"
-  command = "yarn install && yarn build"
+  publish = "website/build/react-native"
+  command = "sed -i -e \"s|const baseUrl .*|const baseUrl = '/';|g\" siteConfig.js && yarn install && yarn build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  base    = "website"
+  publish = "website/build"
+  command = "yarn install && yarn build"


### PR DESCRIPTION
I was tired to checkout every branch to review visual changes and I think that deploying each pull requests could be useful and a time saver for maintainers as well as contributors.

We could easily achieve this with Netlify and their deploy preview service.

Here's deploy preview in action on `react-native-website`: https://github.com/charpeni/react-native-website/pull/3.

![image](https://user-images.githubusercontent.com/7189823/34885839-34118efc-f78f-11e7-9fb4-3d599a43f6f1.png)

Note that [`siteConfig.js`](https://github.com/facebook/react-native-website/blob/master/website/siteConfig.js) will be altered in Netlify infra because we need `baseUrl` to be `/`.

For the additional configuration on GitHub & Netlify let's hook up on Slack @hramos.

🦖 🤖 :tada:

