### PR TITLE
Add page for the Community Github Org with list of repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ lib/core/metadata.js
 lib/core/MetadataBlog.js
 website/translated_docs
 website/build/
+website/community-repos.json
 website/yarn.lock
 website/node_modules
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base    = "website"
   publish = "website/build/react-native"
-  command = "sed -i -e \"s|const baseUrl .*|const baseUrl = '/';|g\" siteConfig.js && yarn install && node netlify-reduce-versions && yarn build"
+  command = "sed -i -e \"s|const baseUrl .*|const baseUrl = '/';|g\" siteConfig.js && yarn install && node netlify-reduce-versions && yarn sync-community-repos && yarn build"

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "start": "docusaurus-start",
     "build": "docusaurus-build",
+    "prepublish-gh-pages": "yarn sync-community-repos",
     "publish-gh-pages": "docusaurus-publish",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
@@ -25,6 +26,7 @@
     "nit:markdown": "prettier  --list-different \"{../docs/*.md,versioned_docs/**/*.md,blog/**/*.md}\"",
     "prettier": "yarn format:source && yarn format:markdown",
     "prettier:diff": "yarn nit:source",
+    "sync-community-repos": "node sync-community-repos.js",
     "sync-guides": "node sync-guides.js",
     "test": "yarn build"
   },
@@ -44,6 +46,7 @@
     "glob": "^7.1.2",
     "glob-promise": "^3.3.0",
     "husky": "^1.3.1",
+    "node-fetch": "^2.3.0",
     "path": "^0.12.7",
     "prettier": "1.16.4",
     "pretty-quick": "^1.10.0"

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -8,6 +8,13 @@
 const RemarkablePlugins = require('./core/RemarkablePlugins');
 
 const users = require('./showcase.json');
+let communityRepos = [];
+try {
+  communityRepos = require('./community-repos.json');
+} catch (e) {
+  // We don't care if there are no repos synced locally
+  // We only care if we are on the CI server and about to deploy
+}
 const defaultVersionShown = '0.59';
 const baseUrl = '/react-native/';
 const repoUrl = 'https://github.com/facebook/react-native';
@@ -20,6 +27,7 @@ const siteConfig = {
   repoUrl,
   defaultVersionShown,
   users,
+  communityRepos,
   editUrl: 'https://github.com/facebook/react-native-website/blob/master/docs/',
   headerLinks: [
     {doc: 'getting-started', label: 'Docs'},

--- a/website/sync-community-repos.js
+++ b/website/sync-community-repos.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const process = require('process');
+const fetch = require('node-fetch');
+const fs = require('fs-extra');
+
+async function graphqlQuery(after = null) {
+  const repoArgs = `privacy: PUBLIC, isFork: false, first: 20 ${
+    after ? `after: ${after}` : ''
+  }`;
+  const query = {
+    query: `{
+      organization(login: "react-native-community") {
+        repositories(${repoArgs}) {
+          totalCount
+          pageInfo {
+            endCursor
+            startCursor
+          }
+          nodes {
+            id
+            name
+            description
+            isArchived
+            url
+            licenseInfo {
+              key
+            }
+            repositoryTopics(first: 100) {
+              nodes {
+                topic {
+                  name
+                }
+              }
+            }
+            packagejson: object(expression: "master:package.json") {
+              ... on Blob {
+                text
+              }
+            }
+            stargazers {
+              totalCount
+            }
+            issues(states:OPEN) {
+              totalCount
+            }
+            pullRequests(states:OPEN) {
+              totalCount
+            }
+          }
+        }
+      }
+    }`,
+  };
+
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `bearer ${process.env.GITHUB_TOKEN}`,
+    },
+    body: JSON.stringify(query),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Got an error from the Github API: ${text}`);
+  }
+
+  return await response.json();
+}
+
+async function collectRepos() {
+  const repos = [];
+
+  let endCursor = null;
+  do {
+    const json = await graphqlQuery(endCursor);
+
+    const {repositories} = json.data.organization;
+    repos.push(...repositories.nodes);
+
+    const {pageInfo} = repositories;
+    endCursor = pageInfo.endCursor;
+  } while (endCursor != null);
+
+  return repos;
+}
+
+async function parseRepos(repos) {
+  const filteredRepos = repos.filter(repo => !repo.isArchived);
+
+  const parsedRepos = filteredRepos.map(repo => {
+    let hasCommunityEslint = false;
+    if (repo.packagejson && repo.packagejson.text) {
+      const packagejson = JSON.parse(repo.packagejson.text);
+
+      hasCommunityEslint = !!(
+        packagejson.devDependencies &&
+        packagejson.devDependencies['@react-native-community/eslint-config']
+      );
+    }
+
+    const usesMitLicense = !!(
+      repo.licenseInfo && repo.licenseInfo.key === 'mit'
+    );
+
+    return {
+      name: repo.name,
+      url: repo.url,
+      description: repo.description,
+      stars: repo.stargazers.totalCount,
+      topics: repo.repositoryTopics.nodes.map(topic => topic.topic.name),
+      openIssues: repo.issues.totalCount,
+      openPullRequests: repo.pullRequests.totalCount,
+      features: {
+        communityEslint: hasCommunityEslint,
+        mitLicense: usesMitLicense,
+      },
+    };
+  });
+
+  parsedRepos.sort((a, b) => a.name.localeCompare(b.name));
+
+  return parsedRepos;
+}
+
+async function syncCommunityRepos() {
+  if (!process.env.GITHUB_TOKEN) {
+    console.error(
+      `You must have a GITHUB_TOKEN set to call "sync-community-repos"`
+    );
+    process.exit(1);
+  }
+
+  const collectedRepos = await collectRepos();
+  const parsedRepos = await parseRepos(collectedRepos);
+  fs.writeFileSync(
+    './community-repos.json',
+    JSON.stringify(parsedRepos, null, 2)
+  );
+}
+
+syncCommunityRepos();

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4234,6 +4234,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"


### PR DESCRIPTION
# What's in this PR?

* A script to fetch the list of repos from the Community Github Org and then parse out the information that we need.
* An example page to display the repo information.
* Run the scripts when the CI server, and Netlify, builds the website.

# Still to do
This PR is meant to start a conversation about what we would like to include on the community page of the website. There are still lots of open questions:

## What do we want to include on the community page?
Currently, I have just included the first paragraph of the [meta repo](https://github.com/react-native-community/meta) and a bare bones repo list. There is a lot more we could include:

* Highlight the key repos like "releases", "discussions-and-proposals", and "meta".
* Include some information about why the org exists and what the difference between the libraries contained in it and from other community members is.
* Highlights of the guidelines we impose and why it matters (consistent code standards and well tested).

## How do we make the repo list nicer?
Currently, I have just used the styling of the "showcase" to make a grid and included the repo name and the description. Other information we could include is:

* Number of stars.
* How "standards-compliant" the repo is.
* How active the repo is.
* How many downloads it has had.

## Where should this page live in the navigation structure?
There is currently a "community" link in the header, however, this goes to the "help" page which then includes help links and links to 3rd-party communities. This is useful information so we should keep it.

To me, it makes sense to have the new Community page go to the new page in this PR and have the current Help page accessible under a new "Help" link in the header.

## Anything else?
This is meant to start a conversation, so... GO!