### PR TITLE
Adjust getting started wording

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,9 +5,9 @@ title: Getting Started
 
 This page will help you install and build your first React Native app. If you already have React Native installed, you can skip ahead to the [Tutorial](tutorial.md).
 
-<strong>If you are coming from a web background</strong>, the easiest way to get started with React Native is with Expo tools because they allow you to start a project without installing and configuring Xcode or Android Studio. Expo CLI sets up a development environment on your local machine and you can begin writing a React Native app within minutes. For instant development, you can use [Snack](https://snack.expo.io/) to try React Native out directly in your web browser.
+<strong>If you are new to mobile development</strong>, the easiest way to get started is with Expo CLI. Expo is a set of tools built around React Native and, while it has many [features](https://expo.io/features), the most relevant feature for us right now is that it can get you writing a React Native app within minutes. You will only need a recent version of Node.js and a phone or emulator. If you'd like to try out React Native directly in your web browser before installing any tools, you can try out [Snack](https://snack.expo.io/).
 
-<strong>If you are familiar with native development</strong>, you will likely want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
+<strong>If you are already familiar with mobile development</strong>, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
 <div class="toggler">
   <ul role="tablist" id="toggle-guide">
@@ -22,7 +22,7 @@ This page will help you install and build your first React Native app. If you al
 
 <block class="quickstart mac windows linux ios android" />
 
-Assuming that you have [Node 10+](https://nodejs.org/en/download/) installed, you can use npm to install the Expo CLI command line utility:
+Assuming that you have [Node 10 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
 ```sh
 npm install -g expo-cli
@@ -84,7 +84,7 @@ If you're integrating React Native into an existing project, you'll want to skip
 
 <block class="native mac windows linux ios android" />
 
-<p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Expo</a> or Create React Native App, you'll need this section.</p>
+<p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Expo</a>, you'll need this section.</p>
 
 The instructions are a bit different depending on your development operating system, and whether you want to start developing for iOS or Android. If you want to develop for both iOS and Android, that's fine - you just have to pick one to start with, since the setup is a bit different.
 

--- a/website/versioned_docs/version-0.60/getting-started.md
+++ b/website/versioned_docs/version-0.60/getting-started.md
@@ -6,9 +6,9 @@ original_id: getting-started
 
 This page will help you install and build your first React Native app. If you already have React Native installed, you can skip ahead to the [Tutorial](tutorial.md).
 
-<strong>If you are coming from a web background</strong>, the easiest way to get started with React Native is with Expo tools because they allow you to start a project without installing and configuring Xcode or Android Studio. Expo CLI sets up a development environment on your local machine and you can begin writing a React Native app within minutes. For instant development, you can use [Snack](https://snack.expo.io/) to try React Native out directly in your web browser.
+<strong>If you are new to mobile development</strong>, the easiest way to get started is with Expo CLI. Expo is a set of tools built around React Native and, while it has many [features](https://expo.io/features), the most relevant feature for us right now is that it can get you writing a React Native app within minutes. You will only need a recent version of Node.js and a phone or emulator. If you'd like to try out React Native directly in your web browser before installing any tools, you can try out [Snack](https://snack.expo.io/).
 
-<strong>If you are familiar with native development</strong>, you will likely want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
+<strong>If you are already familiar with mobile development</strong>, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
 <div class="toggler">
   <ul role="tablist" id="toggle-guide">
@@ -23,7 +23,7 @@ This page will help you install and build your first React Native app. If you al
 
 <block class="quickstart mac windows linux ios android" />
 
-Assuming that you have [Node 10+](https://nodejs.org/en/download/) installed, you can use npm to install the Expo CLI command line utility:
+Assuming that you have [Node 10 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
 ```sh
 npm install -g expo-cli
@@ -85,24 +85,24 @@ If you're integrating React Native into an existing project, you'll want to skip
 
 <block class="native mac windows linux ios android" />
 
-<p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Expo</a> or Create React Native App, you'll need this section.</p>
+<p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Expo</a>, you'll need this section.</p>
 
 The instructions are a bit different depending on your development operating system, and whether you want to start developing for iOS or Android. If you want to develop for both iOS and Android, that's fine - you just have to pick one to start with, since the setup is a bit different.
 
 <div class="toggler">
   <span>Development OS:</span>
   <span role="tablist" id="toggle-os">
-    <button role="tab" class="button-mac" onclick="displayTab('os', 'mac')">macOS</button>
-    <button role="tab" class="button-windows" onclick="displayTab('os', 'windows')">Windows</button>
-    <button role="tab" class="button-linux" onclick="displayTab('os', 'linux')">Linux</button>
+    <button role="tab" class="button-mac" onclick="displayTab('os', 'mac')">macOS</a>
+    <button role="tab" class="button-windows" onclick="displayTab('os', 'windows')">Windows</a>
+    <button role="tab" class="button-linux" onclick="displayTab('os', 'linux')">Linux</a>
   </span>
 </div>
 
 <div class="toggler">
   <span>Target OS:</span>
   <span role="tablist" id="toggle-platform">
-    <button role="tab" class="button-ios" onclick="displayTab('platform', 'ios')">iOS</button>
-    <button role="tab" class="button-android" onclick="displayTab('platform', 'android')">Android</button>
+    <button role="tab" class="button-ios" onclick="displayTab('platform', 'ios')">iOS</a>
+    <button role="tab" class="button-android" onclick="displayTab('platform', 'android')">Android</a>
   </span>
 </div>
 


### PR DESCRIPTION
I had a video chat with @rachelnabors today and during the call she raised two issues that have come up when discussing documentation with the community:

1. We currently provide advice for people who come "from a web development background" or are "familiar with native development", but there is no explicit advice for people who don't fit into those categories.
2. It is not explained well enough what Expo is and how it relates to React Native in the intro paragraph.

In order to address point 1, I directed the advice towards people who are "new to mobile development" or "already familiar with mobile development", which I believe should cover everybody.

In order to address point 2, I rewrote the Expo CLI introduction paragraph to attempt to concisely explain how Expo relates  to React Native. This was tough to do! I think the changes are an improvement though.

For your consideration, my attempt at writing words instead of code.