### PR TITLE
update datepickerIOS with new APIs for #929

### DIFF
--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -50,12 +50,14 @@ const styles = StyleSheet.create({
 - [View props...](view.md#props)
 
 * [`date`](datepickerios.md#date)
-* [`onDateChange`](datepickerios.md#ondatechange)
+* [`initialDate`](initalDate.md#initialDate)
+* [`locale`](datepickerios.md#locale)
 * [`maximumDate`](datepickerios.md#maximumdate)
 * [`minimumDate`](datepickerios.md#minimumdate)
 * [`minuteInterval`](datepickerios.md#minuteinterval)
 * [`mode`](datepickerios.md#mode)
-* [`locale`](datepickerios.md#locale)
+* [`onChange`](datepickerios.md#onChange)
+* [`onDateChange`](datepickerios.md#ondatechange)
 * [`timeZoneOffsetInMinutes`](datepickerios.md#timezoneoffsetinminutes)
 
 ---
@@ -71,6 +73,20 @@ The currently selected date.
 | Type | Required |
 | ---- | -------- |
 | Date | Yes      |
+
+---
+
+### `onChange`
+
+Date change handler.
+
+This is called when the user changes the date or time in the UI.
+The first and only argument is an Event. For getting the date the picker
+was changed to, use onDateChange instead.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
 
 ---
 
@@ -161,3 +177,20 @@ By default, the date picker will use the device's timezone. With this parameter,
 | Type   | Required |
 | ------ | -------- |
 | number | No       |
+
+
+---
+
+### `initialDate`
+
+Provides an initial value that will change when the user starts selecting
+a date. It is useful for simple use-cases where you do not want to deal
+with listening to events and updating the date prop to keep the
+controlled state in sync. The controlled state has known bugs which
+causes it to go out of sync with native. The initialDate prop is intended
+to allow you to have native be source of truth.
+
+| Type   | Required |
+| ------ | -------- |
+| Date   | No       |
+


### PR DESCRIPTION
Adding APIs for #929 

Alphabetized

Added APIs

-initialDate
-onChange

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
