### PR TITLE
Fix `start/end_cursor` type (`CameraRoll`)

### DIFF
--- a/docs/cameraroll.md
+++ b/docs/cameraroll.md
@@ -101,8 +101,8 @@ Returns a Promise which when resolved will be of the following shape:
       * `speed`: {number}
 * `page_info` : {object} : An object with the following shape:
   * `has_next_page`: {boolean}
-  * `start_cursor`: {boolean}
-  * `end_cursor`: {boolean}
+  * `start_cursor`: {string}
+  * `end_cursor`: {string}
 
 #### Example
 


### PR DESCRIPTION
This PR fixes the wrong type of `start_cursor` and `end_cursor` properties.

Screenshot:

<img width="701" alt="react native debugger 2018-02-03 16-45-23" src="https://user-images.githubusercontent.com/1467712/35768895-fb03c83e-0902-11e8-8d81-2688e0837858.png">
