### PR TITLE
Use authorImageURL, authorImage is deprecated in Docusaurus

### DIFF
--- a/website/blog/2018-05-07-using-typescript-with-react-native.md
+++ b/website/blog/2018-05-07-using-typescript-with-react-native.md
@@ -3,7 +3,7 @@ title: Using TypeScript with React Native
 author: Ash Furrow
 authorTitle: Software Engineer at Artsy
 authorURL: https://github.com/ashfurrow
-authorImage: https://avatars2.githubusercontent.com/u/498212?s=460&v=4
+authorImageURL: https://avatars2.githubusercontent.com/u/498212?s=460&v=4
 authorTwitter: ashfurrow
 category: engineering
 ---


### PR DESCRIPTION
Follow on to: https://github.com/facebook/react-native-website/pull/314

Relates to: https://github.com/facebook/Docusaurus/pull/652 (future version of Docusaurus will not respect deprecated `authorImage`)

IS:
![image](https://user-images.githubusercontent.com/1372946/39898248-cfe6c0f8-546a-11e8-9ac8-05dc61bddcd7.png)

cc @yangshun 