### PR TITLE
Update cameraroll.md permissions section

### DIFF
--- a/docs/cameraroll.md
+++ b/docs/cameraroll.md
@@ -11,6 +11,8 @@ On iOS, the `CameraRoll` API requires the `RCTCameraRoll` library to be linked. 
 
 The user's permission is required in order to access the Camera Roll on devices running iOS 10 or later. Add the `NSPhotoLibraryUsageDescription` key in your `Info.plist` with a string that describes how your app will use this data. This key will appear as `Privacy - Photo Library Usage Description` in Xcode.
 
+If you are targeting devices running iOS 11 or later you will also need to add the `NSPhotoLibraryAddUsageDescription` key in your `Info.plist` with a string that describes how your app will use this data. This key will give you write-only access and without it if you try to save to the camera roll your app will exit.
+
 ### Methods
 
 * [`saveToCameraRoll`](cameraroll.md#savetocameraroll)

--- a/docs/cameraroll.md
+++ b/docs/cameraroll.md
@@ -11,7 +11,7 @@ On iOS, the `CameraRoll` API requires the `RCTCameraRoll` library to be linked. 
 
 The user's permission is required in order to access the Camera Roll on devices running iOS 10 or later. Add the `NSPhotoLibraryUsageDescription` key in your `Info.plist` with a string that describes how your app will use this data. This key will appear as `Privacy - Photo Library Usage Description` in Xcode.
 
-If you are targeting devices running iOS 11 or later you will also need to add the `NSPhotoLibraryAddUsageDescription` key in your `Info.plist` with a string that describes how your app will use this data. This key will give you write-only access and without it if you try to save to the camera roll your app will exit.
+If you are targeting devices running iOS 11 or later, you will also need to add the `NSPhotoLibraryAddUsageDescription` key in your `Info.plist`. Use this key to define a string that describes how your app will use this data. By adding this key to your `Info.plist`, you will be able to request write-only access permission from the user. If you try to save to the camera roll without this permission, your app will exit.
 
 ### Methods
 


### PR DESCRIPTION
Add a section to include an extra key required on iOS 11 and later in order to write to the camera roll.

Thank you for the PR! Contributors like you keep React Native awesome!

