### PR TITLE
Update height-and-width.md incorrect code block

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -52,7 +52,6 @@ export default class FlexDimensionsBasics extends Component {
     );
   }
 }
-```
+````
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).
-````


### PR DESCRIPTION
Little fix in the last code block, the code incorporated the last line of text and the example didn't worked.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
