### PR TITLE
Split up Docs and API

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3242,6 +3242,7 @@
     },
     "links": {
       "Docs": "Docs",
+      "API": "API",
       "Community": "Community",
       "Blog": "Blog",
       "GitHub": "GitHub"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -52,7 +52,9 @@
       "headless-js-android",
       "signed-apk-android",
       "removing-default-permissions"
-    ],
+    ]
+  },
+  "api": {
     "Components": [
       "activityindicator",
       "button",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -31,6 +31,7 @@ const siteConfig = {
   editUrl: 'https://github.com/facebook/react-native-website/blob/master/docs/',
   headerLinks: [
     {doc: 'getting-started', label: 'Docs'},
+    {doc: 'activityindicator', label: 'API'},
     {page: 'help', label: 'Community'},
     {blog: true, label: 'Blog'},
     {search: true},

--- a/website/versioned_sidebars/version-0.59-sidebars.json
+++ b/website/versioned_sidebars/version-0.59-sidebars.json
@@ -52,7 +52,9 @@
       "version-0.59-headless-js-android",
       "version-0.59-signed-apk-android",
       "version-0.59-removing-default-permissions"
-    ],
+    ]
+  },
+  "version-0.59-api": {
     "Components": [
       "version-0.59-activityindicator",
       "version-0.59-button",


### PR DESCRIPTION
As a follow up of #934, by @cpojer 

> I'm wondering if there is a way to split up the Docs and API pages into two separate top-level entry points both with their own sidebars? For Docs, it should only have the Guides sections and for API it should have the Components and API sections. Is this possible?

This PR splits up the Docs and API pages into two separate navigations.

Note that this only takes effect in the 0.59 docs onwards. We could technically go back and edit the sidebars for all the previous versions but not sure if it'll be worth it. I could do it the maintainers think it's necessary. But modifying old versions is not recommended and even I'm not sure what undesired consequences there will be.

### Test Plan

Now there are two top-level entry points for docs-related content - Docs and API

<img width="1552" alt="Screen Shot 2019-05-26 at 11 31 47 AM" src="https://user-images.githubusercontent.com/1315101/58385784-9acffa80-7faa-11e9-84ed-fc68870245b0.png">
<img width="1552" alt="Screen Shot 2019-05-26 at 11 31 51 AM" src="https://user-images.githubusercontent.com/1315101/58385785-9acffa80-7faa-11e9-8782-d6814b66e987.png">
