### PR TITLE
fix(docs): add missing methods on the TextInput doc for focus and blur

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -781,6 +781,22 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ## Methods
 
+### `.focus()`
+
+```jsx
+focus();
+```
+
+Makes the native input request focus.
+
+### `.blur()`
+
+```jsx
+blur();
+```
+
+Makes the native input lose focus.
+
 ### `clear()`
 
 ```jsx


### PR DESCRIPTION
fixes #400
