### PR TITLE
fixes type for ItemSeparatorComponent prop

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -193,7 +193,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type      | Required |
 | --------- | -------- |
-| component | No       |
+| function  | No       |
 
 ---
 


### PR DESCRIPTION
The `ItemSeparatorComponent` prop for `FlatList` seems to take a function, not a component.