### PR TITLE
Updates Docs: Linking

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -127,6 +127,7 @@ Linking.canOpenURL(url)
 - [`canOpenURL`](linking.md#canopenurl)
 - [`openSettings`](linking.md#opensettings)
 - [`getInitialURL`](linking.md#getinitialurl)
+- [`sendIntent`](linking.md#sendIntent)
 
 ---
 
@@ -233,3 +234,13 @@ getInitialURL();
 If the app launch was triggered by an app link, it will give the link url, otherwise it will give `null`
 
 > To support deep linking on Android, refer http://developer.android.com/training/app-indexing/deep-linking.html#handling-intents
+
+---
+
+### `sendIntent()`
+
+```javascript
+sendIntent();
+```
+
+Android only. Launch an Android intent, and also with extras (optional key-value pair of data).

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -20,7 +20,7 @@ title: Linking
 
 #### Handling deep links
 
-If your app was launched from an external url registered to your app you can access and handle it from any component you want with
+If your app was launched from an external url registered to your app you can access and handle it from any component you want with:
 
 ```javascript
 componentDidMount() {
@@ -82,7 +82,7 @@ If your app is using [Universal Links](https://developer.apple.com/library/prere
 }
 ```
 
-And then on your React component you'll be able to listen to the events on `Linking` as follows
+And then on your React component you'll be able to listen to the events on `Linking` as follows:
 
 ```javascript
 componentDidMount() {
@@ -98,13 +98,13 @@ _handleOpenURL(event) {
 
 #### Opening external links
 
-To start the corresponding activity for a link (web URL, email, contact etc.), call
+To start the corresponding activity for a link (web URL, email, contact etc.), call:
 
 ```javascript
 Linking.openURL(url).catch((err) => console.error('An error occurred', err));
 ```
 
-If you want to check if any installed app can handle a given URL beforehand you can call
+If you want to check if any installed app can handle a given URL beforehand you can call:
 
 ```javascript
 Linking.canOpenURL(url)
@@ -149,7 +149,7 @@ constructor();
 addEventListener(type, handler);
 ```
 
-Add a handler to Linking changes by listening to the `url` event type and providing the handler
+Add a handler to Linking changes by listening to the `url` event type and providing the handler.
 
 ---
 
@@ -159,7 +159,7 @@ Add a handler to Linking changes by listening to the `url` event type and provid
 removeEventListener(type, handler);
 ```
 
-Remove a handler by passing the `url` event type and the handler
+Remove a handler by passing the `url` event type and the handler.
 
 ---
 
@@ -231,7 +231,7 @@ Open the Settings app and displays the app’s custom settings, if it has any.
 getInitialURL();
 ```
 
-If the app launch was triggered by an app link, it will give the link url, otherwise it will give `null`
+If the app launch was triggered by an app link, it will give the link url, otherwise it will give `null`.
 
 > To support deep linking on Android, refer http://developer.android.com/training/app-indexing/deep-linking.html#handling-intents
 

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -243,4 +243,6 @@ If the app launch was triggered by an app link, it will give the link url, other
 sendIntent();
 ```
 
-Android only. Launch an Android intent, and also with extras (optional key-value pair of data).
+Android-Only. Launch an Android intent, and also with extras (optional key-value pair of data).
+
+> See https://facebook.github.io/react-native/docs/linking.html#sendintent

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -243,6 +243,6 @@ If the app launch was triggered by an app link, it will give the link url, other
 sendIntent();
 ```
 
-Android-Only. Launch an Android intent, and also with extras (optional key-value pair of data).
+Android-Only. Launch an Android intent, and also with extras (optional key-value pair).
 
 > See https://facebook.github.io/react-native/docs/linking.html#sendintent

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -243,6 +243,6 @@ If the app launch was triggered by an app link, it will give the link url, other
 sendIntent();
 ```
 
-Android-Only. Launch an Android intent, and also with extras (optional key-value pair).
+Android-Only. Launch an Android intent, with or without extras (optional key-value pair).
 
 > See https://facebook.github.io/react-native/docs/linking.html#sendintent


### PR DESCRIPTION
This PR is in reference to Issue [#929](https://github.com/facebook/react-native-website/issues/929)

Pertinent code is [here](https://github.com/SaraChicaD/react-native-website/blob/master/docs/linking.md):

```
sendIntent()

javascript
sendIntent();


Android-Only. Launch an Android intent, with or without extras (optional key-value pair).
```

and is derived from [here](https://github.com/facebook/react-native/blob/master/Libraries/Linking/Linking.js):

```
  /*
   * Launch an Android intent with extras (optional)
   *
   * @platform android
   *
   * See https://facebook.github.io/react-native/docs/linking.html#sendintent
   */
  sendIntent(
    action: string,
    extras?: Array<{key: string, value: string | number | boolean}>,
  ): Promise<void> {
    if (Platform.OS === 'android') {
      return NativeLinking.sendIntent(action, extras);
    }
    return new Promise((resolve, reject) => reject(new Error('Unsupported')));
  }
```

Also updated punctuation for consistency. 

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#929 // Website Redesign and Documentation Rewrite #929
-->
