### PR TITLE
Update ellipsizeMode prop of Text

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -265,8 +265,6 @@ This can be one of the following values:
 
 The default is `tail`.
 
-> `clip` is working only for iOS
-
 | Type                                   | Required |
 | -------------------------------------- | -------- |
 | enum('head', 'middle', 'tail', 'clip') | No       |


### PR DESCRIPTION
This removes the "`clip` only for IOS" message, since
now android also has support for it

Related PR:

facebook/react-native#18540