### PR TITLE
fix(typo): add horizontal rule

### DIFF
--- a/docs/appregistry.md
+++ b/docs/appregistry.md
@@ -168,6 +168,8 @@ static registerCancellableHeadlessTask(taskKey, taskProvider, taskCancelProvider
 
 Register a headless task which can be cancelled. A headless task is a bit of code that runs without a UI. @param taskKey the key associated with this task @param taskProvider a promise returning function that takes some data passed from the native side as the only argument; when the promise is resolved or rejected the native side is notified of this event and it may decide to destroy the JS context. @param taskCancelProvider a void returning function that takes no arguments; when a cancellation is requested, the function being executed by taskProvider should wrap up and return ASAP.
 
+---
+
 ### `startHeadlessTask()`
 
 ```javascript


### PR DESCRIPTION
There is a missing horizontal section rule between `registerCancellableHeadlessTask()` & `startHeadlessTask()`, thus, rendering the text in a large font. Corrects rendering of paragraph text.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Here is the complete description of the current issue.

![Screenshot 2019-05-05 at 11 22 46 PM](https://user-images.githubusercontent.com/10234615/57198171-580f9980-6f8d-11e9-9533-33f71e392f75.png)
