### PR TITLE
Render example correctly on iPhone

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -47,7 +47,7 @@ class Greeting extends Component {
 export default class LotsOfGreetings extends Component {
   render() {
     return (
-      <View style={{alignItems: 'center'}}>
+      <View style={{alignItems: 'center', top: 50}}>
         <Greeting name='Rexxar' />
         <Greeting name='Jaina' />
         <Greeting name='Valeera' />


### PR DESCRIPTION
Due to the full bleed on iPhone X, the top gets completely cut off in this example. Setting the view 50 from the top makes all of the greetings visible.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
