### PR TITLE
document existence of `anchor` option

### DIFF
--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -28,6 +28,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
 - `tintColor` (string) - the [color](colors.md) used for non-destructive button titles
+- `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 

--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -27,8 +27,8 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `destructiveButtonIndex` (int) - index of destructive button in `options`
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
-- `tintColor` (string) - the [color](colors.md) used for non-destructive button titles
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
+- `tintColor` (string) - the [color](colors.md) used for non-destructive button titles
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 


### PR DESCRIPTION
`ActionSheetIOS.showActionSheetWithOptions()` accepts `anchor` as options (cf https://github.com/facebook/react-native/blob/758eb9fa7bba1d1a14fd8c8870e2a00ad3a31809/Libraries/ActionSheetIOS/ActionSheetIOS.js#L46), but it is not documented.

resolves #892 
