### PR TITLE
Update getting started for AMD users.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -309,11 +309,8 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 * `Android SDK`
 * `Android SDK Platform`
-* `Performance (Intel ® HAXM)` 
+* `Performance (Intel ® HAXM)` ([See here for AMD](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
 * `Android Virtual Device`
-
-* Unfortunately this is not working for the "AMD processors" as there Intel HAXM is not available. But there is 'Microsoft WHPX' for the same purpose. Please follow some steps as suggested by the android team.
-https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html
 
 <block class="native linux android" />
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -309,8 +309,11 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 * `Android SDK`
 * `Android SDK Platform`
-* `Performance (Intel ® HAXM)`
+* `Performance (Intel ® HAXM)` 
 * `Android Virtual Device`
+
+* Unfortunately this is not working for the "AMD processors" as there Intel HAXM is not available. But there is 'Microsoft WHPX' for the same purpose. Please follow some steps as suggested by the android team.
+https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html
 
 <block class="native linux android" />
 


### PR DESCRIPTION
As I faced problem in setting up the react-native environment in my windows machine with AMD processor. It is hard to understand where the problem is. Most of the time we guide on the basis of Operating system but sometimes all the things are not working same in all the processors. Here 'android-studio' is not working correctly. The android emulator is not able to open as there is no intel HAXM. This is simple update for the AMD users.

