### PR TITLE
[DOCS] autoCapitalize caveat for name-phone-pad

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -167,7 +167,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ### `autoCapitalize`
 
-Can tell `TextInput` to automatically capitalize certain characters.
+Can tell `TextInput` to automatically capitalize certain characters. This property is not supported by some keyboard types such as `name-phone-pad`.
 
 * `characters`: all characters.
 * `words`: first letter of each word.


### PR DESCRIPTION
https://developer.apple.com/documentation/uikit/uikeyboardtype/namephonepad

> UIKeyboardType.namePhonePad specifies a keypad designed for entering a person’s name or phone number. This keyboard type does not support auto-capitalization.