### PR TITLE
Fix default ActivityIndicator color on Android

### DIFF
--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -72,7 +72,7 @@ Whether to show the indicator (true, the default) or hide it (false).
 
 ### `color`
 
-The foreground color of the spinner (default is gray).
+The foreground color of the spinner (default is gray on iOS and dark cyan on Android).
 
 | Type               | Required |
 | ------------------ | -------- |


### PR DESCRIPTION
The docs say that the default color of the activity indicator is gray, however it is a dark cyan shade on Android.
Updating the docs to state it correctly.

To be precise, the default color depends on the Android theme that a developer chooses or the default theme of the phone. However, unless something is modified, it's mostly this green.

<table>
<tr>
<td align="center">
Native <br/><code>ActivityIndicator</code><br/> on Android
</td>
<td align="center">
Native <br/><code>ActivityIndicator</code><br/> on iOS
</td>
</tr>
<tr>
<td align="center">
<img src="https://raw.githubusercontent.com/Kida007/react-native-normalized/HEAD/readme-assets/native-activityindicator.png"/>
</td>
<td align="center">
<img src="https://raw.githubusercontent.com/Kida007/react-native-normalized/HEAD/readme-assets/ios-activityindicator.png"/>
</td>
</tr>
</table>
