### PR TITLE
Add doc for countdown

### DIFF
--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -148,9 +148,9 @@ Example with `minuteInterval` set to `10`:
 
 The date picker mode.
 
-| Type                             | Required |
-| -------------------------------- | -------- |
-| enum('date', 'time', 'datetime') | No       |
+| Type                                          | Required |
+| --------------------------------------------- | -------- |
+| enum('date', 'time', 'datetime', 'countdown') | No       |
 
 Example with `mode` set to `date`, `time`, and `datetime`: ![](/react-native/docs/assets/DatePickerIOS/mode.png)
 


### PR DESCRIPTION
Countdown is actually a native prop in iOS and can be used.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
