### PR TITLE
added docs for viewabilityConfig based on ViewabilityConfig interface

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -438,6 +438,54 @@ See `ViewabilityHelper.js` for flow type and further documentation.
 | ----------------- | -------- |
 | ViewabilityConfig | No       |
 
+`viewabilityConfig` takes a type `ViewabilityConfig` an object with following properties
+
+| Property                         | Required | Type    |
+| -------------------------------- | -------- | ------- |
+| minimumViewTime                  | No       | number  |
+| viewAreaCoveragePercentThreshold | No       | number  |
+| itemVisiblePercentThreshold      | No       | number  |
+| waitForInteraction               | No       | boolean |
+
+At least one of the `viewAreaCoveragePercentThreshold` or `itemVisiblePercentThreshold` is required. This needs to be done in the `constructor` to avoid following error ([ref](https://github.com/facebook/react-native/issues/17408)):
+
+```
+  Error: Changing viewabilityConfig on the fly is not supported`
+```
+
+```javascript
+constructor (props) {
+  super(props)
+
+  this.viewabilityConfig = {
+      waitForInteraction: true,
+      viewAreaCoveragePercentThreshold: 95
+  }
+}
+```
+
+```javascript
+<FlatList
+    viewabilityConfig={this.viewabilityConfig}
+  ...
+```
+
+#### minimumViewTime
+
+Minimum amount of time (in milliseconds) that an item must be physically viewable before the viewability callback will be fired. A high number means that scrolling through content without stopping will not mark the content as viewable.
+
+#### viewAreaCoveragePercentThreshold
+
+Percent of viewport that must be covered for a partially occluded item to count as "viewable", 0-100. Fully visible items are always considered viewable. A value of 0 means that a single pixel in the viewport makes the item viewable, and a value of 100 means that an item must be either entirely visible or cover the entire viewport to count as viewable.
+
+#### itemVisiblePercentThreshold
+
+Similar to `viewAreaPercentThreshold`, but considers the percent of the item that is visible, rather than the fraction of the viewable area it covers.
+
+#### waitForInteraction
+
+Nothing is considered viewable until the user scrolls or `recordInteraction` is called after render.
+
 ---
 
 ### `viewabilityConfigCallbackPairs`


### PR DESCRIPTION
I've just updated the `docs/flatlist.md` file with updated info based on `ViewabilityConfig` interface. I've tried to upload screenshots but was unable to update the local website. There were no error though from `docusaurus`.

Pull Request explains the properties taken by `viewabilityConfig` and the error and how to avoid  #17408 on `react-native` repo.
