### PR TITLE
Remove Expo SDK version mapping for embeds and use latest instead

### DIFF
--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -43,22 +43,6 @@ function htmlForCodeBlock(code) {
  * that requires a newer Expo SDK release.
  */
 const LatestSDKVersion = '26.0.0';
-const ReactNativeToExpoSDKVersionMap = {
-  '0.54': '26.0.0',
-  '0.52': '25.0.0',
-  '0.51': '24.0.0',
-  '0.50': '23.0.0',
-  '0.49': '22.0.0',
-  '0.48': '21.0.0',
-  '0.47': '20.0.0',
-  '0.46': '19.0.0',
-  '0.45': '18.0.0',
-  '0.44': '17.0.0',
-  '0.43': '16.0.0',
-  '0.42': '15.0.0',
-  '0.41': '14.0.0',
-};
-
 /**
  * Use the SnackPlayer by including a ```SnackPlayer``` block in markdown.
  *
@@ -96,12 +80,6 @@ function SnackPlayer(md) {
     const platform = params.platform ? params.platform : 'ios';
     const rnVersion = params.version ? params.version : 'next';
 
-    // Default to the latest SDK configured above.
-    const expoVersion =
-      rnVersion === 'next'
-        ? LatestSDKVersion
-        : ReactNativeToExpoSDKVersionMap[version] || LatestSDKVersion;
-
     return (
       '<div class="snack-player">' +
       '<div class="mobile-friendly-snack" style="display: none">' +
@@ -114,7 +92,6 @@ function SnackPlayer(md) {
         data-snack-code="${encodedSampleCode}"
         data-snack-platform="${platform}"
         data-snack-preview="true"
-        data-snack-sdk-version="${expoVersion}"
         style="
           overflow: hidden;
           background: #fafafa;


### PR DESCRIPTION
The Expo SDK version map for embeds isn't being kept up to date and I believe it makes most sense / is consistent with the React Native Web Player to just use the latest version all the time.

## Before

<img width="1269" alt="Screen Shot 2019-07-22 at 16 39 37" src="https://user-images.githubusercontent.com/90494/61734436-c5ce9480-ad36-11e9-85be-548fdcf4b2c3.png">

## After

<img width="1379" alt="Screen Shot 2019-07-23 at 10 45 47" src="https://user-images.githubusercontent.com/90494/61734637-25c53b00-ad37-11e9-954e-ef3404ff5df5.png">


