### PR TITLE
Update use of density independent pixels

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -29,7 +29,7 @@ export default class FixedDimensionsBasics extends Component {
 AppRegistry.registerComponent('AwesomeProject', () => FixedDimensionsBasics);
 ```
 
-Setting dimensions this way is common for components that should always render at exactly the same size, regardless of screen dimensions.
+Setting dimensions this way is common for components that should always render at exactly the same size for screens of same size, regardless of their pixel densities.
 
 ## Flex Dimensions
 


### PR DESCRIPTION
Density independent pixels are useful for same size screens with different pixel densities. When screen dimensions change, the components might not render at exactly the same size.
Reference: https://developer.android.com/training/multiscreen/screendensities

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
