### PR TITLE
update Android SDK to 28 in docs

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -13,9 +13,9 @@ Assuming you have the Android SDK installed, run `android` to open the Android S
 
 Make sure you have the following installed:
 
-1. Android SDK version 26 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
-2. SDK build tools version 26.0.3 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
-3. Android Support Repository >= 26 (for Android Support Library)
+1. Android SDK version 28 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+2. SDK build tools version 28.0.3 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+3. Android Support Repository >= 28 (for Android Support Library)
 4. Android NDK (download links and installation instructions below)
 
 #### Point Gradle to your Android SDK:
@@ -32,7 +32,7 @@ Example:
 
 ```
 export ANDROID_SDK=/Users/your_unix_name/android-sdk-macosx
-export ANDROID_NDK=/Users/your_unix_name/android-ndk/android-ndk-r10e
+export ANDROID_NDK=/Users/your_unix_name/android-ndk/android-ndk-r17c
 ```
 
 **Step 2:** Create a `local.properties` file in the `android` directory of your react-native app with the following contents:
@@ -41,15 +41,15 @@ Example:
 
 ```
 sdk.dir=/Users/your_unix_name/android-sdk-macosx
-ndk.dir=/Users/your_unix_name/android-ndk/android-ndk-r17b
+ndk.dir=/Users/your_unix_name/android-ndk/android-ndk-r17c
 ```
 
 #### Download links for Android NDK
 
-1. Mac OS (64-bit) - http://dl.google.com/android/repository/android-ndk-r17b-darwin-x86_64.zip
-2. Linux (64-bit) - http://dl.google.com/android/repository/android-ndk-r17b-linux-x86_64.zip
-3. Windows (64-bit) - http://dl.google.com/android/repository/android-ndk-r17b-windows-x86_64.zip
-4. Windows (32-bit) - http://dl.google.com/android/repository/android-ndk-r17b-windows-x86.zip
+1. Mac OS (64-bit) - http://dl.google.com/android/repository/android-ndk-r17c-darwin-x86_64.zip
+2. Linux (64-bit) - http://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
+3. Windows (64-bit) - http://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip
+4. Windows (32-bit) - http://dl.google.com/android/repository/android-ndk-r17c-windows-x86.zip
 
 You can find further instructions on the [official page](https://developer.android.com/ndk/index.html).
 
@@ -72,8 +72,8 @@ Add `gradle-download-task` as dependency in `android/build.gradle`:
 ```gradle
 ...
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'de.undercouch:gradle-download-task:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'de.undercouch:gradle-download-task:3.4.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -328,7 +328,7 @@ Once setup has finalized and you're presented with the Welcome screen, proceed t
 
 #### 2. Install the Android SDK
 
-Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 8.1 (Oreo)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
+Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 9 (Pie)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 
 The SDK Manager can be accessed from the "Welcome to Android Studio" screen. Click on "Configure", then select "SDK Manager".
 
@@ -344,12 +344,12 @@ The SDK Manager can be accessed from the "Welcome to Android Studio" screen. Cli
 
 > The SDK Manager can also be found within the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
 
-Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 8.1 (Oreo)` entry, then make sure the following items are checked:
+Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 9 (Pie)` entry, then make sure the following items are checked:
 
-* `Android SDK Platform 27`
+* `Android SDK Platform 28`
 * `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `27.0.3` is selected.
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `28.0.3` is selected.
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
@@ -465,7 +465,7 @@ If you use Android Studio to open `./AwesomeProject/android`, you can see the li
 
 ![Android Studio AVD Manager](/react-native/docs/assets/GettingStartedAndroidStudioAVD.png)
 
-If you have just installed Android Studio, you will likely need to [create a new AVD](https://developer.android.com/studio/run/managing-avds.html). Select "Create Virtual Device...", then pick any Phone from the list and click "Next", then select the **Oreo** API Level 27 image.
+If you have just installed Android Studio, you will likely need to [create a new AVD](https://developer.android.com/studio/run/managing-avds.html). Select "Create Virtual Device...", then pick any Phone from the list and click "Next", then select the **Pie** API Level 28 image.
 
 <block class="native linux android" />
 

--- a/website/versioned_docs/version-0.5/building-from-source.md
+++ b/website/versioned_docs/version-0.5/building-from-source.md
@@ -14,9 +14,9 @@ Assuming you have the Android SDK installed, run `android` to open the Android S
 
 Make sure you have the following installed:
 
-1. Android SDK version 26 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
-2. SDK build tools version 26.0.3 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
-3. Android Support Repository >= 26 (for Android Support Library)
+1. Android SDK version 28 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+2. SDK build tools version 28.0.3 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+3. Android Support Repository 28 (for Android Support Library)
 4. Android NDK (download links and installation instructions below)
 
 #### Point Gradle to your Android SDK:
@@ -33,7 +33,7 @@ Example:
 
 ```
 export ANDROID_SDK=/Users/your_unix_name/android-sdk-macosx
-export ANDROID_NDK=/Users/your_unix_name/android-ndk/android-ndk-r10e
+export ANDROID_NDK=/Users/your_unix_name/android-ndk/android-ndk-r17c
 ```
 
 **Step 2:** Create a `local.properties` file in the `android` directory of your react-native app with the following contents:
@@ -42,15 +42,15 @@ Example:
 
 ```
 sdk.dir=/Users/your_unix_name/android-sdk-macosx
-ndk.dir=/Users/your_unix_name/android-ndk/android-ndk-r17b
+ndk.dir=/Users/your_unix_name/android-ndk/android-ndk-r17c
 ```
 
 #### Download links for Android NDK
 
-1. Mac OS (64-bit) - http://dl.google.com/android/repository/android-ndk-r17b-darwin-x86_64.zip
-2. Linux (64-bit) - http://dl.google.com/android/repository/android-ndk-r17b-linux-x86_64.zip
-3. Windows (64-bit) - http://dl.google.com/android/repository/android-ndk-r17b-windows-x86_64.zip
-4. Windows (32-bit) - http://dl.google.com/android/repository/android-ndk-r17b-windows-x86.zip
+1. Mac OS (64-bit) - http://dl.google.com/android/repository/android-ndk-r17c-darwin-x86_64.zip
+2. Linux (64-bit) - http://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
+3. Windows (64-bit) - http://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip
+4. Windows (32-bit) - http://dl.google.com/android/repository/android-ndk-r17c-windows-x86.zip
 
 You can find further instructions on the [official page](https://developer.android.com/ndk/index.html).
 
@@ -73,8 +73,8 @@ Add `gradle-download-task` as dependency in `android/build.gradle`:
 ```gradle
 ...
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'de.undercouch:gradle-download-task:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'de.undercouch:gradle-download-task:3.4.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/website/versioned_docs/version-0.5/getting-started.md
+++ b/website/versioned_docs/version-0.5/getting-started.md
@@ -329,7 +329,7 @@ Once setup has finalized and you're presented with the Welcome screen, proceed t
 
 #### 2. Install the Android SDK
 
-Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 8.1 (Oreo)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
+Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 9 (Pie)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 
 The SDK Manager can be accessed from the "Welcome to Android Studio" screen. Click on "Configure", then select "SDK Manager".
 
@@ -345,12 +345,12 @@ The SDK Manager can be accessed from the "Welcome to Android Studio" screen. Cli
 
 > The SDK Manager can also be found within the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
 
-Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 8.1 (Oreo)` entry, then make sure the following items are checked:
+Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 9 (Pie)` entry, then make sure the following items are checked:
 
-* `Android SDK Platform 27`
+* `Android SDK Platform 28`
 * `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `27.0.3` is selected.
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `28.0.3` is selected.
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
@@ -466,7 +466,7 @@ If you use Android Studio to open `./AwesomeProject/android`, you can see the li
 
 ![Android Studio AVD Manager](/react-native/docs/assets/GettingStartedAndroidStudioAVD.png)
 
-If you have just installed Android Studio, you will likely need to [create a new AVD](https://developer.android.com/studio/run/managing-avds.html). Select "Create Virtual Device...", then pick any Phone from the list and click "Next", then select the **Oreo** API Level 27 image.
+If you have just installed Android Studio, you will likely need to [create a new AVD](https://developer.android.com/studio/run/managing-avds.html). Select "Create Virtual Device...", then pick any Phone from the list and click "Next", then select the **Pie** API Level 28 image.
 
 <block class="native linux android" />
 


### PR DESCRIPTION
In RN 0.58, we use Android SDK 28, NDK 17c and build tools 28.0.3. This corrects tools version in the doc.