### PR TITLE
Updates React Native with TypeScript post with Babel 7 instructions

### DIFF
--- a/website/blog/2018-05-07-using-typescript-with-react-native.md
+++ b/website/blog/2018-05-07-using-typescript-with-react-native.md
@@ -10,7 +10,17 @@ category: engineering
 
 JavaScript! We all love it. But some of us also love [types](https://en.wikipedia.org/wiki/Data_type). Luckily, options exist to add stronger types to JavaScript. My favourite is [TypeScript](https://www.typescriptlang.org), but React Native supports [Flow](https://flow.org) out of the box. Which you prefer is a matter of preference, they each have their own approach on how to add the magic of types to JavaScript. Today, we're going to look at how to use TypeScript in React Native apps.
 
-We'll be using Microsoft's [TypeScript-React-Native-Starter](https://github.com/Microsoft/TypeScript-React-Native-Starter) repo as a guide.
+This post uses Microsoft's [TypeScript-React-Native-Starter](https://github.com/Microsoft/TypeScript-React-Native-Starter) repo as a guide.
+
+**Update**: Since this blog post was written, [Babel 7 was released with integrated TypeScript support](https://blogs.msdn.microsoft.com/typescript/2018/08/27/typescript-and-babel-7/). Babel 7 replaces all the set up described in this blog post with just one command:
+
+```sh
+react-native init MyAwesomeProject --template typescript
+```
+
+However, there _are_ some limitations to Babel's TypeScript support, which the blog post above goes into in detail. The steps outlined in _this_ post still work, and Artsy is still using [react-native-typescript-transformer](https://github.com/ds300/react-native-typescript-transformer) in production, but the fastest way to get up and running with React Native and TypeScript is using the above command. You can always switch later if you have to.
+
+In any case, have fun! The original blog post continues below.
 
 ## Prerequisites
 


### PR DESCRIPTION
Good morning! I wrote this blog post earlier this year, but Babel 7 has since been released with builtin TypeScript support. Since this blog post has become very popular among people looking for TypeScript with React Native, I have been receiving an increasing number of requests from the community to update the blog post to point to Babel 7 instructions.

This pull request adds a section to the introduction of my blog post that gives instructions for Babel 7, includes a brief description of its limitations, and points to workarounds written by @damassi. /cc @ds300 who wrote react-native-typescript-transformer.