### PR TITLE
Change to export default class

### DIFF
--- a/docs/communication-android.md
+++ b/docs/communication-android.md
@@ -43,7 +43,7 @@ public class MainActivity extends ReactActivity {
 import React from 'react';
 import {AppRegistry, View, Image} from 'react-native';
 
-class ImageBrowserApp extends React.Component {
+export default class ImageBrowserApp extends React.Component {
   renderImage(imgURI) {
     return <Image source={{uri: imgURI}} />;
   }
@@ -52,7 +52,6 @@ class ImageBrowserApp extends React.Component {
   }
 }
 
-AppRegistry.registerComponent('AwesomeProject', () => ImageBrowserApp);
 ```
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.


### PR DESCRIPTION
Old code did no longer work, in the new react-native versions this is supposed to be used

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
