### PR TITLE
Add deprecation notice to NetInfo

### DIFF
--- a/docs/netinfo.md
+++ b/docs/netinfo.md
@@ -3,6 +3,8 @@ id: netinfo
 title: NetInfo
 ---
 
+NOTE: `NetInfo` is being deprecated. Use [react-native-community/react-native-netinfo](https://github.com/react-native-community/react-native-netinfo) instead.
+
 NetInfo exposes info about online/offline status
 
 ```javascript


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

I think it would be helpful to mention that NetInfo is deprecated since v0.59.
