### PR TITLE
Add missing method on PushNotificationIOS

### DIFF
--- a/docs/javascript-environment.md
+++ b/docs/javascript-environment.md
@@ -51,7 +51,7 @@ Stage 3
 
 Specific
 
-* [JSX](https://facebook.github.io/react/jsx-in-depth.md): `<View style={{color: 'red'}} />`
+* [JSX](https://reactjs.org/docs/jsx-in-depth.html): `<View style={{color: 'red'}} />`
 * [Flow](http://flowtype.org/): `function foo(x: ?number): string {}`
 
 ## Polyfills

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -62,6 +62,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`removeAllDeliveredNotifications`](pushnotificationios.md#removealldeliverednotifications)
@@ -92,6 +93,32 @@ And then in your AppDelegate implementation add the following:
 # Reference
 
 ## Methods
+
+### `presentLocalNotification()`
+
+```javascript
+PushNotificationIOS.presentLocalNotification(details);
+```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+| Name    | Type   | Required | Description |
+| ------- | ------ | -------- | ----------- |
+| details | object | Yes      | See below.  |
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
+
+---
 
 ### `scheduleLocalNotification()`
 

--- a/website/versioned_docs/version-0.38/pushnotificationios.md
+++ b/website/versioned_docs/version-0.38/pushnotificationios.md
@@ -63,7 +63,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`setApplicationIconBadgeNumber`](pushnotificationios.md#setapplicationiconbadgenumber)
@@ -90,11 +90,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 

--- a/website/versioned_docs/version-0.39/pushnotificationios.md
+++ b/website/versioned_docs/version-0.39/pushnotificationios.md
@@ -63,7 +63,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`setApplicationIconBadgeNumber`](pushnotificationios.md#setapplicationiconbadgenumber)
@@ -90,11 +90,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 

--- a/website/versioned_docs/version-0.40/pushnotificationios.md
+++ b/website/versioned_docs/version-0.40/pushnotificationios.md
@@ -53,7 +53,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`setApplicationIconBadgeNumber`](pushnotificationios.md#setapplicationiconbadgenumber)
@@ -80,11 +80,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 

--- a/website/versioned_docs/version-0.44/pushnotificationios.md
+++ b/website/versioned_docs/version-0.44/pushnotificationios.md
@@ -53,7 +53,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`removeAllDeliveredNotifications`](pushnotificationios.md#removealldeliverednotifications)
@@ -83,11 +83,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 

--- a/website/versioned_docs/version-0.45/pushnotificationios.md
+++ b/website/versioned_docs/version-0.45/pushnotificationios.md
@@ -63,7 +63,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`removeAllDeliveredNotifications`](pushnotificationios.md#removealldeliverednotifications)
@@ -93,11 +93,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 

--- a/website/versioned_docs/version-0.46/pushnotificationios.md
+++ b/website/versioned_docs/version-0.46/pushnotificationios.md
@@ -63,7 +63,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`removeAllDeliveredNotifications`](pushnotificationios.md#removealldeliverednotifications)
@@ -94,11 +94,26 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
+
 
 ---
 

--- a/website/versioned_docs/version-0.47/pushnotificationios.md
+++ b/website/versioned_docs/version-0.47/pushnotificationios.md
@@ -63,7 +63,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`removeAllDeliveredNotifications`](pushnotificationios.md#removealldeliverednotifications)
@@ -95,11 +95,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 

--- a/website/versioned_docs/version-0.49/pushnotificationios.md
+++ b/website/versioned_docs/version-0.49/pushnotificationios.md
@@ -63,7 +63,7 @@ And then in your AppDelegate implementation add the following:
 
 ### Methods
 
-* [`=`](pushnotificationios.md#)
+* [`presentLocalNotification`](pushnotificationios.md#presentLocalNotification)
 * [`scheduleLocalNotification`](pushnotificationios.md#schedulelocalnotification)
 * [`cancelAllLocalNotifications`](pushnotificationios.md#cancelalllocalnotifications)
 * [`removeAllDeliveredNotifications`](pushnotificationios.md#removealldeliverednotifications)
@@ -95,11 +95,25 @@ And then in your AppDelegate implementation add the following:
 
 ## Methods
 
-### `=()`
+### `presentLocalNotification()`
 
 ```javascript
-=(NewData, NoData, ResultFailed, }, static, (, :)
+PushNotificationIOS.presentLocalNotification(details);
 ```
+
+Schedules the localNotification for immediate presentation.
+
+**Parameters:**
+
+details is an object containing:
+
+ * `alertBody` : The message displayed in the notification alert.
+ * `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
+ * `soundName` : The sound played when the notification is fired (optional).
+ * `isSilent`  : If true, the notification will appear without sound (optional).
+ * `category`  : The category of this notification, required for actionable notifications (optional).
+ * `userInfo`  : An optional object containing additional notification data.
+ * `applicationIconBadgeNumber` (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
 
 ---
 


### PR DESCRIPTION
I have been changed for missing method called `presentLocalNotification` on `PushNotificationIOS`.

Fixed broken link on `JavaScript Environment`.
