### PR TITLE
Remove absoluteFillObject link

### DIFF
--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -47,7 +47,6 @@ Code quality:
 
 * [`hairlineWidth`](stylesheet.md#hairlinewidth)
 * [`absoluteFill`](stylesheet.md#absolutefill)
-* [`absoluteFillObject`](stylesheet.md#absolutefillobject)
 
 ---
 


### PR DESCRIPTION
Forgot to remove that in my last PR. https://github.com/facebook/react-native-website/commit/5dd1bf4df7bf4b5bab6aa94d43017a4b589e06fe
