### PR TITLE
Update accessibilityinfo.md

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -18,7 +18,7 @@ class ScreenReaderStatusExample extends React.Component {
       'change',
       this._handleScreenReaderToggled
     );
-    AccessibilityInfo.fetch().done((isEnabled) => {
+    AccessibilityInfo.fetch().then((isEnabled) => {
       this.setState({
         screenReaderEnabled: isEnabled,
       });


### PR DESCRIPTION
Method `.fetch` returns a promise. Using `.done` method of the promise does not work in android. `.then` works for both platforms. `Promise.prototype.done` is a non-standard method, that exists only in some promise libraries
