### PR TITLE
Update switch.md

### DIFF
--- a/docs/switch.md
+++ b/docs/switch.md
@@ -18,7 +18,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 * [`ios_backgroundColor`](switch.md#ios_backgroundColor)
 * [`onValueChange`](switch.md#onvaluechange)
 * [`testID`](switch.md#testid)
-* [`_thumbColor`](switch.md#_thumbColor)
+* [`thumbColor`](switch.md#thumbColor)
 * [`tintColor`](switch.md#tintcolor)
 * [`value`](switch.md#value)
 
@@ -80,9 +80,9 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `_thumbColor`
+### `thumbColor`
 
-Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow. `thumbTintColor` is now deprecated.
+Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -18,7 +18,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 * [`ios_backgroundColor`](switch.md#ios_backgroundColor)
 * [`onValueChange`](switch.md#onvaluechange)
 * [`testID`](switch.md#testid)
-* [`thumbTintColor`](switch.md#thumbtintcolor)
+* [`_thumbColor`](switch.md#_thumbColor)
 * [`tintColor`](switch.md#tintcolor)
 * [`value`](switch.md#value)
 

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -80,9 +80,9 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `thumbTintColor`
+### `_thumbColor`
 
-Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow.
+Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow. `thumbTintColor` is now deprecated.
 
 | Type               | Required |
 | ------------------ | -------- |


### PR DESCRIPTION
It seems for some reason `thumbTintColor` has been renamed to `_thumbColor` according to this warning:

```
// react-native/Libraries/Components/Switch/Switch.js:112
'Switch: `thumbTintColor` is deprecated, use `_thumbColor` instead.',
```

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
