### PR TITLE
[FlatList] Add note on multi-column layouts

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -14,6 +14,7 @@ A performant interface for rendering simple, flat lists, supporting the most han
 - Pull to Refresh.
 - Scroll loading.
 - ScrollToIndex support.
+- Multiple column support.
 
 If you need section support, use [`<SectionList>`](sectionlist.md).
 
@@ -25,6 +26,8 @@ Minimal Example:
   renderItem={({item}) => <Text>{item.key}</Text>}
 />
 ```
+
+To render multiple columns, use the [`numColumns`](flatlist.md#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
 More complex, multi-select example demonstrating `PureComponent` usage for perf optimization and avoiding bugs.
 
@@ -144,7 +147,7 @@ Also inherits [ScrollView Props](scrollview.md#props), unless it is nested in an
 ### `renderItem`
 
 ```javascript
-renderItem({ item: Object, index: number, separators: { highlight: Function, unhighlight: Function, updateProps: Function(select: string, newProps: Object) } }) => ?React.Element
+renderItem({item, index, separators});
 ```
 
 Takes an item from `data` and renders it into the list.
@@ -155,6 +158,15 @@ Provides additional metadata like `index` if you need it, as well as a more gene
 | -------- | -------- |
 | function | Yes      |
 
+- `item` (Object): The item from `data` being rendered.
+- `index` (number): The index corresponding to this item in the `data` array.
+- `separators` (Object)
+  - `highlight` (Function)
+  - `unhighlight` (Function)
+  - `updateProps` (Function)
+    - `select` (enum('leading', 'trailing'))
+    - `newProps` (Object)
+
 Example usage:
 
 ```javascript
@@ -163,7 +175,7 @@ Example usage:
     <View style={[style.separator, highlighted && {marginLeft: 0}]} />
   )}
   data={[{title: 'Title Text', key: 'item1'}]}
-  renderItem={({item, separators}) => (
+  renderItem={({item, index, separators}) => (
     <TouchableHighlight
       onPress={() => this._onPress(item)}
       onShowUnderlay={separators.highlight}

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -46,7 +46,7 @@ class Footer extends React.Component {
           <div>
             <h5>Community</h5>
             <a href={this.props.config.baseUrl + 'help.html'}>
-              Community Resources
+              The React Native Community
             </a>
             <a href={this.props.config.baseUrl + 'showcase.html'}>
               Who's using React Native?
@@ -54,12 +54,14 @@ class Footer extends React.Component {
             <a
               href="http://stackoverflow.com/questions/tagged/react-native"
               target="_blank">
-              Stack Overflow
+              Ask Questions on Stack Overflow
             </a>
-            <a href="https://discord.gg/0ZcbPKXt5bZjGY5n">Reactiflux Chat</a>
+            <a href="https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md">
+              Contributor Guide
+            </a>
           </div>
           <div>
-            <h5>More</h5>
+            <h5>More Resources</h5>
             <a href={this.props.config.baseUrl + 'blog/'}>Blog</a>
             <a href="https://twitter.com/reactnative" target="_blank">
               Twitter


### PR DESCRIPTION
Call out flexWrap anti-pattern for multi-column layouts.
Clean up renderItem docs a bit.


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->