### PR TITLE
Feature/add decimal pad to android

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -353,6 +353,7 @@ Determines which keyboard to open, e.g.`numeric`.
 The following values work across platforms:
 
 * `default`
+* `decimal-pad`
 * `numeric`
 * `email-address`
 * `phone-pad`
@@ -366,7 +367,6 @@ The following values work on iOS only:
 * `url`
 * `number-pad`
 * `name-phone-pad`
-* `decimal-pad`
 * `twitter`
 * `web-search`
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -353,6 +353,7 @@ Determines which keyboard to open, e.g.`numeric`.
 The following values work across platforms:
 
 * `default`
+* `number-pad`
 * `decimal-pad`
 * `numeric`
 * `email-address`
@@ -365,7 +366,6 @@ The following values work on iOS only:
 * `ascii-capable`
 * `numbers-and-punctuation`
 * `url`
-* `number-pad`
 * `name-phone-pad`
 * `twitter`
 * `web-search`


### PR DESCRIPTION
PR accompanying https://github.com/facebook/react-native/pull/19714, which adds Android support for keyboardType `decimal-pad`. So now it is a cross platform property.

## What changed?
* Now lists `number-pad` as cross platform since https://github.com/facebook/react-native/commit/b638847a46491bd75e7ce7928c73f7cb78399195 landed.
* Now lists `decimal-pad` as cross platform accompanying https://github.com/facebook/react-native/pull/19714