### PR TITLE
Change docs to use "contain" instead Image.resizeMode.contain

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -131,7 +131,7 @@ Sometimes, you might be getting encoded image data from a REST API call. You can
   style={{
     width: 51,
     height: 51,
-    resizeMode: Image.resizeMode.contain,
+    resizeMode: 'contain',
   }}
   source={{
     uri:


### PR DESCRIPTION
Image no longer has a resizeMode property.