### PR TITLE
Add style props for TouchableOpacity

### DIFF
--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -92,6 +92,7 @@ AppRegistry.registerComponent('App', () => App)
 
 * [TouchableWithoutFeedback props...](touchablewithoutfeedback.md#props)
 
+- [`style`](touchableopacity.md#style)
 - [`activeOpacity`](touchableopacity.md#activeopacity)
 - [`tvParallaxProperties`](touchableopacity.md#tvparallaxproperties)
 - [`hasTVPreferredFocus`](touchableopacity.md#hastvpreferredfocus)
@@ -105,6 +106,14 @@ AppRegistry.registerComponent('App', () => App)
 # Reference
 
 ## Props
+
+### `style`
+
+| Type       | Required |
+| ---------- | -------- |
+| View.style | No       |
+
+---
 
 ### `activeOpacity`
 


### PR DESCRIPTION
RN's touchableOpacity appears to be sensitive for `style` prop, but I us not included in docs (neither here nor in `touchableWithoutFeedback`). I'm not sure whether this feature should be documented. If not, please close this PR.
