### PR TITLE
Update the ProgressBarAndroid copy and example 

### DIFF
--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -3,25 +3,45 @@ id: progressbarandroid
 title: ProgressBarAndroid
 ---
 
-React component that wraps the Android-only `ProgressBar`. This component is used to indicate that the app is loading or there is some activity in the app.
+Android-only React component used to indicate that the app is loading or there is some activity in the app.
 
 Example:
 
 ```
-render: function() {
-  var progressBar =
-    <View style={styles.container}>
-      <ProgressBar styleAttr="Inverse" />
-    </View>;
+import React, { Component } from "react";
+import {
+  ProgressBarAndroid,
+  AppRegistry,
+  StyleSheet,
+  View
+} from "react-native";
 
-  return (
-    <MyLoadingComponent
-      componentView={componentView}
-      loadingView={progressBar}
-      style={styles.loadingComponent}
-    />
-  );
-},
+export default class App extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <ProgressBarAndroid />
+        <ProgressBarAndroid styleAttr="Horizontal" />
+        <ProgressBarAndroid styleAttr="Horizontal" color="#2196F3" />
+        <ProgressBarAndroid
+          styleAttr="Horizontal"
+          indeterminate={false}
+          progress={0.5}
+        />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "space-evenly",
+    padding: 10
+  }
+});
+
+AppRegistry.registerComponent("App", () => App);
 ```
 
 ### Props


### PR DESCRIPTION
This PR is for the confusing docs on the `ProgressBarAndroid` component.

I've done the following:
- Re-phrased the initial copy for the component description
- Add a copy pastable snippet that can work out of the box in "create-react-naitve-app" and or in expo
- Hopefully made the docs a bit better for everybody 😄 

This is a screnshot of the snippet running in an emulator

![screenshot_1523456136](https://user-images.githubusercontent.com/3579758/38622804-e5d793fa-3d9b-11e8-8351-15058d0b12a6.png)

and here is running on expo
https://snack.expo.io/rysZ_cooz