### PR TITLE
Typo in ScrollView documentation #883

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -152,9 +152,9 @@ Determines when the keyboard should stay visible after a tap.
 
 - `'never'` (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
 - `'always'`, the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
-- `'handled'`, the keyboard will not dismiss automatically when the tap was handled by a children, (or captured by an ancestor).
-- `false`, ***deprecated***, use 'never' instead
-- `true`, ***deprecated***, use 'always' instead
+- `'handled'`, the keyboard will not dismiss automatically when the tap was handled by children of the scroll view (or captured by an ancestor).
+- `false`, **_deprecated_**, use 'never' instead
+- `true`, **_deprecated_**, use 'always' instead
 
 | Type                                            | Required |
 | ----------------------------------------------- | -------- |

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3083,6 +3083,9 @@
       "version-0.59/version-0.59-imagestore": {
         "title": "ImageStore"
       },
+      "version-0.59/version-0.59-linking": {
+        "title": "Linking"
+      },
       "version-0.59/version-0.59-maskedviewios": {
         "title": "MaskedViewIOS"
       },

--- a/website/versioned_docs/version-0.59/scrollview.md
+++ b/website/versioned_docs/version-0.59/scrollview.md
@@ -153,7 +153,7 @@ Determines when the keyboard should stay visible after a tap.
 
 - `'never'` (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
 - `'always'`, the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
-- `'handled'`, the keyboard will not dismiss automatically when the tap was handled by a children, (or captured by an ancestor).
+- `'handled'`, the keyboard will not dismiss automatically when the tap was handled by children of the scroll view (or captured by an ancestor).
 - `false`, deprecated, use 'never' instead
 - `true`, deprecated, use 'always' instead
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Original issue #883 

#### Changed
"the keyboard will not dismiss automatically when the tap was handled by a children"
#### to
"the keyboard will not dismiss automatically when the tap was handled by children of the scroll view"

as suggested by @wagnermaciel

This is my first time ever making a pull request to an open source project and i'm not entierly sure about the changes in `website/i18n/en.json`  but they were automatically generated and i saw that that particular file was supposed to be included according to the `.gitignore` so i left them there and brought them along.