### PR TITLE
Make module's constructor package-private

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -44,7 +44,7 @@ public class ToastModule extends ReactContextBaseJavaModule {
   private static final String DURATION_SHORT_KEY = "SHORT";
   private static final String DURATION_LONG_KEY = "LONG";
 
-  public ToastModule(ReactApplicationContext reactContext) {
+  ToastModule(ReactApplicationContext reactContext) {
     super(reactContext);
   }
 }
@@ -412,7 +412,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
     }
   };
 
-  public ImagePickerModule(ReactApplicationContext reactContext) {
+  ImagePickerModule(ReactApplicationContext reactContext) {
     super(reactContext);
 
     // Add the listener for `onActivityResult`


### PR DESCRIPTION
The module's constructor is only used in the corresponding package, so it seems good practice to make it package-private by default and only extend accessibility when required.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
