### PR TITLE
[0.59][Blog] Add missing contributors to attribution list for JSC changes

### DIFF
--- a/website/blog/2019-03-12-releasing-react-native-059.md
+++ b/website/blog/2019-03-12-releasing-react-native-059.md
@@ -26,7 +26,7 @@ Be sure to give this a try in your apps. We hope that you find the reuse as exci
 
 React Native uses JSC ([JavaScriptCore](https://webkit.org/)) to power your application. JSC on Android was a few years old, which meant that a lot of modern JavaScript features weren't supported. Even worse, it performed poorly compared iOS's modern JSC. With this release, that all changes.
 
-Thanks to some awesome work by [@DanielZlotin](https://github.com/danielzlotin), JSC has caught up with the past few years. This brings with it 64-bit support, modern JavaScript support, and [big performance improvements](https://github.com/react-native-community/jsc-android-buildscripts/tree/master/measure). Kudos to Daniel for also making this a maintainable process now so that we can take advantage of future WebKit improvements without so much legwork.
+Thanks to some awesome work by [@DanielZlotin](https://github.com/danielzlotin), [@dulmandakh](https://github.com/dulmandakh), [@gengjiawen](https://github.com/gengjiawen), [@kmagiera](https://github.com/kmagiera), and [@kudo](https://github.com/kudo) JSC has caught up with the past few years. This brings with it 64-bit support, modern JavaScript support, and [big performance improvements](https://github.com/react-native-community/jsc-android-buildscripts/tree/master/measure). Kudos for also making this a maintainable process now so that we can take advantage of future WebKit improvements without so much legwork, and thank you Software Mansion and Expo for making this work possible.
 
 ## 💨 Faster app launches with inline requires
 


### PR DESCRIPTION
The JSC changes in the 0.59 blogpost had an incomplete contributors list. There are a lot of folks who put in work over a multi-year timespan that I missed. This PR adds those missing parties based off of discussions with those involved and research I did.