### PR TITLE
Use correct component name in ProgressBarAndroid example

### DIFF
--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -11,7 +11,7 @@ Example:
 render: function() {
   var progressBar =
     <View style={styles.container}>
-      <ProgressBar styleAttr="Inverse" />
+      <ProgressBarAndroid styleAttr="Inverse" />
     </View>;
 
   return (


### PR DESCRIPTION
The example provided for [`ProgressBarAndroid`](https://facebook.github.io/react-native/docs/progressbarandroid.html) creates a `progressBar` component upon `ProgressBar` instead of `ProgressBarAndroid`. This can be confusing to novices like me.