### PR TITLE
fix DatePickerIOS example

### DIFF
--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -23,7 +23,7 @@ export default class App extends Component {
     this.setDate = this.setDate.bind(this);
   }
 
-  setDate(newDate) {
+  setDate = (newDate) => {
     this.setState({chosenDate: newDate})
   }
 


### PR DESCRIPTION
Using an arrow function prevents `this.setState is not a function` error with the current example (missing bind).

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
