### PR TITLE
Add reference to shadow props in View style docs

### DIFF
--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -5,6 +5,9 @@ title: View Style Props
 
 ### Props
 
+* [Layout Props](layout-props.md#props)
+* [Shadow Props](shadow-props.md#props)
+* [Transforms](transforms.md#props)
 * [`borderRightColor`](view-style-props.md#borderrightcolor)
 * [`backfaceVisibility`](view-style-props.md#backfacevisibility)
 * [`borderBottomColor`](view-style-props.md#borderbottomcolor)


### PR DESCRIPTION
The `Shadow Props` are currently only references in the `Image` > `style` section, which suggests they're only available there. I think that's misleading and the shadow properties are also available in `View` styles. Along the (more obvious) layout and transform props. 

This PR aims to make it clear which properties can be used within a `View`'s style.