### PR TITLE
docs: keep consistency of stylesheet declaration

### DIFF
--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -78,7 +78,7 @@ Flattens an array of style objects, into one aggregated style object. Alternativ
 Example:
 
 ```jsx
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   listItem: {
     flex: 1,
     fontSize: 16,
@@ -96,7 +96,7 @@ StyleSheet.flatten([styles.listItem, styles.selectedListItem]);
 Alternative use:
 
 ```jsx
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   listItem: {
     flex: 1,
     fontSize: 16,
@@ -131,7 +131,7 @@ static compose(style1, style2)
 This is defined as the width of a thin line on the platform. It can be used as the thickness of a border or division between two elements. Example:
 
 ```jsx
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   separator: {
     borderBottomColor: '#bbb',
     borderBottomWidth: StyleSheet.hairlineWidth,


### PR DESCRIPTION
There are some code snippets that use `var` for declaring `styles` whereas some other snippets use `const`.
Modified the page to all use `const` for consistency.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
