### PR TITLE
Anchor links should be lowercase

### DIFF
--- a/docs/imagebackground.md
+++ b/docs/imagebackground.md
@@ -23,8 +23,8 @@ return (
 
 - [`Image` props...](image.md#props)
 - [`style`](imagebackground.md#style)
-- [`imageStyle`](imagebackground.md#imageStyle)
-- [`imageRef`](imagebackground.md#imageRef)
+- [`imageStyle`](imagebackground.md#imagestyle)
+- [`imageRef`](imagebackground.md#imageref)
 
 ---
 


### PR DESCRIPTION
Hi, the anchor links for the **imageStyle** and **imageRef** props on the ImageBackground page should be **lowercase** instead **lowerCamelCase**

![pr-1](https://user-images.githubusercontent.com/461124/63788984-0c765800-c8bc-11e9-99f9-3e7f291eb6da.png)
![pr-2](https://user-images.githubusercontent.com/461124/63788985-0c765800-c8bc-11e9-8531-b2b9bf459196.png)
