### PR TITLE
Fix broken link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,7 +171,7 @@ The instructions are a bit different depending on your development operating sys
 
 ## Unsupported
 
-<blockquote><p>A Mac is required to build projects with native code for iOS. You can follow the <a href="getting-started.md" onclick="displayTab('guide', 'quickstart')">Quick Start</a> to learn how to build your app using Create React Native App instead.</p></blockquote>
+<blockquote><p>A Mac is required to build projects with native code for iOS. You can follow the <a href="getting-started.html" onclick="displayTab('guide', 'quickstart')">Quick Start</a> to learn how to build your app using Create React Native App instead.</p></blockquote>
 
 <block class="native mac ios" />
 


### PR DESCRIPTION
The `.md` here will not be translated to `.html` when we build the site. As a result, we should change it to `.html` in the source.

FYI, we had something similar at https://github.com/facebook/react-native-website/blame/master/docs/getting-started.md#L156

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
