### PR TITLE
typo: alignItems: 'stretch'

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -84,11 +84,11 @@ export default class AlignItemsBasics extends Component {
         flex: 1,
         flexDirection: 'column',
         justifyContent: 'center',
-        alignItems: 'center',
+        alignItems: 'stretch',
       }}>
         <View style={{width: 50, height: 50, backgroundColor: 'powderblue'}} />
-        <View style={{width: 50, height: 50, backgroundColor: 'skyblue'}} />
-        <View style={{width: 50, height: 50, backgroundColor: 'steelblue'}} />
+        <View style={{height: 50, backgroundColor: 'skyblue'}} />
+        <View style={{height: 100, backgroundColor: 'steelblue'}} />
       </View>
     );
   }


### PR DESCRIPTION
The description text is talking about alignItems: 'stretch' property, but used alignItems: 'center' instead.

Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
