### PR TITLE
Make the comment easier to read

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -158,7 +158,7 @@ For example, you may want to think about your `Animated.Value` as going from 0 t
     transform: [{
       translateY: this.state.fadeAnim.interpolate({
         inputRange: [0, 1],
-        outputRange: [150, 0]  // 0 : 150, 0.5 : 75, 1 : 0
+        outputRange: [150, 0]  // 0 : 150 // 0.5 : 75 // 1 : 0
       }),
     }],
   }}


### PR DESCRIPTION
By using the comment symbol you can not only separate the value pairs remarkably, but also simplify them by removing extra comas and using well known comment symbols which can't be used in any way other than to separate stuff.

UX texts, baby!