### PR TITLE
Update React DevTools link in 0.60

### DIFF
--- a/website/versioned_docs/version-0.60/debugging.md
+++ b/website/versioned_docs/version-0.60/debugging.md
@@ -89,7 +89,7 @@ However, there are some disadvantages:
 
 ## React Developer Tools
 
-You can use [the standalone version of React Developer Tools](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools) to debug the React component hierarchy. To use it, install the `react-devtools` package globally:
+You can use [the standalone version of React Developer Tools](https://github.com/facebook/react/tree/master/packages/react-devtools) to debug the React component hierarchy. To use it, install the `react-devtools` package globally:
 
 ```
 npm install -g react-devtools


### PR DESCRIPTION
## Overview 

Adds https://github.com/facebook/react-native-website/pull/1195 to the current version