### PR TITLE
Fix AppState Apple documentation link

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -16,7 +16,7 @@ AppState is frequently used to determine the intent and proper behavior when han
   - [Android] on another `Activity` (even if it was launched by your app)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the Multitasking view or in the event of an incoming call
 
-For more information, see [Apple's documentation](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html)
+For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
 
 ### Basic Usage
 


### PR DESCRIPTION
The previous link seems to have been deprecated and is currently displaying an index page for UIKit.