### PR TITLE
Mention `alertTitle` parameter for `presentLocalNotification`

### DIFF
--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -161,6 +161,7 @@ Schedules the localNotification for immediate presentation.
 details is an object containing:
 
 - `alertBody` : The message displayed in the notification alert.
+- `alertTitle` : The text displayed as the title of the notification alert.
 - `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
 - `soundName` : The sound played when the notification is fired (optional).
 - `isSilent` : If true, the notification will appear without sound (optional).


### PR DESCRIPTION
The `details` parameter of `presentLocalNotifications` is translated to a OBJ-C [`UILocalNotification`](https://developer.apple.com/documentation/uikit/uilocalnotification) and thus has all its parameters, including `alertTitle`.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
