### PR TITLE
Update docs on splitting APKs

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -112,6 +112,9 @@ By default, the generated APK has the native code for both x86 and ARMv7a CPU ar
 You can create an APK for each CPU by changing the following line in android/app/build.gradle:
 
 ```diff
+- ndk {
+-   abiFilters "armeabi-v7a", "x86"
+- }
 - def enableSeparateBuildPerCPUArchitecture = false
 + def enableSeparateBuildPerCPUArchitecture = true
 ```


### PR DESCRIPTION
Improve docs on splitting APKs for newer version of gradle

Gradle v3.1 complains about conflicting configuration as below

<pre>
Conflicting configuration : 'armeabi-v7a,x86' in ndk abiFilters cannot be present when splits abi filters are set : x86,armeabi-v7a
</pre>

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
