### PR TITLE
Add no support for numberOfLines on nested Text

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -507,3 +507,7 @@ When `true`, no visual change is made when text is pressed down. By default, a g
 | Type | Required | Platform |
 | ---- | -------- | -------- |
 | bool | No       | iOS      |
+
+# Known issues
+
+* [react-native#22811](https://github.com/facebook/react-native/issues/22811): Nested Text elements do not support `numberOfLines` attribute


### PR DESCRIPTION
This feature is difficult to implement at the native level.

Original issue: https://github.com/facebook/react-native/issues/22811
