### PR TITLE
Explicitly state that `activeOpacity` requires `underlayColor`

### DIFF
--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -110,7 +110,7 @@ AppRegistry.registerComponent('App', () => App)
 
 ### `activeOpacity`
 
-Determines what the opacity of the wrapped view should be when touch is active. The value should be between 0 and 1. Defaults to 0.85.
+Determines what the opacity of the wrapped view should be when touch is active. The value should be between 0 and 1. Defaults to 0.85.  Requires `underlayColor` to be set.
 
 | Type   | Required |
 | ------ | -------- |

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -110,7 +110,7 @@ AppRegistry.registerComponent('App', () => App)
 
 ### `activeOpacity`
 
-Determines what the opacity of the wrapped view should be when touch is active. The value should be between 0 and 1. Defaults to 0.85.  Requires `underlayColor` to be set.
+Determines what the opacity of the wrapped view should be when touch is active. The value should be between 0 and 1. Defaults to 0.85. Requires `underlayColor` to be set.
 
 | Type   | Required |
 | ------ | -------- |


### PR DESCRIPTION
It's clear from https://github.com/facebook/react-native/issues/11834 that the underlying issue won't be fixed, so we should update the documentation so people understand that for `activeOpacity` to work they need to set `underlayColor`.