### PR TITLE
Add Ignite CLI to Getting Started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -445,7 +445,7 @@ Use the React Native command line interface to generate a new React Native proje
 react-native init AwesomeProject
 ```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Create React Native App, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Create React Native App, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
 <block class="native mac windows linux android" />
 


### PR DESCRIPTION
My team is working on a proposal for making the Getting Started Guide more clear (right now, most people think the only way to use React Native is via Expo). In the meantime, I'd like to make this small addition.

With nearly 10k stars on Github, Ignite CLI has been the most popular third-party CLI to init React Native apps for three years now. So I'd like to add it to the Getting Started Guide.

