### PR TITLE
Better instructions for "Configure app to use static bundle" when releasing iOS app

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -352,10 +352,14 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 During the development process, React Native has loaded your JavaScript code dynamically at runtime. For a production build, you want to pre-package the JavaScript bundle and distribute it inside your application. Doing this requires a code change in your code so that it knows to load the static bundle.
 
-In `AppDelegate.m`, change the default `jsCodeLocation` to point to the static bundle that is built in Release.
+In `AppDelegate.m`, change `jsCodeLocation` to point to the static bundle if you're not in debug mode.
 
 ```objc
+#ifdef DEBUG
+   jsCodeLocation = // Your Static Location
+#else
   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
 ```
 
 This will now reference the `main.jsbundle` resource file that is created during the `Bundle React Native code and images` Build Phase in Xcode.

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -356,7 +356,7 @@ In `AppDelegate.m`, change `jsCodeLocation` to point to the static bundle if you
 
 ```objc
 #ifdef DEBUG
-   jsCodeLocation = // Your Static Location
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 #else
   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif


### PR DESCRIPTION
Current instructions imply that you should update this line of code to switch between release and debug. Actually, you should just add a conditional statement to do so.