### PR TITLE
Remove `openSettings` from docs for v0.59

### DIFF
--- a/website/versioned_docs/version-0.59/linking.md
+++ b/website/versioned_docs/version-0.59/linking.md
@@ -215,16 +215,6 @@ The `Promise` will reject on Android if it was impossible to check if the URL ca
 
 ---
 
-### `openSettings()`
-
-```jsx
-openSettings();
-```
-
-Open the Settings app and displays the app’s custom settings, if it has any.
-
----
-
 ### `getInitialURL()`
 
 ```jsx


### PR DESCRIPTION
"openSettings" is only available from v0.60 on.
See https://github.com/facebook/react-native/blob/0.59-stable/Libraries/Linking/Linking.js.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
