### PR TITLE
Correct documentation for `onSelectionChange`

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -569,7 +569,7 @@ Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`. M
 
 ### `onSelectionChange`
 
-Callback that is called when the text input selection is changed. This will be called with `{ nativeEvent: { selection: { start, end } } }`. Does not work when `multiline={true}` is not specified.
+Callback that is called when the text input selection is changed. This will be called with `{ nativeEvent: { selection: { start, end } } }`. This prop requires `multiline={true}` to be set.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -569,7 +569,7 @@ Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`. M
 
 ### `onSelectionChange`
 
-Callback that is called when the text input selection is changed. This will be called with `{ nativeEvent: { selection: { start, end } } }`.
+Callback that is called when the text input selection is changed. This will be called with `{ nativeEvent: { selection: { start, end } } }`. Does not work when `multiline={true}` is not specified.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
It would have been helpful to know that `onSelectionChange` only works when `multiline` is enabled, hence the change to help others from running into the same issue without knowing what is wrong :)

Fixes #880 
