### PR TITLE
Add Ignite CLI to iOS section too

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -433,7 +433,7 @@ Use the React Native command line interface to generate a new React Native proje
 react-native init AwesomeProject
 ```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo (or Create React Native App), or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo (or Create React Native App), or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
 <block class="native mac windows linux android" />
 


### PR DESCRIPTION
Following up on #749, I missed a section. This adds it there too.

cc @charpeni 