### PR TITLE
remove methods from the KeyboardAvoidingView docs

### DIFF
--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -21,18 +21,18 @@ import { KeyboardAvoidingView } from 'react-native';
 
 ### Props
 
-- [View props...](view.md#props)
+* [View props...](view.md#props)
 
-* [`keyboardVerticalOffset`](keyboardavoidingview.md#keyboardverticaloffset)
-* [`behavior`](keyboardavoidingview.md#behavior)
-* [`contentContainerStyle`](keyboardavoidingview.md#contentcontainerstyle)
-* [`enabled`](keyboardavoidingview.md#enabled)
+- [`keyboardVerticalOffset`](keyboardavoidingview.md#keyboardverticaloffset)
+- [`behavior`](keyboardavoidingview.md#behavior)
+- [`contentContainerStyle`](keyboardavoidingview.md#contentcontainerstyle)
+- [`enabled`](keyboardavoidingview.md#enabled)
 
 ### Methods
 
-- [`relativeKeyboardHeight`](keyboardavoidingview.md#relativekeyboardheight)
-- [`onKeyboardChange`](keyboardavoidingview.md#onkeyboardchange)
-- [`onLayout`](keyboardavoidingview.md#onlayout)
+* [`relativeKeyboardHeight`](keyboardavoidingview.md#relativekeyboardheight)
+* [`onKeyboardChange`](keyboardavoidingview.md#onkeyboardchange)
+* [`onLayout`](keyboardavoidingview.md#onlayout)
 
 ---
 

--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -28,12 +28,6 @@ import { KeyboardAvoidingView } from 'react-native';
 - [`contentContainerStyle`](keyboardavoidingview.md#contentcontainerstyle)
 - [`enabled`](keyboardavoidingview.md#enabled)
 
-### Methods
-
-* [`relativeKeyboardHeight`](keyboardavoidingview.md#relativekeyboardheight)
-* [`onKeyboardChange`](keyboardavoidingview.md#onkeyboardchange)
-* [`onLayout`](keyboardavoidingview.md#onlayout)
-
 ---
 
 # Reference

--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -21,18 +21,18 @@ import { KeyboardAvoidingView } from 'react-native';
 
 ### Props
 
-* [View props...](view.md#props)
+- [View props...](view.md#props)
 
-- [`keyboardVerticalOffset`](keyboardavoidingview.md#keyboardverticaloffset)
-- [`behavior`](keyboardavoidingview.md#behavior)
-- [`contentContainerStyle`](keyboardavoidingview.md#contentcontainerstyle)
-- [`enabled`](keyboardavoidingview.md#enabled)
+* [`keyboardVerticalOffset`](keyboardavoidingview.md#keyboardverticaloffset)
+* [`behavior`](keyboardavoidingview.md#behavior)
+* [`contentContainerStyle`](keyboardavoidingview.md#contentcontainerstyle)
+* [`enabled`](keyboardavoidingview.md#enabled)
 
 ### Methods
 
-* [`relativeKeyboardHeight`](keyboardavoidingview.md#relativekeyboardheight)
-* [`onKeyboardChange`](keyboardavoidingview.md#onkeyboardchange)
-* [`onLayout`](keyboardavoidingview.md#onlayout)
+- [`relativeKeyboardHeight`](keyboardavoidingview.md#relativekeyboardheight)
+- [`onKeyboardChange`](keyboardavoidingview.md#onkeyboardchange)
+- [`onLayout`](keyboardavoidingview.md#onlayout)
 
 ---
 
@@ -77,27 +77,3 @@ Enabled or disabled KeyboardAvoidingView. The default is `true`.
 | Type    | Required |
 | ------- | -------- |
 | boolean | No       |
-
-## Methods
-
-### `relativeKeyboardHeight()`
-
-```javascript
-relativeKeyboardHeight(keyboardFrame: object):
-```
-
----
-
-### `onKeyboardChange()`
-
-```javascript
-onKeyboardChange((event: object));
-```
-
----
-
-### `onLayout()`
-
-```javascript
-onLayout((event: ViewLayoutEvent));
-```

--- a/website/versioned_docs/version-0.57/keyboardavoidingview.md
+++ b/website/versioned_docs/version-0.57/keyboardavoidingview.md
@@ -29,12 +29,6 @@ import { KeyboardAvoidingView } from 'react-native';
 - [`contentContainerStyle`](keyboardavoidingview.md#contentcontainerstyle)
 - [`enabled`](keyboardavoidingview.md#enabled)
 
-### Methods
-
-* [`relativeKeyboardHeight`](keyboardavoidingview.md#relativekeyboardheight)
-* [`onKeyboardChange`](keyboardavoidingview.md#onkeyboardchange)
-* [`onLayout`](keyboardavoidingview.md#onlayout)
-
 ---
 
 # Reference
@@ -78,27 +72,3 @@ Enabled or disabled KeyboardAvoidingView. The default is `true`.
 | Type    | Required |
 | ------- | -------- |
 | boolean | No       |
-
-## Methods
-
-### `relativeKeyboardHeight()`
-
-```javascript
-relativeKeyboardHeight(keyboardFrame: object):
-```
-
----
-
-### `onKeyboardChange()`
-
-```javascript
-onKeyboardChange((event: object));
-```
-
----
-
-### `onLayout()`
-
-```javascript
-onLayout((event: ViewLayoutEvent));
-```


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
I removed the `Methods` section from the `KeyboardAvoidingView` docs.  

These methods aren't really meant to be called by the user and the method names were incorrect in the documentation.  If there is a scenario where these methods may legitimately be called by a user, let me know and I'll re-add the methods and fix their names instead