### PR TITLE
add warnings to deprecated components

### DIFF
--- a/docs/alertios.md
+++ b/docs/alertios.md
@@ -3,6 +3,8 @@ id: alertios
 title: AlertIOS
 ---
 
+> **Deprecated.** `AlertIOS` has been moved to [`Alert`](alert.md)
+
 `AlertIOS` provides functionality to create an iOS alert dialog with a message or create a prompt for user input.
 
 Creating an iOS alert:

--- a/docs/imageeditor.md
+++ b/docs/imageeditor.md
@@ -3,6 +3,8 @@ id: imageeditor
 title: ImageEditor
 ---
 
+> **Deprecated.** Use [@react-native-community/image-editor](https://github.com/react-native-community/react-native-image-editor) instead.
+
 ### Methods
 
 - [`cropImage`](imageeditor.md#cropimage)

--- a/docs/imagepickerios.md
+++ b/docs/imagepickerios.md
@@ -3,6 +3,8 @@ id: imagepickerios
 title: ImagePickerIOS
 ---
 
+> **Deprecated.** Use [@react-native-community/image-picker-ios](https://github.com/react-native-community/react-native-image-picker-ios) instead.
+
 ### Methods
 
 - [`canRecordVideos`](imagepickerios.md#canrecordvideos)

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -3,6 +3,8 @@ id: pushnotificationios
 title: PushNotificationIOS
 ---
 
+> **Deprecated.** Use [@react-native-community/push-notification-ios](https://github.com/react-native-community/react-native-push-notification-ios) instead.
+
 <div class="banner-crna-ejected">
   <h3>Projects with Native Code Only</h3>
   <p>

--- a/docs/segmentedcontrolios.md
+++ b/docs/segmentedcontrolios.md
@@ -3,6 +3,8 @@ id: segmentedcontrolios
 title: SegmentedControlIOS
 ---
 
+> **Deprecated.** Use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
+
 Use `SegmentedControlIOS` to render a UISegmentedControl iOS.
 
 #### Programmatically changing selected index

--- a/docs/statusbarios.md
+++ b/docs/statusbarios.md
@@ -3,7 +3,7 @@ id: statusbarios
 title: StatusBarIOS
 ---
 
-Use `StatusBar` for mutating the status bar.
+> Use `StatusBar` for mutating the status bar.
 
 ---
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This PR add warnings to:

- `ImageEditor`
- `AlertIOS`
- `ImagePickerIOS`
- `PushNotificationIOS`
- `SegmentedControlIOS`
- `StatusBarIOS`

see #1130 too
