### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .DS_Store
+.idea
 lib/core/metadata.js
 lib/core/MetadataBlog.js
 website/translated_docs


### PR DESCRIPTION
Just a small one... I have included the `.idea` folder in the `.gitignore` for developers who use any editor from the IDEA family like myself. I figured if something like `.DS_Store` is in there then it's probably useful to have this 😄.  
