### PR TITLE
chore: Update CLI instructions to use @react-native-community/cli.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -193,7 +193,7 @@ Node comes with npm, which lets you install the React Native command line interf
 Run the following command in a Terminal:
 
 ```
-npm install -g react-native-cli
+npm install -g @react-native-community/cli
 ```
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
@@ -207,7 +207,7 @@ Node comes with npm, which lets you install the React Native command line interf
 Run the following command in a Command Prompt or shell:
 
 ```powershell
-npm install -g react-native-cli
+npm install -g @react-native-community/cli
 ```
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.


### PR DESCRIPTION
## Summary: 

Updated docs to recommend installation of CLI through @react-native-community/cli.

This seems to be the direction recommendations are moving at https://github.com/react-native-community/cli/blob/master/docs/init.md and https://github.com/react-native-community/cli#about, though there also seems to be tendency toward local installation. If we want to go that direction here, we'll need to also update the `react-native init` references to include some `npx` or `yarn` prefix.