### PR TITLE
note to not have a gradle setting which breaks android release build

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -76,6 +76,8 @@ $ cd android && ./gradlew assembleRelease
 
 Gradle's `assembleRelease` will bundle all the JavaScript needed to run your app into the APK. If you need to change the way the JavaScript bundle and/or drawable resources are bundled (e.g. if you changed the default file/folder names or the general structure of the project), have a look at `android/app/build.gradle` to see how you can update it to reflect these changes.
 
+> Note: Make sure gradle.properties does not include *org.gradle.configureondemand=true* as that will make release build skip bundling JS and assets into the APK.
+
 The generated APK can be found under `android/app/build/outputs/apk/app-release.apk`, and is ready to be distributed.
 
 ### Testing the release build of your app


### PR DESCRIPTION
If org.gradle.configureondemand=true is set for gradle, gradle will skip bundleJsAndAsset gradle task, which will result into the app crashing on startup with this in the logs:

java.lang.RuntimeException: Unable to load script from assets 'index.android.bundle'. Make sure your bundle is packaged correctly or you're running a packager server

Since it is not clear from the error what is causing this, I would recommend adding this additional note to potentially save a lot of time for people figuring this out (it was not trivial to find the answer by googling).