### PR TITLE
fixes to sectionlist docs

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -178,7 +178,7 @@ A marker property for telling the list to re-render (since it implements `PureCo
 
 ### `ItemSeparatorComponent`
 
-Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Separator]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
+Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Section]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
 
 | Type                           | Required |
 | ------------------------------ | -------- |
@@ -323,7 +323,7 @@ Rendered at the top of each section. These stick to the top of the `ScrollView` 
 
 ### `SectionSeparatorComponent`
 
-Rendered at the top and bottom of each section (note this is different from `ItemSeparatorComponent` which is only rendered between items). These are intended to separate sections from the headers above and below and typically have the same highlight response as `ItemSeparatorComponent`. Also receives `highlighted`, `[leading/trailing][Item/Separator]`, and any custom props from `separators.updateProps`.
+Rendered at the top and bottom of each section (note this is different from `ItemSeparatorComponent` which is only rendered between items). These are intended to separate sections from the headers above and below and typically have the same highlight response as `ItemSeparatorComponent`. Also receives `highlighted`, `[leading/trailing][Item/Section]`, and any custom props from `separators.updateProps`.
 
 | Type              | Required |
 | ----------------- | -------- |


### PR DESCRIPTION
As mentioned in the issue it should be `Section` and not `Separator`

Fixes: https://github.com/facebook/react-native-website/issues/855
