### PR TITLE
adds default exporting of `App`

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -32,6 +32,8 @@ const App = createStackNavigator({
   Home: { screen: HomeScreen },
   Profile: { screen: ProfileScreen },
 });
+
+export default App;
 ```
 
 Each screen component can set navigation options such as the header title. It can use action creators on the `navigation` prop to link to other screens:


### PR DESCRIPTION
What?
Adds the default exporting of `App` in `App.js`

Why?
Without exporting, `index.js` was not able to easily identify the App as described in the steps. This solved our problem and we were up and running.