### PR TITLE
Update running-on-device.md

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -270,7 +270,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 App Transport Security is a security feature introduced in iOS 9 that rejects all HTTP requests that are not sent over HTTPS. This can result in HTTP traffic being blocked, including the developer React Native server. ATS is disabled for `localhost` by default in React Native projects in order to make development easier.
 
-You should re-enable ATS prior to building your app for production by removing the `localhost` entry from the `NSExceptionDomains` dictionary in your `Info.plist` file in the `ios/` folder. You can also re-enable ATS from within Xcode by opening your target properties under the Info pane and editing the App Transport Security Settings entry.
+You should re-enable ATS prior to building your app for production by removing the `localhost` entry from the `NSExceptionDomains` dictionary and setting `NSAllowsArbitraryLoads` to `false` in your `Info.plist` file in the `ios/` folder. You can also re-enable ATS from within Xcode by opening your target properties under the Info pane and editing the App Transport Security Settings entry.
 
 > If your application needs to access HTTP resources on production, see [this post](http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/) to learn how to configure ATS on your project.
 


### PR DESCRIPTION
`NSAllowsArbitraryLoads` was introduced in https://github.com/facebook/react-native/pull/19643 and defaults to `true`. That means that removing `localhost` from `NSExceptionDomains` is not enough anymore, as describe in https://github.com/facebook/react-native-website/issues/1058.

Kudos to @Ashoat who tracked down the origin of the issue: https://github.com/facebook/react-native-website/issues/1058#issuecomment-532856679

Closes https://github.com/facebook/react-native-website/issues/1058

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
