### PR TITLE
Fix compilation warning for mismatched param types

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -73,8 +73,8 @@ If you're targeting iOS 8.x or older, you can use the following code instead:
 If your app is using [Universal Links](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html), you'll need to add the following code as well:
 
 ```objectivec
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
- restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity
+ restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
 {
  return [RCTLinkingManager application:application
                   continueUserActivity:userActivity


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

## What this does
When I copied this example code into my AppDelegate.m:
```
- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
 restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
{
 return [RCTLinkingManager application:application
                  continueUserActivity:userActivity
                    restorationHandler:restorationHandler];
}
```

I got the following warning when compiling my project:
```
⚠️  /my/file/ios/Project/AppDelegate.m:72:152: conflicting parameter types in implementation of 'application:continueUserActivity:restorationHandler:': 'void (^ _Nonnull __strong)(NSArray<id<UIUserActivityRestoring>> * _Nullable __strong)' vs 'void (^__strong _Nonnull)(NSArray * _Nullable __strong)' [-Wmismatched-parameter-types]

- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
                                                                                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```

So instead of the signature used in the docs, I just used the autofill value that Xcode selects if you type `continueUserActivity`  in AppDelegate.m and press enter.

You can also verify that this new version better matches Apple's doc by visiting their page [here](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application?language=objc).

## How I tested it
I confirmed that the warning went away.

## That's it
Thanks for taking a look!