### PR TITLE
Update docs for cross-platform setAccessibilityFocus

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -96,7 +96,7 @@ Add an event handler. Supported events:
 static setAccessibilityFocus(reactTag)
 ```
 
-iOS-Only. Set accessibility focus to a react component.
+Set accessibility focus to a React component. On Android, this is equivalent to `UIManager.sendAccessibilityEvent(reactTag, UIManager.AccessibilityEventTypes.typeViewFocused);`.
 
 ---
 


### PR DESCRIPTION
This updates the documentation for setAccessibilityFocus to reflect the changes in this PR:
https://github.com/facebook/react-native/pull/20229
