### PR TITLE
added createAppContainer to example

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -24,12 +24,14 @@ npm install --save react-navigation
 Then you can quickly create an app with a home screen and a profile screen:
 
 ```javascript
-import {createStackNavigator} from 'react-navigation';
+import {createStackNavigator, createAppNavigator} from 'react-navigation';
 
-const App = createStackNavigator({
+const MainNavigator = createStackNavigator({
   Home: {screen: HomeScreen},
   Profile: {screen: ProfileScreen},
 });
+
+const App = createAppNavigator(MainNavigator);
 
 export default App;
 ```


### PR DESCRIPTION
Issue #684 

Added `createAppContainer` to example to conform to the React-Navigation breaking changes listed here

https://reactnavigation.org/blog/2018/11/17/react-navigation-3.0.html