### PR TITLE
Add a note about CPFRN in the troubleshooting next to the other CP issues

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,6 +61,10 @@ pod 'React', :path => '../node_modules/react-native', :subspecs => [
 
 Next, make sure you have run `pod install` and that a `Pods/` directory has been created in your project with React installed. CocoaPods will instruct you to use the generated `.xcworkspace` file henceforth to be able to use these installed dependencies.
 
+#### React Native does not compile when being used as a CocoaPod
+
+There is a CocoaPods plugin called [cocoapods-fix-react-native](https://github.com/orta/cocoapods-fix-react-native) which handles any potential post-fixing of the source code due to differences when using a dependency manager.
+
 #### Argument list too long: recursive header expansion failed
 
 In the project's build settings, `User Search Header Paths` and `Header Search Paths` are two configs that specify where Xcode should look for `#import` header files specified in the code. For Pods, CocoaPods uses a default array of specific folders to look in. Verify that this particular config is not overwritten, and that none of the folders configured are too large. If one of the folders is a large folder, Xcode will attempt to recursively search the entire directory and throw above error at some point.

--- a/website/versioned_docs/version-0.5/troubleshooting.md
+++ b/website/versioned_docs/version-0.5/troubleshooting.md
@@ -62,6 +62,10 @@ pod 'React', :path => '../node_modules/react-native', :subspecs => [
 
 Next, make sure you have run `pod install` and that a `Pods/` directory has been created in your project with React installed. CocoaPods will instruct you to use the generated `.xcworkspace` file henceforth to be able to use these installed dependencies.
 
+#### React Native does not compile when being used as a CocoaPod
+
+There is a CocoaPods plugin called [cocoapods-fix-react-native](https://github.com/orta/cocoapods-fix-react-native) which handles any potential post-fixing of the source code due to differences when using a dependency manager.
+
 #### Argument list too long: recursive header expansion failed
 
 In the project's build settings, `User Search Header Paths` and `Header Search Paths` are two configs that specify where Xcode should look for `#import` header files specified in the code. For Pods, CocoaPods uses a default array of specific folders to look in. Verify that this particular config is not overwritten, and that none of the folders configured are too large. If one of the folders is a large folder, Xcode will attempt to recursively search the entire directory and throw above error at some point.


### PR DESCRIPTION
There are a bunch of "CocoaPods doesn't compile with version `0.xx.y` of RN" issues on facebook/react-native, and this plugin addresses those. The lib will port any changes to the source code that are needed to make it run automatically.