### PR TITLE
Testing page detox

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@ Whenever you are fixing a bug or adding new functionality to React Native, you s
 * [Android](testing.md#android)
 * [iOS](testing.md#ios)
 * [Apple TV](testing.md#apple-tv)
-* [End-to-end tests](testing.md#end-to-end-tests)
+* [Manual end-to-end tests](testing.md#manual-end-to-end-tests)
 * [Updating the Documentation](testing.md#updating-the-documentation)
 
 ## JavaScript
@@ -128,9 +128,9 @@ You can run Apple TV unit and integration tests locally by running the following
     $ cd react-native
     $ ./scripts/objc-test-tvos.sh (make sure the line `TEST="test"` is uncommented)
 
-## End-to-end tests
+## Manual end-to-end tests
 
-Finally, make sure end-to-end tests run successfully by executing the following script:
+Finally, make sure manual end-to-end tests run successfully by executing the following script:
 
     $ cd react-native
     $ ./scripts/test-manual-e2e.sh

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,6 +107,18 @@ A common type of integration test is the snapshot test. These tests render a com
 
 If you make a change that affects a snapshot test in a PR, such as adding a new example case to one of the examples that is snapshotted, you'll need to re-record the snapshot reference image. To do this, simply change to `_runner.recordMode = YES;` in [RNTester/RNTesterSnapshotTests.m](https://github.com/facebook/react-native/blob/master/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m#L42), re-run the failing tests, then flip record back to `NO` and submit/update your PR and wait to see if the Circle build passes.
 
+### Automated End-to-End Tests
+
+End-to-end tests written in Detox confirm that React Native components and APIs function correctly in the context of a running app. They run the RNTester app in the simulator and simulate a user interacting with the app.
+
+You can run Detox end-to-end tests locally by [installing the Detox CLI](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md#step-1-install-dependencies) on macOS, then running the following in the command line:
+
+    $ cd react-native
+    $ npm run build-ios-e2e
+    $ npm run test-ios-e2e
+
+If you work on a component or API that isn't convered by a Detox test, please consider adding one. Detox tests are stored under `RNTester/e2e/__tests__`.
+
 ## Apple TV
 
 The same tests discussed above for iOS will also run on tvOS. In the RNTester Xcode project, select the RNTester-tvOS target, and you can follow the same steps above to run the tests in Xcode.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,7 +117,7 @@ You can run Detox end-to-end tests locally by [installing the Detox CLI](https:/
     $ npm run build-ios-e2e
     $ npm run test-ios-e2e
 
-If you work on a component or API that isn't convered by a Detox test, please consider adding one. Detox tests are stored under `RNTester/e2e/__tests__`.
+If you work on a component or API that isn't convered by a Detox test, please consider adding one. Detox tests are stored under [`RNTester/e2e/__tests__`](https://github.com/facebook/react-native/tree/master/RNTester/e2e/__tests__).
 
 ## Apple TV
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,7 +109,7 @@ If you make a change that affects a snapshot test in a PR, such as adding a new 
 
 ### Automated End-to-End Tests
 
-End-to-end tests written in Detox confirm that React Native components and APIs function correctly in the context of a running app. They run the RNTester app in the simulator and simulate a user interacting with the app.
+End-to-end tests written in [Detox](https://github.com/wix/Detox) confirm that React Native components and APIs function correctly in the context of a running app. They run the RNTester app in the simulator and simulate a user interacting with the app.
 
 You can run Detox end-to-end tests locally by [installing the Detox CLI](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md#step-1-install-dependencies) on macOS, then running the following in the command line:
 


### PR DESCRIPTION
Adds information about Detox end-to-end tests to the "Contributing > Testing your Changes" page.

This makes it easier for contributors to understand the role Detox tests play, encourages them to add additional tests, and will serve as a linking point for more thorough "how to add Detox tests" content to be added soon.