### PR TITLE
Remove linking for gesture handler

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -27,12 +27,6 @@ yarn add react-native-gesture-handler
 # npm install --save react-native-gesture-handler
 ```
 
-Now we need to link our react-native to react-native-gesture-handler
-
-```
-react-native link react-native-gesture-handler
-```
-
 Then you can quickly create an app with a home screen and a profile screen:
 
 ```jsx


### PR DESCRIPTION
As from 0.60 modules has to be linked automatically.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
