### PR TITLE
No need to install / link any library

### DIFF
--- a/docs/cameraroll.md
+++ b/docs/cameraroll.md
@@ -3,7 +3,7 @@ id: cameraroll
 title: CameraRoll
 ---
 
-`CameraRoll` provides access to the local camera roll / gallery. Before using this you must link the `RCTCameraRoll` library. You can refer to [Linking](linking-libraries-ios.md) for help.
+`CameraRoll` provides access to the local camera roll / gallery.
 
 ### Permissions
 


### PR DESCRIPTION
CameraRoll API doesn't require any library install / link.