### PR TITLE
Fix registerCancellableHeadlessTask description

### DIFF
--- a/docs/appregistry.md
+++ b/docs/appregistry.md
@@ -166,7 +166,7 @@ Register a headless task. A headless task is a bit of code that runs without a U
 static registerCancellableHeadlessTask(taskKey, taskProvider, taskCancelProvider)
 ```
 
-## Register a headless task which can be cancelled. A headless task is a bit of code that runs without a UI. @param taskKey the key associated with this task @param taskProvider a promise returning function that takes some data passed from the native side as the only argument; when the promise is resolved or rejected the native side is notified of this event and it may decide to destroy the JS context. @param taskCancelProvider a void returning function that takes no arguments; when a cancellation is requested, the function being executed by taskProvider should wrap up and return ASAP.
+Register a headless task which can be cancelled. A headless task is a bit of code that runs without a UI. @param taskKey the key associated with this task @param taskProvider a promise returning function that takes some data passed from the native side as the only argument; when the promise is resolved or rejected the native side is notified of this event and it may decide to destroy the JS context. @param taskCancelProvider a void returning function that takes no arguments; when a cancellation is requested, the function being executed by taskProvider should wrap up and return ASAP.
 
 ### `startHeadlessTask()`
 


### PR DESCRIPTION
Fix `registerCancellableHeadlessTask` description formatting from `h2` to regular text
