### PR TITLE
use [snack.io][PLAYER] instead of react-native-web-player 

### DIFF
--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -7,7 +7,7 @@ Displays a circular loading indicator.
 
 ### Example
 
-```ReactNativeWebPlayer name=activityindicator&platform=web
+```SnackPlayer name=activityindicator&platform=web
 import React, { Component } from 'react'
 import {
   ActivityIndicator,

--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -104,6 +104,10 @@ Many of the following components provide wrappers for commonly used UIKit classe
     <h3><a href="./imagepickerios">ImagePickerIOS</a></h3>
     <p>Renders a image picker on iOS.</p>
   </div>
+   <div class="component">
+    <h3><a href="./navigatorios">NavigatorIOS</a></h3>
+    <p>A wrapper around <code>UINavigationController</code>, enabling you to implement a navigation stack.</p>
+  </div>
   <div class="component">
     <h3><a href="./progressviewios">ProgressViewIOS</a></h3>
     <p>Renders a <code>UIProgressView</a></code> on iOS.</p>

--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -104,7 +104,7 @@ Many of the following components provide wrappers for commonly used UIKit classe
     <h3><a href="./imagepickerios">ImagePickerIOS</a></h3>
     <p>Renders a image picker on iOS.</p>
   </div>
-   <div class="component">
+  <div class="component">
     <h3><a href="./navigatorios">NavigatorIOS</a></h3>
     <p>A wrapper around <code>UINavigationController</code>, enabling you to implement a navigation stack.</p>
   </div>

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -31,7 +31,7 @@ In the following example the red, yellow and the green views are all children in
 
 LEARN MORE [HERE](https://yogalayout.com/docs/flex-direction)
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Flex%20Direction
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -75,7 +75,7 @@ Layout direction specifies the direction in which children and text in a hierarc
 
 LEARN MORE [HERE](https://yogalayout.com/docs/justify-content)
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Justify%20Content
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -118,7 +118,7 @@ export default class JustifyContentBasics extends Component {
 
 LEARN MORE [HERE](https://yogalayout.com/docs/align-items)
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Align%20Items
 import React, { Component } from 'react';
 import { View } from 'react-native';
 

--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -7,7 +7,7 @@ title: Handling Text Input
 
 For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
 
-```SnackPlayer name=Handling%2Text%20Input&platform=web
+```SnackPlayer name=Handling%20Text%20Input&platform=web
 import React, { Component } from 'react';
 import { Text, TextInput, View } from 'react-native';
 

--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -7,7 +7,7 @@ title: Handling Text Input
 
 For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Handling%2Text%20Input
 import React, { Component } from 'react';
 import { Text, TextInput, View } from 'react-native';
 

--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -9,7 +9,7 @@ A component's height and width determine its size on the screen.
 
 The simplest way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are unitless, and represent density-independent pixels.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Height%20and%20Width
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -34,7 +34,7 @@ Use `flex` in a component's style to have the component expand and shrink dynami
 
 > A component can only expand to fill available space if its parent has dimensions greater than 0. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of 0 and the `flex` children will not be visible.
 
-```ReactNativeWebPlayer
+````SnackPlayer name=Flex%20Dimensions
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -55,3 +55,4 @@ export default class FlexDimensionsBasics extends Component {
 ```
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).
+````

--- a/docs/image.md
+++ b/docs/image.md
@@ -9,7 +9,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 > Note that for network and data images, you will need to manually specify the dimensions of your image!
 
-```ReactNativeWebPlayer name=Image&platform=web
+```SnackPlayer name=Image&platform=web
 import React, { Component } from 'react';
 import { View, Image } from 'react-native';
 
@@ -36,7 +36,7 @@ export default class DisplayAnImage extends Component {
 
 You can also add `style` to an image:
 
-```ReactNativeWebPlayer name=Image&platform=web
+```SnackPlayer name=Image&platform=web
 import React, { Component } from 'react';
 import { View, Image, StyleSheet } from 'react-native';
 

--- a/docs/inputaccessoryview.md
+++ b/docs/inputaccessoryview.md
@@ -7,7 +7,7 @@ A component which enables customization of the keyboard input accessory view on 
 
 To use this component wrap your custom toolbar with the InputAccessoryView component, and set a `nativeID`. Then, pass that `nativeID` as the `inputAccessoryViewID` of whatever `TextInput` you desire. A simple example:
 
-```ReactNativeWebPlayer name=InputAccessoryView&platform=web
+```SnackPlayer name=InputAccessoryView&platform=web
 import React, { Component } from 'react';
 import { View, ScrollView, TextInput, InputAccessoryView, Button } from 'react-native';
 

--- a/docs/props.md
+++ b/docs/props.md
@@ -7,7 +7,7 @@ Most components can be customized when they are created, with different paramete
 
 For example, one basic React Native component is the `Image`. When you create an image, you can use a prop named `source` to control what image it shows.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Props
 import React, { Component } from 'react';
 import { Image } from 'react-native';
 
@@ -27,7 +27,7 @@ Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX.
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place. Just refer to `this.props` in your `render` function. Here's an example:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Props
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -9,7 +9,7 @@ In general, you should initialize `state` in the constructor, and then call `set
 
 For example, let's say we want to make text that blinks all the time. The text itself gets set once when the blinking component gets created, so the text itself is a `prop`. The "whether the text is currently on or off" changes over time, so that should be kept in `state`.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=State
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -9,7 +9,7 @@ The `style` prop can be a plain old JavaScript object. That's the simplest and w
 
 As a component grows in complexity, it is often cleaner to use `StyleSheet.create` to define several styles in one place. Here's an example:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Style
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -9,7 +9,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-```ReactNativeWebPlayer name=Text&platform=web
+```SnackPlayer name=Text&platform=web
 import React, { Component } from 'react';
 import { Text, StyleSheet } from 'react-native';
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
 
 Both iOS and Android allow you to display formatted text by annotating ranges of a string with specific formatting like bold or colored text (`NSAttributedString` on iOS, `SpannableString` on Android). In practice, this is very tedious. For React Native, we decided to use web paradigm for this where you can nest text to achieve the same effect.
 
-```ReactNativeWebPlayer name=Nested&platform=web
+```SnackPlayer name=Nested&platform=web
 import React, { Component } from 'react';
 import { Text } from 'react-native';
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -7,7 +7,7 @@ A foundational component for inputting text into the app via a keyboard. Props p
 
 The simplest use case is to plop down a `TextInput` and subscribe to the `onChangeText` events to read the user input. There are also other events, such as `onSubmitEditing` and `onFocus` that can be subscribed to. A simple example:
 
-```ReactNativeWebPlayer name=TextInput&platform=web
+```SnackPlayer name=TextInput&platform=web
 import React, { Component } from 'react';
 import { TextInput } from 'react-native';
 
@@ -33,7 +33,7 @@ Two methods exposed via the native element are .focus() and .blur() that will fo
 
 Note that some props are only available with `multiline={true/false}`. Additionally, border styles that apply to only one side of the element (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if `multiline=false`. To achieve the same effect, you can wrap your `TextInput` in a `View`:
 
-```ReactNativeWebPlayer name=TextInput&platform=web
+```SnackPlayer name=TextInput&platform=web
 import React, { Component } from 'react';
 import { View, TextInput } from 'react-native';
 

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -26,7 +26,7 @@ renderButton: function() {
 
 ### Example
 
-```ReactNativeWebPlayer name=TouchableHighlight&platform=web
+```SnackPlayer name=TouchableHighlight&platform=web
 import React, { Component } from 'react'
 import {
   StyleSheet,

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -24,7 +24,7 @@ renderButton: function() {
 
 ### Example
 
-```ReactNativeWebPlayer name=TouchableOpacity&platform=web
+```SnackPlayer name=TouchableOpacity&platform=web
 import React, { Component } from 'react'
 import {
   StyleSheet,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,7 +11,7 @@ Let's do this thing.
 
 In accordance with the ancient traditions of our people, we must first build an app that does nothing except say "Hello, world!". Here it is:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Hello%20World
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
 

--- a/docs/using-a-scrollview.md
+++ b/docs/using-a-scrollview.md
@@ -7,7 +7,7 @@ The [ScrollView](scrollview.md) is a generic scrolling container that can host m
 
 This example creates a vertical `ScrollView` with both images and text mixed together.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Using%20ScrollView
 import React, { Component } from 'react';
 import { ScrollView, Image, Text } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/activityindicator.md
+++ b/website/versioned_docs/version-0.60/activityindicator.md
@@ -8,7 +8,7 @@ Displays a circular loading indicator.
 
 ### Example
 
-```ReactNativeWebPlayer
+```SnackPlayer name=activityindicator&platform=web
 import React, { Component } from 'react'
 import {
   ActivityIndicator,

--- a/website/versioned_docs/version-0.60/flexbox.md
+++ b/website/versioned_docs/version-0.60/flexbox.md
@@ -32,7 +32,7 @@ In the following example the red, yellow and the green views are all children in
 
 LEARN MORE [HERE](https://yogalayout.com/docs/flex-direction)
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Flex%20Direction&platform=web
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -76,7 +76,7 @@ Layout direction specifies the direction in which children and text in a hierarc
 
 LEARN MORE [HERE](https://yogalayout.com/docs/justify-content)
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Justify%20Content&platform=web
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -119,7 +119,7 @@ export default class JustifyContentBasics extends Component {
 
 LEARN MORE [HERE](https://yogalayout.com/docs/align-items)
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Align%20Items&platform=web
 import React, { Component } from 'react';
 import { View } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/handling-text-input.md
+++ b/website/versioned_docs/version-0.60/handling-text-input.md
@@ -8,7 +8,7 @@ original_id: handling-text-input
 
 For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Handling%20Text%20Input&platform=web
 import React, { Component } from 'react';
 import { Text, TextInput, View } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/image.md
+++ b/website/versioned_docs/version-0.60/image.md
@@ -10,7 +10,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 > Note that for network and data images, you will need to manually specify the dimensions of your image!
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Image&platform=web
 import React, { Component } from 'react';
 import { View, Image } from 'react-native';
 
@@ -37,7 +37,7 @@ export default class DisplayAnImage extends Component {
 
 You can also add `style` to an image:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Image&platform=web
 import React, { Component } from 'react';
 import { View, Image, StyleSheet } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/state.md
+++ b/website/versioned_docs/version-0.60/state.md
@@ -10,7 +10,7 @@ In general, you should initialize `state` in the constructor, and then call `set
 
 For example, let's say we want to make text that blinks all the time. The text itself gets set once when the blinking component gets created, so the text itself is a `prop`. The "whether the text is currently on or off" changes over time, so that should be kept in `state`.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=State&platform=web
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/style.md
+++ b/website/versioned_docs/version-0.60/style.md
@@ -10,7 +10,7 @@ The `style` prop can be a plain old JavaScript object. That's the simplest and w
 
 As a component grows in complexity, it is often cleaner to use `StyleSheet.create` to define several styles in one place. Here's an example:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Style&platform=web
 import React, { Component } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/text.md
+++ b/website/versioned_docs/version-0.60/text.md
@@ -10,7 +10,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Text&platform=web
 import React, { Component } from 'react';
 import { Text, StyleSheet } from 'react-native';
 
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 
 Both iOS and Android allow you to display formatted text by annotating ranges of a string with specific formatting like bold or colored text (`NSAttributedString` on iOS, `SpannableString` on Android). In practice, this is very tedious. For React Native, we decided to use web paradigm for this where you can nest text to achieve the same effect.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Nested&platform=web
 import React, { Component } from 'react';
 import { Text } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/textinput.md
+++ b/website/versioned_docs/version-0.60/textinput.md
@@ -8,7 +8,7 @@ A foundational component for inputting text into the app via a keyboard. Props p
 
 The simplest use case is to plop down a `TextInput` and subscribe to the `onChangeText` events to read the user input. There are also other events, such as `onSubmitEditing` and `onFocus` that can be subscribed to. A simple example:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=TextInput&platform=web
 import React, { Component } from 'react';
 import { TextInput } from 'react-native';
 
@@ -34,7 +34,7 @@ Two methods exposed via the native element are .focus() and .blur() that will fo
 
 Note that some props are only available with `multiline={true/false}`. Additionally, border styles that apply to only one side of the element (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if `multiline=false`. To achieve the same effect, you can wrap your `TextInput` in a `View`:
 
-```ReactNativeWebPlayer
+```SnackPlayer name=TextInput&platform=web
 import React, { Component } from 'react';
 import { View, TextInput } from 'react-native';
 

--- a/website/versioned_docs/version-0.60/touchablehighlight.md
+++ b/website/versioned_docs/version-0.60/touchablehighlight.md
@@ -27,7 +27,7 @@ renderButton: function() {
 
 ### Example
 
-```ReactNativeWebPlayer
+```SnackPlayer name=TouchableHighlight&platform=web
 import React, { Component } from 'react'
 import {
   StyleSheet,

--- a/website/versioned_docs/version-0.60/touchableopacity.md
+++ b/website/versioned_docs/version-0.60/touchableopacity.md
@@ -25,7 +25,7 @@ renderButton: function() {
 
 ### Example
 
-```ReactNativeWebPlayer
+```SnackPlayer name=TouchableOpacity&platform=web
 import React, { Component } from 'react'
 import {
   StyleSheet,

--- a/website/versioned_docs/version-0.60/using-a-scrollview.md
+++ b/website/versioned_docs/version-0.60/using-a-scrollview.md
@@ -8,7 +8,7 @@ The [ScrollView](scrollview.md) is a generic scrolling container that can host m
 
 This example creates a vertical `ScrollView` with both images and text mixed together.
 
-```ReactNativeWebPlayer
+```SnackPlayer name=Using%20ScrollView&platform=web
 import React, { Component } from 'react';
 import { ScrollView, Image, Text } from 'react-native';
 


### PR DESCRIPTION
### Use `Snack.io` player instead of the `react-native-web-player` in the following sections.

Related issue #1131 

- [x] The Basics
- [x]  Guides
- [x] Guides (IOS)
- [x] Guides (Android)
- [x] Components
- [x] API

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
