### PR TITLE
Update Headless Tasks for Android

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -10,7 +10,9 @@ Headless JS is a way to run tasks in JavaScript while your app is in the backgro
 A task is a simple async function that you register on `AppRegistry`, similar to registering React applications:
 
 ```javascript
-AppRegistry.registerHeadlessTask('SomeTaskName', () => require('SomeTaskName'));
+import SomeTask from "./tasks/SomeTask";
+
+AppRegistry.registerHeadlessTask('SomeTaskName', () => SomeTask);
 ```
 
 Then, in `SomeTaskName.js`:


### PR DESCRIPTION
Hi all,

Seems to me the docs for Headless Tasks on Android are incorrect. Instead of registering a function that require()'s the task, you should return the task function instead.

Also see https://github.com/facebook/react-native/blob/master/Libraries/ReactNative/AppRegistry.js#L265. `taskProvider()` returns the task function which then gets called with the data.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
