### PR TITLE
Add 'Optional Chaining' to list of JS transformations

### DIFF
--- a/docs/javascript-environment.md
+++ b/docs/javascript-environment.md
@@ -26,33 +26,37 @@ ES5
 
 ES6
 
-* [Arrow functions](http://babeljs.io/docs/learn-es2015/#arrows): `<C onPress={() => this.setState({pressed: true})}`
+* [Arrow functions](http://babeljs.io/docs/learn-es2015/#arrows): `<C onPress={() => this.setState({pressed: true})} />`
 * [Block scoping](https://babeljs.io/docs/learn-es2015/#let-const): `let greeting = 'hi';`
 * [Call spread](http://babeljs.io/docs/learn-es2015/#default-rest-spread): `Math.max(...array);`
 * [Classes](http://babeljs.io/docs/learn-es2015/#classes): `class C extends React.Component { render() { return <View />; } }`
 * [Constants](https://babeljs.io/docs/learn-es2015/#let-const): `const answer = 42;`
 * [Destructuring](http://babeljs.io/docs/learn-es2015/#destructuring): `var {isActive, style} = this.props;`
-* [for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of): `for (var num of [1, 2, 3]) {}`
+* [for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of): `for (var num of [1, 2, 3]) {};`
 * [Modules](http://babeljs.io/docs/learn-es2015/#modules): `import React, { Component } from 'react';`
 * [Computed Properties](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals): `var key = 'abc'; var obj = {[key]: 10};`
 * [Object Concise Method](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals): `var obj = { method() { return 10; } };`
 * [Object Short Notation](http://babeljs.io/docs/learn-es2015/#enhanced-object-literals): `var name = 'vjeux'; var obj = { name };`
-* [Rest Params](https://github.com/sebmarkbage/ecmascript-rest-spread): `function(type, ...args) { }`
+* [Rest Params](https://github.com/sebmarkbage/ecmascript-rest-spread): `function(type, ...args) {};`
 * [Template Literals](http://babeljs.io/docs/learn-es2015/#template-strings): `` var who = 'world'; var str = `Hello ${who}`; ``
 
 ES8
 
-* [Function Trailing Comma](https://github.com/jeffmo/es-trailing-function-commas): `function f(a, b, c,) { }`
-* [Async Functions](https://github.com/tc39/ecmascript-asyncawait): `async function doStuffAsync() { const foo = await doOtherStuffAsync(); }`;
+* [Function Trailing Comma](https://github.com/jeffmo/es-trailing-function-commas): `function f(a, b, c,) {};`
+* [Async Functions](https://github.com/tc39/ecmascript-asyncawait): `async function doStuffAsync() { const foo = await doOtherStuffAsync(); };`
 
 Stage 3
 
 * [Object Spread](https://github.com/sebmarkbage/ecmascript-rest-spread): `var extended = { ...obj, a: 10 };`
 
+Stage 1
+
+* [Optional Chaining](https://github.com/tc39/proposal-optional-chaining): `var name = obj.user?.name;`
+
 Specific
 
 * [JSX](https://reactjs.org/docs/jsx-in-depth.html): `<View style={{color: 'red'}} />`
-* [Flow](http://flowtype.org/): `function foo(x: ?number): string {}`
+* [Flow](http://flowtype.org/): `function foo(x: ?number): string {};`
 
 ## Polyfills
 


### PR DESCRIPTION
`metro-react-native-babel-preset` includes 'Optional Chaining' proposal so I thought that this is interesting enough feature to highlight it on the list of available JS transformations in RN environment.  

I have also introduced few small changes to examples just to make them consistent in code style.