### PR TITLE
Fix getScrollableNode and getScrollableNode url

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -134,8 +134,8 @@ Also inherits [ScrollView Props](scrollview.md#props), unless it is nested in an
 ### Methods
 
 - [`flashScrollIndicators`](flatlist.md#flashscrollindicators)
-- [`getScrollResponder`](flatlist.md#getScrollResponder)
-- [`getScrollableNode`](flatlist.md#getScrollableNode)
+- [`getScrollResponder`](flatlist.md#getscrollresponder)
+- [`getScrollableNode`](flatlist.md#getscrollablenode)
 - [`scrollToEnd`](flatlist.md#scrolltoend)
 - [`scrollToIndex`](flatlist.md#scrolltoindex)
 - [`scrollToItem`](flatlist.md#scrolltoitem)


### PR DESCRIPTION
Links https://facebook.github.io/react-native/docs/flatlist#getScrollableNode and https://facebook.github.io/react-native/docs/flatlist#getScrollResponder aren’t working.