### PR TITLE
Updated packager config to include project dir

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -357,6 +357,11 @@ Now that we have a RAM bundle, there is overhead for calling `require`. `require
 Create a folder in your project called packager, and create a single file named config.js. Add the following:
 
 ```
+const resolve = require('path').resolve;
+
+// Update the following line if the root folder of your app is somewhere else.
+const ROOT_FOLDER = resolve(__dirname, '..');
+
 const config = {
   transformer: {
     getTransformOptions: () => {
@@ -365,6 +370,7 @@ const config = {
       };
     },
   },
+  projectRoot: ROOT_FOLDER,
 };
 
 module.exports = config;
@@ -459,7 +465,7 @@ const config = {
       };
     },
   },
-  projectRoot:ROOT_FOLDER,
+  projectRoot: ROOT_FOLDER,
 };
 
 module.exports = config;


### PR DESCRIPTION
The initial packager config doesn't have the project directory in the config, and running it without it causes the packager look for files in the packager folder, not the intended project folder.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
