### PR TITLE
Fix dev menu button references for Android TV

### DIFF
--- a/docs/building-for-apple-tv.md
+++ b/docs/building-for-apple-tv.md
@@ -214,7 +214,7 @@ class Game2048 extends React.Component {
 
 <block class="android" />
 
-* _Dev Menu support_: On the simulator, cmd-M will bring up the developer menu, just like on Android. To bring it up on a real Android TV device, make a long press on the play/pause button on the remote. (Please do not shake the Android TV device, that will not work :) )
+* _Dev Menu support_: On the simulator, cmd-M will bring up the developer menu, just like on Android. To bring it up on a real Android TV device, press the menu button or long press the fast-forward button on the remote. (Please do not shake the Android TV device, that will not work :) )
 
 <block class="ios" />
 


### PR DESCRIPTION
This PR updates the `Building for TV` doc page so that it correctly lists the dev menu buttons on Android.

Previously it says long press play/pause, however this is incorrect. The buttons are either normal press 'menu', or long press 'fast-forward'.

You can see that here:
Menu: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java#L145
FF: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java#L162

I have also confirmed this on my own Android TV!

If anyone can tell me if the iOS button is incorrect, I can also update that. 
