### PR TITLE
autoCompleteType Spelling Error

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -188,7 +188,7 @@ Can tell `TextInput` to automatically capitalize certain characters. This proper
 
 ### `autoCompleteType`
 
-Specifies autocomplete hints for the system, so it can provide autofill. On Android, the system will aways attempt to offer autofill by using heuristics to identify the type of content. To disable autocomplete, set `autoCompleteType` to `off`.
+Specifies autocomplete hints for the system, so it can provide autofill. On Android, the system will always attempt to offer autofill by using heuristics to identify the type of content. To disable autocomplete, set `autoCompleteType` to `off`.
 
 Possible values for `autoCompleteType` are:
 


### PR DESCRIPTION
Always was missing an "l".

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
