### PR TITLE
Add an example to KeyboardAvoidingView

### DIFF
--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -5,6 +5,17 @@ title: KeyboardAvoidingView
 
 It is a component to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust either its position or bottom padding based on the position of the keyboard.
 
+Example usage:
+
+```
+import { KeyboardAvoidingView } from 'react-native';
+...
+
+<KeyboardAvoidingView style={styles.container} behavior="padding">
+  ... your UI ...
+</KeyboardAvoidingView>
+```
+
 ### Example
 
 ![](/react-native/docs/assets/KeyboardAvoidingView/example.gif)

--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -9,7 +9,6 @@ Example usage:
 
 ```
 import { KeyboardAvoidingView } from 'react-native';
-...
 
 <KeyboardAvoidingView style={styles.container} behavior="padding">
   ... your UI ...


### PR DESCRIPTION
I saw a question about `KeyboardAvoidingView` on StackOverflow and realized the docs were missing example usage (see e.g. [`Button`](https://github.com/facebook/react-native-website/edit/master/docs/button.md)).

Preview:

<img src="https://user-images.githubusercontent.com/346214/36934030-d7c2f4d8-1eda-11e8-8b09-ab54f23cd8d8.png">
