### PR TITLE
Clarify how to include static html

### DIFF
--- a/docs/webview.md
+++ b/docs/webview.md
@@ -81,7 +81,7 @@ You can use this component to navigate back and forth in the web view's history 
 
 ### `source`
 
-Loads static html or a uri (with optional headers) in the WebView.
+Loads static html or a uri (with optional headers) in the WebView. Note that static html will require setting of `originWhitelist` for example to `["*"]`.
 
 | Type                                                                                                                | Required |
 | ------------------------------------------------------------------------------------------------------------------- | -------- |


### PR DESCRIPTION
As of React Native 0.56 to include static html you seem to need to set `originWhitelist` prop otherwise it will fail with an unhelpful error.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
