### PR TITLE
Update keytool parameter in signed-apk-android.md

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -9,7 +9,7 @@ Android requires that all apps be digitally signed with a certificate before the
 
 You can generate a private signing key using `keytool`. On Windows `keytool` must be run from `C:\Program Files\Java\jdkx.x.x_x\bin`.
 
-    $ keytool -genkey -v -keystore my-release-key.keystore -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
+    $ keytool -genkeypair -v -keystore my-release-key.keystore -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
 
 This command prompts you for passwords for the keystore and key and for the Distinguished Name fields for your key. It then generates the keystore as a file called `my-release-key.keystore`.
 


### PR DESCRIPTION
The `-genkey` parameter for `keytool` is deprecated, `-genkeypair` is preferred according to the [keytool docs](https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html#genkeypairCmd).

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
