### PR TITLE
Fixed typos in viewpagerandroid.md

### DIFF
--- a/docs/viewpagerandroid.md
+++ b/docs/viewpagerandroid.md
@@ -41,22 +41,22 @@ var styles = {
 
 ### Props
 
-* [View props...](view.md#props)
+- [View props...](view.md#props)
 
-- [`initialPage`](viewpagerandroid.md#initialpage)
-- [`keyboardDismissMode`](viewpagerandroid.md#keyboarddismissmode)
-- [`onPageScroll`](viewpagerandroid.md#onpagescroll)
-- [`onPageScrollStateChanged`](viewpagerandroid.md#onpagescrollstatechanged)
-- [`onPageSelected`](viewpagerandroid.md#onpageselected)
-- [`pageMargin`](viewpagerandroid.md#pagemargin)
-- [`peekEnabled`](viewpagerandroid.md#peekenabled)
-- [`scrollEnabled`](viewpagerandroid.md#scrollenabled)
-- [`setPage`](viewpagerandroid.md#setpage)
-- [`setPageWithoutAnimation`](viewpagerandroid.md#setpagewithoutanimation)
+* [`initialPage`](viewpagerandroid.md#initialpage)
+* [`keyboardDismissMode`](viewpagerandroid.md#keyboarddismissmode)
+* [`onPageScroll`](viewpagerandroid.md#onpagescroll)
+* [`onPageScrollStateChanged`](viewpagerandroid.md#onpagescrollstatechanged)
+* [`onPageSelected`](viewpagerandroid.md#onpageselected)
+* [`pageMargin`](viewpagerandroid.md#pagemargin)
+* [`peekEnabled`](viewpagerandroid.md#peekenabled)
+* [`scrollEnabled`](viewpagerandroid.md#scrollenabled)
+* [`setPage`](viewpagerandroid.md#setpage)
+* [`setPageWithoutAnimation`](viewpagerandroid.md#setpagewithoutanimation)
 
 ### Type Definitions
 
-* [`ViewPagerScrollState`](viewpagerandroid.md#viewpagerscrollstate)
+- [`ViewPagerScrollState`](viewpagerandroid.md#viewpagerscrollstate)
 
 ---
 
@@ -78,8 +78,8 @@ Index of initial page that should be selected. Use `setPage` method to update th
 
 Determines whether the keyboard gets dismissed in response to a drag.
 
-* 'none' (the default), drags do not dismiss the keyboard.
-* 'on-drag', the keyboard is dismissed when a drag begins.
+- 'none' (the default), drags do not dismiss the keyboard.
+- 'on-drag', the keyboard is dismissed when a drag begins.
 
 | Type                    | Required |
 | ----------------------- | -------- |
@@ -89,10 +89,10 @@ Determines whether the keyboard gets dismissed in response to a drag.
 
 ### `onPageScroll`
 
-Executed when transitioning between pages (ether because of animation for the requested page change or when user is swiping/dragging between pages) The `event.nativeEvent` object for this callback will carry following data:
+Executed when transitioning between pages (either because of animation for the requested page change or when user is swiping/dragging between pages) The `event.nativeEvent` object for this callback will carry following data:
 
-* position - index of first page from the left that is currently visible
-* offset - value from range [0,1) describing stage between page transitions. Value x means that (1 - x) fraction of the page at "position" index is visible, and x fraction of the next page is visible.
+- position - index of first page from the left that is currently visible
+- offset - value from range [0, 1] describing stage between page transitions. Value x means that (1 - x) fraction of the page at "position" index is visible, and x fraction of the next page is visible.
 
 | Type     | Required |
 | -------- | -------- |
@@ -104,9 +104,9 @@ Executed when transitioning between pages (ether because of animation for the re
 
 Function called when the page scrolling state has changed. The page scrolling state can be in 3 states:
 
-* idle, meaning there is no interaction with the page scroller happening at the time
-* dragging, meaning there is currently an interaction with the page scroller
-* settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- idle, meaning there is no interaction with the page scroller happening at the time
+- dragging, meaning there is currently an interaction with the page scroller
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |
@@ -118,7 +118,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 This callback will be called once ViewPager finish navigating to selected page (when user swipes between pages). The `event.nativeEvent` object passed to this callback will have following fields:
 
-* position - index of page that has been selected
+- position - index of page that has been selected
 
 | Type     | Required |
 | -------- | -------- |
@@ -160,7 +160,7 @@ When false, the content does not scroll. The default value is true.
 
 A helper function to scroll to a specific page in the ViewPager. The transition between pages will be animated.
 
-* position - index of page that will be selected
+- position - index of page that will be selected
 
 | Type   | Required |
 | ------ | -------- |
@@ -172,7 +172,7 @@ A helper function to scroll to a specific page in the ViewPager. The transition 
 
 A helper function to scroll to a specific page in the ViewPager. The transition between pages will _not_ be animated.
 
-* position - index of page that will be selected
+- position - index of page that will be selected
 
 | Type   | Required |
 | ------ | -------- |

--- a/docs/viewpagerandroid.md
+++ b/docs/viewpagerandroid.md
@@ -43,16 +43,16 @@ var styles = {
 
 - [View props...](view.md#props)
 
-* [`initialPage`](viewpagerandroid.md#initialpage)
-* [`keyboardDismissMode`](viewpagerandroid.md#keyboarddismissmode)
-* [`onPageScroll`](viewpagerandroid.md#onpagescroll)
-* [`onPageScrollStateChanged`](viewpagerandroid.md#onpagescrollstatechanged)
-* [`onPageSelected`](viewpagerandroid.md#onpageselected)
-* [`pageMargin`](viewpagerandroid.md#pagemargin)
-* [`peekEnabled`](viewpagerandroid.md#peekenabled)
-* [`scrollEnabled`](viewpagerandroid.md#scrollenabled)
-* [`setPage`](viewpagerandroid.md#setpage)
-* [`setPageWithoutAnimation`](viewpagerandroid.md#setpagewithoutanimation)
+- [`initialPage`](viewpagerandroid.md#initialpage)
+- [`keyboardDismissMode`](viewpagerandroid.md#keyboarddismissmode)
+- [`onPageScroll`](viewpagerandroid.md#onpagescroll)
+- [`onPageScrollStateChanged`](viewpagerandroid.md#onpagescrollstatechanged)
+- [`onPageSelected`](viewpagerandroid.md#onpageselected)
+- [`pageMargin`](viewpagerandroid.md#pagemargin)
+- [`peekEnabled`](viewpagerandroid.md#peekenabled)
+- [`scrollEnabled`](viewpagerandroid.md#scrollenabled)
+- [`setPage`](viewpagerandroid.md#setpage)
+- [`setPageWithoutAnimation`](viewpagerandroid.md#setpagewithoutanimation)
 
 ### Type Definitions
 

--- a/website/versioned_docs/version-0.56/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.56/viewpagerandroid.md
@@ -90,10 +90,10 @@ Determines whether the keyboard gets dismissed in response to a drag.
 
 ### `onPageScroll`
 
-Executed when transitioning between pages (ether because of animation for the requested page change or when user is swiping/dragging between pages) The `event.nativeEvent` object for this callback will carry following data:
+Executed when transitioning between pages (either because of animation for the requested page change or when user is swiping/dragging between pages) The `event.nativeEvent` object for this callback will carry following data:
 
 * position - index of first page from the left that is currently visible
-* offset - value from range [0,1) describing stage between page transitions. Value x means that (1 - x) fraction of the page at "position" index is visible, and x fraction of the next page is visible.
+* offset - value from range [0, 1] describing stage between page transitions. Value x means that (1 - x) fraction of the page at "position" index is visible, and x fraction of the next page is visible.
 
 | Type     | Required |
 | -------- | -------- |
@@ -107,7 +107,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 * idle, meaning there is no interaction with the page scroller happening at the time
 * dragging, meaning there is currently an interaction with the page scroller
-* settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+* settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
Corrected few typos on ```docs/viewpagerandroid.md``` & ```versioned_docs/version-0.56/viewpagerandroid.md```

These typos exist under **onPageScroll** & **onPageScrollStateChanged** 

List of corrected typos:
- ether > either
- [0,1) > [0, 1]
- it's > its
