### PR TITLE
Make FlatList reference link

### DIFF
--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than `FlatList` provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 


### PR DESCRIPTION
Noticed the FlatList in the previous section was a link but not the next reference. Made it a clickable link.
