### PR TITLE
Fixed prop descriptions of 'color' and 'value' props in picker-item.md

### DIFF
--- a/docs/picker-item.md
+++ b/docs/picker-item.md
@@ -28,7 +28,7 @@ Text to display for this item.
 
 ### `color`
 
-The value to be passed to picker's `onValueChange` callback when this item is selected. Can be a string or an integer.
+Color of this item's text.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -44,7 +44,7 @@ Used to locate the item in end-to-end tests.
 
 ### `value`
 
-Color of this item's text.
+The value to be passed to picker's `onValueChange` callback when this item is selected. Can be a string or an integer.
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
The prop descriptions of the 'color' and 'value' prop in picker-item.md were switched. Changed them to their proper positions.