### PR TITLE
Update gradle version in example to match RN master

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -72,7 +72,7 @@ Add `gradle-download-task` as dependency in `android/build.gradle`:
 ```gradle
 ...
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'de.undercouch:gradle-download-task:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
The current gradle version doesn't match the version in the example.
If anyone wants to build React Native Android from source won't be able to find that string because of the version mismatch.

This PR sets the gradle version to match the latest RN version (0.56)
