### PR TITLE
Update direct-manipulation.md

### DIFF
--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -191,7 +191,11 @@ Determines the location of the given view in the window and returns the values v
 
 Like `measure()`, but measures the view relative an ancestor, specified as `relativeToNativeNode`. This means that the returned x, y are relative to the origin x, y of the ancestor view.
 
-As always, to obtain a native node handle for a component, you can use `findNodeHandle(component)` (imported from `react-native`).
+As always, to obtain a native node handle for a component, you can use `findNodeHandle(component)`.
+
+```javascript
+import {findNodeHandle} from 'react-native';
+```
 
 ### focus()
 

--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -191,7 +191,7 @@ Determines the location of the given view in the window and returns the values v
 
 Like `measure()`, but measures the view relative an ancestor, specified as `relativeToNativeNode`. This means that the returned x, y are relative to the origin x, y of the ancestor view.
 
-As always, to obtain a native node handle for a component, you can use `ReactNative.findNodeHandle(component)`.
+As always, to obtain a native node handle for a component, you can use `findNodeHandle(component)` (imported from `react-native`).
 
 ### focus()
 


### PR DESCRIPTION
`findNodeHandle` is now directly imported from ReactNative as `import { findNodeHandle } from 'react-native'` instead of the static method.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
