### PR TITLE
Text/TextInput: Android now supports `maxFontSizeMultiplier` prop

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -389,9 +389,9 @@ Specifies largest possible scale a font can reach when `allowFontScaling` is ena
 * `0`: no max, ignore parent/global default
 * `>= 1`: sets the `maxFontSizeMultiplier` of this node to this value
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
 
 ---
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -419,9 +419,9 @@ Specifies largest possible scale a font can reach when `allowFontScaling` is ena
 * `0`: no max, ignore parent/global default
 * `>= 1`: sets the `maxFontSizeMultiplier` of this node to this value
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
 
 ---
 


### PR DESCRIPTION
Introduced by this commit: https://github.com/facebook/react-native/commit/4936d284df36071047ce776d9e2486c0371f7b97

Adam Comella
Microsoft Corp.