### PR TITLE
Display a right side nav

### DIFF
--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -102,7 +102,7 @@ function SnackPlayer(md) {
           border: 1px solid rgba(0,0,0,.16);
           border-radius: 4px;
           height: 514px;
-          width: 880px;
+          width: 100%;
         "
       >` +
       '</div>' +

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -88,6 +88,7 @@ const siteConfig = {
     zIndex: 100,
   },
   docsSideNavCollapsible: true,
+  onPageNav: 'separate',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
We had to fix the width of Snack player to `100%` instead of a specific dimension.