### PR TITLE
Small clarification in Native Modules (iOS)

### DIFF
--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -27,6 +27,8 @@ In addition to implementing the `RCTBridgeModule` protocol, your class must also
 
 ```objectivec
 // CalendarManager.m
+#import "CalendarManager.h"
+
 @implementation CalendarManager
 
 // To export a module named CalendarManager


### PR DESCRIPTION
I'm an iOS beginner and missed this import. I later figured it out, but hopefully this PR will save others some time.

The import is correctly added in the next code sample below but I believe we should add it right in the first example - this is the first bit of code people copy&paste and it doesn't work currently.