### PR TITLE
Fix invalid example of <View> pointer-events value

### DIFF
--- a/docs/view.md
+++ b/docs/view.md
@@ -327,7 +327,7 @@ Controls whether the `View` can be the target of touch events.
      pointer-events: none;
 }
 .box-none * {
-     pointer-events: all;
+     pointer-events: auto;
 }
 ```
 
@@ -335,7 +335,7 @@ Controls whether the `View` can be the target of touch events.
 
 ```
 .box-only {
-     pointer-events: all;
+     pointer-events: auto;
 }
 .box-only * {
      pointer-events: none;


### PR DESCRIPTION
The example for the `pointer-events` prop of view specifies an invalid value of `all`. This PR corrects this by changing the example value to `auto` instead.