### PR TITLE
Text: Indicate that `letterSpacing` works on Android

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -151,9 +151,9 @@ Set to `false` to remove extra font padding intended to make space for certain a
 
 ### `letterSpacing`
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   | Required | Platform            |
+| ------ | -------- | ------------------- |
+| number | No       | iOS, Android >= 5.0 |
 
 ---
 


### PR DESCRIPTION
The docs say that `letterSpacing` is iOS-only but it also works on Android.

Why do we document the `Text` styles in both `text.md` and `text-style-props.md`?

Adam Comella
Microsoft Corp.