### PR TITLE
Update keyboard example.md

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -14,12 +14,12 @@ import React, { Component } from 'react';
 import { Keyboard, TextInput } from 'react-native';
 
 class Example extends Component {
-  componentWillMount () {
+  componentDidMount () {
     this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', this._keyboardDidShow);
     this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this._keyboardDidHide);
   }
 
-  componentDidmount () {
+  componentWillUnmount () {
     this.keyboardDidShowListener.remove();
     this.keyboardDidHideListener.remove();
   }

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -19,7 +19,7 @@ class Example extends Component {
     this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this._keyboardDidHide);
   }
 
-  componentWillUnmount () {
+  componentDidmount () {
     this.keyboardDidShowListener.remove();
     this.keyboardDidHideListener.remove();
   }


### PR DESCRIPTION
According to the official React documentation on ComponentWillMount method: 

> Avoid introducing any side-effects or subscriptions in this method. For those use cases, use componentDidMount() instead.