### PR TITLE
Update pushnotificationios.md

### DIFF
--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -18,7 +18,11 @@ Handle push notifications for your app, including permission handling and icon b
 
 To get up and running, [configure your notifications with Apple](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW6) and your server-side system.
 
-[Manually link](linking-libraries-ios.md#manual-linking) the PushNotificationIOS library
+React Native version higher than 0.60.0: 
+- Autolinking in 0.60.0 handles the linking for you!
+
+React Native versions lower than 0.60.0: 
+- [Manually link](linking-libraries-ios.md#manual-linking) the PushNotificationIOS library
 
 - Add the following to your Project: `node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj`
 - Add the following to `Link Binary With Libraries`: `libRCTPushNotification.a`


### PR DESCRIPTION
Just tried the guide with RN 0.60.0 and the `PushNotificationIOS` library was automatically linked in the `Pods` project, so it cannot build if the library is also manually linked in the main project.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
