### PR TITLE
Integration with iOS apps - Include RCTAnimation

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -234,7 +234,8 @@ target 'NumberTileGame' do
     'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
     'RCTText',
     'RCTNetwork',
-    'RCTWebSocket', # needed for debugging
+    'RCTWebSocket', # Needed for debugging
+    'RCTAnimation', # Needed for FlatList and animations running on native UI thread
     # Add any other subspecs you want to use in your project
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0


### PR DESCRIPTION
Preview here:
https://deploy-preview-217--react-native.netlify.com/docs/next/integration-with-existing-apps.html

`RCTAnimation` is needed for `FlatList`, otherwise we get an error:

<img width="400" alt="screen shot 2018-02-25 at 12 26 07" src="https://user-images.githubusercontent.com/346214/36641519-aa15bf9a-1a28-11e8-8de6-ac48f2eb38d5.png">

Most mobile apps use some sort of a scrollable list and [FlatList](https://facebook.github.io/react-native/docs/flatlist.html) is the default way to do that. Therefore most people will need to include `RCTAnimation`, and this PR saves time Googling.

I added comment so it's clear what this dependency is for and people can always remove it if not needed.