### PR TITLE
Update Docusaurus to v1.11.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -36,7 +36,7 @@
     }
   },
   "dependencies": {
-    "docusaurus": "1.9.0",
+    "docusaurus": "1.11.0",
     "highlight.js": "^9.12.0",
     "remarkable": "^1.7.1"
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1933,11 +1933,6 @@ deep-is@0.1.2:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.2.tgz#9ced65ea0bc0b09f42a6d79c1b1903f9d913cc18"
   integrity sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg=
 
-deepmerge@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
-
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -2018,10 +2013,10 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-docusaurus@1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.9.0.tgz#cb670d70c7bdabd9d2f6e26cd697b50bb4f28bfe"
-  integrity sha512-FyZ7Bk82PB5cE3xWnO/lAH41T4UkY68ME+pHmhCXveZs+/cjaH5F7DZGlasf+JFeixYjnQvcHWc6ugw/cDB9Ig==
+docusaurus@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.11.0.tgz#8c39261ca4487b700dd190dcc5c3b54e90e29c74"
+  integrity sha512-UhsSvfyKoC0EYvc9ieKSLQZNhDZpsC3bqBuRCmldP/pQs4mVIHjwXG5uKEo3lfaflO3tBqsa0EQNtxtScJUL9w==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"
@@ -2041,7 +2036,6 @@ docusaurus@1.9.0:
     cross-spawn "^6.0.5"
     crowdin-cli "^0.3.0"
     cssnano "^3.10.0"
-    deepmerge "^2.1.1"
     escape-string-regexp "^1.0.5"
     express "^4.15.3"
     feed "^1.1.0"
@@ -2065,7 +2059,7 @@ docusaurus@1.9.0:
     react-dom "^16.5.0"
     remarkable "^1.7.1"
     request "^2.87.0"
-    shelljs "^0.7.8"
+    shelljs "^0.8.3"
     sitemap "^1.13.0"
     tcp-port-used "^0.1.2"
     tiny-lr "^1.1.1"
@@ -5640,10 +5634,10 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
Follow up of https://github.com/facebook/react-native-website/pull/934. Upgrades Docusaurus to v1.11.0 which contains a fix of the problem where the blog sidebar was collapsed because the docs had a collapsible sidebar.

<img width="1113" alt="Screen Shot 2019-05-30 at 11 26 40 PM" src="https://user-images.githubusercontent.com/1315101/58686064-8b4a0c00-8332-11e9-8d29-47e79fdd6036.png">
