### PR TITLE
Behavior changes to the `cancelable` option

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -38,9 +38,7 @@ On Android at most three buttons can be specified. Android has a concept of a ne
 - Two buttons mean 'negative', 'positive' (such as 'Cancel', 'OK')
 - Three buttons mean 'neutral', 'negative', 'positive' (such as 'Later', 'Cancel', 'OK')
 
-By default alerts on Android can be dismissed by tapping outside of the alert box. This event can be handled by providing an optional `options` parameter, with an `onDismiss` callback property `{ onDismiss: () => {} }`.
-
-Alternatively, the dismissing behavior can be disabled altogether by providing an optional `options` parameter with the `cancelable` property set to `false` i.e. `{ cancelable: false }`
+By default alerts on Android are not dismissable by tapping outside of the alert box (since v0.60). To enable it, you can pass an optional `options` object with the `cancelable` property set to `true`. The dismissal event can be handled by adding an `onDismiss` callback property to `options`. Note: Alerts are never dismissable on iOS.
 
 Example usage:
 
@@ -58,7 +56,8 @@ Alert.alert(
     },
     {text: 'OK', onPress: () => console.log('OK Pressed')},
   ],
-  {cancelable: false},
+  // Cancelability by tapping outside the popup can be enabled on Android
+  {cancelable: true, onDismiss: () => {}},
 );
 ```
 


### PR DESCRIPTION
In the next version of RN, `cancelable` will be `false` by default.
I changed the documentation to explain not how to opt-out but instead to opt-in to dismissable popups.

I have also mentioned that the behavior changed in v0.60 and have clarified that the option has no effect on iOS.