### PR TITLE
Explicitly mention how to upgrade RN when switching to Hermes

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -9,7 +9,9 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for running React Native apps on Android. For many apps, simply enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native. If you're upgrading an existing app ensure everything works before trying to switch to Hermes.
+First, ensure you're using at least version 0.60.4 of React Native.
+
+If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/react-native/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
 
 > ## Note for Windows users.
 >


### PR DESCRIPTION
This Hermes issue points out that the documentation for turning on Hermes in an existing app is quite terse: https://github.com/facebook/hermes/issues/96

This diff adds links to the existing RN docs, and is generally more verbose.