### PR TITLE
Add ProGuard rule for using Hermes

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -21,6 +21,12 @@ Edit your `android/app/build.gradle` file and make the change illustrated below:
   ]
 ```
 
+Also, if you're using ProGuard, you will need to add this rule in `proguard-rules.pro` :
+
+```
+-keep class com.facebook.hermes.unicode.** { *; }
+```
+
 Next, if you've already built your app at least once, clean the build:
 
 ```shell


### PR DESCRIPTION
Related to : https://github.com/facebook/react-native/issues/25679

To use `Hermes` with `ProGuard`, rule should be added to prevent crash.
It would be nice to let everyone know this in the document.