### PR TITLE
Add link to install instructions for emulators

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,7 +137,7 @@ If you're curious to learn more about React Native, continue on to the [Tutorial
 
 ### Running your app on a simulator or virtual device
 
-Create React Native App makes it really easy to run your React Native app on a physical device without setting up a development environment. If you want to run your app on the iOS Simulator or an Android Virtual Device, please refer to the instructions for building projects with native code to learn how to install Xcode and set up your Android development environment.
+Create React Native App makes it really easy to run your React Native app on a physical device without setting up a development environment. If you want to run your app on the iOS Simulator or an Android Virtual Device, please refer to the [instructions for building projects with native code](#installing-dependencies) to learn how to install Xcode and set up your Android development environment.
 
 Once you've set these up, you can launch your app on an Android Virtual Device by running `npm run android`, or on the iOS Simulator by running `npm run ios` (macOS only).
 


### PR DESCRIPTION
The Quick Start doesn't mention where the instructions for running on emulators actually are in the docs; it's not obvious this means the tab at the top of the page.