### PR TITLE
Update navigation.md. Use createStackNavigator

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -25,10 +25,10 @@ Then you can quickly create an app with a home screen and a profile screen:
 
 ```
 import {
-  StackNavigator,
+  createStackNavigator,
 } from 'react-navigation';
 
-const App = StackNavigator({
+const App = createStackNavigator({
   Home: { screen: HomeScreen },
   Profile: { screen: ProfileScreen },
 });


### PR DESCRIPTION
StackNavigator is deprecated and `createStackNavigator` should be used instead.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
