### PR TITLE
requestAnimationFrame polyfill now in global scope

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -91,9 +91,7 @@ Sometimes, if we do an action in the same frame that we are adjusting the opacit
 
 ```javascript
 handleOnPress() {
-  // Always use TimerMixin with requestAnimationFrame, setTimeout and
-  // setInterval
-  this.requestAnimationFrame(() => {
+  requestAnimationFrame(() => {
     this.doExpensiveAction();
   });
 }


### PR DESCRIPTION
rAF is not available via TimerMixin anymore. It's polyfilled into the global scope and the documentation needs to reflect that.