### PR TITLE
Adds some notes about the CLI config file

### DIFF
--- a/docs/understanding-cli.md
+++ b/docs/understanding-cli.md
@@ -24,3 +24,52 @@ module.exports = {
 ### Parameters
 
 The command name identifies the parameters that a command would expect. When the command parameter is surrounded by greater-than, less-than symbols `< >`, this indicates that the parameter is expected. When a parameter is surrounded by brackets `[ ]`, this indicates that the parameter is optional.
+
+### Getting a list of all CLI commands
+
+Running `react-native --help` from inside a React Native project will list all of your current commands. Here is an example from version `0.56`:
+
+```sh
+  Usage: react-native [options] [command]
+
+  Options:
+
+    -V, --version                      output the version number
+    -h, --help                         output usage information
+
+  Commands:
+
+    start [options]                    starts the webserver
+    run-ios [options]                  builds your app and starts it on iOS simulator
+    run-android [options]              builds your app and starts it on a connected Android emulator or device
+    new-library [options]              generates a native library bridge
+    bundle [options]                   builds the javascript bundle for offline use
+    unbundle [options]                 builds javascript as "unbundle" for offline use
+    eject [options]                    Re-create the iOS and Android folders and native code
+    link [options] [packageName]       links all native dependencies (updates native build files)
+    unlink [options] <packageName>     unlink native dependency
+    install [options] <packageName>    install and link native dependencies
+    uninstall [options] <packageName>  uninstall and unlink native dependencies
+    upgrade [options]                  upgrade your app's template files to the latest version; run this after updating the react-native version in your package.json and running npm install
+    log-android [options]              starts adb logcat
+    log-ios [options]                  starts iOS device syslog tail
+    dependencies [options]             lists dependencies
+    info [options]                     Get relevant version info about OS, toolchain and libraries
+```
+
+### CLI Configs
+
+When using `react-native start`, its platform derivatives, and `react-native bundle` you can use a file to define the CLI options used by React Native by default. If you create a file `rn-cli.config.js` in the root of your project, it will be evaluated and options for the commands will come from there.
+
+You can see the options for the CLI config file inside the [source code for Metro here](https://github.com/facebook/metro/blob/master/packages/metro/src/Config.js), and here is a common `rn-cli.config.js` used for supporting TypeScript in React Native projects:
+
+```js
+module.exports = {
+  getTransformModulePath() {
+    return require.resolve('react-native-typescript-transformer');
+  },
+  getSourceExts() {
+    return ['ts', 'tsx'];
+  }
+}
+```


### PR DESCRIPTION
Hello there 👋 

It was noted in https://github.com/facebook/react-native/issues/18967 that maybe these could be some docs about how a `rn-cli.config.js` works. This gives a rough overview and include the one used in TypeScript projects, as it's quite likely that's what a lot of people are using this for.