### PR TITLE
Add warning about multiline centering the text on Android

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -437,7 +437,7 @@ Limits the maximum number of characters that can be entered. Use this instead of
 
 ### `multiline`
 
-If `true`, the text input can be multiple lines. The default value is `false`.
+If `true`, the text input can be multiple lines. The default value is `false`. It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.
 
 | Type | Required |
 | ---- | -------- |


### PR DESCRIPTION
React Native has this issue where when using a `TextInput` with `multiline` set as `true`, the text is aligned to the top on iOS and to the center on Android by default, which causes confusion, evidenced by the amount of likes in [this comment](https://github.com/facebook/react-native/issues/13897#issuecomment-300735822). I believe the `textAlignVertical` default should be changed when `multiline` is `true`, but since I don't know if there are any reasons the issue I linked was closed, I suggest this is at least documented.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
