### PR TITLE
Fix button orders and indexes in ActionSheetIOS examples

### DIFF
--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -35,7 +35,7 @@ Minimal example:
 
 ```
 ActionSheetIOS.showActionSheetWithOptions({
-  options: ['Remove', 'Cancel'],
+  options: ['Cancel', 'Remove'],
   destructiveButtonIndex: 1,
   cancelButtonIndex: 0,
 },

--- a/website/versioned_docs/version-0.51/actionsheetios.md
+++ b/website/versioned_docs/version-0.51/actionsheetios.md
@@ -36,9 +36,9 @@ Minimal example:
 
 ```
 ActionSheetIOS.showActionSheetWithOptions({
-  options: ['Remove', 'Cancel'],
-  destructiveButtonIndex: 0,
-  cancelButtonIndex: 1,
+  options: ['Cancel', 'Remove'],
+  destructiveButtonIndex: 1,
+  cancelButtonIndex: 0,
 },
 (buttonIndex) => {
   if (buttonIndex === 1) { /* destructive action */ }

--- a/website/versioned_docs/version-0.52/actionsheetios.md
+++ b/website/versioned_docs/version-0.52/actionsheetios.md
@@ -36,7 +36,7 @@ Minimal example:
 
 ```
 ActionSheetIOS.showActionSheetWithOptions({
-  options: ['Remove', 'Cancel'],
+  options: ['Cancel', 'Remove'],
   destructiveButtonIndex: 1,
   cancelButtonIndex: 0,
 },


### PR DESCRIPTION
Hi, where is a small mistake in the example for ActionSheetIOS button orders and the array index. 'Remove' should be the destructive button and 'Cancel' is for cancel. Destructive button renders on top of cancel, even if it has a lower index(tested on RN 51)