### PR TITLE
Update ReactNativeWebPlayer version, bump Expo SDK version

### DIFF
--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -35,15 +35,6 @@ function htmlForCodeBlock(code) {
 }
 
 /**
- * Expo SDKs lag stable React Native versions by a week or two.
- * This mapping informs the SnackPlayer which version of Expo whenever
- * a React Native version param is passed. There's no harm in keeping this
- * list up to date, but in practical terms you will only need to do so
- * whenever an example that uses the SnackPlayer is updated with code
- * that requires a newer Expo SDK release.
- */
-const LatestSDKVersion = '31.0.0';
-/**
  * Use the SnackPlayer by including a ```SnackPlayer``` block in markdown.
  *
  * Optionally, include url parameters directly after the block's language.

--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -42,7 +42,7 @@ function htmlForCodeBlock(code) {
  * whenever an example that uses the SnackPlayer is updated with code
  * that requires a newer Expo SDK release.
  */
-const LatestSDKVersion = '26.0.0';
+const LatestSDKVersion = '31.0.0';
 /**
  * Use the SnackPlayer by including a ```SnackPlayer``` block in markdown.
  *
@@ -133,7 +133,7 @@ function ReactNativeWebPlayer(md) {
     env,
     self
   ) {
-    const WEB_PLAYER_VERSION = '1.10.0';
+    const WEB_PLAYER_VERSION = '2.0.0-alpha.8';
 
     let sampleCode = tokens[idx].content;
     let hash = `#code=${encodeURIComponent(sampleCode)}`;


### PR DESCRIPTION
The InputAccessoryView docs have a web player that is failing with this error:

    Invariant Violation: Minified React error #130; visit http://facebook.github.io/react/docs/error-decoder.html?invariant=130&amp;args[]=undefined&amp;args[]=%20Check%20the%20render%20method%20of%20%60UselessTextInput%60. for the full message or use the non-minified dev environment for full errors and additional helpful warnings.

The full error message is:

    Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: [missing argument].[missing argument]

I noticed we're using a three year old build of the react-native-web-player. Upgrading to the latest 2.0.0 alpha version seems to have fixed it.

At the same time, I updated the Snack player to use a newer Expo SDK version.

## Test Plan

I loaded InputAccessoryView, Flexbox, Style, and various other docs that use the web player. They all appeared nominal.
