### PR TITLE
Remove references to Nested Views

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -83,32 +83,6 @@ Behind the scenes, React Native converts this to a flat `NSAttributedString` or 
 9-17: bold, red
 ```
 
-## Nested views (iOS only)
-
-On iOS, you can nest views within your Text component. Here's an example:
-
-```ReactNativeWebPlayer
-import React, { Component } from 'react';
-import { AppRegistry, Text, View } from 'react-native';
-
-export default class BlueIsCool extends Component {
-  render() {
-    return (
-      <Text>
-        There is a blue square
-        <View style={{width: 50, height: 50, backgroundColor: 'steelblue'}} />
-        in between my text.
-      </Text>
-    );
-  }
-}
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => BlueIsCool);
-```
-
-> In order to use this feature, you must give the view a `width` and a `height`.
-
 ## Containers
 
 The `<Text>` element is special relative to layout: everything inside is no longer using the flexbox layout but using text layout. This means that elements inside of a `<Text>` are no longer rectangles, but wrap when they see the end of the line.


### PR DESCRIPTION
This feature was removed in 0.56 due to the decision of trying and aligning iOS and Android development.