### PR TITLE
Correct a11y prop name in example

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -232,7 +232,7 @@ _onPress: function() {
 }
 
 <CustomRadioButton
-  accessibleComponentType={this.state.radioButton}
+  accessibilityComponentType={this.state.radioButton}
   onPress={this._onPress}/>
 ```
 


### PR DESCRIPTION
"accessibleComponentType" => "accessibilityComponentType" 

This is on `CustomRadioButton` so it's not technically wrong, but I would presume a component that eventually renders a `View` with `accessibilityComponentType` would use that name in its own API.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
