### PR TITLE
Documentation update for Switch "thumbTintColor" to "thumbColor"

### DIFF
--- a/docs/switch.md
+++ b/docs/switch.md
@@ -18,7 +18,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 * [`ios_backgroundColor`](switch.md#ios_backgroundColor)
 * [`onValueChange`](switch.md#onvaluechange)
 * [`testID`](switch.md#testid)
-* [`thumbTintColor`](switch.md#thumbtintcolor)
+* [`thumbColor`](switch.md#thumbcolor)
 * [`tintColor`](switch.md#tintcolor)
 * [`value`](switch.md#value)
 
@@ -80,7 +80,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `thumbTintColor`
+### `thumbColor`
 
 Color of the foreground switch grip. If this is set on iOS, the switch grip will lose its drop shadow.
 


### PR DESCRIPTION
"thumbTintColor" is deprecated so I would recommend changing the documentation to "thumbColor".

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
