### PR TITLE
docs for `textTransform` +Android style

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -175,9 +175,9 @@ Set to `false` to remove extra font padding intended to make space for certain a
 
 ### `textTransform`
 
-| Type                                                 | Required | Platform |
-| ---------------------------------------------------- | -------- | -------- |
-| enum('none', 'uppercase', 'lowercase', 'capitalize') | No       | iOS      |
+| Type                                                 | Required |
+| ---------------------------------------------------- | -------- |
+| enum('none', 'uppercase', 'lowercase', 'capitalize') | No       |
 
 ---
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -427,7 +427,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 - **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
 
-- **`textTransform`**: enum('none', 'uppercase', 'lowercase', 'capitalize') (_iOS_)
+- **`textTransform`**: enum('none', 'uppercase', 'lowercase', 'capitalize')
 
 - **`writingDirection`**: enum('auto', 'ltr', 'rtl') (_iOS_)
 


### PR DESCRIPTION
[This PR](https://github.com/facebook/react-native/pull/20572) makes `textTransform` be for Android too.

This PR just removes the "iOS"-tags from the style, to reflect that it's for Android too, now