### PR TITLE
Fix props link for Picker component

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -19,7 +19,7 @@ Renders the native picker component on iOS and Android. Example:
 
 ### Props
 
-- [View props...](view.md#props)
+- [View props...](picker.md#props)
 
 * [`onValueChange`](picker.md#onvaluechange)
 * [`selectedValue`](picker.md#selectedvalue)


### PR DESCRIPTION
The Picker props link currently links to the View props rather than the Picker props.