### PR TITLE
Missing code for passing result to ReactInstanceManager

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -663,7 +663,7 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 }
 ```
 
-Finally, the `onActivityResult()` method (as shown in the code below) has to be overridden to handle the permission Accepted or Denied cases for consistent UX.
+Finally, the `onActivityResult()` method (as shown in the code below) has to be overridden to handle the permission Accepted or Denied cases for consistent UX. Also, for integrating Native Modules which use `startActivityForResult`, we need to pass the result to the `onActivityResult` method of our `ReactInstanceManager` instance.
 
 ```java
 @Override
@@ -675,6 +675,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
             }
         }
     }
+    mReactInstanceManager.onActivityResult( this, requestCode, resultCode, data );
 }
 ```
 


### PR DESCRIPTION
> This is for projects which integrate react-native in existing android applications.

Any Native Module which uses `startActivityForResult()` and expects to catch the result in its `onActivityResult()` would fail if we do not override the `onActivityResult()` in our React Activity and pass it on to the `ReactInstanceManager` instance created.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
