### PR TITLE
Remove absoluteFillObject

### DIFF
--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -147,18 +147,12 @@ A line with hairline width may not be visible if your simulator is downscaled.
 
 ### `absoluteFill`
 
-A very common pattern is to create overlays with position absolute and zero positioning (`position: 'absolute', left: 0, right: 0, top: 0, bottom: 0`), so `absoluteFill` can be used for convenience and to reduce duplication of these repeated styles.
-
----
-
-### `absoluteFillObject`
-
-Sometimes you may want absoluteFill but with a couple tweaks - absoluteFillObject can be used to create a customized entry in a StyleSheet, e.g.:
+A very common pattern is to create overlays with position absolute and zero positioning (`position: 'absolute', left: 0, right: 0, top: 0, bottom: 0`), so `absoluteFill` can be used for convenience and to reduce duplication of these repeated styles. If you want, absoluteFill can be used to create a customized entry in a StyleSheet, e.g.:
 
 ```javascript
 const styles = StyleSheet.create({
   wrapper: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     top: 10,
     backgroundColor: 'transparent',
   },


### PR DESCRIPTION
It literally points to the same reference as absoluteFill.

https://stackoverflow.com/questions/53676723/react-native-what-is-the-difference-between-stylesheet-absolutefill-and-styl/53775303#53775303

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
