### PR TITLE
TouchableWithoutFeedback responder props gotcha

### DIFF
--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -5,7 +5,23 @@ title: TouchableWithoutFeedback
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 
-TouchableWithoutFeedback supports only one child. If you wish to have several child components, wrap them in a View.
+`TouchableWithoutFeedback` supports only one child. If you wish to have several child components, wrap them in a View. Importantly, `TouchableWithoutFeedback` works by cloning its child and applying responder props to it. It is therefore required that any intermediary components pass through those props to the underlying React Native component.
+
+### Usage Example
+
+```javascript
+function MyComponent(props) {
+    return (
+        <View {...props} style={{ flex: 1, backgroundColour: "#fff" }}>
+            <Text>My Component</Text>
+        </View>
+    );
+}
+
+<TouchableWithoutFeedback onPress={() => alert("Pressed!")}>
+    <MyComponent />
+</TouchableWithoutFeedback>
+```
 
 ### Props
 


### PR DESCRIPTION
As explained in https://github.com/facebook/react-native/issues/1352#issuecomment-106938999 any child components passed to TouchableWithoutFeedback must pass through their props to the React Native View component. This adds that information to its docs.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
