### PR TITLE
docs(status): add platform for for non-cross-platform methods

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -166,7 +166,7 @@ Set the status bar style
 static setNetworkActivityIndicatorVisible(visible: boolean)
 ```
 
-Control the visibility of the network activity indicator
+Control the visibility of the network activity indicator. iOS-only.
 
 **Parameters:**
 
@@ -182,7 +182,7 @@ Control the visibility of the network activity indicator
 static setBackgroundColor(color: string, [animated]: boolean)
 ```
 
-Set the background color for the status bar
+Set the background color for the status bar. Android-only
 
 **Parameters:**
 
@@ -199,7 +199,7 @@ Set the background color for the status bar
 static setTranslucent(translucent: boolean)
 ```
 
-Control the translucency of the status bar
+Control the translucency of the status bar. Android-only.
 
 **Parameters:**
 


### PR DESCRIPTION
* [`setNetworkActivityIndicatorVisible` is only available on iOS' ](https://github.com/facebook/react-native/blob/master/Libraries/Components/StatusBar/StatusBar.js#L290)
* [`setBackgroundColor` is only available on Android](url);
* [`setTranslucent` is only available on Android](https://github.com/facebook/react-native/blob/master/Libraries/Components/StatusBar/StatusBar.js#L319)