### PR TITLE
Correction in Animation: fadeAdmin example

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -36,7 +36,7 @@ const FadeInView = (props) => {
     <Animated.View                 // Special animatable View
       style={{
         ...props.style,
-        opacity: fadeAdnim,         // Bind opacity to animated value
+        opacity: fadeAdmin,         // Bind opacity to animated value
       }}
     >
       {props.children}


### PR DESCRIPTION
The code is breaking and giving the error about fadeAdmin. Corrected the issue.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
