### PR TITLE
Update README for contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ React Native showcase.
 ### Make the change
 
 1. Follow the "Running locally" instructions 
-1. `open http://localhost:3000/react-native/versions.html` to see other versions.
 1. Save the files and check in the browser. Some changes may require a server restart.
+1. Changes to /docs will only be visible in the latest version of the documentation (master). 
+
+`open http://localhost:3000/react-native/versions.html`to see other versions.
 
 ### Test the change
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo contains the website configuration and documentation powering the
 1. Node: install version 6.2.2 or greater
 1. Yarn: See
    [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/)
+1. A fork of the repo (for any contributions)
 1. A clone of the `react-native-website` repo.
 1. Docusaurus: Run `yarn global add docusaurus-init` or `npm install --global
    docusaurus-init`
@@ -137,9 +138,9 @@ React Native showcase.
 
 ### Make the change
 
-1. Follow the "Running locally" instructions
-1. Save the files and check in the browser. Some changes may require a server
-   restart.
+1. Follow the "Running locally" instructions 
+1. `open http://localhost:3000/react-native/versions.html` to see other versions.
+1. Save the files and check in the browser. Some changes may require a server restart.
 
 ### Test the change
 


### PR DESCRIPTION
Just started contributing to this repo today and had trouble viewing changes I made to some markdown files. Thanks to @charpeni's comment on #169, I realized you have to switch to the MASTER version. This update clarifies that in the README. I also figured the README should remind people to fork the repo when cloning like the README in [reactjs](https://github.com/reactjs/reactjs.org).