### PR TITLE
updated docs to show support for snapToInterval/Alignment on android

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -539,9 +539,9 @@ When `snapToInterval` is set, `snapToAlignment` will define the relationship of 
 * `'center'` will align the snap in the center
 * `'end'` will align the snap at the right (horizontal) or bottom (vertical)
 
-| Type                           | Required | Platform |
-| ------------------------------ | -------- | -------- |
-| enum('start', 'center', 'end') | No       | iOS      |
+| Type                           | Required |
+| ------------------------------ | -------- |
+| enum('start', 'center', 'end') | No       |
 
 ---
 
@@ -549,9 +549,11 @@ When `snapToInterval` is set, `snapToAlignment` will define the relationship of 
 
 When set, causes the scroll view to stop at multiples of the value of `snapToInterval`. This can be used for paginating through children that have lengths smaller than the scroll view. Typically used in combination with `snapToAlignment` and `decelerationRate="fast"`. Overrides less configurable `pagingEnabled` prop.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+Note: Vertical snapToInterval is not supported on Android.
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
 
 ---
 


### PR DESCRIPTION
Updated docs to show horizontal support for snapToInterval and snapToAlignment on android.

<img width="1250" alt="screen shot 2018-04-02 at 2 41 30 pm" src="https://user-images.githubusercontent.com/10122678/38210253-dcb631e6-3684-11e8-9c2c-3a13b116dd18.png">

References this [PR](https://github.com/facebook/react-native/pull/18648)
