### PR TITLE
More modest introduction to React Native.

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -13,9 +13,7 @@ const Container = CompLibrary.Container;
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 
-const pinnedApps = siteConfig.users.filter(app => {
-  return app.pinned;
-});
+const pinnedApps = siteConfig.users.filter(app => app.pinned);
 
 class Button extends React.Component {
   render() {
@@ -108,24 +106,24 @@ class Features extends React.Component {
               <MarkdownBlock>
                 React Native lets you build mobile apps using only JavaScript.
                 It uses the same design as React, letting you compose a rich
-                mobile UI from declarative components.
+                mobile UI using declarative components.
               </MarkdownBlock>
             </div>
             <MarkdownBlock>
               {`\`\`\`javascript
-import React, { Component } from 'react';
-import { Text, View } from 'react-native';
+import React, {Component} from 'react';
+import {Text, View} from 'react-native';
 
-class WhyReactNativeIsSoGreat extends Component {
+class HelloReactNative extends Component {
   render() {
     return (
       <View>
         <Text>
-          If you like React on the web, you'll like React Native.
+          If you like React, you'll also like React Native.
         </Text>
         <Text>
-          You just use native components like 'View' and 'Text',
-          instead of web components like 'div' and 'span'.
+          Instead of 'div' and 'span', you'll use native components
+          like 'View' and 'Text'.
         </Text>
       </View>
     );
@@ -140,26 +138,25 @@ class WhyReactNativeIsSoGreat extends Component {
             <div className="blockContent">
               <h2>A React Native app is a real mobile app</h2>
               <MarkdownBlock>
-                With React Native, you don't build a "mobile web app", an "HTML5
-                app", or a "hybrid app". You build a real mobile app that's
-                indistinguishable from an app built using Objective-C or Java.
-                React Native uses the same fundamental UI building blocks as
-                regular iOS and Android apps. You just put those building blocks
-                together using JavaScript and React.
+                The apps you are building with React Native aren't mobile web
+                apps because React Native uses the same fundamental UI building
+                blocks as regular iOS and Android apps. Instead of using Swift,
+                Kotlin or Java, you are putting those building blocks together
+                using JavaScript and React.
               </MarkdownBlock>
             </div>
             <MarkdownBlock>
               {`\`\`\`javascript
-import React, { Component } from 'react';
-import { Image, ScrollView, Text } from 'react-native';
+import React, {Component} from 'react';
+import {Image, ScrollView, Text} from 'react-native';
 
-class AwkwardScrollingImageWithText extends Component {
+class ScrollingImageWithText extends Component {
   render() {
     return (
       <ScrollView>
         <Image
-          source={{uri: 'https://i.chzbgr.com/full/7345954048/h7E2C65F9/'}}
-          style={{width: 320, height:180}}
+          source={{uri: 'https://facebook.github.io/react-native/img/header_logo.png'}}
+          style={{width: 66, height: 58}}
         />
         <Text>
           On iOS, a React Native ScrollView uses a native UIScrollView.
@@ -169,7 +166,7 @@ class AwkwardScrollingImageWithText extends Component {
           On Android, it uses a native ImageView.
 
           React Native wraps the fundamental native components, giving you
-          the performance of a native app, plus the clean design of React.
+          the performance of a native app using the APIs of React.
         </Text>
       </ScrollView>
     );
@@ -207,7 +204,7 @@ class AwkwardScrollingImageWithText extends Component {
               <div>
                 <MarkdownBlock>
                   React Native combines smoothly with components written in
-                  Objective-C, Java, or Swift. It's simple to drop down to
+                  Swift, Java, or Objective-C. It's simple to drop down to
                   native code if you need to optimize a few aspects of your
                   application. It's also easy to build part of your app in React
                   Native, and part of your app using native code directly -
@@ -218,18 +215,18 @@ class AwkwardScrollingImageWithText extends Component {
             <MarkdownBlock>
               {`
 \`\`\`javascript
-import React, { Component } from 'react';
-import { Text, View } from 'react-native';
-import { TheGreatestComponentInTheWorld } from './your-native-code';
+import React, {Component} from 'react';
+import {Text, View} from 'react-native';
+import {MapViewComponent} from './your-native-map-implementation';
 
-class SomethingFast extends Component {
+class CustomMapView extends Component {
   render() {
     return (
       <View>
-        <TheGreatestComponentInTheWorld />
+        <MapViewComponent />
         <Text>
-          TheGreatestComponentInTheWorld could use native Objective-C,
-          Java, or Swift - the product development process is the same.
+          MapViewComponent could use native Swift, Java, or Objective-C -
+          the product development process is the same.
         </Text>
       </View>
     );


### PR DESCRIPTION
I am planning a more thorough overhaul of the home page but I want to get these small changes in for now, even if they won't stay around for too long. After reading through the React Native website I got the feeling that the React Native project is somewhat pretentious. I'm not trying to blame anyone, I believe this accumulated over years and 2019 is quite different from 2015 – I would have probably written things in a similar style back then. I would like to thoroughly change the website to give a more modest and mature impression of React Native. Instead of touting how amazing React Native can be, I believe we should aim to be highly informative and simplistic in our language instead of joking around. Let the technology speak for itself and give people that wow effect.

The particular changes in this PR are:
* Changed the first component name from `WhyReactNativeIsSoGreat` to `HelloReactNative`.
* Slightly reworded the first component's example text to be shorter.
* Changed the text about React Native being a "real app" to remove the quotes around "mobile web app". I get what the paragraph is trying to say, but it sounds like mobile web apps are inherently bad. We don't need to imply anything like that.
* Removed `Awkward` from one component example.
* Changed the example image from a silly animated gif to the React logo (boo, I'm boring, sue me).
* Renamed `SomethingFast` and `TheGreatestComponentInTheWorld` to a possible real world example.
* Changed the formatting to be in line with the project's source code (no spaces around curly braces).

Again, there is a ton more to be done here, I just wanna put some patches in place before overhauling everything in a bigger change.