### PR TITLE
Fixed props.md example on Greetings component

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -37,7 +37,9 @@ import { AppRegistry, Text, View } from 'react-native';
 class Greeting extends Component {
   render() {
     return (
-      <Text>Hello {this.props.name}!</Text>
+      <View style={{alignItems: 'center'}}>
+        <Text>Hello {this.props.name}!</Text>
+      </View>
     );
   }
 }


### PR DESCRIPTION
Greetings component example in procs.md didnn't have enclosing jsx tag and thus failed, this is to fix that.