### PR TITLE
Update native-components-ios.md

### DIFF
--- a/docs/native-components-ios.md
+++ b/docs/native-components-ios.md
@@ -52,7 +52,7 @@ Then you just need a little bit of JavaScript to make this a usable React compon
 import { requireNativeComponent } from 'react-native';
 
 // requireNativeComponent automatically resolves 'RNTMap' to 'RNTMapManager'
-module.exports = requireNativeComponent('RNTMap', null);
+module.exports = requireNativeComponent('RNTMap');
 
 // MyApp.js
 


### PR DESCRIPTION
The sample code here produces a Flow error because `requireNativeComponent` now only takes one argument. Here's an example of that error from another codebase:

![Flow error](https://user-images.githubusercontent.com/73652/54565891-52eb9080-49c7-11e9-8be2-c24fde1634b8.png)

This PR fixes this error.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
