### PR TITLE
playableDuration property missing in documentation

### DIFF
--- a/docs/cameraroll.md
+++ b/docs/cameraroll.md
@@ -85,6 +85,7 @@ Returns a Promise which when resolved will be of the following shape:
       * `height`: {number}
       * `width`: {number}
       * `isStored`: {boolean}
+      * `playableDuration`: {number}
     * `timestamp`: {number}
     * `location`: {object} : An object with the following shape:
       * `latitude`: {number}


### PR DESCRIPTION
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
