### PR TITLE
Text/TextInput: Document `maxFontSizeMultiplier` prop

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -226,6 +226,7 @@ We believe that this more constrained way to style text will yield better apps:
 * [`onPress`](text.md#onpress)
 * [`pressRetentionOffset`](text.md#pressretentionoffset)
 * [`allowFontScaling`](text.md#allowfontscaling)
+* [`maxFontSizeMultiplier`](text.md#maxfontsizemultiplier)
 * [`style`](text.md#style)
 * [`testID`](text.md#testid)
 * [`disabled`](text.md#disabled)
@@ -377,6 +378,20 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 | Type | Required |
 | ---- | -------- |
 | bool | No       |
+
+---
+
+### `maxFontSizeMultiplier`
+
+Specifies largest possible scale a font can reach when `allowFontScaling` is enabled. Possible values:
+
+* `null/undefined` (default): inherit from the parent node or the global default (0)
+* `0`: no max, ignore parent/global default
+* `>= 1`: sets the `maxFontSizeMultiplier` of this node to this value
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | iOS      |
 
 ---
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -114,6 +114,7 @@ Note that on Android performing text selection in input can change app's activit
 - [`inlineImagePadding`](textinput.md#inlineimagepadding)
 - [`keyboardAppearance`](textinput.md#keyboardappearance)
 - [`keyboardType`](textinput.md#keyboardtype)
+- [`maxFontSizeMultiplier`](text.md#maxfontsizemultiplier)
 - [`maxLength`](textinput.md#maxlength)
 - [`multiline`](textinput.md#multiline)
 - [`numberOfLines`](textinput.md#numberoflines)
@@ -182,28 +183,30 @@ Can tell `TextInput` to automatically capitalize certain characters. This proper
 ---
 
 ### `autoComplete`
- Specifies autocomplete hints for the system, so it can provide autofill.
- On Android, the system will aways attempt to offer autofill by using heuristics to identify the type of content. To disable autocomplete, set `autoComplete` to `off`.
- 
- Possible values for `autoComplete` are:
- * `off`
- * `username`
- * `password`
- * `email`
- * `name`
- * `tel`
- * `street-address`
- * `postal-code`
- * `cc-number`
- * `cc-csc`
- * `cc-exp`
- * `cc-exp-month`
- * `cc-exp-year`
 
- | Type                                                                                                                                                     | Required | Platform |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
-| enum('off', 'username', 'password', 'email', 'name', 'tel', 'street-address', 'postal-code', 'cc-number', 'cc-csc', 'cc-exp', 'cc-exp-month', 'cc-exp-year') | No       | Android      |
- ---
+Specifies autocomplete hints for the system, so it can provide autofill. On Android, the system will aways attempt to offer autofill by using heuristics to identify the type of content. To disable autocomplete, set `autoComplete` to `off`.
+
+Possible values for `autoComplete` are:
+
+* `off`
+* `username`
+* `password`
+* `email`
+* `name`
+* `tel`
+* `street-address`
+* `postal-code`
+* `cc-number`
+* `cc-csc`
+* `cc-exp`
+* `cc-exp-month`
+* `cc-exp-year`
+
+| Type                                                                                                                                                         | Required | Platform |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | -------- |
+| enum('off', 'username', 'password', 'email', 'name', 'tel', 'street-address', 'postal-code', 'cc-number', 'cc-csc', 'cc-exp', 'cc-exp-month', 'cc-exp-year') | No       | Android  |
+
+---
 
 ### `autoCorrect`
 
@@ -405,6 +408,20 @@ The following values work on Android only:
 | Type                                                                                                                                                                                                    | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | enum('default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter', 'web-search', 'visible-password') | No       |
+
+---
+
+### `maxFontSizeMultiplier`
+
+Specifies largest possible scale a font can reach when `allowFontScaling` is enabled. Possible values:
+
+* `null/undefined` (default): inherit from the parent node or the global default (0)
+* `0`: no max, ignore parent/global default
+* `>= 1`: sets the `maxFontSizeMultiplier` of this node to this value
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | iOS      |
 
 ---
 


### PR DESCRIPTION
RN PR that introduced the `maxFontSizeMultiplier` prop on iOS: https://github.com/facebook/react-native/pull/20915

There are some other minor changes due to running prettier on the files I touched.

Adam Comella
Microsoft Corp.