### PR TITLE
Fix react-native-git-upgrade documentation

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -51,7 +51,7 @@ Run the following command to start the process of upgrading to the latest versio
 $ react-native-git-upgrade
 ```
 
-> You may specify a React Native version by passing an argument: `react-native-git-upgrade X.Y`
+> You may specify a React Native version by passing an argument: `react-native-git-upgrade X.Y.Z`
 
 The templates are upgraded in a optimized way. You still may encounter conflicts but only where the Git 3-way merge have failed, depending on the version and how you modified your sources.
 


### PR DESCRIPTION
The documentation says that "You may specify a React Native version by passing an argument: `react-native-git-upgrade X.Y`". However, if I run `react-native-git-upgrade 0.53` I get 
```
Error: The specified version of React Native 0.53 doesn't exist.
Re-run the react-native-git-upgrade command with an existing version,
for example: "react-native-git-upgrade 0.38.0",
```
Running `react-native-git-upgrade 0.53.3` works.

This pull request changes the documentation so that it says "You may specify a React Native version by passing an argument: `react-native-git-upgrade X.Y.Z`" so that it is uniform with the error message.
