### PR TITLE
Minor header changes

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -150,7 +150,6 @@
     "Community": "Community",
     "Blog": "Blog",
     "GitHub": "GitHub",
-    "React": "React",
     "The Basics": "The Basics",
     "Guides": "Guides",
     "Guides (iOS)": "Guides (iOS)",
@@ -160,8 +159,10 @@
     "APIs": "APIs"
   },
   "pages-strings": {
-    "Help Translate|recruit community translators for your project": "Help Translate",
+    "Help Translate|recruit community translators for your project":
+      "Help Translate",
     "Edit this Doc|recruitment message asking to edit the doc source": "Edit",
-    "Translate this Doc|recruitment message asking to translate the docs": "Translate"
+    "Translate this Doc|recruitment message asking to translate the docs":
+      "Translate"
   }
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -27,7 +27,6 @@ const siteConfig = {
     {blog: true, label: 'Blog'},
     {search: true},
     {href: repoUrl, label: 'GitHub'},
-    {href: 'https://reactjs.org/', label: 'React'},
   ],
   headerIcon: 'img/header_logo.png',
   footerIcon: 'img/header_logo.png',

--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -1,0 +1,13 @@
+.fixedHeaderContainer header h3 {
+  font-size: 14px;
+  margin-left: 8px;
+  text-decoration: none;
+}
+
+.fixedHeaderContainer header h3:hover {
+  opacity: 0.8;
+}
+
+li.navSearchWrapper {
+  font-size: 16px;
+}


### PR DESCRIPTION
I'm starting on revamping the website a bit. This is a very simple first step. This diff changes the header to:

* Remove the link to React. I'm sure people can find the React website on their own, and we can reclaim some header real-estate for later use.
* Fix the search icon which was way too low
* Make the version number slightly less prominent by removing the underline and making the font smaller.

Before and after:
<img width="1122" alt="screen shot 2019-01-04 at 17 05 20" src="https://user-images.githubusercontent.com/13352/50678632-f4a74680-1042-11e9-8439-119201a360a1.png">
