### PR TITLE
Update gradle documentation

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -553,9 +553,9 @@ Add the React Native dependency to your app's `build.gradle` file:
 
 ```
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    implementation 'com.android.support:appcompat-v7:23.0.1'
     ...
-    compile "com.facebook.react:react-native:+" // From node_modules
+    implementation "com.facebook.react:react-native:+" // From node_modules
 }
 ```
 


### PR DESCRIPTION
`compile` is now deprecated in favor of `implementation`.

https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
