### PR TITLE
Clean up usage of AppRegistry in examples

### DIFF
--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -11,7 +11,6 @@ Displays a circular loading indicator.
 import React, { Component } from 'react'
 import {
   ActivityIndicator,
-  AppRegistry,
   StyleSheet,
   Text,
   View,
@@ -41,8 +40,6 @@ const styles = StyleSheet.create({
     padding: 10
   }
 })
-
-AppRegistry.registerComponent('App', () => App)
 ```
 
 ### Props

--- a/docs/communication-android.md
+++ b/docs/communication-android.md
@@ -41,9 +41,9 @@ public class MainActivity extends ReactActivity {
 
 ```jsx
 import React from 'react';
-import {AppRegistry, View, Image} from 'react-native';
+import {View, Image} from 'react-native';
 
-class ImageBrowserApp extends React.Component {
+export default class ImageBrowserApp extends React.Component {
   renderImage(imgURI) {
     return <Image source={{uri: imgURI}} />;
   }
@@ -51,8 +51,6 @@ class ImageBrowserApp extends React.Component {
     return <View>{this.props.images.map(this.renderImage)}</View>;
   }
 }
-
-AppRegistry.registerComponent('AwesomeProject', () => ImageBrowserApp);
 ```
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.

--- a/docs/communication-ios.md
+++ b/docs/communication-ios.md
@@ -34,9 +34,9 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
 
 ```jsx
 import React from 'react';
-import {AppRegistry, View, Image} from 'react-native';
+import {View, Image} from 'react-native';
 
-class ImageBrowserApp extends React.Component {
+export default class ImageBrowserApp extends React.Component {
   renderImage(imgURI) {
     return <Image source={{uri: imgURI}} />;
   }
@@ -44,8 +44,6 @@ class ImageBrowserApp extends React.Component {
     return <View>{this.props.images.map(this.renderImage)}</View>;
   }
 }
-
-AppRegistry.registerComponent('ImageBrowserApp', () => ImageBrowserApp);
 ```
 
 `RCTRootView` also provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -33,7 +33,7 @@ LEARN MORE [HERE](https://yogalayout.com/docs/flex-direction)
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class FlexDirectionBasics extends Component {
   render() {
@@ -47,9 +47,6 @@ export default class FlexDirectionBasics extends Component {
     );
   }
 };
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FlexDirectionBasics);
 ```
 
 ![Flex Direction](https://cdn-images-1.medium.com/max/800/1*rA7IbuUsJWsx6evKAsabVw.png)
@@ -80,7 +77,7 @@ LEARN MORE [HERE](https://yogalayout.com/docs/justify-content)
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class JustifyContentBasics extends Component {
   render() {
@@ -99,9 +96,6 @@ export default class JustifyContentBasics extends Component {
     );
   }
 };
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => JustifyContentBasics);
 ```
 
 ![Justify Content](https://cdn-images-1.medium.com/max/800/1*i5TVlme-TisAVvD5ax2yPA.png)
@@ -126,7 +120,7 @@ LEARN MORE [HERE](https://yogalayout.com/docs/align-items)
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class AlignItemsBasics extends Component {
   render() {
@@ -147,9 +141,6 @@ export default class AlignItemsBasics extends Component {
     );
   }
 };
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => AlignItemsBasics);
 ```
 
 ![Align Items](https://cdn-images-1.medium.com/max/800/1*evkM7zfxt-9p-HJ1M0Bh2g.png)

--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -9,7 +9,7 @@ For example, let's say that as the user types, you're translating their words in
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, TextInput, View } from 'react-native';
+import { Text, TextInput, View } from 'react-native';
 
 export default class PizzaTranslator extends Component {
   constructor(props) {
@@ -33,9 +33,6 @@ export default class PizzaTranslator extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => PizzaTranslator);
 ```
 
 In this example, we store `text` in the state, because it changes over time.

--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -26,7 +26,7 @@ Go ahead and play around with the `Button` component using the example below. Yo
 
 ```SnackPlayer name=Button%20Basics
 import React, { Component } from 'react';
-import { Alert, AppRegistry, Button, StyleSheet, View } from 'react-native';
+import { Alert, Button, StyleSheet, View } from 'react-native';
 
 export default class ButtonBasics extends Component {
   _onPressButton() {
@@ -79,9 +79,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between'
   }
 });
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => ButtonBasics);
 ```
 
 ## Touchables
@@ -104,7 +101,7 @@ Let's see all of these in action:
 
 ```SnackPlayer platform=android&name=Touchables
 import React, { Component } from 'react';
-import { Alert, AppRegistry, Platform, StyleSheet, Text, TouchableHighlight, TouchableOpacity, TouchableNativeFeedback, TouchableWithoutFeedback, View } from 'react-native';
+import { Alert, Platform, StyleSheet, Text, TouchableHighlight, TouchableOpacity, TouchableNativeFeedback, TouchableWithoutFeedback, View } from 'react-native';
 
 export default class Touchables extends Component {
   _onPressButton() {
@@ -169,9 +166,6 @@ const styles = StyleSheet.create({
     color: 'white'
   }
 });
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => Touchables);
 ```
 
 ## Scrolling lists, swiping pages, and pinch-to-zoom

--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -11,7 +11,7 @@ The simplest way to set the dimensions of a component is by adding a fixed `widt
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class FixedDimensionsBasics extends Component {
   render() {
@@ -24,9 +24,6 @@ export default class FixedDimensionsBasics extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FixedDimensionsBasics);
 ```
 
 Setting dimensions this way is common for components that should always render at exactly the same size, regardless of screen dimensions.
@@ -39,7 +36,7 @@ Use `flex` in a component's style to have the component expand and shrink dynami
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class FlexDimensionsBasics extends Component {
   render() {
@@ -55,9 +52,6 @@ export default class FlexDimensionsBasics extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FlexDimensionsBasics);
 ```
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).

--- a/docs/image.md
+++ b/docs/image.md
@@ -11,7 +11,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View, Image } from 'react-native';
+import { View, Image } from 'react-native';
 
 export default class DisplayAnImage extends Component {
   render() {
@@ -32,16 +32,13 @@ export default class DisplayAnImage extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('DisplayAnImage', () => DisplayAnImage);
 ```
 
 You can also add `style` to an image:
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View, Image, StyleSheet } from 'react-native';
+import { View, Image, StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   stretch: {
@@ -62,12 +59,6 @@ export default class DisplayAnImageWithStyle extends Component {
     );
   }
 }
-
-// skip these lines if using Create React Native App
-AppRegistry.registerComponent(
-  'DisplayAnImageWithStyle',
-  () => DisplayAnImageWithStyle
-);
 ```
 
 ### GIF and WebP support on Android

--- a/docs/inputaccessoryview.md
+++ b/docs/inputaccessoryview.md
@@ -9,7 +9,7 @@ To use this component wrap your custom toolbar with the InputAccessoryView compo
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { View, ScrollView, AppRegistry, TextInput, InputAccessoryView, Button } from 'react-native';
+import { View, ScrollView, TextInput, InputAccessoryView, Button } from 'react-native';
 
 export default class UselessTextInput extends Component {
   constructor(props) {
@@ -42,9 +42,6 @@ export default class UselessTextInput extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
 ```
 
 This component can also be used to create sticky text inputs (text inputs which are anchored to the top of the keyboard). To do this, wrap a `TextInput` with the `InputAccessoryView` component, and don't set a `nativeID`. For an example, look at [InputAccessoryViewExample.js](https://github.com/facebook/react-native/blob/master/RNTester/js/InputAccessoryViewExample.js).

--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -9,7 +9,7 @@ Example:
 
 ```jsx
 import React, {Component} from 'react';
-import {ProgressBarAndroid, AppRegistry, StyleSheet, View} from 'react-native';
+import {ProgressBarAndroid, StyleSheet, View} from 'react-native';
 
 export default class App extends Component {
   render() {
@@ -35,8 +35,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-
-AppRegistry.registerComponent('App', () => App);
 ```
 
 ### Props

--- a/docs/props.md
+++ b/docs/props.md
@@ -9,7 +9,7 @@ For example, one basic React Native component is the `Image`. When you create an
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Image } from 'react-native';
+import { Image } from 'react-native';
 
 export default class Bananas extends Component {
   render() {
@@ -21,9 +21,6 @@ export default class Bananas extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => Bananas);
 ```
 
 Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX. You can put any JavaScript expression inside braces in JSX.
@@ -32,7 +29,7 @@ Your own components can also use `props`. This lets you make a single component 
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 class Greeting extends Component {
   render() {
@@ -55,9 +52,6 @@ export default class LotsOfGreetings extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => LotsOfGreetings);
 ```
 
 Using `name` as a prop lets us customize the `Greeting` component, so we can reuse that component for each of our greetings. This example also uses the `Greeting` component in JSX, just like the built-in components. The power to do this is what makes React so cool - if you find yourself wishing that you had a different set of UI primitives to work with, you just invent new ones.

--- a/docs/state.md
+++ b/docs/state.md
@@ -11,7 +11,7 @@ For example, let's say we want to make text that blinks all the time. The text i
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 class Blink extends Component {
 
@@ -50,9 +50,6 @@ export default class BlinkApp extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => BlinkApp);
 ```
 
 In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.

--- a/docs/style.md
+++ b/docs/style.md
@@ -11,7 +11,7 @@ As a component grows in complexity, it is often cleaner to use `StyleSheet.creat
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 const styles = StyleSheet.create({
   bigBlue: {
@@ -36,9 +36,6 @@ export default class LotsOfStyles extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => LotsOfStyles);
 ```
 
 One common pattern is to make your component accept a `style` prop which in turn is used to style subcomponents. You can use this to make styles "cascade" the way they do in CSS.

--- a/docs/text.md
+++ b/docs/text.md
@@ -11,7 +11,7 @@ In the following example, the nested title and body text will inherit the `fontF
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 
 export default class TextInANest extends Component {
   constructor(props) {
@@ -45,9 +45,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('TextInANest', () => TextInANest);
 ```
 
 ## Nested text
@@ -56,7 +53,7 @@ Both iOS and Android allow you to display formatted text by annotating ranges of
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text } from 'react-native';
+import { Text } from 'react-native';
 
 export default class BoldAndBeautiful extends Component {
   render() {
@@ -70,9 +67,6 @@ export default class BoldAndBeautiful extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => BoldAndBeautiful);
 ```
 
 Behind the scenes, React Native converts this to a flat `NSAttributedString` or `SpannableString` that contains the following information:

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -9,7 +9,7 @@ The simplest use case is to plop down a `TextInput` and subscribe to the `onChan
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, TextInput } from 'react-native';
+import { TextInput } from 'react-native';
 
 export default class UselessTextInput extends Component {
   constructor(props) {
@@ -27,9 +27,6 @@ export default class UselessTextInput extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
 ```
 
 Two methods exposed via the native element are .focus() and .blur() that will focus or blur the TextInput programmatically.
@@ -38,7 +35,7 @@ Note that some props are only available with `multiline={true/false}`. Additiona
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View, TextInput } from 'react-native';
+import { View, TextInput } from 'react-native';
 
 class UselessTextInput extends Component {
   render() {
@@ -79,12 +76,6 @@ export default class UselessTextInputMultiline extends Component {
     );
   }
 }
-
-// skip these lines if using Create React Native App
-AppRegistry.registerComponent(
- 'AwesomeProject',
- () => UselessTextInputMultiline
-);
 ```
 
 `TextInput` has by default a border at the bottom of its view. This border has its padding set by the background image provided by the system, and it cannot be changed. Solutions to avoid this is to either not set height explicitly, case in which the system will take care of displaying the border in the correct position, or to not display the border by setting `underlineColorAndroid` to transparent.

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -29,14 +29,13 @@ renderButton: function() {
 ```ReactNativeWebPlayer
 import React, { Component } from 'react'
 import {
-  AppRegistry,
   StyleSheet,
   TouchableHighlight,
   Text,
   View,
 } from 'react-native'
 
-class App extends Component {
+export default class App extends Component {
   constructor(props) {
     super(props)
     this.state = { count: 0 }
@@ -86,8 +85,6 @@ const styles = StyleSheet.create({
     color: '#FF00FF'
   }
 })
-
-AppRegistry.registerComponent('App', () => App)
 ```
 
 ### Props

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -27,14 +27,13 @@ renderButton: function() {
 ```ReactNativeWebPlayer
 import React, { Component } from 'react'
 import {
-  AppRegistry,
   StyleSheet,
   TouchableOpacity,
   Text,
   View,
 } from 'react-native'
 
-class App extends Component {
+export default class App extends Component {
   constructor(props) {
     super(props)
     this.state = { count: 0 }
@@ -84,8 +83,6 @@ const styles = StyleSheet.create({
     color: '#FF00FF'
   }
 })
-
-AppRegistry.registerComponent('App', () => App)
 ```
 
 ### Props

--- a/docs/using-a-listview.md
+++ b/docs/using-a-listview.md
@@ -13,7 +13,7 @@ This example creates a simple `FlatList` of hardcoded data. Each item in the `da
 
 ```SnackPlayer name=FlatList%20Basics
 import React, { Component } from 'react';
-import { AppRegistry, FlatList, StyleSheet, Text, View } from 'react-native';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
 
 export default class FlatListBasics extends Component {
   render() {
@@ -48,16 +48,13 @@ const styles = StyleSheet.create({
     height: 44,
   },
 })
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FlatListBasics);
 ```
 
 If you want to render a set of data broken into logical sections, maybe with section headers, similar to `UITableView`s on iOS, then a [SectionList](sectionlist.md) is the way to go.
 
 ```SnackPlayer name=SectionList%20Basics
 import React, { Component } from 'react';
-import { AppRegistry, SectionList, StyleSheet, Text, View } from 'react-native';
+import { SectionList, StyleSheet, Text, View } from 'react-native';
 
 export default class SectionListBasics extends Component {
   render() {
@@ -97,9 +94,6 @@ const styles = StyleSheet.create({
     height: 44,
   },
 })
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => SectionListBasics);
 ```
 
 One of the most common uses for a list view is displaying data that you fetch from a server. To do that, you will need to [learn about networking in React Native](network.md).

--- a/docs/using-a-scrollview.md
+++ b/docs/using-a-scrollview.md
@@ -9,7 +9,7 @@ This example creates a vertical `ScrollView` with both images and text mixed tog
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, ScrollView, Image, Text } from 'react-native';
+import { ScrollView, Image, Text } from 'react-native';
 
 export default class IScrolledDownAndWhatHappenedNextShockedMe extends Component {
   render() {
@@ -50,11 +50,6 @@ export default class IScrolledDownAndWhatHappenedNextShockedMe extends Component
     );
   }
 }
-
-// skip these lines if using Create React Native App
-AppRegistry.registerComponent(
-  'AwesomeProject',
-  () => IScrolledDownAndWhatHappenedNextShockedMe);
 ```
 
 ScrollViews can be configured to allow paging through views using swiping gestures by using the `pagingEnabled` props. Swiping horizontally between views can also be implemented on Android using the [ViewPager](https://github.com/react-native-community/react-native-viewpager) component.

--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -142,11 +142,10 @@ function SnackPlayer(md) {
  * E.g.
  * ```ReactNativeWebPlayer platform=android
  * import React from 'react';
- * import { AppRegistry, Text } from 'react-native';
+ * import { Text } from 'react-native';
  *
  * const App = () => <Text>Hello World!</Text>;
- *
- * AppRegistry.registerComponent('MyApp', () => App);
+ * export default App;
  * ```
  */
 function ReactNativeWebPlayer(md) {

--- a/website/versioned_docs/version-0.60/activityindicator.md
+++ b/website/versioned_docs/version-0.60/activityindicator.md
@@ -12,7 +12,6 @@ Displays a circular loading indicator.
 import React, { Component } from 'react'
 import {
   ActivityIndicator,
-  AppRegistry,
   StyleSheet,
   Text,
   View,
@@ -42,8 +41,6 @@ const styles = StyleSheet.create({
     padding: 10
   }
 })
-
-AppRegistry.registerComponent('App', () => App)
 ```
 
 ### Props

--- a/website/versioned_docs/version-0.60/communication-android.md
+++ b/website/versioned_docs/version-0.60/communication-android.md
@@ -42,7 +42,7 @@ public class MainActivity extends ReactActivity {
 
 ```jsx
 import React from 'react';
-import {AppRegistry, View, Image} from 'react-native';
+import {View, Image} from 'react-native';
 
 class ImageBrowserApp extends React.Component {
   renderImage(imgURI) {
@@ -52,8 +52,6 @@ class ImageBrowserApp extends React.Component {
     return <View>{this.props.images.map(this.renderImage)}</View>;
   }
 }
-
-AppRegistry.registerComponent('AwesomeProject', () => ImageBrowserApp);
 ```
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.

--- a/website/versioned_docs/version-0.60/flexbox.md
+++ b/website/versioned_docs/version-0.60/flexbox.md
@@ -34,7 +34,7 @@ LEARN MORE [HERE](https://yogalayout.com/docs/flex-direction)
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class FlexDirectionBasics extends Component {
   render() {
@@ -48,9 +48,6 @@ export default class FlexDirectionBasics extends Component {
     );
   }
 };
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FlexDirectionBasics);
 ```
 
 ![Flex Direction](https://cdn-images-1.medium.com/max/800/1*rA7IbuUsJWsx6evKAsabVw.png)
@@ -81,7 +78,7 @@ LEARN MORE [HERE](https://yogalayout.com/docs/justify-content)
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class JustifyContentBasics extends Component {
   render() {
@@ -100,9 +97,6 @@ export default class JustifyContentBasics extends Component {
     );
   }
 };
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => JustifyContentBasics);
 ```
 
 ![Justify Content](https://cdn-images-1.medium.com/max/800/1*i5TVlme-TisAVvD5ax2yPA.png)
@@ -127,7 +121,7 @@ LEARN MORE [HERE](https://yogalayout.com/docs/align-items)
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View } from 'react-native';
+import { View } from 'react-native';
 
 export default class AlignItemsBasics extends Component {
   render() {
@@ -148,9 +142,6 @@ export default class AlignItemsBasics extends Component {
     );
   }
 };
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => AlignItemsBasics);
 ```
 
 ![Align Items](https://cdn-images-1.medium.com/max/800/1*evkM7zfxt-9p-HJ1M0Bh2g.png)

--- a/website/versioned_docs/version-0.60/handling-text-input.md
+++ b/website/versioned_docs/version-0.60/handling-text-input.md
@@ -10,7 +10,7 @@ For example, let's say that as the user types, you're translating their words in
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, TextInput, View } from 'react-native';
+import { Text, TextInput, View } from 'react-native';
 
 export default class PizzaTranslator extends Component {
   constructor(props) {
@@ -34,9 +34,6 @@ export default class PizzaTranslator extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => PizzaTranslator);
 ```
 
 In this example, we store `text` in the state, because it changes over time.

--- a/website/versioned_docs/version-0.60/image.md
+++ b/website/versioned_docs/version-0.60/image.md
@@ -12,7 +12,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View, Image } from 'react-native';
+import { View, Image } from 'react-native';
 
 export default class DisplayAnImage extends Component {
   render() {
@@ -33,16 +33,13 @@ export default class DisplayAnImage extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('DisplayAnImage', () => DisplayAnImage);
 ```
 
 You can also add `style` to an image:
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View, Image, StyleSheet } from 'react-native';
+import { View, Image, StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   stretch: {
@@ -63,12 +60,6 @@ export default class DisplayAnImageWithStyle extends Component {
     );
   }
 }
-
-// skip these lines if using Create React Native App
-AppRegistry.registerComponent(
-  'DisplayAnImageWithStyle',
-  () => DisplayAnImageWithStyle
-);
 ```
 
 ### GIF and WebP support on Android

--- a/website/versioned_docs/version-0.60/progressbarandroid.md
+++ b/website/versioned_docs/version-0.60/progressbarandroid.md
@@ -10,7 +10,7 @@ Example:
 
 ```jsx
 import React, {Component} from 'react';
-import {ProgressBarAndroid, AppRegistry, StyleSheet, View} from 'react-native';
+import {ProgressBarAndroid, StyleSheet, View} from 'react-native';
 
 export default class App extends Component {
   render() {
@@ -36,8 +36,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-
-AppRegistry.registerComponent('App', () => App);
 ```
 
 ### Props

--- a/website/versioned_docs/version-0.60/state.md
+++ b/website/versioned_docs/version-0.60/state.md
@@ -12,7 +12,7 @@ For example, let's say we want to make text that blinks all the time. The text i
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 class Blink extends Component {
 
@@ -51,9 +51,6 @@ export default class BlinkApp extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => BlinkApp);
 ```
 
 In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.

--- a/website/versioned_docs/version-0.60/style.md
+++ b/website/versioned_docs/version-0.60/style.md
@@ -12,7 +12,7 @@ As a component grows in complexity, it is often cleaner to use `StyleSheet.creat
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 const styles = StyleSheet.create({
   bigBlue: {
@@ -37,9 +37,6 @@ export default class LotsOfStyles extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => LotsOfStyles);
 ```
 
 One common pattern is to make your component accept a `style` prop which in turn is used to style subcomponents. You can use this to make styles "cascade" the way they do in CSS.

--- a/website/versioned_docs/version-0.60/text.md
+++ b/website/versioned_docs/version-0.60/text.md
@@ -12,7 +12,7 @@ In the following example, the nested title and body text will inherit the `fontF
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet } from 'react-native';
 
 export default class TextInANest extends Component {
   constructor(props) {
@@ -46,9 +46,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('TextInANest', () => TextInANest);
 ```
 
 ## Nested text
@@ -57,7 +54,7 @@ Both iOS and Android allow you to display formatted text by annotating ranges of
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, Text } from 'react-native';
+import { Text } from 'react-native';
 
 export default class BoldAndBeautiful extends Component {
   render() {
@@ -71,9 +68,6 @@ export default class BoldAndBeautiful extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => BoldAndBeautiful);
 ```
 
 Behind the scenes, React Native converts this to a flat `NSAttributedString` or `SpannableString` that contains the following information:

--- a/website/versioned_docs/version-0.60/textinput.md
+++ b/website/versioned_docs/version-0.60/textinput.md
@@ -10,7 +10,7 @@ The simplest use case is to plop down a `TextInput` and subscribe to the `onChan
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, TextInput } from 'react-native';
+import { TextInput } from 'react-native';
 
 export default class UselessTextInput extends Component {
   constructor(props) {
@@ -28,9 +28,6 @@ export default class UselessTextInput extends Component {
     );
   }
 }
-
-// skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => UselessTextInput);
 ```
 
 Two methods exposed via the native element are .focus() and .blur() that will focus or blur the TextInput programmatically.
@@ -39,7 +36,7 @@ Note that some props are only available with `multiline={true/false}`. Additiona
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, View, TextInput } from 'react-native';
+import { View, TextInput } from 'react-native';
 
 class UselessTextInput extends Component {
   render() {
@@ -80,12 +77,6 @@ export default class UselessTextInputMultiline extends Component {
     );
   }
 }
-
-// skip these lines if using Create React Native App
-AppRegistry.registerComponent(
- 'AwesomeProject',
- () => UselessTextInputMultiline
-);
 ```
 
 `TextInput` has by default a border at the bottom of its view. This border has its padding set by the background image provided by the system, and it cannot be changed. Solutions to avoid this is to either not set height explicitly, case in which the system will take care of displaying the border in the correct position, or to not display the border by setting `underlineColorAndroid` to transparent.

--- a/website/versioned_docs/version-0.60/touchablehighlight.md
+++ b/website/versioned_docs/version-0.60/touchablehighlight.md
@@ -30,14 +30,13 @@ renderButton: function() {
 ```ReactNativeWebPlayer
 import React, { Component } from 'react'
 import {
-  AppRegistry,
   StyleSheet,
   TouchableHighlight,
   Text,
   View,
 } from 'react-native'
 
-class App extends Component {
+export default class App extends Component {
   constructor(props) {
     super(props)
     this.state = { count: 0 }
@@ -87,8 +86,6 @@ const styles = StyleSheet.create({
     color: '#FF00FF'
   }
 })
-
-AppRegistry.registerComponent('App', () => App)
 ```
 
 ### Props

--- a/website/versioned_docs/version-0.60/touchableopacity.md
+++ b/website/versioned_docs/version-0.60/touchableopacity.md
@@ -28,14 +28,13 @@ renderButton: function() {
 ```ReactNativeWebPlayer
 import React, { Component } from 'react'
 import {
-  AppRegistry,
   StyleSheet,
   TouchableOpacity,
   Text,
   View,
 } from 'react-native'
 
-class App extends Component {
+export default class App extends Component {
   constructor(props) {
     super(props)
     this.state = { count: 0 }
@@ -85,8 +84,6 @@ const styles = StyleSheet.create({
     color: '#FF00FF'
   }
 })
-
-AppRegistry.registerComponent('App', () => App)
 ```
 
 ### Props

--- a/website/versioned_docs/version-0.60/using-a-scrollview.md
+++ b/website/versioned_docs/version-0.60/using-a-scrollview.md
@@ -10,7 +10,7 @@ This example creates a vertical `ScrollView` with both images and text mixed tog
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { AppRegistry, ScrollView, Image, Text } from 'react-native';
+import { ScrollView, Image, Text } from 'react-native';
 
 export default class IScrolledDownAndWhatHappenedNextShockedMe extends Component {
   render() {
@@ -51,11 +51,6 @@ export default class IScrolledDownAndWhatHappenedNextShockedMe extends Component
     );
   }
 }
-
-// skip these lines if using Create React Native App
-AppRegistry.registerComponent(
-  'AwesomeProject',
-  () => IScrolledDownAndWhatHappenedNextShockedMe);
 ```
 
 ScrollViews can be configured to allow paging through views using swiping gestures by using the `pagingEnabled` props. Swiping horizontally between views can also be implemented on Android using the [ViewPager](https://github.com/react-native-community/react-native-viewpager) component.


### PR DESCRIPTION
Currently we include `AppRegistry.registerComponent(...)` in basic React Native Web Player examples, but we don't need to do this since the player automatically registering the default exported component. This is also the case for apps you initialize through `react-native init` -- `App.js` just does `export default class App..` and `AppRegistry` is invoked in `index.js`. This PR also removes the comment about "Create React Native App" which no longer is a thing.