### PR TITLE
Lower cased “versions”

### DIFF
--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -69,7 +69,7 @@ class Versions extends React.Component {
     return (
       <div className="pageContainer">
         <Container className="mainContainer documentContainer postContainer">
-          <h1>React Native Versions</h1>
+          <h1>React Native versions</h1>
           <p>
             Open source React Native releases follow a monthly release train
             that is coordinated on GitHub through the


### PR DESCRIPTION
Changed it to be consistent with the rest of the titles with “versions” in it.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
