### PR TITLE
Emphasize non-Oracle OpenJDK distributions in Getting Started guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,7 @@ below.
 **[Getting Started](https://facebook.github.io/react-native/docs/tutorial.html)**
 is relatively informal. Resist adding too much detail to the Quick Start. The
 native code instructions should contain the minimal set of steps to get to a
-working development environment, and is expected to contain a longer set of
-steps to get a working development environment. Whatever the case, it should be
+working development environment. Whatever the case, it should be
 possible for a beginner to mechanically follow every instruction, and still get
 to a working React Native app.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,7 +301,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 ### Java Development Kit
 
-React Native works best with version 8 or newer of the Java SE Development Kit (JDK). You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager. You may also [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if desired.
+React Native requires version 8 or newer of the Java SE Development Kit (JDK). You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager. You may also [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if desired.
 
 <block class="native mac linux windows android" />
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -214,18 +214,22 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <block class="native mac ios android" />
 
-### Node, Watchman
+### Node, Watchman, JDK
 
-We recommend installing Node and Watchman using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
+We recommend installing Node, Watchman, and JDK using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
 
 ```
 brew install node
 brew install watchman
+brew tap AdoptOpenJDK/openjdk
+brew cask install adoptopenjdk8
 ```
 
 If you have already installed Node on your system, make sure it is Node 8.3 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
+
+If you have already installed JDK on your system, make sure it is JDK 8 or newer.
 
 <block class="native linux android" />
 
@@ -293,11 +297,11 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 ![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
 
-<block class="native mac linux android" />
+<block class="native linux android" />
 
 ### Java Development Kit
 
-React Native requires a recent version of the Java SE Development Kit (JDK). [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if needed. You can also use [OpenJDK 8](http://openjdk.java.net/install/) as an alternative.
+React Native works best with version 8 or newer of the Java SE Development Kit (JDK). You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager. You may also [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if desired.
 
 <block class="native mac linux windows android" />
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,7 +301,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 ### Java Development Kit
 
-React Native requires version 8 or newer of the Java SE Development Kit (JDK). You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager. You may also [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if desired.
+React Native requires version 8 of the Java SE Development Kit (JDK). You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager. You may also [Download and install Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) if desired.
 
 <block class="native mac linux windows android" />
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

As discussed with @cpojer - we should stop directing people to a JDK download site where it is seemingly impossible to fetch a JDK8 install, and even if it were possible would be subject to sub-optimal update and license policies.

Commit message with resasoning for the specific change and a link for more context follows:

Markdown: emphasize non-Oracle OpenJDK distribution
   
As of April 2019 Oracle restricts it's non-OpenJDK distributions to
non-commercial use, and the Oracle OpenJDK builds will not be updated
promptly for security patches

non-Oracle OpenJDK versions will still be distributed as users would expect
(open-source and unrestricted commercial use, plus regular updates), so the
getting started guide should emphasize non-Oracle OpenJDK versions

Of those, the AdoptOpenJDK project appears to hae solid delivery for macOS
via brew and for non-system-packager Linux, so it is linked first

Context: https://medium.com/@javachampions/java-is-still-free-2-0-0-6b9aa8d6d244
