### PR TITLE
Fix path of generated APK

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -91,7 +91,7 @@ Gradle's `assembleRelease` will bundle all the JavaScript needed to run your app
 
 > Note: Make sure gradle.properties does not include _org.gradle.configureondemand=true_ as that will make the release build skip bundling JS and assets into the APK.
 
-The generated APK can be found under `android/app/build/outputs/apk/app-release.apk`, and is ready to be distributed.
+The generated APK can be found under `android/app/build/outputs/apk/release/app-release.apk`, and is ready to be distributed.
 
 ### Testing the release build of your app
 


### PR DESCRIPTION
In React Native v0.57.4, the generated APK can be found under `android/app/build/outputs/apk/release/app-release.apk`.

This path seems to have changed with the Android Gradle plugin v3.0.0, however, there doesn’t seem to be a good reference for this change. I’ve only found similar remarks on [Stack Overflow](https://stackoverflow.com/questions/46985530/change-apk-output-folder-in-gradle-4-1/48121314#comment81522854_46985530) and on [F-Droid’s issue tracker](https://gitlab.com/fdroid/fdroidserver/issues/363#note_38091024).