### PR TITLE
Update keyboard.md

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -76,7 +76,7 @@ This function then returns the reference to the listener.
 - `keyboardWillChangeFrame`
 - `keyboardDidChangeFrame`
 
-Note that if you set `android:windowSoftInputMode` to `adjustResize` or `adjustNothing`, only `keyboardDidShow` and `keyboardDidHide` events will be available on Android. `keyboardWillShow` as well as `keyboardWillHide` are generally not available on Android since there is no native corresponding event.
+Note that if you set `android:windowSoftInputMode` to `adjustResize`, only `keyboardDidShow` and `keyboardDidHide` events will be available on Android. If you set `android:windowSoftInputMode` to `adjustNothing`, no events will be available on Android. `keyboardWillShow` as well as `keyboardWillHide` are generally not available on Android since there is no native corresponding event.
 
 @param {function} callback function to be called when the event fires.
 


### PR DESCRIPTION
Update description around `adjustNothing`.

According to [andreicoman11's comment](https://github.com/facebook/react-native/issues/2852#issuecomment-141712317), and my own observation, both `keyboardDidShow` and `keyboardDidHide` do not work when `android:windowSoftInputMode` = `adjustNothing`. Therefore, I propose to update the documentation to reflect the fact.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#2852
-->
