### PR TITLE
Adds a basic example to Share API

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -78,7 +78,7 @@ import {Share, Button} from 'react-native'
 
 class ShareExample extends Component {
 
-  async onShare() {
+  async onShare = () => {
     try {
       const result = await Share.share({
         message:
@@ -97,11 +97,11 @@ class ShareExample extends Component {
     } catch (error) {
       alert(error.message);
     }
-  }
+  };
 
   render() {
     return (
-      <Button onPress={() => this.onShare()}>Share</Button>
+      <Button onPress={this.onShare}>Share</Button>
     );
   }
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -69,3 +69,41 @@ static dismissedAction()
 ```
 
 The dialog has been dismissed. @platform ios
+
+
+## Basic Example
+```javascript
+import React, {Component} from 'react'
+import {Share, Button} from 'react-native'
+
+class ShareExample extends Component {
+
+  async onShare() {
+    try {
+      const result = await Share.share({
+        message:
+          'React Native | A framework for building native apps using React',
+      })
+
+      if (result.action === Share.sharedAction) {
+        if (result.activityType) {
+          // shared with activity type of result.activityType
+        } else {
+          // shared
+        }
+      } else if (result.action === Share.dismissedAction) {
+        // dismissed
+      }
+    } catch (error) {
+      alert(error.message);
+    }
+  }
+
+  render() {
+    return (
+      <Button onPress={() => this.onShare()}>Share</Button>
+    );
+  }
+
+}
+```

--- a/docs/share.md
+++ b/docs/share.md
@@ -68,10 +68,11 @@ The content was successfully shared.
 static dismissedAction()
 ```
 
-The dialog has been dismissed. @platform ios
+_iOS Only_. The dialog has been dismissed. 
 
 
 ## Basic Example
+
 ```javascript
 import React, {Component} from 'react'
 import {Share, Button} from 'react-native'


### PR DESCRIPTION
This commit adds a basic example to the Share API. The example highlights use of the Share.sharedAction, Share.dismissedAction, and Share.share methods as well as how they are intended to be used together.

This PR seeks to enhance API documentation through examples.