### PR TITLE
Grammar and sentence flow in FlatList docs

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -253,7 +253,7 @@ A marker property for telling the list to re-render (since it implements `PureCo
 (data, index) => {length: number, offset: number, index: number}
 ```
 
-`getItemLayout` is an optional optimization that let us skip the measurement of dynamic content if you know the items' height. `getItemLayout` is both efficient and easy to use if you have fixed height items, for example:
+`getItemLayout` is an optional optimization that let us skip the measurement of dynamic content if you know the item's height ahead of time. `getItemLayout` is both efficient and easy to use if you have fixed height items, for example:
 
 ```javascript
   getItemLayout={(data, index) => (

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -253,7 +253,7 @@ A marker property for telling the list to re-render (since it implements `PureCo
 (data, index) => {length: number, offset: number, index: number}
 ```
 
-`getItemLayout` is an optional optimization that let us skip the measurement of dynamic content if you know the item's height ahead of time. `getItemLayout` is both efficient and easy to use if you have fixed height items, for example:
+`getItemLayout` is an optional optimization that let us skip the measurement of dynamic content if you know the height of items ahead of time. `getItemLayout` is both efficient and easy to use if you have fixed height items, for example:
 
 ```javascript
   getItemLayout={(data, index) => (

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -253,7 +253,7 @@ A marker property for telling the list to re-render (since it implements `PureCo
 (data, index) => {length: number, offset: number, index: number}
 ```
 
-`getItemLayout` is an optional optimization that let us skip measurement of dynamic content if you know the height of items a priori. `getItemLayout` is the most efficient, and is easy to use if you have fixed height items, for example:
+`getItemLayout` is an optional optimization that let us skip the measurement of dynamic content if you know the items' height. `getItemLayout` is both efficient and easy to use if you have fixed height items, for example:
 
 ```javascript
   getItemLayout={(data, index) => (


### PR DESCRIPTION
Modified the getItemLayout section such that it is easier to read through. Even though "a priori" technically a correct term, I feel like changing it will save some people (including me) a Google search.
