### PR TITLE
Removed performance section from stylesheet as no longer true

### DIFF
--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -37,11 +37,6 @@ Code quality:
 * By moving styles away from the render function, you're making the code easier to understand.
 * Naming the styles is a good way to add meaning to the low level components in the render function.
 
-Performance:
-
-* Making a stylesheet from a style object makes it possible to refer to it by ID instead of creating a new style object every time.
-* It also allows to send the style only once through the bridge. All subsequent uses are going to refer an id (not implemented yet).
-
 ### Methods
 
 * [`setStyleAttributePreprocessor`](stylesheet.md#setstyleattributepreprocessor)


### PR DESCRIPTION
See https://github.com/facebook/react-native/commit/a8e3c7f5780516eb0297830632862484ad032c10
`StyleSheet.create` is now an identity function, the `ReactNativePropRegistry` (`StyleSheetRegistry`) was removed.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
