### PR TITLE
delete deprecated duration prop from ScrollView

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -718,23 +718,17 @@ Displays the scroll indicators momentarily.
 
 ```javascript
 scrollTo(
-  ([y]: number),
-  object,
-  ([x]: number),
-  ([animated]: boolean),
-  ([duration]: number),
+	y?: number | {x?: number, y?: number, animated?: boolean},
+	x?: number,
+	animated?: boolean,
 );
 ```
 
-Scrolls to a given x, y offset, either immediately, with a smooth animation, or, for Android only, a custom animation duration time.
+Scrolls to a given x, y offset, either immediately, with a smooth animation.
 
 Example:
 
 `scrollTo({x: 0, y: 0, animated: true})`
-
-Example with duration (Android only):
-
-`scrollTo({x: 0, y: 0, duration: 500})`
 
 Note: The weird function signature is due to the fact that, for historical reasons, the function also accepts separate arguments as an alternative to the options object. This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -718,9 +718,9 @@ Displays the scroll indicators momentarily.
 
 ```javascript
 scrollTo(
-	y?: number | {x?: number, y?: number, animated?: boolean},
-	x?: number,
-	animated?: boolean,
+  options?: {x?: number, y?: number, animated?: boolean} | number,
+  deprecatedX?: number,
+	deprecatedAnimated?: boolean,
 );
 ```
 


### PR DESCRIPTION
The `duration` prop was added in [#22884](https://github.com/facebook/react-native/pull/22884). But was revert [here](https://github.com/facebook/react-native/commit/4c69ccd0fb55e994bd4604e5194206e442ec5958#diff-f8f8b220fc0d1573e4f8b78c84415075).

See the issue [#25589](https://github.com/facebook/react-native/issues/25589) in the React Native repository.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
