### PR TITLE
Bug with extra back-ticks is fixed

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -34,7 +34,7 @@ Use `flex` in a component's style to have the component expand and shrink dynami
 
 > A component can only expand to fill available space if its parent has dimensions greater than 0. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of 0 and the `flex` children will not be visible.
 
-````SnackPlayer name=Flex%20Dimensions
+```SnackPlayer name=Flex%20Dimensions
 import React, { Component } from 'react';
 import { View } from 'react-native';
 
@@ -55,4 +55,3 @@ export default class FlexDimensionsBasics extends Component {
 ```
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).
-````


### PR DESCRIPTION
unnecessary back-ticks are breaking the layout of the page and the last example

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
