### PR TITLE
redirect for react-native android-setup

### DIFF
--- a/website/static/docs/android-setup.html
+++ b/website/static/docs/android-setup.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=getting-started.html">
+    <script type="text/javascript">
+      window.location.href = 'getting-started.html';
+    </script>
+    <title>React Native · A framework for building native apps using React</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this <a href="getting-started.html">link</a>.
+  </body>
+</html>


### PR DESCRIPTION
## Motivation

Fixes #385 

## Test Plan
- [X] Test on development
```
cd website
yarn start
```

Open http://localhost:3000/react-native/docs/android-setup.html, got redirected
<img width="960" alt="android-setup" src="https://user-images.githubusercontent.com/17883920/40733250-becb2176-6467-11e8-9817-574b346be159.PNG">

- [X] Test on production files
Serve with simple python HttpServer
```
cd website
yarn build
cd build
python -m SimpleHTTPServer 8000
```

Open http://localhost:8000/react-native/docs/android-setup.html, got redirected
<img width="864" alt="python-http" src="https://user-images.githubusercontent.com/17883920/40733110-7bd0a0e4-6467-11e8-8934-31a16f00962f.PNG">

- [X] Test using netlify
Open https://deploy-preview-390--react-native.netlify.com/docs/android-setup.html and got redirected
<img width="537" alt="netlify" src="https://user-images.githubusercontent.com/17883920/40733954-922db794-6469-11e8-85ab-12ddb3191072.PNG">

