### PR TITLE
Node version requirement made more prevalent

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ This page will help you install and build your first React Native app. If you al
 
 [Expo](https://expo.io) is the easiest way to start building a new React Native application. It allows you to start a project without installing or configuring any tools to build native code - no Xcode or Android Studio installation required (see [Caveats](getting-started.md#caveats)).
 
-Assuming that you have [Node](https://nodejs.org/en/download/) installed, you can use npm to install the Expo CLI command line utility:
+Assuming that you have [Node 8+](https://nodejs.org/en/download/) installed, you can use npm to install the Expo CLI command line utility:
 
 ```sh
 npm install -g expo-cli


### PR DESCRIPTION
Reading the first page of https://facebook.github.io/react-native/docs/getting-started.html, it is not clear that the node version needs to be 8+. Just adding this here to help others with installation, specially those of us who already have node running and need to upgrade.