### PR TITLE
SectionList > scrollToLocation: Alternative onScrollToIndexFailed

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -346,7 +346,7 @@ scrollToLocation(params);
 
 Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the section) positioned in the viewable area such that `viewPosition` 0 places it at the top (and may be covered by a sticky header), 1 at the bottom, and 0.5 centered in the middle.
 
-> Note: Cannot scroll to locations outside the render window without specifying the `getItemLayout` prop.
+> Note: Cannot scroll to locations outside the render window without specifying the `getItemLayout` or `onScrollToIndexFailed` prop.
 
 **Parameters:**
 


### PR DESCRIPTION
Include the alternative to provide an error callback instead of providing the itemLayout in SectionList to fullfill requirements to use  scrollToLocation.
