### PR TITLE
docs: getting-started: change npm to yarn in some commands

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Then run the following commands to create a new React Native project called "Awe
 create-react-native-app AwesomeProject
 
 cd AwesomeProject
-npm start
+yarn start
 ```
 
 This will start a development server for you, and print a QR code in your terminal.
@@ -139,7 +139,7 @@ If you're curious to learn more about React Native, continue on to the [Tutorial
 
 Create React Native App makes it really easy to run your React Native app on a physical device without setting up a development environment. If you want to run your app on the iOS Simulator or an Android Virtual Device, please refer to the instructions for building projects with native code to learn how to install Xcode and set up your Android development environment.
 
-Once you've set these up, you can launch your app on an Android Virtual Device by running `npm run android`, or on the iOS Simulator by running `npm run ios` (macOS only).
+Once you've set these up, you can launch your app on an Android Virtual Device by running `yarn run android`, or on the iOS Simulator by running `yarn run ios` (macOS only).
 
 ### Caveats
 


### PR DESCRIPTION
After creating a new app using create-react-native-app it suggests to use yarn instead of npm.
Since yarn is more secure than npm and effectively has the same functionality, swap out the npm commands for the yarn commands as described after creating a new app:

```
Success! Created AwesomeReactApp at /home/simao/workspace/AwesomeReactApp
Inside that directory, you can run several commands:

  yarn start
    Starts the development server so you can open your app in the Expo
    app on your phone.

  yarn run ios
    (Mac only, requires Xcode)
    Starts the development server and loads your app in an iOS simulator.

  yarn run android
    (Requires Android build tools)
    Starts the development server and loads your app on a connected Android
    device or emulator.

  yarn test
    Starts the test runner.

  yarn run eject
    Removes this tool and copies build dependencies, configuration files
    and scripts into the app directory. If you do this, you can’t go back!

We suggest that you begin by typing:

  cd AwesomeReactApp
  yarn start

Happy hacking!

```
