### PR TITLE
Kotlin content for "Integration w/ Existing Apps"

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -55,14 +55,14 @@ title: Integration with Existing Apps
   }
   .display-language-objc .toggler .button-objc,
   .display-language-swift .toggler .button-swift,
-  .display-language-android .toggler .button-android {
+  .display-language-java .toggler .button-java {
     background-color: #05A5D1;
     color: white;
   }
   block { display: none; }
   .display-language-objc .objc,
   .display-language-swift .swift,
-  .display-language-android .android {
+  .display-language-java .java {
     display: block;
   }
 </style>
@@ -79,13 +79,13 @@ The specific steps are different depending on what platform you're targeting.
     <li id="swift" class="button-swift" aria-selected="false" role="tab" tabindex="0" aria-controls="swifttab" onclick="displayTab('language', 'swift')">
       iOS (Swift)
     </li>
-    <li id="android" class="button-android" aria-selected="false" role="tab" tabindex="0" aria-controls="androidtab" onclick="displayTab('language', 'android')">
+    <li id="java" class="button-java" aria-selected="false" role="tab" tabindex="0" aria-controls="javatab" onclick="displayTab('language', 'java')">
       Android (Java)
     </li>
   </ul>
 </div>
 
-<block class="objc swift android" />
+<block class="objc swift java" />
 
 ## Key Concepts
 
@@ -101,7 +101,7 @@ The keys to integrating React Native components into your iOS application are to
 6. Start the React Native server and run your native application.
 7. Verify that the React Native aspect of your application works as expected.
 
-<block class="android" />
+<block class="java" />
 
 The keys to integrating React Native components into your Android application are to:
 
@@ -111,7 +111,7 @@ The keys to integrating React Native components into your Android application ar
 4. Start the React Native server and run your native application.
 5. Verify that the React Native aspect of your application works as expected.
 
-<block class="objc swift android" />
+<block class="objc swift java" />
 
 ## Prerequisites
 
@@ -123,7 +123,7 @@ Follow the instructions for building apps with native code from the [Getting Sta
 
 To ensure a smooth experience, create a new folder for your integrated React Native project, then copy your existing iOS project to a `/ios` subfolder.
 
-<block class="android" />
+<block class="java" />
 
 Follow the instructions for building apps with native code from the [Getting Started guide](getting-started.md) to configure your development environment for building React Native apps for Android.
 
@@ -131,7 +131,7 @@ Follow the instructions for building apps with native code from the [Getting Sta
 
 To ensure a smooth experience, create a new folder for your integrated React Native project, then copy your existing Android project to an `/android` subfolder.
 
-<block class="objc swift android" />
+<block class="objc swift java" />
 
 ### 2. Install JavaScript dependencies
 
@@ -552,7 +552,7 @@ You can examine the code that added the React Native screen to our sample app on
 
 You can examine the code that added the React Native screen to our sample app on [GitHub](https://github.com/JoelMarcey/swift-2048/commit/13272a31ee6dd46dc68b1dcf4eaf16c1a10f5229).
 
-<block class="android" />
+<block class="java" />
 
 ## Adding React Native to your app
 
@@ -828,7 +828,7 @@ $ react-native bundle --platform android --dev false --entry-file index.js --bun
 
 Now just create a release build of your native app from within Android Studio as usual and you should be good to go!
 
-<block class="objc swift android" />
+<block class="objc swift java" />
 
 ### Now what?
 
@@ -912,9 +912,9 @@ At this point you can continue developing your app as usual. Refer to our [debug
                 displayTab('platform', 'ios');
                 foundHash = true;
               } else if (
-                parent.className.indexOf('android') > -1
+                parent.className.indexOf('java') > -1
               ) {
-                displayTab('platform', 'android');
+                displayTab('platform', 'java');
                 foundHash = true;
               } else {
                 break;
@@ -942,7 +942,7 @@ At this point you can continue developing your app as usual. Refer to our [debug
     if (!foundHash) {
       var isMac = navigator.platform === 'MacIntel';
       var isWindows = navigator.platform === 'Win32';
-      displayTab('platform', isMac ? 'ios' : 'android');
+      displayTab('platform', isMac ? 'ios' : 'java');
       displayTab(
         'os',
         isMac ? 'mac' : isWindows ? 'windows' : 'linux'

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -90,7 +90,7 @@ The specific steps are different depending on what platform you're targeting.
   </ul>
 </div>
 
-<block class="objc swift java" />
+<block class="objc swift java kotlin" />
 
 ## Key Concepts
 
@@ -106,7 +106,7 @@ The keys to integrating React Native components into your iOS application are to
 6. Start the React Native server and run your native application.
 7. Verify that the React Native aspect of your application works as expected.
 
-<block class="java" />
+<block class="java kotlin" />
 
 The keys to integrating React Native components into your Android application are to:
 
@@ -116,7 +116,7 @@ The keys to integrating React Native components into your Android application ar
 4. Start the React Native server and run your native application.
 5. Verify that the React Native aspect of your application works as expected.
 
-<block class="objc swift java" />
+<block class="objc swift java kotlin" />
 
 ## Prerequisites
 
@@ -128,7 +128,7 @@ Follow the instructions for building apps with native code from the [Getting Sta
 
 To ensure a smooth experience, create a new folder for your integrated React Native project, then copy your existing iOS project to a `/ios` subfolder.
 
-<block class="java" />
+<block class="java kotlin" />
 
 Follow the instructions for building apps with native code from the [Getting Started guide](getting-started.md) to configure your development environment for building React Native apps for Android.
 
@@ -136,7 +136,7 @@ Follow the instructions for building apps with native code from the [Getting Sta
 
 To ensure a smooth experience, create a new folder for your integrated React Native project, then copy your existing Android project to an `/android` subfolder.
 
-<block class="objc swift java" />
+<block class="objc swift java kotlin" />
 
 ### 2. Install JavaScript dependencies
 
@@ -557,7 +557,7 @@ You can examine the code that added the React Native screen to our sample app on
 
 You can examine the code that added the React Native screen to our sample app on [GitHub](https://github.com/JoelMarcey/swift-2048/commit/13272a31ee6dd46dc68b1dcf4eaf16c1a10f5229).
 
-<block class="java" />
+<block class="java kotlin" />
 
 ## Adding React Native to your app
 
@@ -654,6 +654,8 @@ AppRegistry.registerComponent('MyReactNativeApp', () => HelloWorld);
 
 If your app is targeting the Android `API level 23` or greater, make sure you have the permission `android.permission.SYSTEM_ALERT_WINDOW` enabled for the development build. You can check this with `Settings.canDrawOverlays(this);`. This is required in dev builds because React Native development errors must be displayed above all the other windows. Due to the new permissions system introduced in the API level 23 (Android M), the user needs to approve it. This can be achieved by adding the following code to your Activity's in `onCreate()` method.
 
+<block class="java" />
+
 ```java
 private final int OVERLAY_PERMISSION_REQ_CODE = 1;  // Choose any value
 
@@ -668,7 +670,25 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 }
 ```
 
+```kotlin
+private const val OVERLAY_PERMISSION_REQ_CODE = 1  // Choose any value
+
+...
+
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (!Settings.canDrawOverlays(this)) {
+        val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                            Uri.parse("package:$packageName"))
+        startActivityForResult(intent, OVERLAY_PERMISSION_REQ_CODE)
+    }
+}
+```
+
+<block class="java kotlin" />
+
 Finally, the `onActivityResult()` method (as shown in the code below) has to be overridden to handle the permission Accepted or Denied cases for consistent UX.
+
+<block class="java" />
 
 ```java
 @Override
@@ -683,11 +703,28 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 
+<block class="kotlin" />
+
+```kotlin
+override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+    if (requestCode == OVERLAY_PERMISSION_REQ_CODE) {
+        if (!canDrawOverlays(this)) {
+            // SYSTEM_ALERT_WINDOW permission not granted
+        }
+    }
+}
+```
+
+<block class="java kotlin" />
+
 #### The Magic: `ReactRootView`
 
 Let's add some native code in order to start the React Native runtime and tell it to render our JS component. To do this, we're going to create an `Activity` that creates a `ReactRootView`, starts a React application inside it and sets it as the main content view.
 
 > If you are targetting Android version <5, use the `AppCompatActivity` class from the `com.android.support:appcompat` package instead of `Activity`.
+
+<block class="java" />
 
 ```java
 public class MyReactActivity extends Activity implements DefaultHardwareBackBtnHandler {
@@ -721,6 +758,40 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
 }
 ```
 
+<block class="kotlin" />
+
+```kotlin
+public class MyReactActivity: Activity(), DefaultHardwareBackBtnHandler {
+    private lateinit var reactRootView: ReactRootView
+    private lateinit var reactInstanceManager: ReactInstanceManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        reactRootView = ReactRootView(this)
+        reactInstanceManager = ReactInstanceManager.builder()
+                .setApplication(application)
+                .setBundleAssetName("index.android.bundle")
+                .setJSMainModulePath("index")
+                .addPackage(MainReactPackage())
+                .setUseDeveloperSupport(BuildConfig.DEBUG)
+                .setInitialLifecycleState(LifecycleState.RESUMED)
+                .build()
+        // The string here (e.g. "MyReactNativeApp") has to match
+        // the string in AppRegistry.registerComponent() in index.js
+        reactRootView?.startReactApplication(reactInstanceManager, "MyReactNativeApp", null)
+
+        setContentView(reactRootView)
+    }
+
+    override fun invokeDefaultOnBackPressed() {
+        super.onBackPressed();
+    }
+}
+```
+
+<block class="java kotlin" />
+
 > If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
 
 If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `facebook` package.
@@ -738,6 +809,8 @@ We need set the theme of `MyReactActivity` to `Theme.AppCompat.Light.NoActionBar
 > A `ReactInstanceManager` can be shared by multiple activities and/or fragments. You will want to make your own `ReactFragment` or `ReactActivity` and have a singleton _holder_ that holds a `ReactInstanceManager`. When you need the `ReactInstanceManager` (e.g., to hook up the `ReactInstanceManager` to the lifecycle of those Activities or Fragments) use the one provided by the singleton.
 
 Next, we need to pass some activity lifecycle callbacks to the `ReactInstanceManager` and `ReactRootView`:
+
+<block class="java" />
 
 ```java
 @Override
@@ -771,7 +844,31 @@ protected void onDestroy() {
 }
 ```
 
+<block class="kotlin" />
+
+```kotlin
+override fun onPause() {
+    super.onPause()
+    reactInstanceManager?.onHostPause(this)
+}
+
+override fun onResume() {
+    super.onResume()
+    reactInstanceManager?.onHostResume(this, this)
+}
+
+override fun onDestroy() {
+    super.onDestroy()
+    reactInstanceManager?.onHostDestroy(this)
+    reactRootView?.unmountReactApplication()
+}
+```
+
+<block class="java kotlin" />
+
 We also need to pass back button events to React Native:
+
+<block class="java" />
 
 ```java
 @Override
@@ -784,9 +881,25 @@ We also need to pass back button events to React Native:
 }
 ```
 
+<block class="kotlin" />
+
+```kotlin
+override fun onBackPressed() {
+    if (reactInstanceManager != null) {
+        reactInstanceManager.onBackPressed()
+    } else {
+        super.onBackPressed()
+    }
+}
+```
+
+<block class="java kotlin" />
+
 This allows JavaScript to control what happens when the user presses the hardware back button (e.g. to implement navigation). When JavaScript doesn't handle the back button press, your `invokeDefaultOnBackPressed` method will be called. By default this simply finishes your `Activity`.
 
 Finally, we need to hook up the dev menu. By default, this is activated by (rage) shaking the device, but this is not very useful in emulators. So we make it show when you press the hardware menu button (use `Ctrl + M` if you're using Android Studio emulator):
+
+<block class="java" />
 
 ```java
 @Override
@@ -798,6 +911,20 @@ public boolean onKeyUp(int keyCode, KeyEvent event) {
     return super.onKeyUp(keyCode, event);
 }
 ```
+
+<block class="kotlin" />
+
+```kotlin
+override fun onKeyUp(keyCode: Int, event: KeyEvent) =
+    if (keyCode == KEYCODE_MENU && reactInstanceManager != null) {
+        reactInstanceManager?.showDevOptionsDialog()
+        true
+    } else {
+        super.onKeyUp(keyCode, event)
+    }
+```
+
+<block class="java kotlin" />
 
 Now your activity is ready to run some JavaScript code.
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -787,7 +787,7 @@ class MyReactActivity: Activity(), DefaultHardwareBackBtnHandler {
     }
 
     override fun invokeDefaultOnBackPressed() {
-        super.onBackPressed();
+        super.onBackPressed()
     }
 }
 ```

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -763,7 +763,7 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
 <block class="kotlin" />
 
 ```kotlin
-public class MyReactActivity: Activity(), DefaultHardwareBackBtnHandler {
+class MyReactActivity: Activity(), DefaultHardwareBackBtnHandler {
     private lateinit var reactRootView: ReactRootView
     private lateinit var reactInstanceManager: ReactInstanceManager
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -779,7 +779,7 @@ public class MyReactActivity: Activity(), DefaultHardwareBackBtnHandler {
                 .build()
         // The string here (e.g. "MyReactNativeApp") has to match
         // the string in AppRegistry.registerComponent() in index.js
-        reactRootView?.startReactApplication(reactInstanceManager, "MyReactNativeApp", null)
+        reactRootView.startReactApplication(reactInstanceManager, "MyReactNativeApp", null)
 
         setContentView(reactRootView)
     }
@@ -849,18 +849,18 @@ protected void onDestroy() {
 ```kotlin
 override fun onPause() {
     super.onPause()
-    reactInstanceManager?.onHostPause(this)
+    reactInstanceManager.onHostPause(this)
 }
 
 override fun onResume() {
     super.onResume()
-    reactInstanceManager?.onHostResume(this, this)
+    reactInstanceManager.onHostResume(this, this)
 }
 
 override fun onDestroy() {
     super.onDestroy()
-    reactInstanceManager?.onHostDestroy(this)
-    reactRootView?.unmountReactApplication()
+    reactInstanceManager.onHostDestroy(this)
+    reactRootView.unmountReactApplication()
 }
 ```
 
@@ -885,11 +885,7 @@ We also need to pass back button events to React Native:
 
 ```kotlin
 override fun onBackPressed() {
-    if (reactInstanceManager != null) {
-        reactInstanceManager.onBackPressed()
-    } else {
-        super.onBackPressed()
-    }
+    reactInstanceManager.onBackPressed()
 }
 ```
 
@@ -916,8 +912,8 @@ public boolean onKeyUp(int keyCode, KeyEvent event) {
 
 ```kotlin
 override fun onKeyUp(keyCode: Int, event: KeyEvent) =
-    if (keyCode == KEYCODE_MENU && reactInstanceManager != null) {
-        reactInstanceManager?.showDevOptionsDialog()
+    if (keyCode == KEYCODE_MENU) {
+        reactInstanceManager.showDevOptionsDialog()
         true
     } else {
         super.onKeyUp(keyCode, event)

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -670,6 +670,8 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 }
 ```
 
+<block class="kotlin" />
+
 ```kotlin
 private const val OVERLAY_PERMISSION_REQ_CODE = 1  // Choose any value
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -55,14 +55,16 @@ title: Integration with Existing Apps
   }
   .display-language-objc .toggler .button-objc,
   .display-language-swift .toggler .button-swift,
-  .display-language-java .toggler .button-java {
+  .display-language-java .toggler .button-java,
+  .display-language-kotlin .toggler .button-kotlin, {
     background-color: #05A5D1;
     color: white;
   }
   block { display: none; }
   .display-language-objc .objc,
   .display-language-swift .swift,
-  .display-language-java .java {
+  .display-language-java .java,
+  .display-language-kotlin .kotlin {
     display: block;
   }
 </style>
@@ -81,6 +83,9 @@ The specific steps are different depending on what platform you're targeting.
     </li>
     <li id="java" class="button-java" aria-selected="false" role="tab" tabindex="0" aria-controls="javatab" onclick="displayTab('language', 'java')">
       Android (Java)
+    </li>
+    <li id="kotlin" class="button-kotlin" aria-selected="false" role="tab" tabindex="0" aria-controls="kotlintab" onclick="displayTab('language', 'kotlin')">
+      Android (Kotlin)
     </li>
   </ul>
 </div>


### PR DESCRIPTION
This adds Kotlin instructions to the "Integration w/ Existing Apps" page, to complement the existing Java instructions. @dgreenhalgh and I were able to get a Kotlin app working during a hackathon following these steps, so we can confirm it works. This will lower the barrier to entry of Kotlin devs who aren't as familiar with Java, or don't want to go through the syntax translation.