### PR TITLE
Add key prop to Example usage of FlatList's `renderItem` prop

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -221,6 +221,7 @@ Example usage:
   data={[{title: 'Title Text', key: 'item1'}]}
   renderItem={({item, index, separators}) => (
     <TouchableHighlight
+      key={item.key}
       onPress={() => this._onPress(item)}
       onShowUnderlay={separators.highlight}
       onHideUnderlay={separators.unhighlight}>


### PR DESCRIPTION
I think there should be key inside `renderItem` callback
