### PR TITLE
Split components and APIs grid in 2 or 3

### DIFF
--- a/website/static/css/react-native.css
+++ b/website/static/css/react-native.css
@@ -155,10 +155,7 @@ a code {
   }
 }
 
-@media only screen and (min-device-width: 768px) {
-  .mainContainer .component-grid {
-    width: 768px;
-  }
+@media only screen and (min-width: 768px) {
   .mainContainer .component-grid.component-grid-border {
     border-bottom: 1px solid #f1eff0;
   }
@@ -171,7 +168,12 @@ a code {
 
   @supports (display: grid) {
     .mainContainer .component-grid {
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(2, 1fr);
+    }
+    @media only screen and (min-width: 1440px) {
+      .mainContainer .component-grid {
+        grid-template-columns: repeat(3, 1fr);
+      }
     }
     .mainContainer .component {
       width: auto;


### PR DESCRIPTION
Fixed the issue @rachelnabors found since the new side nav.

| State | `min-width: 768px` | `min-width: 1440px` |
| - | - | - |
| Before | <img src="https://user-images.githubusercontent.com/7189823/64248479-7d97ba00-cf11-11e9-8c48-1553a09a1fd9.png" /> | <img src="https://user-images.githubusercontent.com/7189823/64248411-4923fe00-cf11-11e9-83d7-b2d074782025.png" /> |
| After | <img src="https://user-images.githubusercontent.com/7189823/64248257-fb0efa80-cf10-11e9-8b96-b49de530df7a.png" /> | <img src="https://user-images.githubusercontent.com/7189823/64248336-1ed24080-cf11-11e9-8f69-e73b444e7925.png" /> |




