### PR TITLE
Emulator bash_profile update

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -395,6 +395,7 @@ export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
+export PATH=$PATH:$ANDROID_HOME/emulator
 ```
 
 <block class="native linux android" />
@@ -404,6 +405,7 @@ export ANDROID_HOME=$HOME/Android/Sdk
 export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
+export PATH=$PATH:$ANDROID_HOME/emulator
 ```
 
 <block class="native mac linux android" />


### PR DESCRIPTION
Using `export PATH=$PATH:$ANDROID_HOME/emulator` instead of  `export PATH=$PATH:$ANDROID_HOME/tools` Because of Android Studio Emulator path Update, (https://stackoverflow.com/questions/40931254/could-not-launch-emulator-in-android-studio/51902207#51902207)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
