### PR TITLE
Document Image resizeMode=center

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -251,6 +251,8 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 * `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
 
+* `center`: Center the image in the view along both dimensions. If the image is larger than the view, scale it down uniformly so that it is contained in the view.
+
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |
 | enum('cover', 'contain', 'stretch', 'repeat', 'center') | No       |


### PR DESCRIPTION
Related to, but IMHO shouldn't be blocked by, https://github.com/facebook/react-native/pull/17759.