### PR TITLE
Fix an error in 'Integration with existing apps' (iOS)

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -280,6 +280,8 @@ end
 
 After you have created your `Podfile`, you are ready to install the React Native pod.
 
+First, go to Xcode and in Preferences > Locations, make sure you have the Command Line Tools assigned. This is needed for installation of some of the third-party dependencies (for example GLog).
+
 ```
 $ pod install
 ```
@@ -296,6 +298,8 @@ Integrating client project
 Sending stats
 Pod installation complete! There are 3 dependencies from the Podfile and 1 total pod installed.
 ```
+
+> If this fails with errors mentioning `xcrun`, make sure that in Xcode in Preferences > Locations, you have the Command Line Tools assigned.
 
 <block class="swift" />
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -200,9 +200,9 @@ Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a 
 
 ![Before RN Integration](/react-native/docs/assets/react-native-existing-app-integration-ios-before.png)
 
-### Xcode Command Line Tools
+### Command Line Tools for Xcode
 
-Install the Xcode Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+Install the Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 ![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -280,7 +280,9 @@ end
 
 After you have created your `Podfile`, you are ready to install the React Native pod.
 
-First, go to Xcode and in Preferences > Locations, make sure you have the Command Line Tools assigned. This is needed for installation of some of the third-party dependencies (for example GLog).
+You will also need to install the Xcode Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+
+![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
 
 ```
 $ pod install
@@ -299,7 +301,7 @@ Sending stats
 Pod installation complete! There are 3 dependencies from the Podfile and 1 total pod installed.
 ```
 
-> If this fails with errors mentioning `xcrun`, make sure that in Xcode in Preferences > Locations, you have the Command Line Tools assigned.
+> If this fails with errors mentioning `xcrun`, make sure that in Xcode in Preferences > Locations the Command Line Tools are assigned.
 
 <block class="swift" />
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -200,6 +200,12 @@ Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a 
 
 ![Before RN Integration](/react-native/docs/assets/react-native-existing-app-integration-ios-before.png)
 
+### Xcode Command Line Tools
+
+Install the Xcode Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+
+![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
+
 ### Configuring CocoaPods dependencies
 
 Before you integrate React Native into your application, you will want to decide what parts of the React Native framework you would like to integrate. We will use CocoaPods to specify which of these "subspecs" your app will depend on.
@@ -279,10 +285,6 @@ end
 <block class="objc swift" />
 
 After you have created your `Podfile`, you are ready to install the React Native pod.
-
-You will also need to install the Xcode Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
-
-![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
 
 ```
 $ pod install


### PR DESCRIPTION
I followed the [guide](https://facebook.github.io/react-native/docs/next/integration-with-existing-apps.html) step by step and ran into an error on my machine. I've spent a while googling and finally found a solution here:
https://github.com/facebook/react-native/issues/7965

Adding this step should prevent the error.

(I'm using the same screenshot as used here: https://facebook.github.io/react-native/docs/getting-started.html)