### PR TITLE
Docs - Alert.alert() does not have a type argument

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -75,5 +75,5 @@ Alert.alert(
 ### `alert()`
 
 ```javascript
-static alert(title, message?, buttons?, options?, type?)
+static alert(title, message?, buttons?, options?)
 ```


### PR DESCRIPTION
As can be seen in the implementation, there is no type argument for `Alert.alert`:

https://github.com/facebook/react-native/blob/master/Libraries/Alert/Alert.js#L47
