### PR TITLE
Set back the default to 59

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -15,7 +15,7 @@ try {
   // We don't care if there are no repos synced locally
   // We only care if we are on the CI server and about to deploy
 }
-const defaultVersionShown = '0.60';
+const defaultVersionShown = '0.59';
 const baseUrl = '/react-native/';
 const repoUrl = 'https://github.com/facebook/react-native';
 const siteConfig = {


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

The website should still default to 59 until we release 0.60.0.

And we are still having issues publishing 0.60 RC 0.

Having the website point to a version not out yet will only lead to confusion.
