### PR TITLE
Added value prop to the TextInput

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -24,6 +24,7 @@ export default class PizzaTranslator extends Component {
           style={{height: 40}}
           placeholder="Type here to translate!"
           onChangeText={(text) => this.setState({text})}
+          value={this.state.text}
         />
         <Text style={{padding: 10, fontSize: 42}}>
           {this.state.text.split(' ').map((word) => word && '🍕').join(' ')}


### PR DESCRIPTION
As seen in the "Controlled Components" article, it is generally recommended to keep state as "true". In this TextInput, the value prop is not set to the state like in the "textinput.md" doc.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
