### PR TITLE
Added instrutions to add platform-tools to Path.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -405,10 +405,6 @@ You can find the actual location of the SDK in the Android Studio "Preferences" 
 
 Open a new Command Prompt window to ensure the new environment variable is loaded before proceeding to the next step.
 
-<block class="native linux android" />
-
-<block class="native windows android" />
-
 #### 4. Add platform-tools to Path
 
 Open the System pane under **System and Security** in the Windows Control Panel, then click on **Change settings...**. Open the **Advanced** tab and click on **Environment Variables...**. Select the **Path** variable, then click **Edit**. Click **New** and add the path to platform-tools to the list.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -407,6 +407,20 @@ Open a new Command Prompt window to ensure the new environment variable is loade
 
 <block class="native linux android" />
 
+<block class="native windows android" />
+
+#### 4. Add platform-tools to Path
+
+Open the System pane under **System and Security** in the Windows Control Panel, then click on **Change settings...**. Open the **Advanced** tab and click on **Environment Variables...**. Select the **Path** variable, then click **Edit**. Click **New** and add the path to platform-tools to the list.
+
+The default location for this folder is:
+
+```powershell
+c:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk\platform-tools
+```
+
+<block class="native linux android" />
+
 ### Watchman
 
 Follow the [Watchman installation guide](https://facebook.github.io/watchman/docs/install.html#buildinstall) to compile and install Watchman from source.


### PR DESCRIPTION
This allows windows to find adb.exe, a file required for react-native run-android to work properly.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
