### PR TITLE
Added description to animated prop in Modal.md

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -187,3 +187,9 @@ Default is set to `overFullScreen` or `fullScreen` depending on `transparent` pr
 | Type                                                           | Required | Platform |
 | -------------------------------------------------------------- | -------- | -------- |
 | enum('fullScreen', 'pageSheet', 'formSheet', 'overFullScreen') | No       | iOS      |
+
+---
+
+### `animated`
+
+Deprecated. Use the `animationType` prop instead.


### PR DESCRIPTION
In Props section animated prop is mentioned and the description is missing. Either we should add description to the prop or remove animated prop in Props list. 
In this commit, description is added as animated prop is deprecated. Use the animationType prop instead.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
