### PR TITLE
Add note concerning opened Modals

### DIFF
--- a/docs/backhandler.md
+++ b/docs/backhandler.md
@@ -12,6 +12,7 @@ tvOS: Detect presses of the menu button on the TV remote. (Still to be implement
 iOS: Not applicable.
 
 The event subscriptions are called in reverse order (i.e. last registered subscription first), and if one subscription returns true then subscriptions registered earlier will not be called.
+Beware: If your app shows an opened `Modal`, BackHandler will not publish any events ([see `Modal` docs](https://facebook.github.io/react-native/docs/modal#onrequestclose)).
 
 Example:
 


### PR DESCRIPTION
This behaviour is unexpected and part of its API, so I think it it's important to mention this in the BackHandler docs as well.
I hope this will save some developers from a lot of headache.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
