### PR TITLE
Fix formatting problem in sectionlist.md

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -19,7 +19,18 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 Simple Examples:
- // Example 1 (Homogeneous Rendering) <SectionList renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>} renderSectionHeader={({ section: { title } }) => <Text style={{ fontWeight: 'bold' }}>{title}</Text>} sections={[ { title: 'Title1', data: ['item1', 'item2'] }, { title: 'Title2', data: ['item3', 'item4'] }, { title: 'Title3', data: ['item5', 'item6'] }, ]} keyExtractor={(item, index) => item + index} />
+ 
+    // Example 1 (Homogeneous Rendering) 
+    <SectionList 
+      renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>} 
+      renderSectionHeader={({ section: { title } }) => <Text style={{ fontWeight: 'bold' }}>{title}</Text>} 
+      sections={[ 
+         { title: 'Title1', data: ['item1', 'item2'] }, 
+         { title: 'Title2', data: ['item3', 'item4'] }, 
+         { title: 'Title3', data: ['item5', 'item6'] }, 
+       ]} 
+      keyExtractor={(item, index) => item + index} 
+    />
 
     // Example 2 (Heterogeneous Rendering / No Section Headers)
     const overrideRenderItem = ({ item, index, section: { title, data } }) => <Text key={index}>Override{item}</Text>


### PR DESCRIPTION
The code example for homogenous rendering was not formatted correctly. This PR fixes it