### PR TITLE
Update Docusaurus to 1.9.0

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -68,8 +68,7 @@ Let's break down what's happening here. In the `FadeInView` constructor, a new `
 
 When the component mounts, the opacity is set to 0. Then, an easing animation is started on the `fadeAnim` animated value, which will update all of its dependent mappings (in this case, just the opacity) on each frame as the value animates to the final value of 1.
 
-This is done in an optimized way that is faster than calling `setState` and re-rendering.  
-Because the entire configuration is declarative, we will be able to implement further optimizations that serialize the configuration and runs the animation on a high-priority thread.
+This is done in an optimized way that is faster than calling `setState` and re-rendering. Because the entire configuration is declarative, we will be able to implement further optimizations that serialize the configuration and runs the animation on a high-priority thread.
 
 ### Configuring animations
 
@@ -257,7 +256,7 @@ You may notice that there is no obvious way to read the current value while anim
 
 ### Using the native driver
 
-The `Animated` API is designed to be serializable. By using the [native driver](http://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html), we send everything about the animation to native before starting the animation, allowing native code to perform the animation on the UI thread without having to go through the bridge on every frame. Once the animation has started, the JS thread can be blocked without affecting the animation.
+The `Animated` API is designed to be serializable. By using the [native driver](http://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated), we send everything about the animation to native before starting the animation, allowing native code to perform the animation on the UI thread without having to go through the bridge on every frame. Once the animation has started, the JS thread can be blocked without affecting the animation.
 
 Using the native driver for normal animations is quite simple. Just add `useNativeDriver: true` to the animation config when starting it.
 
@@ -414,4 +413,4 @@ As mentioned [in the Direct Manipulation section](direct-manipulation.md), `setN
 
 We could use this in the Rebound example to update the scale - this might be helpful if the component that we are updating is deeply nested and hasn't been optimized with `shouldComponentUpdate`.
 
-If you find your animations with dropping frames (performing below 60 frames per second), look into using `setNativeProps` or `shouldComponentUpdate` to optimize them. Or you could run the animations on the UI thread rather than the JavaScript thread [with the useNativeDriver option](http://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html). You may also want to defer any computationally intensive work until after animations are complete, using the [InteractionManager](interactionmanager.md). You can monitor the frame rate by using the In-App Developer Menu "FPS Monitor" tool.
+If you find your animations with dropping frames (performing below 60 frames per second), look into using `setNativeProps` or `shouldComponentUpdate` to optimize them. Or you could run the animations on the UI thread rather than the JavaScript thread [with the useNativeDriver option](http://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated). You may also want to defer any computationally intensive work until after animations are complete, using the [InteractionManager](interactionmanager.md). You can monitor the frame rate by using the In-App Developer Menu "FPS Monitor" tool.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -23,7 +23,7 @@ Instead of recompiling your app every time you make a change, you can reload you
 
 You can speed up your development times by having your app reload automatically any time your code changes. Automatic reloading can be enabled by selecting "Enable Live Reload" from the Developer Menu.
 
-You may even go a step further and keep your app running as new versions of your files are injected into the JavaScript bundle automatically by enabling [Hot Reloading](https://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) from the Developer Menu. This will allow you to persist the app's state through reloads.
+You may even go a step further and keep your app running as new versions of your files are injected into the JavaScript bundle automatically by enabling [Hot Reloading](https://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading) from the Developer Menu. This will allow you to persist the app's state through reloads.
 
 > There are some instances where hot reloading cannot be implemented perfectly. If you run into any issues, use a full reload to reset your app.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,7 +162,7 @@ If you're integrating React Native into an existing project, you'll want to skip
 
 <block class="native mac windows linux ios android" />
 
-<p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started.html" onclick="displayTab('guide', 'quickstart')">Expo</a> or Create React Native App, you'll need this section.</p>
+<p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Expo</a> or Create React Native App, you'll need this section.</p>
 
 The instructions are a bit different depending on your development operating system, and whether you want to start developing for iOS or Android. If you want to develop for both iOS and Android, that's fine - you just have to pick one to start with, since the setup is a bit different.
 
@@ -180,7 +180,7 @@ The instructions are a bit different depending on your development operating sys
 
 ## Unsupported
 
-<blockquote><p>A Mac is required to build projects with native code for iOS. You can follow the <a href="getting-started.html" onclick="displayTab('guide', 'quickstart')">Quick Start</a> to learn how to build your app using Expo instead.</p></blockquote>
+<blockquote><p>A Mac is required to build projects with native code for iOS. You can follow the <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Quick Start</a> to learn how to build your app using Expo instead.</p></blockquote>
 
 <block class="native mac ios" />
 

--- a/docs/more-resources.md
+++ b/docs/more-resources.md
@@ -15,7 +15,7 @@ If you're looking for a library that does a specific thing, check out [Awesome R
 
 ## Examples
 
-Try out apps from the [Showcase](/react-native/showcase.html) to see what React Native is capable of! There are also some [example apps on GitHub](https://github.com/ReactNativeNews/React-Native-Apps). You can run the apps on a simulator or device, and you can see the source code for these apps, which is neat.
+Try out apps from the [Showcase](/react-native/showcase/) to see what React Native is capable of! There are also some [example apps on GitHub](https://github.com/ReactNativeNews/React-Native-Apps). You can run the apps on a simulator or device, and you can see the source code for these apps, which is neat.
 
 The folks who built the app for Facebook's F8 conference also [open-sourced the code](https://github.com/fbsamples/f8app) and wrote up a [detailed series of tutorials](http://makeitopen.com/). This is useful if you want a more in-depth example that's more realistic than most sample apps out there.
 

--- a/website/package.json
+++ b/website/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "docusaurus": "1.8.0",
+    "docusaurus": "1.9.0",
     "highlight.js": "^9.12.0",
     "remarkable": "^1.7.1"
   },

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -30,7 +30,7 @@ class VersionItem extends React.Component {
           this.props.baseUrl +
           'docs/' +
           (isCurrentVersion ? '' : version + '/') +
-          'getting-started.html'
+          'getting-started'
         }>
         Documentation
       </a>
@@ -83,15 +83,17 @@ class Versions extends React.Component {
             is created off the master branch of{' '}
             <a href={'https://github.com/facebook/react-native'}>
               <code>facebook/react-native</code>
-            </a>. The release candidate will soak for a month to allow
-            contributors like yourself to{' '}
-            <a href={siteConfig.baseUrl + 'docs/upgrading.html'}>
+            </a>
+            . The release candidate will soak for a month to allow contributors
+            like yourself to{' '}
+            <a href={siteConfig.baseUrl + 'docs/upgrading'}>
               verify the changes
             </a>{' '}
             and to identify any issues by{' '}
             <a href="https://github.com/facebook/react-native/issues">
               writing clear, actionable bug reports
-            </a>. Eventually, the release candidate will be promoted to stable.
+            </a>
+            . Eventually, the release candidate will be promoted to stable.
           </p>
           <h2>Latest versions</h2>
           <p>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -59,6 +59,11 @@ const siteConfig = {
   gaTrackingId: 'UA-41298772-2',
   scripts: ['https://snack.expo.io/embed.js', baseUrl + 'js/codeblocks.js'],
   cleanUrl: true,
+  scrollToTop: true,
+  scrollToTopOptions: {
+    zIndex: 100,
+  },
+  docsSideNavCollapsible: true,
 };
 
 module.exports = siteConfig;

--- a/website/versioned_docs/version-0.58/geolocation.md
+++ b/website/versioned_docs/version-0.58/geolocation.md
@@ -42,7 +42,7 @@ Android API >= 18 Positions will also contain a `mocked` boolean to indicate if 
 <p>
   Android API >= 23 Requires an additional step to check for, and request
   the ACCESS_FINE_LOCATION permission using
-  the <a href="https://facebook.github.io/react-native/docs/permissionsandroid.html" target="_blank">PermissionsAndroid API</a>.
+  the <a href="https://facebook.github.io/react-native/docs/permissionsandroid" target="_blank">PermissionsAndroid API</a>.
   Failure to do so may result in a hard crash.
 </p>
 

--- a/website/versioned_docs/version-0.58/listview.md
+++ b/website/versioned_docs/version-0.58/listview.md
@@ -4,7 +4,7 @@ title: ListView
 original_id: listview
 ---
 
-DEPRECATED - use one of the new list components, such as [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) for bounded memory use, fewer bugs, better performance, an easier to use API, and more features. Check out this [blog post](https://facebook.github.io/react-native/blog/2017/03/13/better-list-views.html) for more details.
+DEPRECATED - use one of the new list components, such as [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) for bounded memory use, fewer bugs, better performance, an easier to use API, and more features. Check out this [blog post](https://facebook.github.io/react-native/blog/2017/03/13/better-list-views) for more details.
 
 ListView - A core component designed for efficient display of vertically scrolling lists of changing data. The minimal API is to create a [`ListView.DataSource`](listviewdatasource.md), populate it with a simple array of data blobs, and instantiate a `ListView` component with that data source and a `renderRow` callback which takes a blob from the data array and returns a renderable component.
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2018,10 +2018,10 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-docusaurus@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.8.0.tgz#d82eeb426c1f0fb69411f141fa9311213254ad1a"
-  integrity sha512-Hn+/simu3yiX+5ucqNvX6yTyXtH3BFu2UIeGiXcKiRG8Khos206SsQQ2B7DrBzeJ0duhPxi/I7zYMFyaF23UUQ==
+docusaurus@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.9.0.tgz#cb670d70c7bdabd9d2f6e26cd697b50bb4f28bfe"
+  integrity sha512-FyZ7Bk82PB5cE3xWnO/lAH41T4UkY68ME+pHmhCXveZs+/cjaH5F7DZGlasf+JFeixYjnQvcHWc6ugw/cDB9Ig==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"


### PR DESCRIPTION
### Summary

- Update Docusaurus to 1.9.0
- Enable collapsible side bar
- Clean up some hrefs that were pointing to `.html` extensions. This should have been done when the `cleanUrl` option was enabled but it still works because we generate both `/path/index.html` and `/path.html` in v1. This will break in v2 so better change it now.
- Enable the scroll-to-top button

<img width="1552" alt="Screen Shot 2019-05-16 at 11 53 26 AM" src="https://user-images.githubusercontent.com/1315101/57879399-3e622380-77d1-11e9-9dad-a01e9ea94549.png">
