### PR TITLE
File structure should include the 1x version too.

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -19,6 +19,7 @@ You can also use the `@2x` and `@3x` suffixes to provide images for different sc
 .
 ├── button.js
 └── img
+    ├── check.png
     ├── check@2x.png
     └── check@3x.png
 ```


### PR DESCRIPTION
Its unclear in the docs that the 1x version should be included too when providing @2x and @3x images. I believe that you do need it, correct me if I'm wrong?


File structure should be:

```
└── img
    ├── check.png
    ├── check@2x.png	    
    └── check@3x.png	    
```

not

```
└── img
    ├── check@2x.png	    
    └── check@3x.png	    
```