### PR TITLE
remove deprecated NavigatorIOS reference

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -105,10 +105,6 @@ Many of the following components provide wrappers for commonly used UIKit classe
     <p>Renders a image picker on iOS.</p>
   </div>
   <div class="component">
-    <h3><a href="./navigatorios">NavigatorIOS</a></h3>
-    <p>A wrapper around <code>UINavigationController</code>, enabling you to implement a navigation stack.</p>
-  </div>
-  <div class="component">
     <h3><a href="./progressviewios">ProgressViewIOS</a></h3>
     <p>Renders a <code>UIProgressView</a></code> on iOS.</p>
   </div>


### PR DESCRIPTION
This remove the deprecated `NavigatorIOS` from [Components and APIs](https://facebook.github.io/react-native/docs/0.59/components-and-apis) section

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
