### PR TITLE
fix: get rid of View Style Props for Text

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -375,8 +375,6 @@ Specifies largest possible scale a font can reach when `allowFontScaling` is ena
 | ----- | -------- |
 | style | No       |
 
-* [View Style Props...](view-style-props.md#style)
-
 * **`textShadowOffset`**: object: {width: number,height: number}
 
 * **`color`**: [color](colors.md)

--- a/website/versioned_docs/version-0.59/text.md
+++ b/website/versioned_docs/version-0.59/text.md
@@ -376,8 +376,6 @@ Specifies largest possible scale a font can reach when `allowFontScaling` is ena
 | ----- | -------- |
 | style | No       |
 
-* [View Style Props...](view-style-props.md#style)
-
 * **`textShadowOffset`**: object: {width: number,height: number}
 
 * **`color`**: [color](colors.md)


### PR DESCRIPTION
## Summary

`Text` doesn't support View Style Props according to Flow types: https://github.com/facebook/react-native/blob/0.59-stable/Libraries/Text/TextProps.js