### PR TITLE
fix docs: `keyboardVerticalOffset`Not Required

### DIFF
--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -45,7 +45,7 @@ This is the distance between the top of the user screen and the react native vie
 
 | Type   | Required |
 | ------ | -------- |
-| number | Yes      |
+| number | No       |
 
 ---
 


### PR DESCRIPTION
Docs state that the `keyboardVerticalOffset` prop for `keyboardAvoidingView` is required.   
But I do not believe this to be the case.   
I have yet to see a working example where this prop is even supplied.   
Indeed, this component works for me on both ios and android, without supplying it..   
(And when I did briefly try it out, I did not notice any difference.)

I changed the docs from `keyboardVerticalOffset` `Required: Yes` to `Required: No`

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
