### PR TITLE
Remove references to outdated lifecycle hooks

### DIFF
--- a/docs/communication-android.md
+++ b/docs/communication-android.md
@@ -72,7 +72,7 @@ It is fine to update properties anytime. However, updates have to be performed o
 
 There is no way to update only a few properties at a time. We suggest that you build it into your own wrapper instead.
 
-> **_Note:_** Currently, JS functions `componentWillReceiveProps` and `componentWillUpdateProps` of the top level RN component will not be called after a prop update. However, you can access the new props in `componentWillMount` function.
+> **_Note:_** Currently, JS function `componentWillUpdateProps` of the top level RN component will not be called after a prop update. However, you can access the new props in `componentDidMount` function.
 
 ### Passing properties from React Native to native
 

--- a/docs/communication-ios.md
+++ b/docs/communication-ios.md
@@ -63,7 +63,7 @@ It is fine to update properties anytime. However, updates have to be performed o
 
 There is no way to update only a few properties at a time. We suggest that you build it into your own wrapper instead.
 
-> **_Note:_** Currently, JS functions `componentWillReceiveProps` and `componentWillUpdateProps` of the top level RN component will not be called after a prop update. However, you can access the new props in `componentWillMount` function.
+> **_Note:_** Currently, JS function `componentWillUpdateProps` of the top level RN component will not be called after a prop update. However, you can access the new props in `componentDidMount` function.
 
 ### Passing properties from React Native to native
 

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -322,7 +322,7 @@ var ScrollResponderMixin = {
   mixins: [Subscribable.Mixin],
 
 
-  componentWillMount: function() {
+  componentDidMount() {
     ...
     this.addListenerOn(DeviceEventEmitter,
                        'keyboardWillShow',
@@ -339,7 +339,7 @@ You can also directly use the `DeviceEventEmitter` module to listen for events.
 
 ```javascript
 ...
-componentWillMount: function() {
+componentDidMount() {
   DeviceEventEmitter.addListener('keyboardWillShow', function(e: Event) {
     // handle event.
   });


### PR DESCRIPTION
Related to #844 
> Updated occurences of outdated lifecycle methods like `componentWillMount` to `componentDidMount`