### PR TITLE
Default fresco dependency added in doc, which is necessary for gif support.

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -78,6 +78,9 @@ You will need to add some optional modules in `android/app/build.gradle`, depend
 
 ```gradle
 dependencies {
+  //Add fresco for gif support (if not included in your project)
+  implementation 'com.facebook.fresco:fresco:1.13.0'
+
   // If your app supports Android versions before Ice Cream Sandwich (API level 14)
   implementation 'com.facebook.fresco:animated-base-support:1.10.0'
 


### PR DESCRIPTION
Default fresco dependency is needed for gif and webp support on Android/IOS. 

Currently default fresco dependency not included in docs, developer confused sometime by the gif is not working after following the docs correctly. But the problem is that they don't have default fresco dependency in there project.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
