### PR TITLE
tintColor is deprecated, updated docs to reflect this change

### DIFF
--- a/docs/switch.md
+++ b/docs/switch.md
@@ -90,6 +90,8 @@ Color of the foreground switch grip. If this is set on iOS, the switch grip will
 
 ### `tintColor`
 
+`tintColor` is deprecated, use `trackColor` instead.
+
 Border color on iOS and background color on Android when the switch is turned off.
 
 | Type               | Required |


### PR DESCRIPTION
Update the Switch prop tintColor to match source code
https://github.com/facebook/react-native/blob/0.57-stable/Libraries/Components/Switch/Switch.js (line 120)
