### PR TITLE
imp: Add anchors to the getting started tabs

### DIFF
--- a/website/versioned_docs/version-0.60/getting-started.md
+++ b/website/versioned_docs/version-0.60/getting-started.md
@@ -23,6 +23,8 @@ This page will help you install and build your first React Native app. If you al
 
 <block class="quickstart mac windows linux ios android" />
 
+## Expo CLI Quickstart
+
 Assuming that you have [Node 10 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
 ```sh
@@ -84,6 +86,8 @@ Expo CLI configures your project to use the most recent React Native version tha
 If you're integrating React Native into an existing project, you'll want to skip Expo CLI and go directly to setting up the native build environment. Select "React Native CLI Quickstart" above for instructions on configuring a native build environment for React Native.
 
 <block class="native mac windows linux ios android" />
+
+## React Native CLI Quickstart
 
 <p>Follow these instructions if you need to build native code in your project. For example, if you are integrating React Native into an existing application, or if you "ejected" from <a href="getting-started" onclick="displayTab('guide', 'quickstart')">Expo</a>, you'll need this section.</p>
 


### PR DESCRIPTION
Referenced to issue #968. 
Added links with anchors to the quickstart tabs at the Getting Started page to make possible send a link for specific quickstart method.
