### PR TITLE
fixed Layout props saying overflow does not work on android for 0.57+

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -475,7 +475,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/min-width for more details.
 
 ### `overflow`
 
-`overflow` controls how children are measured and displayed. `overflow: hidden` causes views to be clipped while `overflow: scroll` causes views to be measured independently of their parents main axis. It works like `overflow` in CSS (default: visible). See https://developer.mozilla.org/en/docs/Web/CSS/overflow for more details. `overflow: visible` only works on iOS. On Android, all views will clip their children.
+`overflow` controls how children are measured and displayed. `overflow: hidden` causes views to be clipped while `overflow: scroll` causes views to be measured independently of their parents main axis. It works like `overflow` in CSS (default: visible). See https://developer.mozilla.org/en/docs/Web/CSS/overflow for more details.
 
 | Type                                | Required |
 | ----------------------------------- | -------- |

--- a/website/versioned_docs/version-0.57/layout-props.md
+++ b/website/versioned_docs/version-0.57/layout-props.md
@@ -1,5 +1,5 @@
 ---
-id: version-0.58-layout-props
+id: version-0.57-layout-props
 title: Layout Props
 original_id: layout-props
 ---
@@ -98,9 +98,9 @@ original_id: layout-props
 
 ### `aspectRatio`
 
-Aspect ratio controls the size of the undefined dimension of a node. Aspect ratio is a non-standard property only available in React Native and not CSS.
+Aspect ratio control the size of the undefined dimension of a node. Aspect ratio is a non-standard property only available in react native and not CSS.
 
-- On a node with a set width/height aspect ratio controls the size of the unset dimension
+- On a node with a set width/height aspect ratio control the size of the unset dimension
 - On a node with a set flex basis aspect ratio controls the size of the node in the cross axis if unset
 - On a node with a measure function aspect ratio works as though the measure function measures the flex basis
 - On a node with flex grow/shrink aspect ratio controls the size of the node in the cross axis if unset
@@ -190,15 +190,15 @@ It works similarly to `bottom` in CSS, but in React Native you must use points o
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of how `bottom` affects layout.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |
@@ -224,9 +224,9 @@ When the direction is `ltr`, `end` is equivalent to `right`. When the direction 
 
 This style takes precedence over the `left` and `right` styles.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -250,9 +250,9 @@ flexGrow, flexShrink, and flexBasis work the same as in CSS.
 
 ### `flexBasis`
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -298,9 +298,9 @@ flexGrow, flexShrink, and flexBasis work the same as in CSS.
 
 It works similarly to `height` in CSS, but in React Native you must use points or percentages. Ems and other units are not supported. See https://developer.mozilla.org/en-US/docs/Web/CSS/height for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -322,9 +322,9 @@ It works similarly to `left` in CSS, but in React Native you must use points or 
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/left for more details of how `left` affects layout.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -332,9 +332,9 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/left for more details of ho
 
 Setting `margin` has the same effect as setting each of `marginTop`, `marginLeft`, `marginBottom`, and `marginRight`. See https://developer.mozilla.org/en-US/docs/Web/CSS/margin for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -342,9 +342,9 @@ Setting `margin` has the same effect as setting each of `marginTop`, `marginLeft
 
 `marginBottom` works like `margin-bottom` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -352,9 +352,9 @@ Setting `margin` has the same effect as setting each of `marginTop`, `marginLeft
 
 When direction is `ltr`, `marginEnd` is equivalent to `marginRight`. When direction is `rtl`, `marginEnd` is equivalent to `marginLeft`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -362,9 +362,9 @@ When direction is `ltr`, `marginEnd` is equivalent to `marginRight`. When direct
 
 Setting `marginHorizontal` has the same effect as setting both `marginLeft` and `marginRight`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -372,9 +372,9 @@ Setting `marginHorizontal` has the same effect as setting both `marginLeft` and 
 
 `marginLeft` works like `margin-left` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -382,9 +382,9 @@ Setting `marginHorizontal` has the same effect as setting both `marginLeft` and 
 
 `marginRight` works like `margin-right` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -392,9 +392,9 @@ Setting `marginHorizontal` has the same effect as setting both `marginLeft` and 
 
 When direction is `ltr`, `marginStart` is equivalent to `marginLeft`. When direction is `rtl`, `marginStart` is equivalent to `marginRight`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -402,9 +402,9 @@ When direction is `ltr`, `marginStart` is equivalent to `marginLeft`. When direc
 
 `marginTop` works like `margin-top` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -412,9 +412,9 @@ When direction is `ltr`, `marginStart` is equivalent to `marginLeft`. When direc
 
 Setting `marginVertical` has the same effect as setting both `marginTop` and `marginBottom`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -426,9 +426,9 @@ It works similarly to `max-height` in CSS, but in React Native you must use poin
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/max-height for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -440,9 +440,9 @@ It works similarly to `max-width` in CSS, but in React Native you must use point
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/max-width for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -454,9 +454,9 @@ It works similarly to `min-height` in CSS, but in React Native you must use poin
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/min-height for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -468,9 +468,9 @@ It works similarly to `min-width` in CSS, but in React Native you must use point
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/min-width for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -488,9 +488,9 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/min-width for more details.
 
 Setting `padding` has the same effect as setting each of `paddingTop`, `paddingBottom`, `paddingLeft`, and `paddingRight`. See https://developer.mozilla.org/en-US/docs/Web/CSS/padding for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -498,9 +498,9 @@ Setting `padding` has the same effect as setting each of `paddingTop`, `paddingB
 
 `paddingBottom` works like `padding-bottom` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -508,9 +508,9 @@ Setting `padding` has the same effect as setting each of `paddingTop`, `paddingB
 
 When direction is `ltr`, `paddingEnd` is equivalent to `paddingRight`. When direction is `rtl`, `paddingEnd` is equivalent to `paddingLeft`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -518,9 +518,9 @@ When direction is `ltr`, `paddingEnd` is equivalent to `paddingRight`. When dire
 
 Setting `paddingHorizontal` is like setting both of `paddingLeft` and `paddingRight`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -528,9 +528,9 @@ Setting `paddingHorizontal` is like setting both of `paddingLeft` and `paddingRi
 
 `paddingLeft` works like `padding-left` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -538,9 +538,9 @@ Setting `paddingHorizontal` is like setting both of `paddingLeft` and `paddingRi
 
 `paddingRight` works like `padding-right` in CSS. See https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -548,9 +548,9 @@ Setting `paddingHorizontal` is like setting both of `paddingLeft` and `paddingRi
 
 When direction is `ltr`, `paddingStart` is equivalent to `paddingLeft`. When direction is `rtl`, `paddingStart` is equivalent to `paddingRight`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -568,9 +568,9 @@ When direction is `ltr`, `paddingStart` is equivalent to `paddingLeft`. When dir
 
 Setting `paddingVertical` is like setting both of `paddingTop` and `paddingBottom`.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -598,9 +598,9 @@ It works similarly to `right` in CSS, but in React Native you must use points or
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/right for more details of how `right` affects layout.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -610,9 +610,9 @@ When the direction is `ltr`, `start` is equivalent to `left`. When the direction
 
 This style takes precedence over the `left`, `right`, and `end` styles.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -624,9 +624,9 @@ It works similarly to `top` in CSS, but in React Native you must use points or p
 
 See https://developer.mozilla.org/en-US/docs/Web/CSS/top for more details of how `top` affects layout.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 
@@ -636,9 +636,9 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/top for more details of how
 
 It works similarly to `width` in CSS, but in React Native you must use points or percentages. Ems and other units are not supported. See https://developer.mozilla.org/en-US/docs/Web/CSS/width for more details.
 
-| Type           | Required |
-| -------------- | -------- |
-| number, string | No       |
+| Type            | Required |
+| --------------- | -------- |
+| number, ,string | No       |
 
 ---
 


### PR DESCRIPTION
Hello react-native-website team

Based on https://github.com/react-native-community/releases/blob/master/CHANGELOG.md , https://github.com/facebook/react-native/commit/b81c8b5 , and https://github.com/facebook/react-native/commit/5906c26466f347ff74fc637ecb33ceeb908269e0 , the bug specified in the docs, which says "overflow: visible only works on iOS. On Android, all views will clip their children." should be fixed for 0.57 and up. 

Sorry if I did something wrong, first time :)