### PR TITLE
Add a new page documenting React Native's out-of-tree platform support

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -1,0 +1,38 @@
+---
+id: out-of-tree-platforms
+title: Out-of-Tree Platforms
+---
+
+React Native is not just for Android and iOS - there are community-supported projects that bring it to other platforms, such as:
+
+ * [React Native Windows](https://github.com/Microsoft/react-native-windows) - React Native support for Microsoft's Universal Windows Platform (UWP) and the Windows Presentation Foundation (WPF)
+ * [React Native DOM](https://github.com/vincentriemer/react-native-dom) - An experimental, comprehensive port of React Native to the web. (Not to be confused with [React Native Web](https://github.com/necolas/react-native-web), which has different goals)
+ * [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
+ * [React Native macOS](https://github.com/ptmt/react-native-macos) - An experimental React Native fork targeting macOS and Cocoa
+
+## Creating your own React Native platform
+
+Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-arcitecture ([Fabric](https://facebook.github.io/react-native/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+
+### Bundling
+
+As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
+
+To register your platform with RNPM, your module's name must start with a `react-native-` suffix. You must also have an entry in your `package.json` like this:
+
+```json
+{
+  "rnpm": {
+    "haste": {
+      "providesModuleNodeModules": [
+        "react-native-example"
+      ],
+      "platforms": [
+        "example"
+      ]
+    }
+  }
+}
+```
+
+`"providesModuleNodeModules"` is an array of modules that will get added to the Haste module search path, and `"platforms"` is an array of platform suffixes that will be added as valid platforms.

--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -12,7 +12,7 @@ React Native is not just for Android and iOS - there are community-supported pro
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-arcitecture ([Fabric](https://facebook.github.io/react-native/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](https://facebook.github.io/react-native/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -82,6 +82,7 @@
     "navigatorios": "NavigatorIOS",
     "netinfo": "NetInfo",
     "network": "Networking",
+    "out-of-tree-platforms": "Out-of-Tree Platforms",
     "panresponder": "PanResponder",
     "performance": "Performance",
     "permissionsandroid": "PermissionsAndroid",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,8 +13,7 @@
       "using-a-scrollview",
       "using-a-listview",
       "network",
-      "more-resources",
-      "out-of-tree-platforms"
+      "more-resources"
     ],
     "Guides": [
       "components-and-apis",
@@ -36,7 +35,8 @@
       "running-on-device",
       "upgrading",
       "troubleshooting",
-      "native-modules-setup"
+      "native-modules-setup",
+      "out-of-tree-platforms"
     ],
     "Guides (iOS)": [
       "native-modules-ios",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,7 +13,8 @@
       "using-a-scrollview",
       "using-a-listview",
       "network",
-      "more-resources"
+      "more-resources",
+      "out-of-tree-platforms"
     ],
     "Guides": [
       "components-and-apis",


### PR DESCRIPTION
This PR adds a new page to the React Native docs that showcases other platforms that have been developed for React Native, and a bit documenting the API change that was added in https://github.com/facebook/react-native/pull/20825 . In the future, this should be able to be expanded with more information on making/maintaining React Native platforms.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
