### PR TITLE
Replace bash profile to bashrc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,7 +359,7 @@ The React Native tools require some environment variables to be set up in order 
 
 <block class="native mac linux android" />
 
-Add the following lines to your `$HOME/.bashrc` config file:
+Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` config file:
 
 <block class="native mac android" />
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -359,7 +359,7 @@ The React Native tools require some environment variables to be set up in order 
 
 <block class="native mac linux android" />
 
-Add the following lines to your `$HOME/.bash_profile` config file:
+Add the following lines to your `$HOME/.bashrc` config file:
 
 <block class="native mac android" />
 


### PR DESCRIPTION
On my machine with Manjaro Linux 18.0.3 bash profile doesn't work, but .bashrc works.
Bash version: 5.0.0(1) release
uname:
Linux marat-pc 4.19.23-1-MANJARO