### PR TITLE
Replaced "compile" to "implementation"

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -79,17 +79,17 @@ You will need to add some optional modules in `android/app/build.gradle`, depend
 ```gradle
 dependencies {
   // If your app supports Android versions before Ice Cream Sandwich (API level 14)
-  compile 'com.facebook.fresco:animated-base-support:1.10.0'
+  implementation 'com.facebook.fresco:animated-base-support:1.10.0'
 
   // For animated GIF support
-  compile 'com.facebook.fresco:animated-gif:1.10.0'
+  implementation 'com.facebook.fresco:animated-gif:1.10.0'
 
   // For WebP support, including animated WebP
-  compile 'com.facebook.fresco:animated-webp:1.10.0'
-  compile 'com.facebook.fresco:webpsupport:1.10.0'
+  implementation 'com.facebook.fresco:animated-webp:1.10.0'
+  implementation 'com.facebook.fresco:webpsupport:1.10.0'
 
   // For WebP support, without animations
-  compile 'com.facebook.fresco:webpsupport:1.10.0'
+  implementation 'com.facebook.fresco:webpsupport:1.10.0'
 }
 ```
 


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html