### PR TITLE
Remove mention of Redux

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -57,7 +57,7 @@ class HomeScreen extends React.Component {
 }
 ```
 
-React Navigation routers make it easy to override navigation logic or integrate it into redux. Because routers can be nested inside each other, developers can override navigation logic for one area of the app without making widespread changes.
+React Navigation routers make it easy to override navigation logic. Because routers can be nested inside each other, developers can override navigation logic for one area of the app without making widespread changes
 
 The views in React Navigation use native components and the [`Animated`](animated.md) library to deliver 60fps animations that are run on the native thread. Plus, the animations and gestures can be easily customized.
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -57,7 +57,7 @@ class HomeScreen extends React.Component {
 }
 ```
 
-React Navigation routers make it easy to override navigation logic. Because routers can be nested inside each other, developers can override navigation logic for one area of the app without making widespread changes
+React Navigation routers make it easy to override navigation logic. Because routers can be nested inside each other, developers can override navigation logic for one area of the app without making widespread changes.
 
 The views in React Navigation use native components and the [`Animated`](animated.md) library to deliver 60fps animations that are run on the native thread. Plus, the animations and gestures can be easily customized.
 


### PR DESCRIPTION
React Navigation no longer encourage support for redux and they will drop support very soon. See https://reactnavigation.org/docs/en/redux-integration.html

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
