### PR TITLE
Bad variable name leading code example to fail.

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -20,11 +20,11 @@ import React, { useState, useEffect } from 'react';
 import { Animated, Text, View } from 'react-native';
 
 const FadeInView = (props) => {
-  const [fadeAdmin] = useState(new Animated.Value(0))  // Initial value for opacity: 0
+  const [fadeAnim] = useState(new Animated.Value(0))  // Initial value for opacity: 0
 
   React.useEffect(() => {
     Animated.timing(
-      fadeAdmin,
+      fadeAnim,
       {
         toValue: 1,
         duration: 10000,
@@ -36,7 +36,7 @@ const FadeInView = (props) => {
     <Animated.View                 // Special animatable View
       style={{
         ...props.style,
-        opacity: fadeAdnim,         // Bind opacity to animated value
+        opacity: fadeAnim,         // Bind opacity to animated value
       }}
     >
       {props.children}


### PR DESCRIPTION
Array destructuring `[fadeAdmin]` instead of `[fadeAnim]` in the SnackPlayer code example.

Renaming to `fadeAnim` in the example. 

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
