### PR TITLE
Update recommended native modules lib

### DIFF
--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -5,22 +5,22 @@ title: Native Modules Setup
 
 Native modules are usually distributed as npm packages, except that on top of the usual Javascript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
 
-To get set up with the basic project structure for a native module we will use a third party tool [react-native-create-library](https://github.com/frostney/react-native-create-library). You can go ahead further and dive deep into how that library works, for our needs we will just need:
+To get set up with the basic project structure for a native module we will use a third party tool [create-react-native-module](https://github.com/brodybits/create-react-native-module). You can go ahead further and dive deep into how that library works, for our needs we will just need:
 
 ```
-$ npm install -g react-native-create-library
-$ react-native-create-library MyLibrary
+$ yarn global add create-react-native-module
+$ create-react-native-module MyLibrary
 ```
 
 Where MyLibrary is the name you would like for the new module. After doing this you will navigate into `MyLibrary` folder and install the npm package to be locally available for your computer by doing:
 
 ```
-$ npm install
+$ yarn install
 ```
 
 After this is done you can go to your main react app folder (which you created by doing `react-native init MyApp`)
 
 - add your newly created module as a dependency in your package.json
-- run `npm install` to bring it along from your local npm repository.
+- run `yarn install` to bring it along from your local npm repository.
 
 After this, you will be able to continue to native-modules-ios or native-module-android to add in some code. Make sure to read the README.md within your `MyLibrary` Directory for platform-specific instructions on how to include the project.

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
     "format:source": "prettier --write \"{core/**/*.js,static/js/**/*.js}\"",
     "format:markdown": "prettier --write \"{../docs/*.md,versioned_docs/**/*.md,blog/**/*.md}\"",
     "nit:source": "prettier --list-different \"{core/**/*.js,static/js/**/*.js}\"",
-    "nit:markdown": "prettier  --list-different \"{../docs/*.md,versioned_docs/**/*.md,blog/**/*.md}\"",
+    "nit:markdown": "prettier --list-different \"{../docs/*.md,versioned_docs/**/*.md,blog/**/*.md}\"",
     "prettier": "yarn format:source && yarn format:markdown",
     "prettier:diff": "yarn nit:source",
     "sync-community-repos": "node sync-community-repos.js",


### PR DESCRIPTION
The third party tool (react-native-create-library) suggested on this page is stale and appears to have been abandoned, in it's current state it does not work on iOS. I've swapped this out for an alternative library that is in active development and is currently working on iOS and android, even on React Native 0.60+
