### PR TITLE
RN expects a string, not a number for keyExtractor

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -118,7 +118,7 @@ export default class FetchExample extends React.Component {
         <FlatList
           data={this.state.dataSource}
           renderItem={({item}) => <Text>{item.title}, {item.releaseYear}</Text>}
-          keyExtractor={(item, index) => index}
+          keyExtractor={(item, index) => index.toString()}
         />
       </View>
     );


### PR DESCRIPTION
Same issue as here: https://github.com/wonday/react-native-pdf/issues/125

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
