### PR TITLE
Add entry for new iOS TextInput prop rejectResponderTermination

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -134,6 +134,7 @@ Note that on Android performing text selection in input can change app's activit
 - [`placeholderTextColor`](textinput.md#placeholdertextcolor)
 - [`returnKeyLabel`](textinput.md#returnkeylabel)
 - [`returnKeyType`](textinput.md#returnkeytype)
+- [`rejectResponderTermination`](textinput.md#rejectResponderTermination)
 - [`scrollEnabled`](textinput.md#scrollenabled)
 - [`secureTextEntry`](textinput.md#securetextentry)
 - [`selection`](textinput.md#selection)
@@ -651,6 +652,18 @@ The following values work on iOS only:
 | Type                                                                                                                              | Required |
 | --------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') | No       |
+
+### `rejectResponderTermination`
+
+Determines how the return key should look. On Android you can also use `returnKeyLabel`.
+
+_iOS Only_
+
+If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
 
 ---
 

--- a/website/versioned_docs/version-0.59/textinput.md
+++ b/website/versioned_docs/version-0.59/textinput.md
@@ -135,6 +135,7 @@ Note that on Android performing text selection in input can change app's activit
 - [`placeholderTextColor`](textinput.md#placeholdertextcolor)
 - [`returnKeyLabel`](textinput.md#returnkeylabel)
 - [`returnKeyType`](textinput.md#returnkeytype)
+- [`rejectResponderTermination`](textinput.md#rejectResponderTermination)
 - [`scrollEnabled`](textinput.md#scrollenabled)
 - [`secureTextEntry`](textinput.md#securetextentry)
 - [`selection`](textinput.md#selection)
@@ -652,6 +653,18 @@ The following values work on iOS only:
 | Type                                                                                                                              | Required |
 | --------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') | No       |
+
+### `rejectResponderTermination`
+
+Determines how the return key should look. On Android you can also use `returnKeyLabel`.
+
+_iOS Only_
+
+If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
 
 ---
 


### PR DESCRIPTION
[A PR in 0.59](https://github.com/facebook/react-native/commit/11df0ea) introduces TextInput prop rejectResponderTermination for iOS; this PR adds the missing docs.

Looks like my format on save also struck and changed a few lines in a table.