### PR TITLE
Minor heading format change for a prop

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -70,7 +70,7 @@ In the above example, VoiceOver will read the hint after the label, if the user 
 Android
 In the above example, Talkback will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### accessibilityIgnoresInvertColors(iOS)
+#### accessibilityIgnoresInvertColors(iOS)
 Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. 
 However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be false so that these specific views won't have their colors inverted. 
 


### PR DESCRIPTION
accessibilityIgnoresInvertColors was incorrectly a H3 when it should be a H4 for consistency.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
