### PR TITLE
Glog lower case matters

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -242,7 +242,7 @@ target 'NumberTileGame' do
 
   # Third party deps podspec link
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'GLog', :podspec => '../node_modules/react-native/third-party-podspecs/GLog.podspec'
+  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
 end


### PR DESCRIPTION
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:


See podspec should be lowercase
https://github.com/facebook/react-native/blob/master/third-party-podspecs/glog.podspec