### PR TITLE
fix typo easing

### DIFF
--- a/docs/easing.md
+++ b/docs/easing.md
@@ -234,7 +234,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 Runs an easing function forwards.

--- a/website/versioned_docs/version-0.12/easing.md
+++ b/website/versioned_docs/version-0.12/easing.md
@@ -153,7 +153,7 @@ static bezier(x1, y1, x2, y2, epsilon?)
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 ---

--- a/website/versioned_docs/version-0.23/easing.md
+++ b/website/versioned_docs/version-0.23/easing.md
@@ -153,7 +153,7 @@ static bezier(x1, y1, x2, y2)
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 ---

--- a/website/versioned_docs/version-0.43/easing.md
+++ b/website/versioned_docs/version-0.43/easing.md
@@ -244,7 +244,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 Runs an easing function forwards.

--- a/website/versioned_docs/version-0.5/easing.md
+++ b/website/versioned_docs/version-0.5/easing.md
@@ -239,7 +239,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 Runs an easing function forwards.

--- a/website/versioned_docs/version-0.51/easing.md
+++ b/website/versioned_docs/version-0.51/easing.md
@@ -239,7 +239,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 Runs an easing function forwards.

--- a/website/versioned_docs/version-0.55/easing.md
+++ b/website/versioned_docs/version-0.55/easing.md
@@ -235,7 +235,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```javascript
-static in easing;
+static in(easing)
 ```
 
 Runs an easing function forwards.


### PR DESCRIPTION
static in easing; 
to
static in(easing)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
