### PR TITLE
Tweak the wording of the getting started to stick to jdk 8

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -290,7 +290,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 ### Java Development Kit
 
-React Native requires a recent version of the Java SE Development Kit (JDK). [Download and install Oracle JDK 8 or newer](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if needed. You can also use [OpenJDK 8 or newer](http://openjdk.java.net/install/) as an alternative.
+React Native requires a recent version of the Java SE Development Kit (JDK). [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if needed. You can also use [OpenJDK 8](http://openjdk.java.net/install/) as an alternative.
 
 <block class="native mac linux windows android" />
 


### PR DESCRIPTION
Basically, when re-installing the whole suite of tools on my new laptop, I noticed that all the newer JDKs where creating issues when trying to run React Native on Android.

So I think we should stick to the JDK 8 until we are fully supporting the newer ones 😅