### PR TITLE
[docs] [Image] Indicate the default `resizeMode`

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -201,7 +201,7 @@ e.g., `onLoadStart={(e) => this.setState({loading: true})}`
 
 ### `resizeMode`
 
-Determines how to resize the image when the frame doesn't match the raw image dimensions.
+Determines how to resize the image when the frame doesn't match the raw image dimensions. Defaults to `cover`.
 
 - `cover`: Scale the image uniformly (maintain the image's aspect ratio) so that both dimensions (width and height) of the image will be equal to or larger than the corresponding dimension of the view (minus padding).
 


### PR DESCRIPTION
In the docs: https://facebook.github.io/react-native/docs/image#resizemode
The default `resizeMode` is not indicated.

In the source: https://github.com/facebook/react-native/blob/master/Libraries/Image/Image.ios.js#L114
The default `resizeMode` is `cover`.
