### PR TITLE
Improved the documentation regarding Picker

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -7,6 +7,7 @@ Renders the native picker component on iOS and Android. Example:
 
     <Picker
       selectedValue={this.state.language}
+      style={{ height: 50, width: 100 }}
       onValueChange={(itemValue, itemIndex) => this.setState({language: itemValue})}>
       <Picker.Item label="Java" value="java" />
       <Picker.Item label="JavaScript" value="js" />


### PR DESCRIPTION
If we render Picker without having width and height set explicitly, the component will not be visible. This caused an issue to a few people that I mentor and each of them spent quite some time debugging.
