### PR TITLE
Change wording to improve sentence

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,7 +140,7 @@ If you're curious to learn more about React Native, continue on to the [Tutorial
 
 ### Running your app on a simulator or virtual device
 
-Expo CLI makes it really easy to run your React Native app on a physical device without setting up a development environment. If you want to run your app on the iOS Simulator or an Android Virtual Device, please refer to the instructions for building projects with native code to learn how to install Xcode and set up your Android development environment.
+Expo CLI makes it really easy to run your React Native app on a physical device without setting up a development environment. If you want to run your app on the iOS Simulator or an Android Virtual Device, please refer to the instructions for building projects with native code to learn how to install Xcode or set up your Android development environment.
 
 Once you've set these up, you can launch your app on an Android Virtual Device by running `npm run android`, or on the iOS Simulator by running `npm run ios` (macOS only).
 


### PR DESCRIPTION
This is a trivial change, it just changes the wording of a sentence because I, subjectively, believe that it conveys better it's meaning that way.
Rationale: the way I read `install Xcode and set up your Android development environment.` is that it's giving instructions in a sequential way, that is, telling the user to install Xcode and, after that, set up the Android dev environment. Of course, after the initial confusion, anybody will be able to tell that such an interpretation is not right and the problem will be solved, but if that initial confusion could be avoided by making the sentence clearer (using "or" instead of "and") I think it'd be great.

This change is a totally subjective nitpick, so if the maintainers disagree with it you can just close the PR.
