### PR TITLE
add default value to TextInput clearButtonMode description

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -222,7 +222,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ### `clearButtonMode`
 
-When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component.
+When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
 | Type                                                       | Required | Platform |
 | ---------------------------------------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.57/textinput.md
+++ b/website/versioned_docs/version-0.57/textinput.md
@@ -223,7 +223,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ### `clearButtonMode`
 
-When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component.
+When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
 | Type                                                       | Required | Platform |
 | ---------------------------------------------------------- | -------- | -------- |


### PR DESCRIPTION
Small documentation tweak - added information about default value of `clearButtonMode` property to `TextInput` component.