### PR TITLE
Update pushnotificationios.md

### DIFF
--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -18,10 +18,16 @@ Handle push notifications for your app, including permission handling and icon b
 
 To get up and running, [configure your notifications with Apple](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW6) and your server-side system.
 
-[Manually link](linking-libraries-ios.md#manual-linking) the PushNotificationIOS library
-
-- Add the following to your Project: `node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj`
-- Add the following to `Link Binary With Libraries`: `libRCTPushNotification.a`
+Add the PushNotificationIOS library to your Podfile:
+./ios/Podfile
+```
+...
+target 'myAwesomeApp' do
+  # Pods for myAwesomeApp
+...
+  pod 'React-RCTPushNotification', :path => '../node_modules/react-native/Libraries/PushNotificationIOS'
+...
+```
 
 Finally, to enable support for `notification` and `register` events you need to augment your AppDelegate.
 


### PR DESCRIPTION
Hi,
I was struggling with porting my current app to RN 0.60 and after checking and hacking I noticed the way the website told me to install the RCTPushNotification lib was still not updated to the pods way.
