### PR TITLE
Documentation Clarification: SectionList

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -36,6 +36,7 @@ Simple Examples:
     const overrideRenderItem = ({ item, index, section: { title, data } }) => <Text key={index}>Override{item}</Text>
 
     <SectionList
+      renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>}
       sections={[
         { title: 'Title1', data: ['item1', 'item2'], renderItem: overrideRenderItem },
         { title: 'Title2', data: ['item3', 'item4'] },

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -19,22 +19,27 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 Simple Examples:
-
+    
+    // Example 1 (Homogeneous Rendering)
     <SectionList
-      renderItem={({item}) => <ListItem title={item} />}
-      renderSectionHeader={({section}) => <Header title={section.title} />}
-      sections={[ // homogeneous rendering between sections
-        {data: [...], title: ...},
-        {data: [...], title: ...},
-        {data: [...], title: ...},
+      renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>}
+      renderSectionHeader={({ section: { title } }) => <Text style={{ fontWeight: 'bold' }}>{title}</Text>}
+      sections={[
+        { title: 'Title1', data: ['item1', 'item2'] },
+        { title: 'Title2', data: ['item3', 'item4'] },
+        { title: 'Title3', data: ['item5', 'item6'] },
       ]}
+      keyExtractor={(item, index) => item + index}
     />
 
+    // Example 2 (Heterogeneous Rendering / No Section Headers)
+    const overrideRenderItem = ({ item, index, section: { title, data } }) => <Text key={index}>Override{item}</Text>
+
     <SectionList
-      sections={[ // heterogeneous rendering between sections
-        {data: [...], renderItem: ...},
-        {data: [...], renderItem: ...},
-        {data: [...], renderItem: ...},
+      sections={[
+        { title: 'Title1', data: ['item1', 'item2'], renderItem: overrideRenderItem },
+        { title: 'Title2', data: ['item3', 'item4'] },
+        { title: 'Title3', data: ['item5', 'item6'] },
       ]}
     />
 


### PR DESCRIPTION
When first going through this example, it was unclear to me that `ListItem` and `Header`  where not importable components. The error was rather cryptic as well.

Also, the heterogeneous example made the sections prop look like it expected a different data structure. Plus, adding explicit function params for clarity.