### PR TITLE
add missing LayoutAnimation import

### DIFF
--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -21,7 +21,7 @@ Example usage:
 
 ```jsx
 import React, {Component} from 'react';
-import {View, Text, TouchableOpacity, Platform, UIManager} from 'react-native';
+import {View, Text, TouchableOpacity, Platform, UIManager, LayoutAnimation} from 'react-native';
 
 if (
   Platform.OS === 'android' &&


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
The demo regarding the use of `LayoutAnimation` API should `import LayoutAnimation from 'react-native'` but it doesn't and therefore you can't run that code right away. 