### PR TITLE
Update flex description

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -231,9 +231,9 @@ This style takes precedence over the `left` and `right` styles.
 
 ### `flex`
 
-In React Native `flex` does not work the same way that it does in CSS. `flex` is a number rather than a string, and it works according to the `Yoga` library at https://github.com/facebook/yoga
+In React Native `flex` is a shorthand for configurations of `flex-grow`, `flex-shrink`, and `flex-basis` as defined by [Yoga](https://yogalayout.com/), a cross platform implementation of the flexbox specification. 
 
-When `flex` is a positive number, it makes the component flexible and it will be sized proportional to its flex value. So a component with `flex` set to 2 will take twice the space as a component with `flex` set to 1.
+When `flex` is a positive number, it makes the component flexible and it will be sized proportional to its flex value. So a component with `flex` set to 2 will take twice the space as a component with `flex` set to 1. `flex: <positive number>` equates to `flexGrow: <positive number>, flexShrink: 1, flexBasis: 0`.
 
 When `flex` is 0, the component is sized according to `width` and `height` and it is inflexible.
 

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -231,7 +231,7 @@ This style takes precedence over the `left` and `right` styles.
 
 ### `flex`
 
-In React Native `flex` is a shorthand for configurations of `flex-grow`, `flex-shrink`, and `flex-basis` as defined by [Yoga](https://yogalayout.com/), a cross platform implementation of the flexbox specification. 
+In React Native `flex` does not work the same way that it does in CSS. `flex` is a number rather than a string, and it works according to the [Yoga](https://github.com/facebook/yoga).
 
 When `flex` is a positive number, it makes the component flexible and it will be sized proportional to its flex value. So a component with `flex` set to 2 will take twice the space as a component with `flex` set to 1. `flex: <positive number>` equates to `flexGrow: <positive number>, flexShrink: 1, flexBasis: 0`.
 


### PR DESCRIPTION
Has been a source of confusion because the wording states that flex on RN is different than CSS but doesn't detail how it's different when actually flex is quite similar to CSS. Ideally it would be nice to get a code pointer to implementation in Yoga but haven't found a clean place to point.

examples of confusion: 
https://stackoverflow.com/questions/43143258/flex-vs-flexgrow-vs-flexshrink-vs-flexbasis-in-react-native
https://github.com/facebook/react-native/issues/11565

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
