### PR TITLE
Don't recommend locking screen orientation

### DIFF
--- a/docs/improvingux.md
+++ b/docs/improvingux.md
@@ -45,7 +45,9 @@ Android API 21+ uses the material design ripple to provide user with feedback wh
 
 ## Screen orientation lock
 
-Unless supporting both, it is considered good practice to lock the screen orientation to either portrait or landscape. On iOS, in the General tab and Deployment Info section of Xcode enable the Device Orientation you want to support (ensure you have selected iPhone from the Devices menu when making the changes). For Android, open the AndroidManifest.xml file and within the activity element add `'android:screenOrientation="portrait"'` to lock to portrait or `'android:screenOrientation="landscape"'` to lock to landscape.
+Multiple screen orientations should work fine by default unless you're using `Dimensions` API and don't handle orientation changes. If you don't want to support multiple screen orientations, you can lock the screen orientation to either portrait or landscape.
+
+On iOS, in the General tab and Deployment Info section of Xcode enable the Device Orientation you want to support (ensure you have selected iPhone from the Devices menu when making the changes). For Android, open the AndroidManifest.xml file and within the activity element add `'android:screenOrientation="portrait"'` to lock to portrait or `'android:screenOrientation="landscape"'` to lock to landscape.
 
 # Learn more
 


### PR DESCRIPTION
Locking screen orientation in your app is not a "good practice". It's not difficult at all to handle multiple orientations. The PR updates the text so that it doesn't sound like we're recommending people to lock the screen orientation.
