### PR TITLE
Fix: accessibilityLabel is a string

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -325,9 +325,9 @@ More details about `resize` and `scale` can be found at http://frescolib.org/doc
 
 The text that's read by the screen reader when the user interacts with the image.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| node | No       | iOS      |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | iOS      |
 
 ---
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -240,9 +240,9 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Overrides the text that's read by the screen reader when the user interacts with the element. By default, the label is constructed by traversing all the children and accumulating all the `Text` nodes separated by space.
 
-| Type | Required |
-| ---- | -------- |
-| node | No       |
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 ---
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -65,9 +65,9 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Overrides the text that's read by the screen reader when the user interacts with the element. By default, the label is constructed by traversing all the children and accumulating all the `Text` nodes separated by space.
 
-| Type | Required |
-| ---- | -------- |
-| node | No       |
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -115,9 +115,9 @@ An accessibility hint helps users understand what will happen when they perform 
 
 Overrides the text that's read by the screen reader when the user interacts with the element. By default, the label is constructed by traversing all the children and accumulating all the `Text` nodes separated by space.
 
-| Type | Required |
-| ---- | -------- |
-| node | No       |
+| Type   | Required |
+| ------ | -------- |
+| string | No       |
 
 ---
 


### PR DESCRIPTION
I noticed RN docs mention type "node" in most place (except button, why? no idea).
But in practise, it seems codebase has this typed as string, see https://github.com/facebook/react-native/search?p=2&q=accessibilitylabel&unscoped_q=accessibilitylabel
You can notice that ios & android implementation explicitly use string (same for the (react-native-)web).
The only place we see node in the codebase, is in the deprecated props, see https://github.com/facebook/react-native/blob/408207b356849ca3cefad0ce91a3889e73bd8682/Libraries/DeprecatedPropTypes/DeprecatedImagePropType.js#L34