### PR TITLE
[Tutorial] Fix 2nd code block rendering

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -34,7 +34,7 @@ Use `flex` in a component's style to have the component expand and shrink dynami
 
 > A component can only expand to fill available space if its parent has dimensions greater than 0. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of 0 and the `flex` children will not be visible.
 
-````SnackPlayer name=Flex%20Dimensions
+```SnackPlayer name=Flex%20Dimensions
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -55,4 +55,3 @@ export default class FlexDimensionsBasics extends Component {
 ```
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).
-````


### PR DESCRIPTION
The 2nd code block was including the following text and throwing an error.

<img width="771" alt="Screen Shot 2019-09-05 at 7 07 57 PM" src="https://user-images.githubusercontent.com/1571586/64389396-81f6cc80-d010-11e9-9f98-33c529bcdc42.png">
