### PR TITLE
Updated react docs with two new props that can be set for accessiblity

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -49,7 +49,8 @@ In the above example, the `accessibilityLabel` on the TouchableOpacity element w
 
 #### accessibilityRole (iOS, Android)
 
-*Note: Accessibility Role and Accessibility States are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+> **Note:** 
+> Accessibility Role and Accessibility States are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
 
 Accessibility Role tells a person using either VoiceOver on iOS or TalkBack on Android the type of element that is focused on. 
 To use, set the `accessibilityRole` property to one of the following strings:
@@ -68,7 +69,8 @@ To use, set the `accessibilityRole` property to one of the following strings:
 
 #### accessibilityState (iOS, Android)
 
-*Note: `accessibilityRole` and `accessibilityStates` are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+> **Note:**
+> `accessibilityRole` and `accessibilityStates` are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
 
 Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on. The state of the element can be set either to `selected` or `disabled` or both:
 
@@ -79,7 +81,8 @@ To use, set the `accessibilityState` to an array containing either `selected`, `
 
 #### accessibilityTraits (iOS)
 
-*Note:`accessibilityTraits` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+> **Note:** 
+> `accessibilityTraits` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
 
 Accessibility traits tell a person using VoiceOver what kind of element they have selected. Is this element a label? A button? A header? These questions are answered by `accessibilityTraits`.
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -47,6 +47,31 @@ To use, set the `accessibilityLabel` property to a custom string on your View:
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
+#### accessibilityRole (iOS, Android)
+
+Accessibility Role tells a person using either VoiceOver on iOS or TalkBack on Android the type of element that is focused on. 
+To use, set the `accessibilityRole` property to one of the following strings:
+
+* **none** Used when the element has no role.
+* **button** Used when the element should be treated as a button.
+* **link** Used when the element should be treated as a link.
+* **search** Used when the text field element should also be treated as a search field.
+* **image** Used when the element should be treated as an image. Can be combined with button or link, for example.
+* **keyboardkey** Used when the element acts as a keyboard key.
+* **text** Used when the element should be treated as static text that cannot change.
+* **adjustable** Used when an element can be "adjusted" (e.g. a slider).
+* **imagebutton** Used when the element should be treated as a button and is also an image.
+* **header** Used when an element acts as a header for a content section (e.g. the title of a navigation bar).
+* **summary** Used when an element can be used to provide a quick summary of current conditions in the app when the app first launches.
+
+#### accessibilityState (iOS, Android)
+Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on. The state of the element can be set either to `selected` or `disabled` or both:
+
+* **selected** Used when the element is in a selected state. For example, a button is selected.
+* **disabled** Used when the element is disabled and cannot be interacted with.
+
+To use, set the `accessibilityState` to an array containing either `selected`, `disabled`, or both.
+
 #### accessibilityTraits (iOS)
 
 Accessibility traits tell a person using VoiceOver what kind of element they have selected. Is this element a label? A button? A header? These questions are answered by `accessibilityTraits`.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -128,7 +128,8 @@ Assign this property to a custom function which will be called when someone perf
 
 #### accessibilityComponentType (Android)
 
-*Note: `accessibilityComponentType` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+> **Note:**
+> `accessibilityComponentType` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
 
 In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. We support 'none', ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’.
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -125,7 +125,7 @@ Assign this property to a custom function which will be called when someone perf
 
 #### accessibilityComponentType (Android)
 
-*Note: `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+*Note: `accessibilityComponentType` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
 
 In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. We support 'none', ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’.
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -49,6 +49,8 @@ In the above example, the `accessibilityLabel` on the TouchableOpacity element w
 
 #### accessibilityRole (iOS, Android)
 
+*Note: Accessibility Role and Accessibility States are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+
 Accessibility Role tells a person using either VoiceOver on iOS or TalkBack on Android the type of element that is focused on. 
 To use, set the `accessibilityRole` property to one of the following strings:
 
@@ -65,6 +67,9 @@ To use, set the `accessibilityRole` property to one of the following strings:
 * **summary** Used when an element can be used to provide a quick summary of current conditions in the app when the app first launches.
 
 #### accessibilityState (iOS, Android)
+
+*Note: `accessibilityRole` and `accessibilityStates` are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
+
 Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on. The state of the element can be set either to `selected` or `disabled` or both:
 
 * **selected** Used when the element is in a selected state. For example, a button is selected.
@@ -73,6 +78,8 @@ Accessibility State tells a person using either VoiceOver on iOS or TalkBack on 
 To use, set the `accessibilityState` to an array containing either `selected`, `disabled`, or both.
 
 #### accessibilityTraits (iOS)
+
+*Note:`accessibilityTraits` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
 
 Accessibility traits tell a person using VoiceOver what kind of element they have selected. Is this element a label? A button? A header? These questions are answered by `accessibilityTraits`.
 
@@ -117,6 +124,8 @@ Use this property to assign a custom function to be called when someone activate
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call, or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
 #### accessibilityComponentType (Android)
+
+*Note: `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.*
 
 In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. We support 'none', ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

I've added two props for accessibility: accessibilityRole and accessibilityStates. These are meant to indicate to talkback on android and voiceover on iOS what the purpose of a focused element is (accessibilityRole) and the state of the focused element (accessibilityState). I added documentation for each of these props.
