### PR TITLE
Remove attachToRelayProfiler, swizzleJSON, measure and measureMethods…

### DIFF
--- a/docs/systrace.md
+++ b/docs/systrace.md
@@ -13,10 +13,6 @@ title: Systrace
 - [`beginAsyncEvent`](systrace.md#beginasyncevent)
 - [`endAsyncEvent`](systrace.md#endasyncevent)
 - [`counterEvent`](systrace.md#counterevent)
-- [`attachToRelayProfiler`](systrace.md#attachtorelayprofiler)
-- [`swizzleJSON`](systrace.md#swizzlejson)
-- [`measureMethods`](systrace.md#measuremethods)
-- [`measure`](systrace.md#measure)
 
 ---
 
@@ -91,47 +87,3 @@ static counterEvent(profileName?, value?)
 ```
 
 Register the value to the profileName on the systrace timeline.
-
----
-
-### `attachToRelayProfiler()`
-
-```javascript
-static attachToRelayProfiler(relayProfiler)
-```
-
-Relay profiles use await calls, so likely occur out of current stack frame therefore async variant of profiling is used.
-
----
-
-### `swizzleJSON()`
-
-```javascript
-static swizzleJSON()
-```
-
-This is not called by default due to performance overhead, but it's useful for finding traces which spend too much time in JSON.
-
----
-
-### `measureMethods()`
-
-```javascript
-static measureMethods(object, objectName, methodNames)
-```
-
-Measures multiple methods of a class. For example, the following will return the `parse` and `stringify` methods of the JSON class: Systrace.measureMethods(JSON, 'JSON', ['parse', 'stringify']);
-
-@param object @param objectName @param methodNames Map from method names to method display names.
-
----
-
-### `measure()`
-
-```javascript
-static measure(objName, fnName, func)
-```
-
-Returns a profiled version of the input function. For example, you can: JSON.parse = Systrace.measure('JSON', 'parse', JSON.parse);
-
-@param objName @param fnName @param {function} func @return {function} replacement function


### PR DESCRIPTION
Systrace is generally broken, but perhaps nevertheless it's still worthwhile to update its documentation as some methods have been removed.

`swizzleJSON`, `measure` and `measureMethods` have been removed in [RN commit 3e141cb](https://github.com/facebook/react-native/commit/3e141cb6c957143e998bf2926b8fe1aabccbce2d)

`attachToRelayProfiler` has been removed in [RN commit a8c4b63](https://github.com/facebook/react-native/commit/a8c4b630fcaee40620060c77c44ab384e9284c0f)