### PR TITLE
remove maskedviewios from sidebars

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -66,7 +66,6 @@
       "imagebackground",
       "inputaccessoryview",
       "keyboardavoidingview",
-      "maskedviewios",
       "modal",
       "picker",
       "pickerios",

--- a/website/versioned_sidebars/version-0.60-RC-sidebars.json
+++ b/website/versioned_sidebars/version-0.60-RC-sidebars.json
@@ -65,7 +65,6 @@
       "version-0.60-RC-imagebackground",
       "version-0.60-RC-inputaccessoryview",
       "version-0.60-RC-keyboardavoidingview",
-      "version-0.60-RC-maskedviewios",
       "version-0.60-RC-modal",
       "version-0.60-RC-picker",
       "version-0.60-RC-pickerios",


### PR DESCRIPTION
Thisi s part of #929 

## This is intended to eliminate all components and API's that were removed from the core and put them together on a single page that refers to all of them

### The `.md` file was previously deleted
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
