### PR TITLE
Update the flags needed for Android compatiblity

### DIFF
--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -9,7 +9,13 @@ A common way to use this API is to call it before calling `setState`.
 
 Note that in order to get this to work on **Android** you need to set the following flags via `UIManager`:
 
-    UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
+```js
+if (Platform.OS === 'android') {
+    if (UIManager.setLayoutAnimationEnabledExperimental) {
+        UIManager.setLayoutAnimationEnabledExperimental(true);
+    }
+}
+```
 
 ### Methods
 


### PR DESCRIPTION
Added a platform check so that the flags will only be set if the OS being run is Android, as they aren't needed for iOS. 

Also changed the original "&&" structure for a simple "if" structure, since the original would incur on a "no-unused-expressions" error on default ESLint configurations. Said error can be overridden by allowing the "allowShortCircuit" option on .eslintrc, but since current guidelines don't recommend it, such cases should be avoided as much as possible, hence the change.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
