### PR TITLE
chore: remove accessibilityComponentType and accessibilityTraits props

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -75,8 +75,6 @@ Inverting screen colors is an Accessibility feature that makes the iPhone and iP
 
 #### accessibilityRole (iOS, Android)
 
-> **Note:** Accessibility Role and Accessibility States are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
-
 Accessibility Role tells a person using either VoiceOver on iOS or TalkBack on Android the type of element that is focused on. To use, set the `accessibilityRole` property to one of the following strings:
 
 - **none** Used when the element has no role.
@@ -93,40 +91,12 @@ Accessibility Role tells a person using either VoiceOver on iOS or TalkBack on A
 
 #### accessibilityStates (iOS, Android)
 
-> **Note:** > `accessibilityRole` and `accessibilityStates` are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
-
 Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on. The state of the element can be set either to `selected` or `disabled` or both:
 
 - **selected** Used when the element is in a selected state. For example, a button is selected.
 - **disabled** Used when the element is disabled and cannot be interacted with.
 
 To use, set the `accessibilityStates` to an array containing either `selected`, `disabled`, or both.
-
-#### accessibilityTraits (iOS)
-
-> **Note:** `accessibilityTraits` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
-
-Accessibility traits tell a person using VoiceOver what kind of element they have selected. Is this element a label? A button? A header? These questions are answered by `accessibilityTraits`.
-
-To use, set the `accessibilityTraits` property to one of (or an array of) accessibility trait strings:
-
-- **none** Used when the element has no traits.
-- **button** Used when the element should be treated as a button.
-- **link** Used when the element should be treated as a link.
-- **header** Used when an element acts as a header for a content section (e.g. the title of a navigation bar).
-- **search** Used when the text field element should also be treated as a search field.
-- **image** Used when the element should be treated as an image. Can be combined with button or link, for example.
-- **selected** Used when the element is selected. For example, a selected row in a table or a selected button within a segmented control.
-- **plays** Used when the element plays its own sound when activated.
-- **key** Used when the element acts as a keyboard key.
-- **text** Used when the element should be treated as static text that cannot change.
-- **summary** Used when an element can be used to provide a quick summary of current conditions in the app when the app first launches. For example, when Weather first launches, the element with today's weather conditions is marked with this trait.
-- **disabled** Used when the control is not enabled and does not respond to user input.
-- **frequentUpdates** Used when the element frequently updates its label or value, but too often to send notifications. Allows an accessibility client to poll for changes. A stopwatch would be an example.
-- **startsMedia** Used when activating an element starts a media session (e.g. playing a movie, recording audio) that should not be interrupted by output from an assistive technology, like VoiceOver.
-- **adjustable** Used when an element can be "adjusted" (e.g. a slider).
-- **allowsDirectInteraction** Used when an element allows direct touch interaction for VoiceOver users (for example, a view representing a piano keyboard).
-- **pageTurn** Informs VoiceOver that it should scroll to the next page when it finishes reading the contents of the element.
 
 #### accessibilityViewIsModal (iOS)
 
@@ -151,23 +121,6 @@ Assign this property to a custom function which will be called when someone perf
 #### onAccessibilityEscape (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
-
-#### accessibilityComponentType (Android)
-
-> **Note:** > `accessibilityComponentType` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`.
-
-In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. We support 'none', ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’.
-
-```javascript
-<TouchableWithoutFeedback accessibilityComponentType=”button”
-  onPress={this._onPress}>
-  <View style={styles.button}>
-    <Text style={styles.buttonText}>Press me!</Text>
-  </View>
-</TouchableWithoutFeedback>
-```
-
-In the above example, the TouchableWithoutFeedback is being announced by TalkBack as a native Button.
 
 #### accessibilityLiveRegion (Android)
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -69,16 +69,18 @@ For `View` responder props (e.g., `onResponderMove`), the synthetic touch event 
 - [`pointerEvents`](view.md#pointerevents)
 - [`removeClippedSubviews`](view.md#removeclippedsubviews)
 - [`style`](view.md#style)
-- [`testID`](view.md#testid)
-- [`accessibilityComponentType`](view.md#accessibilitycomponenttype)
+- [`testID`](view.md#testid) <<<<<<< Updated upstream
+- # [`accessibilityComponentType`](view.md#accessibilitycomponenttype)
+  > > > > > > > Stashed changes
 - [`accessibilityLiveRegion`](view.md#accessibilityliveregion)
 - [`collapsable`](view.md#collapsable)
 - [`importantForAccessibility`](view.md#importantforaccessibility)
 - [`needsOffscreenAlphaCompositing`](view.md#needsoffscreenalphacompositing)
 - [`renderToHardwareTextureAndroid`](view.md#rendertohardwaretextureandroid)
 - [`accessibilityRole`](view.md#accessibilityrole)
-- [`accessibilityStates`](view.md#accessibilitystates)
-- [`accessibilityTraits`](view.md#accessibilitytraits)
+- [`accessibilityStates`](view.md#accessibilitystates) <<<<<<< Updated upstream
+- # [`accessibilityTraits`](view.md#accessibilitytraits)
+  > > > > > > > Stashed changes
 - [`accessibilityViewIsModal`](view.md#accessibilityviewismodal)
 - [`accessibilityElementsHidden`](view.md#accessibilityElementsHidden)
 - [`accessibilityIgnoresInvertColors`](view.md#accessibilityIgnoresInvertColors)
@@ -376,25 +378,6 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `accessibilityComponentType`
-
-_> Note: `accessibilityComponentType`will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead._
-
-Indicates to accessibility services to treat UI component like a native one. Works for Android only.
-
-Possible values are one of:
-
-- `'none'`
-- `'button'`
-- `'radiobutton_checked'`
-- `'radiobutton_unchecked'`
-
-| Type                        | Required | Platform |
-| --------------------------- | -------- | -------- |
-| AccessibilityComponentTypes | No       | Android  |
-
----
-
 ### `accessibilityLiveRegion`
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
@@ -466,8 +449,6 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ### `accessibilityRole`
 
-_> Note: `AccessibilityRole` and `AccessibilityStates` are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`._
-
 Tells the screen reader to treat the currently focused on element as having a specific role.
 
 Possible values for `AccessibilityRole` is one of:
@@ -496,8 +477,6 @@ On Android, these roles have similar functionality on TalkBack as adding Accessi
 
 ### `accessibilityStates`
 
-_> Note: `AccessibilityRole` and `AccessibilityStates` are meant to be a cross-platform solution to replace `accessibilityTraits` and `accessibilityComponentType`, which will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead of `accessibilityTraits` and `accessibilityComponentType`._
-
 Tells the screen reader to treat the currently focused on element as being in a specific state.
 
 You can provide one state, no state, or both states. The states must be passed in through an array. Ex: ['selected'] or ['selected', 'disabled']
@@ -510,42 +489,6 @@ Possible values for `AccessibilityStates` are:
 | Type                        | Required |
 | --------------------------- | -------- |
 | array of AccessibilitStates | No       |
-
----
-
-### `accessibilityTraits`
-
-_> Note: `accessibilityTraits` will soon be deprecated. When possible, use `accessibilityRole` and `accessibilityStates` instead._
-
-Provides additional traits to screen reader. By default no traits are provided unless specified otherwise in element.
-
-You can provide one trait or an array of many traits.
-
-Possible values for `AccessibilityTraits` are:
-
-- `'none'` - The element has no traits.
-- `'button'` - The element should be treated as a button.
-- `'link'` - The element should be treated as a link.
-- `'header'` - The element is a header that divides content into sections.
-- `'search'` - The element should be treated as a search field.
-- `'image'` - The element should be treated as an image.
-- `'selected'` - The element is selected.
-- `'plays'` - The element plays sound.
-- `'key'` - The element should be treated like a keyboard key.
-- `'text'` - The element should be treated as text.
-- `'summary'` - The element provides app summary information.
-- `'disabled'` - The element is disabled.
-- `'frequentUpdates'` - The element frequently changes its value.
-- `'startsMedia'` - The element starts a media session.
-- `'adjustable'` - The element allows adjustment over a range of values.
-- `'allowsDirectInteraction'` - The element allows direct touch interaction for VoiceOver users.
-- `'pageTurn'` - Informs VoiceOver that it should scroll to the next page when it finishes reading the contents of the element.
-
-See the [Accessibility guide](accessibility.md#accessibilitytraits-ios) for more information.
-
-| Type                                               | Required | Platform |
-| -------------------------------------------------- | -------- | -------- |
-| AccessibilityTraits, ,array of AccessibilityTraits | No       | iOS      |
 
 ---
 


### PR DESCRIPTION
https://github.com/facebook/react-native/pull/24344

Remove deprecated `accessibilityComponentType` and `accessibilityTraits` props.

