### PR TITLE
Add example with inline HTML to WebView

### DIFF
--- a/docs/webview.md
+++ b/docs/webview.md
@@ -21,6 +21,24 @@ class MyWeb extends Component {
 }
 ```
 
+Minimal example with inline HTML:
+
+```
+import React, { Component } from 'react';
+import { WebView } from 'react-native';
+
+class MyInlineWeb extends Component {
+  render() {
+    return (
+      <WebView
+        originWhitelist={['*']}
+        source={{ html: '<h1>Hello world</h1>' }}
+      />
+    );
+  }
+}
+```
+
 You can use this component to navigate back and forth in the web view's history and configure various properties for the web content.
 
 > **Security Warning:** Currently, `onMessage` and `postMessage` do not allow specifying an origin. This can lead to cross-site scripting attacks if an unexpected document is loaded within a `WebView` instance. Please refer to the MDN documentation for [`Window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) for more details on the security implications of this.


### PR DESCRIPTION
Recently, a new required prop was introduced to render inline HTML in WebView. This PR adds a "Hello World" example.

PR for: 
- [react-native-community/discussions-and-proposals/issues/5](https://github.com/react-native-community/discussions-and-proposals/issues/5)
- [facebook/react-native/issues/20464](https://github.com/facebook/react-native/issues/20464)