### PR TITLE
Update Fresco version in the docs

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -79,17 +79,17 @@ You will need to add some optional modules in `android/app/build.gradle`, depend
 ```
 dependencies {
   // If your app supports Android versions before Ice Cream Sandwich (API level 14)
-  compile 'com.facebook.fresco:animated-base-support:1.3.0'
+  compile 'com.facebook.fresco:animated-base-support:1.8.1'
 
   // For animated GIF support
-  compile 'com.facebook.fresco:animated-gif:1.3.0'
+  compile 'com.facebook.fresco:animated-gif:1.8.1'
 
   // For WebP support, including animated WebP
-  compile 'com.facebook.fresco:animated-webp:1.3.0'
-  compile 'com.facebook.fresco:webpsupport:1.3.0'
+  compile 'com.facebook.fresco:animated-webp:1.8.1'
+  compile 'com.facebook.fresco:webpsupport:1.8.1'
 
   // For WebP support, without animations
-  compile 'com.facebook.fresco:webpsupport:1.3.0'
+  compile 'com.facebook.fresco:webpsupport:1.8.1'
 }
 ```
 


### PR DESCRIPTION
Following the Fresco update in the upcoming version, I have updated the version of fresco in the docs. 

Related issue: https://github.com/facebook/react-native/pull/18496