### PR TITLE
Update native-components-ios.md

### DIFF
--- a/docs/native-components-ios.md
+++ b/docs/native-components-ios.md
@@ -122,8 +122,7 @@ var RNTMap = requireNativeComponent('RNTMap', MapView);
 module.exports = MapView;
 ```
 
-Now we have a nicely documented wrapper component that is easy to work with. 
-we changed the second argument to `requireNativeComponent` from `null` to the new `MapView` wrapper component. This allows the infrastructure to verify that the propTypes match the native props to reduce the chances of mismatches between the ObjC and JS code.
+Now we have a nicely documented wrapper component that is easy to work with. Note that we changed `requireNativeComponent`'s second argument from `null` to the new `MapView` wrapper component. This allows the infrastructure to verify that the propTypes match the native props in order to reduce the chances of mismatches between the Objective-C and JavaScript code.
 
 Next, let's add the more complex `region` prop. We start by adding the native code:
 

--- a/docs/native-components-ios.md
+++ b/docs/native-components-ios.md
@@ -122,7 +122,8 @@ var RNTMap = requireNativeComponent('RNTMap', MapView);
 module.exports = MapView;
 ```
 
-Now we have a nicely documented wrapper component that is easy to work with. Note that we changed the second argument to `requireNativeComponent` from `null` to the new `MapView` wrapper component. This allows the infrastructure to verify that the propTypes match the native props to reduce the chances of mismatches between the ObjC and JS code.
+Now we have a nicely documented wrapper component that is easy to work with. 
+we changed the second argument to `requireNativeComponent` from `null` to the new `MapView` wrapper component. This allows the infrastructure to verify that the propTypes match the native props to reduce the chances of mismatches between the ObjC and JS code.
 
 Next, let's add the more complex `region` prop. We start by adding the native code:
 
@@ -271,8 +272,7 @@ Until now we've just returned a `MKMapView` instance from our manager's `-(UIVie
 
 @end
 ```
-
-Next, declare an event handler property on `RNTMapManager`, make it a delegate for all the views it exposes, and forward events to JS by calling the event handler block from the native view.
+Note that all `RCTBubblingEventBlock` must be prefixed with `on`. Next, declare an event handler property on `RNTMapManager`, make it a delegate for all the views it exposes, and forward events to JS by calling the event handler block from the native view.
 
 ```objectivec{9,17,31-48}
 // RNTMapManager.m


### PR DESCRIPTION
`RCTBubblingEventBlock` must be prefixed with `on` but this does not mentioned in the documentation. I find it in this [link](https://stackoverflow.com/a/46430329/3127015) and I really waste my time to figure out why my callback does not call. I then think it can be helpful to others to know it as well.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
