### PR TITLE
Fix a warning in the Networking Fetch Example

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -118,7 +118,7 @@ export default class FetchExample extends React.Component {
         <FlatList
           data={this.state.dataSource}
           renderItem={({item}) => <Text>{item.title}, {item.releaseYear}</Text>}
-          keyExtractor={(item, index) => index}
+          keyExtractor={(item, index) => index.toString()}
         />
       </View>
     );

--- a/docs/network.md
+++ b/docs/network.md
@@ -118,7 +118,7 @@ export default class FetchExample extends React.Component {
         <FlatList
           data={this.state.dataSource}
           renderItem={({item}) => <Text>{item.title}, {item.releaseYear}</Text>}
-          keyExtractor={(item, index) => index.toString()}
+          keyExtractor={({id}, index) => id}
         />
       </View>
     );

--- a/website/static/movies.json
+++ b/website/static/movies.json
@@ -2,11 +2,11 @@
   "title": "The Basics - Networking",
   "description": "Your app fetched this from a remote endpoint!",
   "movies": [
-    { "title": "Star Wars", "releaseYear": "1977"},
-    { "title": "Back to the Future", "releaseYear": "1985"},
-    { "title": "The Matrix", "releaseYear": "1999"},
-    { "title": "Inception", "releaseYear": "2010"},
-    { "title": "Interstellar", "releaseYear": "2014"}
+    { "id": "1", "title": "Star Wars", "releaseYear": "1977"},
+    { "id": "2", "title": "Back to the Future", "releaseYear": "1985"},
+    { "id": "3", "title": "The Matrix", "releaseYear": "1999"},
+    { "id": "4", "title": "Inception", "releaseYear": "2010"},
+    { "id": "5", "title": "Interstellar", "releaseYear": "2014"}
   ]
 }
 


### PR DESCRIPTION
While running the fetch example, I saw this warning :
```ExceptionsManager.js:71 Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.```

I verified in the [doc](https://facebook.github.io/react-native/docs/flatlist.html#keyextractor), `keyExtractor` should return a `string`.

