### PR TITLE
Fixed formatting issue in Simple Examples

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -19,8 +19,19 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
 Simple Examples:
- // Example 1 (Homogeneous Rendering) <SectionList renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>} renderSectionHeader={({ section: { title } }) => <Text style={{ fontWeight: 'bold' }}>{title}</Text>} sections={[ { title: 'Title1', data: ['item1', 'item2'] }, { title: 'Title2', data: ['item3', 'item4'] }, { title: 'Title3', data: ['item5', 'item6'] }, ]} keyExtractor={(item, index) => item + index} />
 
+    // Example 1 (Homogeneous Rendering)
+    <SectionList
+      renderItem={({ item, index, section }) => <Text key={index}>{item}</Text>}
+      renderSectionHeader={({ section: { title } }) => <Text style={{ fontWeight: 'bold' }}>{title}</Text>}
+      sections={[
+        { title: 'Title1', data: ['item1', 'item2'] },
+        { title: 'Title2', data: ['item3', 'item4'] },
+        { title: 'Title3', data: ['item5', 'item6'] },
+      ]}
+      keyExtractor={(item, index) => item + index}
+    />
+    
     // Example 2 (Heterogeneous Rendering / No Section Headers)
     const overrideRenderItem = ({ item, index, section: { title, data } }) => <Text key={index}>Override{item}</Text>
 


### PR DESCRIPTION
Example 1 of the simple examples wasn't formatted correctly and looked like one continuing line of plain text. This change fixes that so it looks like readable code again.