### PR TITLE
Add details for Animated.forkEvent

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -367,7 +367,7 @@ Config is an object that may have the following options:
 static forkEvent(event, listener)
 ```
 
-Advanced imperative API for snooping on animated events that are passed in through props. Use values directly where possible.
+Advanced imperative API for snooping on animated events that are passed in through props. It permits to add a new javascript listener to an existing `AnimatedEvent`. If `animatedEvent` is a simple javascript listener, it will merge the 2 listeners into a single one, and if `animatedEvent` is null/undefined, it will assign the javascript listener directly. Use values directly where possible.
 
 ---
 


### PR DESCRIPTION
it was unclear to me if `event` could actually be a considered as an opaque structure, ie if it would work as expected for any kind of thing the user can actually provide as a `onScroll` listener for example.

It should be clear that it's safe to call with null or regular js listener

cc @sahrens

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
