### PR TITLE
Document Animated.loop config in the same style as other functions

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -326,10 +326,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.44/animated.md
+++ b/website/versioned_docs/version-0.44/animated.md
@@ -296,10 +296,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key 'iterations' in the config. Will loop without blocking the UI thread if the child animation is set to 'useNativeDriver'.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.46/animated.md
+++ b/website/versioned_docs/version-0.46/animated.md
@@ -298,10 +298,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key 'iterations' in the config. Will loop without blocking the UI thread if the child animation is set to 'useNativeDriver'.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.48/animated.md
+++ b/website/versioned_docs/version-0.48/animated.md
@@ -298,10 +298,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key 'iterations' in the config. Will loop without blocking the UI thread if the child animation is set to 'useNativeDriver'.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.49/animated.md
+++ b/website/versioned_docs/version-0.49/animated.md
@@ -292,10 +292,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key 'iterations' in the config. Will loop without blocking the UI thread if the child animation is set to 'useNativeDriver'.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.5/animated.md
+++ b/website/versioned_docs/version-0.5/animated.md
@@ -420,16 +420,21 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-Animated.loop(animation);
+Animated.loop(animation, [config]);
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
 
 **Parameters:**
 
 | Name      | Type      | Required | Description        |
 | --------- | --------- | -------- | ------------------ |
 | animation | animation | Yes      | Animation to loop. |
+| config    | object    | No       | See below.         |
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.50/animated.md
+++ b/website/versioned_docs/version-0.50/animated.md
@@ -313,10 +313,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key 'iterations' in the config. Will loop without blocking the UI thread if the child animation is set to 'useNativeDriver'.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.51/animated.md
+++ b/website/versioned_docs/version-0.51/animated.md
@@ -313,10 +313,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.52/animated.md
+++ b/website/versioned_docs/version-0.52/animated.md
@@ -313,10 +313,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.55/animated.md
+++ b/website/versioned_docs/version-0.55/animated.md
@@ -315,10 +315,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.56/animated.md
+++ b/website/versioned_docs/version-0.56/animated.md
@@ -327,10 +327,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 

--- a/website/versioned_docs/version-0.57/animated.md
+++ b/website/versioned_docs/version-0.57/animated.md
@@ -327,10 +327,14 @@ Array of animations may run in parallel (overlap), but are started in sequence w
 ### `loop()`
 
 ```javascript
-static loop(animation)
+static loop(animation, config?)
 ```
 
-Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Can specify number of times to loop using the key `iterations` in the config. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start. Will loop without blocking the UI thread if the child animation is set to `useNativeDriver: true`. In addition, loops can prevent `VirtualizedList`-based components from rendering more rows while the animation is running. You can pass `isInteraction: false` in the child animation config to fix this.
+
+Config is an object that may have the following options:
+
+* `iterations`: Number of times the animation should loop. Default `-1` (infinite).
 
 ---
 


### PR DESCRIPTION
The `Animated.loop` documentation didn't explicitly show it takes an optional `config` object as a second argument nor did it follow the same format as other functions on the same page.

Also went back and updated the docs from `0.44` onwards. That's as far back as the docs mention the `loop` function from what I could see.