### PR TITLE
docs(webview.md): Tell people to use community fork

### DIFF
--- a/docs/webview.md
+++ b/docs/webview.md
@@ -3,6 +3,8 @@ id: webview
 title: WebView
 ---
 
+> **Warning** Please use the [react-native-community/react-native-webview](https://github.com/react-native-community/react-native-webview) fork of this component instead. To reduce the surface area of React Native, `<WebView/>` is going to be removed from the React Native core. For more information, please read [The Slimmening proposal](https://github.com/react-native-community/discussions-and-proposals/issues/6).
+
 `WebView` renders web content in a native view.
 
 ```

--- a/website/versioned_docs/version-0.57/webview.md
+++ b/website/versioned_docs/version-0.57/webview.md
@@ -4,6 +4,8 @@ title: WebView
 original_id: webview
 ---
 
+> **Warning** Please use the [react-native-community/react-native-webview](https://github.com/react-native-community/react-native-webview) fork of this component instead. To reduce the surface area of React Native, `<WebView/>` is going to be removed from the React Native core. For more information, please read [The Slimmening proposal](https://github.com/react-native-community/discussions-and-proposals/issues/6).
+
 `WebView` renders web content in a native view.
 
 ```


### PR DESCRIPTION
We've forked WebView into [react-native-community/react-native-webview](https://github.com/react-native-community/react-native-webview), but I think we forgot to update the documentation. 