### PR TITLE
Fix stetho instruction.

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -202,12 +202,15 @@ Follow this guide to enable Stetho for Debug mode:
        }
 
        public static void addInterceptor() {
-         OkHttpClient client = OkHttpClientProvider.getOkHttpClient()
-                .newBuilder()
-                .addNetworkInterceptor(new StethoInterceptor())
-                .build();
-
-         OkHttpClientProvider.replaceOkHttpClient(client);
+         final OkHttpClient baseClient = OkHttpClientProvider.createClient();
+         OkHttpClientProvider.setOkHttpClientFactory(new OkHttpClientFactory() {
+           @Override
+           public OkHttpClient createNewNetworkModuleClient() {
+             return baseClient.newBuilder()
+                 .addNetworkInterceptor(new StethoInterceptor())
+                 .build();
+           }
+         });
        }
    }
    ```

--- a/website/versioned_docs/version-0.5/debugging.md
+++ b/website/versioned_docs/version-0.5/debugging.md
@@ -203,12 +203,15 @@ Follow this guide to enable Stetho for Debug mode:
        }
 
        public static void addInterceptor() {
-         OkHttpClient client = OkHttpClientProvider.getOkHttpClient()
-                .newBuilder()
-                .addNetworkInterceptor(new StethoInterceptor())
-                .build();
-
-         OkHttpClientProvider.replaceOkHttpClient(client);
+         final OkHttpClient baseClient = OkHttpClientProvider.createClient();
+         OkHttpClientProvider.setOkHttpClientFactory(new OkHttpClientFactory() {
+           @Override
+           public OkHttpClient createNewNetworkModuleClient() {
+             return baseClient.newBuilder()
+                 .addNetworkInterceptor(new StethoInterceptor())
+                 .build();
+           }
+         });
        }
    }
    ```


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
[`OkHttpClientProvider#replaceOkHttpClient`](https://github.com/facebook/react-native/blob/v0.56.0/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java#L49) is no longer effective.
I updated guide for stetho to use `setOkHttpClientFactory` instead of that.
