### PR TITLE
update to rn-diff-purge

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -119,7 +119,7 @@ $ npm install --save react@R
 
 The new npm package may contain updates to the files that are normally generated when you run `react-native init`, like the iOS and the Android sub-projects.
 
-You may consult [rn-diff](https://github.com/ncuillery/rn-diff) to see if there were changes in the project template files. In case there weren't any, simply rebuild the project and continue developing. In case of minor changes, you may update your project manually and rebuild.
+You may consult [rn-diff-purge](https://github.com/pvinis/rn-diff-purge) to see if there were changes in the project template files. In case there weren't any, simply rebuild the project and continue developing. In case of minor changes, you may update your project manually and rebuild.
 
 If there were major changes, run this in a terminal to get these:
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This guide points to rn-diff which is not very active, and uses `git-upgrade` which doesn't show
> changes in the project template files

at all.

[rn-diff-purge](https://github.com/pvinis/rn-diff-purge) is kept up to date, it's much much easier to keep going, as it's literally purging the old version, making a new one and then diffing them. This way people can see the actual changes in the template.

Some more info [here](https://github.com/react-native-community/discussions-and-proposals/issues/68#issuecomment-452227478) if needed.
