### PR TITLE
Added Alt attribute

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -196,7 +196,7 @@ class AwkwardScrollingImageWithText extends Component {
                 </MarkdownBlock>
               </div>
             </div>
-            <img src="https://media.giphy.com/media/13WZniThXy0hSE/giphy.gif" />
+            <img src="https://media.giphy.com/media/13WZniThXy0hSE/giphy.gif" alt="hot-loader" />
           </div>
         </Container>
         <Container>


### PR DESCRIPTION
By adding the attribute to the image tag  accessibility score increased  up to 95% 
in chrome audits tab.
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
