### PR TITLE
add command to start server for running app section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,8 +133,8 @@ Expo also has [docs](https://docs.expo.io) you can reference if you have questio
 
 If you have a problem with Expo, before creating a new issue, please see if there's an existing issue about it:
 
-* in the [Expo CLI issues](https://github.com/expo/expo-cli/issues) (for issues related to Expo CLI), or
-* in the [Expo issues](https://github.com/expo/expo/issues) (for issues about the Expo client or SDK).
+- in the [Expo CLI issues](https://github.com/expo/expo-cli/issues) (for issues related to Expo CLI), or
+- in the [Expo issues](https://github.com/expo/expo/issues) (for issues about the Expo client or SDK).
 
 If you're curious to learn more about React Native, continue on to the [Tutorial](tutorial.md).
 
@@ -307,16 +307,16 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 <block class="native mac windows android" />
 
-* `Android SDK`
-* `Android SDK Platform`
-* `Performance (Intel ® HAXM)` ([See here for AMD](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
-* `Android Virtual Device`
+- `Android SDK`
+- `Android SDK Platform`
+- `Performance (Intel ® HAXM)` ([See here for AMD](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
+- `Android Virtual Device`
 
 <block class="native linux android" />
 
-* `Android SDK`
-* `Android SDK Platform`
-* `Android Virtual Device`
+- `Android SDK`
+- `Android SDK Platform`
+- `Android Virtual Device`
 
 <block class="native mac windows linux android" />
 
@@ -346,8 +346,8 @@ The SDK Manager can be accessed from the "Welcome to Android Studio" screen. Cli
 
 Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 9 (Pie)` entry, then make sure the following items are checked:
 
-* `Android SDK Platform 28`
-* `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
+- `Android SDK Platform 28`
+- `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
 
 Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `28.0.3` is selected.
 
@@ -487,6 +487,17 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 ## Running your React Native application
 
+First you need to run your react-native server
+
+Run `yarn start` inside your React Native project to run your react-native server:
+
+```
+cd AwesomeProject
+yarn start
+```
+
+Then you need to install your react-native app to your device
+
 Run `react-native run-ios` inside your React Native project folder:
 
 ```
@@ -509,6 +520,17 @@ The above command will automatically run your app on the iOS Simulator by defaul
 <block class="native mac windows linux android" />
 
 ## Running your React Native application
+
+First you need to run your react-native server
+
+Run `yarn start` inside your React Native project to run your react-native server:
+
+```
+cd AwesomeProject
+yarn start
+```
+
+Then you need to install your react-native app to your device
 
 Run `react-native run-android` inside your React Native project folder:
 
@@ -541,13 +563,13 @@ Now that you have successfully run the app, let's modify it.
 
 <block class="native mac ios" />
 
-* Open `App.js` in your text editor of choice and edit some lines.
-* Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
+- Open `App.js` in your text editor of choice and edit some lines.
+- Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
 
 <block class="native mac android" />
 
-* Open `App.js` in your text editor of choice and edit some lines.
-* Press the `R` key twice or select `Reload` from the Developer Menu (`⌘M`) to see your changes!
+- Open `App.js` in your text editor of choice and edit some lines.
+- Press the `R` key twice or select `Reload` from the Developer Menu (`⌘M`) to see your changes!
 
 <block class="native windows linux android" />
 
@@ -555,8 +577,8 @@ Now that you have successfully run the app, let's modify it.
 
 Now that you have successfully run the app, let's modify it.
 
-* Open `App.js` in your text editor of choice and edit some lines.
-* Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
+- Open `App.js` in your text editor of choice and edit some lines.
+- Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
 <block class="native mac ios android" />
 
@@ -578,9 +600,9 @@ Congratulations! You've successfully run and modified your first React Native ap
 
 ## Now what?
 
-* Turn on [Live Reload](debugging.md#reloading-javascript) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
+- Turn on [Live Reload](debugging.md#reloading-javascript) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
 
-* If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
+- If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
 If you're curious to learn more about React Native, continue on to the [Tutorial](tutorial.md).
 
@@ -588,9 +610,9 @@ If you're curious to learn more about React Native, continue on to the [Tutorial
 
 ## Now what?
 
-* Turn on [Live Reload](debugging.md#reloading-javascript) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
+- Turn on [Live Reload](debugging.md#reloading-javascript) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
 
-* If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
+- If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
 If you're curious to learn more about React Native, continue on to the [Tutorial](tutorial.md).
 

--- a/website/versioned_docs/version-0.5/getting-started.md
+++ b/website/versioned_docs/version-0.5/getting-started.md
@@ -488,6 +488,17 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 ## Running your React Native application
 
+First you need to run your react-native server
+
+Run `yarn start` inside your React Native project to run your react-native server:
+
+```
+cd AwesomeProject
+yarn start
+```
+
+Then you need to install your react-native app to your device
+
 Run `react-native run-ios` inside your React Native project folder:
 
 ```
@@ -510,6 +521,17 @@ The above command will automatically run your app on the iOS Simulator by defaul
 <block class="native mac windows linux android" />
 
 ## Running your React Native application
+
+First you need to run your react-native server
+
+Run `yarn start` inside your React Native project to run your react-native server:
+
+```
+cd AwesomeProject
+yarn start
+```
+
+Then you need to install your react-native app to your device
 
 Run `react-native run-android` inside your React Native project folder:
 


### PR DESCRIPTION
add step to run react-native server before installing the app 

idk but there is no step/command to run the server, it could confuse some people especially if they jump straight to react-native environment