### PR TITLE
Typo: Change 'indiciating' to 'indicating'

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -212,7 +212,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.5/animated.md
+++ b/website/versioned_docs/version-0.5/animated.md
@@ -254,7 +254,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.50/animated.md
+++ b/website/versioned_docs/version-0.50/animated.md
@@ -209,7 +209,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.51/animated.md
+++ b/website/versioned_docs/version-0.51/animated.md
@@ -209,7 +209,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.52/animated.md
+++ b/website/versioned_docs/version-0.52/animated.md
@@ -209,7 +209,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.55/animated.md
+++ b/website/versioned_docs/version-0.55/animated.md
@@ -211,7 +211,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.56/animated.md
+++ b/website/versioned_docs/version-0.56/animated.md
@@ -213,7 +213,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.

--- a/website/versioned_docs/version-0.57/animated.md
+++ b/website/versioned_docs/version-0.57/animated.md
@@ -213,7 +213,7 @@ Specifying stiffness/damping/mass as parameters makes `Animated.spring` use an a
 Other configuration options are as follows:
 
 * `velocity`: The initial velocity of the object attached to the spring. Default 0 (object is at rest).
-* `overshootClamping`: Boolean indiciating whether the spring should be clamped and not bounce. Default false.
+* `overshootClamping`: Boolean indicating whether the spring should be clamped and not bounce. Default false.
 * `restDisplacementThreshold`: The threshold of displacement from rest below which the spring should be considered at rest. Default 0.001.
 * `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 * `delay`: Start the animation after delay (milliseconds). Default 0.


### PR DESCRIPTION
Presumably docs intend to state: 'indicating'.
