### PR TITLE
Small grammar fix

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -26,7 +26,7 @@ export default class Bananas extends Component {
 AppRegistry.registerComponent('AwesomeProject', () => Bananas);
 ```
 
-Notice that `{pic}` is surrounded by braces, to embed the variable `pic` into JSX. You can put any JavaScript expression inside braces in JSX.
+Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX. You can put any JavaScript expression inside braces in JSX.
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place. Just refer to `this.props` in your `render` function. Here's an example:
 


### PR DESCRIPTION
"Notice that {pic} is surrounded by braces, to embed the variable pic into JSX. " is not a grammatically correct sentence.

It can be quickly fixed by removing the comma, but the sentence can be made more concise and clear.

My proposed fix:
"Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX." 

This changes the focus of the sentence to braces and explains more concisely what function they are performing.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
