### PR TITLE
Update TouchableWithoutFeedback and Building For TV Devices

### DIFF
--- a/docs/building-for-apple-tv.md
+++ b/docs/building-for-apple-tv.md
@@ -139,19 +139,19 @@ var running_on_android_tv = Platform.isTV;
 
 * _Common codebase_: Since tvOS and iOS share most Objective-C and JavaScript code in common, most documentation for iOS applies equally to tvOS.
 
-* _Access to touchable controls_: When running on Apple TV, the native view class is `RCTTVView`, which has additional methods to make use of the tvOS focus engine. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableHighlight` and `TouchableOpacity` will "just work". In particular:
+* _Access to touchable controls_: When running on Apple TV, the native view class is `RCTTVView`, which has additional methods to make use of the tvOS focus engine. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableWithoutFeedback`, `TouchableHighlight` and `TouchableOpacity` will "just work". In particular:
 
-  * `touchableHandleActivePressIn` will be executed when the touchable view goes into focus
-  * `touchableHandleActivePressOut` will be executed when the touchable view goes out of focus
-  * `touchableHandlePress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
+  * `onFocus` will be executed when the touchable view goes into focus
+  * `onBlur` will be executed when the touchable view goes out of focus
+  * `onPress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
 
 <block class="android" />
 
-* _Access to touchable controls_: When running on Android TV the Android framework will automatically apply a directional navigation scheme based on relative position of focusable elements in your views. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableHighlight`, `TouchableOpacity` and `TouchableNativeFeedback` will "just work". In particular:
+* _Access to touchable controls_: When running on Android TV the Android framework will automatically apply a directional navigation scheme based on relative position of focusable elements in your views. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableWithoutFeedback`, `TouchableHighlight`, `TouchableOpacity` and `TouchableNativeFeedback` will "just work". In particular:
 
-  * `touchableHandleActivePressIn` will be executed when the touchable view goes into focus
-  * `touchableHandleActivePressOut` will be executed when the touchable view goes out of focus
-  * `touchableHandlePress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
+  * `onFocus` will be executed when the touchable view goes into focus
+  * `onBlur` will be executed when the touchable view goes out of focus
+  * `onPress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
 
 <block class="ios" />
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -21,6 +21,8 @@ TouchableWithoutFeedback supports only one child. If you wish to have several ch
 * [`delayPressIn`](touchablewithoutfeedback.md#delaypressin)
 * [`delayPressOut`](touchablewithoutfeedback.md#delaypressout)
 * [`disabled`](touchablewithoutfeedback.md#disabled)
+* [`onBlur`](touchablewithoutfeedback.md#onblur)
+* [`onFocus`](touchablewithoutfeedback.md#onfocus)
 * [`onLayout`](touchablewithoutfeedback.md#onlayout)
 * [`onLongPress`](touchablewithoutfeedback.md#onlongpress)
 * [`onPress`](touchablewithoutfeedback.md#onpress)
@@ -149,6 +151,26 @@ If true, disable all interactions for this component.
 | Type | Required |
 | ---- | -------- |
 | bool | No       |
+
+---
+
+### `onBlur`
+
+Invoked when the item loses focus.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onFocus`
+
+Invoked when the item receives focus.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.57/building-for-apple-tv.md
+++ b/website/versioned_docs/version-0.57/building-for-apple-tv.md
@@ -140,19 +140,19 @@ var running_on_android_tv = Platform.isTV;
 
 * _Common codebase_: Since tvOS and iOS share most Objective-C and JavaScript code in common, most documentation for iOS applies equally to tvOS.
 
-* _Access to touchable controls_: When running on Apple TV, the native view class is `RCTTVView`, which has additional methods to make use of the tvOS focus engine. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableHighlight` and `TouchableOpacity` will "just work". In particular:
+* _Access to touchable controls_: When running on Apple TV, the native view class is `RCTTVView`, which has additional methods to make use of the tvOS focus engine. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableWithoutFeedback`, `TouchableHighlight` and `TouchableOpacity` will "just work". In particular:
 
-  * `touchableHandleActivePressIn` will be executed when the touchable view goes into focus
-  * `touchableHandleActivePressOut` will be executed when the touchable view goes out of focus
-  * `touchableHandlePress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
+  * `onFocus` will be executed when the touchable view goes into focus
+  * `onBlur` will be executed when the touchable view goes out of focus
+  * `onPress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
 
 <block class="android" />
 
-* _Access to touchable controls_: When running on Android TV the Android framework will automatically apply a directional navigation scheme based on relative position of focusable elements in your views. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableHighlight`, `TouchableOpacity` and `TouchableNativeFeedback` will "just work". In particular:
+* _Access to touchable controls_: When running on Android TV the Android framework will automatically apply a directional navigation scheme based on relative position of focusable elements in your views. The `Touchable` mixin has code added to detect focus changes and use existing methods to style the components properly and initiate the proper actions when the view is selected using the TV remote, so `TouchableWithoutFeedback`, `TouchableHighlight`, `TouchableOpacity` and `TouchableNativeFeedback` will "just work". In particular:
 
-  * `touchableHandleActivePressIn` will be executed when the touchable view goes into focus
-  * `touchableHandleActivePressOut` will be executed when the touchable view goes out of focus
-  * `touchableHandlePress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
+  * `onFocus` will be executed when the touchable view goes into focus
+  * `onBlur` will be executed when the touchable view goes out of focus
+  * `onPress` will be executed when the touchable view is actually selected by pressing the "select" button on the TV remote.
 
 <block class="ios" />
 

--- a/website/versioned_docs/version-0.57/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.57/touchablewithoutfeedback.md
@@ -153,6 +153,26 @@ If true, disable all interactions for this component.
 
 ---
 
+### `onBlur`
+
+Invoked when the item loses focus.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onFocus`
+
+Invoked when the item receives focus.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
 ### `onLayout`
 
 Invoked on mount and layout changes with

--- a/website/versioned_docs/version-0.57/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.57/touchablewithoutfeedback.md
@@ -22,6 +22,8 @@ TouchableWithoutFeedback supports only one child. If you wish to have several ch
 * [`delayPressIn`](touchablewithoutfeedback.md#delaypressin)
 * [`delayPressOut`](touchablewithoutfeedback.md#delaypressout)
 * [`disabled`](touchablewithoutfeedback.md#disabled)
+* [`onBlur`](touchablewithoutfeedback.md#onblur)
+* [`onFocus`](touchablewithoutfeedback.md#onfocus)
 * [`onLayout`](touchablewithoutfeedback.md#onlayout)
 * [`onLongPress`](touchablewithoutfeedback.md#onlongpress)
 * [`onPress`](touchablewithoutfeedback.md#onpress)


### PR DESCRIPTION
I encountered some problems while developing an app for Android TV using the docs.
After checking react-native commits these are the changes that i think need to be done.

based on PRs https://github.com/facebook/react-native/pull/18470 and https://github.com/facebook/react-native/pull/19718 touchableHandleActivePressIn and touchableHandleActivePressOut are now deprecated and removed forhandling focus and blur interactions and instead touchableHandleFocus and touchableHandleBlur should be used.

In addition i find it a little ambiguous and confusing using the Touchable.js method names instead of components props names. so i changed them too for better readability and integrity.

I also added onBlur and onFoucs to TouchableWithoutFeedback as there had missing description.

TouchableWithoutFeedback  has also been added to "Building For TV Devices" description as a usable touchable component because it is but the current doc implicitly implies it's not by not mentioning it.
