### PR TITLE
Thoroughly document LayoutAnimation API

### DIFF
--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -11,6 +11,39 @@ Note that in order to get this to work on **Android** you need to set the follow
 
     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
 
+Example usage:
+
+```jsx
+import React, {Component} from 'react';
+import {View, Text, TouchableOpacity, Platform, UIManager} from 'react-native';
+
+if (
+  Platform.OS === 'android' &&
+  UIManager.setLayoutAnimationEnabledExperimental
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+class AnimatedCollapsible extends React.Component {
+  state = {expanded: false};
+  render() {
+    return (
+      <View style={{overflow: 'hidden'}}>
+        <TouchableOpacity
+          onPress={() => {
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
+            this.setState({expanded: !this.state.expanded});
+          }}>
+          <Text>
+            Press me to {this.state.expanded ? 'collapse' : 'expand'}!
+          </Text>
+        </TouchableOpacity>
+        {this.state.expanded && <Text>I disappear sometimes!</Text>}
+      </View>
+    );
+  }
+}
+```
+
 ### Methods
 
 - [`configureNext`](layoutanimation.md#configurenext)
@@ -43,14 +76,24 @@ Schedules an animation to happen on the next layout.
 
 | Name              | Type     | Required | Description                                                |
 | ----------------- | -------- | -------- | ---------------------------------------------------------- |
-| config            | object   | Yes      | See config parameters below.                               |
+| config            | object   | Yes      | See config description below.                              |
 | onAnimationDidEnd | function | No       | Called when the animation finished. Only supported on iOS. |
 
-##### config
+The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 
 - `duration` in milliseconds
-- `create`, config for animating in new views (see `Anim` type)
-- `update`, config for animating views that have been updated (see `Anim` type)
+- `create`, optional config for animating in new views
+- `update`, optional config for animating views that have been updated
+- `delete`, optional config for animating views as they are removed
+
+The config that's passed to `create`, `update`, or `delete` has the following keys:
+
+- `type`, the [animation type](layoutanimation.md#types) to use
+- `property`, the [layout property](layoutanimation.md#properties) to animate (optional, but recommended for `create` and `delete`)
+- `springDamping` (number, optional and only for use with `type: Type.spring`)
+- `initialVelocity` (number, optional)
+- `delay` (number, optional)
+- `duration` (number, optional)
 
 ---
 
@@ -60,13 +103,25 @@ Schedules an animation to happen on the next layout.
 static create(duration, type, creationProp)
 ```
 
-Helper for creating a config for `configureNext`.
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
+
+Example usage:
+
+```js
+LayoutAnimation.configureNext(
+  LayoutAnimation.create(
+    500,
+    LayoutAnimation.Types.spring,
+    LayoutAnimation.Properties.scaleXY,
+  ),
+);
+```
 
 ## Properties
 
 ### Types
 
-An enumerate of animation types to be used in [`create`](layoutanimation.md#create) method.
+An enumeration of animation types to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Types.easeIn`)
 
 | Types         |
 | ------------- |
@@ -81,7 +136,7 @@ An enumerate of animation types to be used in [`create`](layoutanimation.md#crea
 
 ### Properties
 
-An enumerate of object property to be animated, used in [`create`](layoutanimation.md#create) method.
+An enumeration of layout properties to be animated to be used in the [`create`](layoutanimation.md#create) method, or in the `create`/`update`/`delete` configs for [`configureNext`](layoutanimation.md#configurenext). (example usage: `LayoutAnimation.Properties.opacity`)
 
 | Properties |
 | ---------- |
@@ -94,7 +149,7 @@ An enumerate of object property to be animated, used in [`create`](layoutanimati
 
 ### Presets
 
-A set of predefined animation config.
+A set of predefined animation configs to pass into [`configureNext`](layoutanimation.md#configurenext).
 
 | Presets       | Value                                                                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -104,18 +159,18 @@ A set of predefined animation config.
 
 ---
 
-### easeInEaseOut
+### `easeInEaseOut()`
 
-Shortcut to bind `configureNext()` methods with `Presets.easeInEaseOut`.
-
----
-
-### linear
-
-Shortcut to bind `configureNext()` methods with `Presets.linear`.
+Calls `configureNext()` with `Presets.easeInEaseOut`.
 
 ---
 
-### spring
+### `linear()`
 
-Shortcut to bind `configureNext()` methods with `Presets.spring`.
+Calls `configureNext()` with `Presets.linear`.
+
+---
+
+### `spring()`
+
+Calls `configureNext()` with `Presets.spring`.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Adds full API documentation for the LayoutAnimation API, and clears up some clarity problems in the LayoutAnimation docs page. There's definitely still room for improvement, but this PR should fix some of the more serious issues.

Changes/Notes:
- Adds a code example at the start to illustrate the use of `LayoutAnimation`. This might not be 100% necessary since the actual mechanism of calling `configureNext` before `setState` is so straightforward. It's easy for someone who isn't interested to skip the code block, though.
- Explicitly has `configureNext` reference `create` and the `Presets` as potential arguments, and vice-versa.
- Spells out the nested object parameter types for `configureNext`'s first argument. The word "config" is a bit overloaded here but I couldn't think of another good word.
- "create" is another overloaded word, so the `create()` description points out that the returned object also has `update` and `delete` fields.
- The `Types` and `Properties` objects are also confusingly named, so I refer to their values (aka their properties, aka their types) as "animation types" and "layout properties", respectively. Also adds links wherever their values are used.
- The bound functions are now written as functions. My instinct is to not move them up into the Methods section, since that order is kind of hard to follow.