### PR TITLE
Rectify ImageBackground documentation

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -199,11 +199,13 @@ You might not want to use `<ImageBackground>` in some cases, since the implement
 
 ```javascript
 return (
-  <ImageBackground source={...}>
+  <ImageBackground source={...} style={{width: '100%', height: '100%'}}>
     <Text>Inside</Text>
   </ImageBackground>
 );
 ```
+
+Note that you must specify some width and height style attributes.
 
 ## iOS Border Radius Styles
 


### PR DESCRIPTION
After losing some time with an error about a "cannot read property 'width' of undefined", I dug into the source and found out that indeed, you MUST provide a `style` prop with key `width` and `height`.

This was not mentioned in the documentation and even made the provided example wrong.
