### PR TITLE
Refactor State doc to return proper element and keep consistent format.

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -16,20 +16,23 @@ import { AppRegistry, Text, View } from 'react-native';
 class Blink extends Component {
   constructor(props) {
     super(props);
-    this.state = {isShowingText: true};
+    this.state = { isShowingText: true };
 
     // Toggle the state every second
-    setInterval(() => {
-      this.setState(previousState => {
-        return { isShowingText: !previousState.isShowingText };
-      });
-    }, 1000);
+    setInterval(() => (
+      this.setState(previousState => (
+        { isShowingText: !previousState.isShowingText }
+      ))
+    ), 1000);
   }
 
   render() {
-    let display = this.state.isShowingText ? this.props.text : ' ';
+    if (!this.state.isShowingText) {
+      return null;
+    }
+
     return (
-      <Text>{display}</Text>
+      <Text>{this.props.text}</Text>
     );
   }
 }


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

I felt like returning unnecessary element with `' '` is not a great practice for beginners to follow along with.
  - Added pre-check condition that returns `null` on `isShowingText is False`.

Functions with just `return` could be wrapped with parenthesis instead of curly brace + `return` keyword.
  - Refactor unnecessary curly braces with parenthesis.