### PR TITLE
Remove duplicate activeOpacity description

### DIFF
--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -127,16 +127,6 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `activeOpacity`
-
-Determines what the opacity of the wrapped view should be when touch is active. Defaults to 0.2.
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
 ### `tvParallaxProperties`
 
 _(Apple TV only)_ Object with properties to control Apple TV parallax effects.


### PR DESCRIPTION
The `activeOpacity` prop is described twice in the document. This PR resolves the duplication.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
