### PR TITLE
Android added support for Image.defaultSource

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -357,6 +357,8 @@ A static image to display while loading the image source.
 | Type           | Required | Platform |
 | -------------- | -------- | -------- |
 | object, number | No       | iOS      |
+| -------------- | -------- | -------- |
+| number         | No       | Android  |
 
 If passing an object, the general shape is `{uri: string, width: number, height: number, scale: number}`:
 
@@ -367,6 +369,8 @@ If passing an object, the general shape is `{uri: string, width: number, height:
 If passing a number:
 
 * `number` - Opaque type returned by something like `require('./image.jpg')`.
+
+**Android**: It works only on release builds, don't worry if it shows nothing on DEBUG builds
 
 ---
 


### PR DESCRIPTION
Release 0.56 added support for Image.defaultSource on Android. This PR changes docs to reflect that https://github.com/facebook/react-native/commit/b0fa3228a77d89d6736da6fcae5dd32f74f3052c