### PR TITLE
Add missing comma to native bridge code sample

### DIFF
--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -198,7 +198,7 @@ Native modules can also fulfill a promise, which can simplify your code, especia
 Refactoring the above code to use a promise instead of callbacks looks like this:
 
 ```objectivec
-RCT_REMAP_METHOD(findEvents
+RCT_REMAP_METHOD(findEvents,
                  findEventsWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
The syntax for `RCT_REMAP_METHOD` is `RCT_REMAP_METHOD(<#js_name#>, <#method#>)`. The code sample is missing a comma. This PR fixes the issue by adding the comma.