### PR TITLE
Updated docs on running on ios simulator

### DIFF
--- a/docs/running-on-simulator-ios.md
+++ b/docs/running-on-simulator-ios.md
@@ -9,6 +9,6 @@ Once you have your React Native project initialized, you can run `react-native r
 
 ## Specifying a device
 
-You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone X"`. If you wish to run your app on an iPhone 4s, just run `react-native run-ios --simulator="iPhone 4s"`.
+You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone X"`. If you wish to run your app on an iPhone 5s, just run `react-native run-ios --simulator="iPhone 5s"`.
 
 The device names correspond to the list of devices available in Xcode. You can check your available devices by running `xcrun simctl list devices` from the console.


### PR DESCRIPTION
Changing iPhone 4s to iPhone 5s as newer xcode versions doesn't support iPhone 4s anymore.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
