### PR TITLE
Remove 'website' from table of contents

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,7 +14,6 @@ Whenever you are fixing a bug or adding new functionality to React Native, you s
 * [iOS](testing.md#ios)
 * [Apple TV](testing.md#apple-tv)
 * [End-to-end tests](testing.md#end-to-end-tests)
-* [Website](testing.md#website)
 
 ## JavaScript
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,7 @@ Whenever you are fixing a bug or adding new functionality to React Native, you s
 * [iOS](testing.md#ios)
 * [Apple TV](testing.md#apple-tv)
 * [End-to-end tests](testing.md#end-to-end-tests)
+* [Updating the Documentation](testing.md#updating-the-documentation)
 
 ## JavaScript
 


### PR DESCRIPTION
It's currently a link to /dev/null