### PR TITLE
Corrected spelling and grammar errors

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -285,7 +285,7 @@ You can see the native driver in action by running the [RNTester app](https://gi
 
 #### Caveats
 
-Not everything you can do with `Animated` is currently supported by the native driver. The main limitation is that you can only animate non-layout properties: things like `transform` and `opacity` will work, but flexbox and position properties will not. When using `Animated.event`, it will only work with direct events and not bubbling events. This means it does not work with `PanResponder` but does work with things like `ScrollView#onScroll`.
+Not everything you can do with `Animated` is currently supported by the native driver. The main limitation is that you can only animate non-layout properties: things like `transform` and `opacity` will work, but Flexbox and position properties will not. When using `Animated.event`, it will only work with direct events and not bubbling events. This means it does not work with `PanResponder` but does work with things like `ScrollView#onScroll`.
 
 When an animation is running, it can prevent `VirtualizedList` components from rendering more rows. If you need to run a long or looping animation while the user is scrolling through a list, you can use `isInteraction: false` in your animation's config to prevent this issue.
 
@@ -314,7 +314,7 @@ The RNTester app has various examples of `Animated` in use:
 
 ## `LayoutAnimation` API
 
-`LayoutAnimation` allows you to globally configure `create` and `update` animations that will be used for all views in the next render/layout cycle. This is useful for doing flexbox layout updates without bothering to measure or calculate specific properties in order to animate them directly, and is especially useful when layout changes may affect ancestors, for example a "see more" expansion that also increases the size of the parent and pushes down the row below which would otherwise require explicit coordination between the components in order to animate them all in sync.
+`LayoutAnimation` allows you to globally configure `create` and `update` animations that will be used for all views in the next render/layout cycle. This is useful for doing Flexbox layout updates without bothering to measure or calculate specific properties in order to animate them directly, and is especially useful when layout changes may affect ancestors, for example a "see more" expansion that also increases the size of the parent and pushes down the row below which would otherwise require explicit coordination between the components in order to animate them all in sync.
 
 Note that although `LayoutAnimation` is very powerful and can be quite useful, it provides much less control than `Animated` and other animation libraries, so you may need to use another approach if you can't get `LayoutAnimation` to do what you want.
 

--- a/docs/communication-ios.md
+++ b/docs/communication-ios.md
@@ -133,7 +133,7 @@ For instance, to make an RN app 200 (logical) pixels high, and the hosting view'
 }
 ```
 
-When we have a fixed size root view, we need to respect its bounds on the JS side. In other words, we need to ensure that the React Native content can be contained within the fixed-size root view. The easiest way to ensure this is to use flexbox layout. If you use absolute positioning, and React components are visible outside the root view's bounds, you'll get overlap with native views, causing some features to behave unexpectedly. For instance, 'TouchableHighlight' will not highlight your touches outside the root view's bounds.
+When we have a fixed size root view, we need to respect its bounds on the JS side. In other words, we need to ensure that the React Native content can be contained within the fixed-size root view. The easiest way to ensure this is to use Flexbox layout. If you use absolute positioning, and React components are visible outside the root view's bounds, you'll get overlap with native views, causing some features to behave unexpectedly. For instance, 'TouchableHighlight' will not highlight your touches outside the root view's bounds.
 
 It's totally fine to update root view's size dynamically by re-setting its frame property. React Native will take care of the content's layout.
 

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -3,7 +3,7 @@ id: flexbox
 title: Layout with Flexbox
 ---
 
-A component can specify the layout of its children using the flexbox algorithm. Flexbox is designed to provide a consistent layout on different screen sizes.
+A component can specify the layout of its children using the Flexbox algorithm. Flexbox is designed to provide a consistent layout on different screen sizes.
 
 You will normally use a combination of `flexDirection`, `alignItems`, and `justifyContent` to achieve the right layout.
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -79,7 +79,7 @@ Behind the scenes, React Native converts this to a flat `NSAttributedString` or 
 
 ## Containers
 
-The `<Text>` element is special relative to layout: everything inside is no longer using the flexbox layout but using text layout. This means that elements inside of a `<Text>` are no longer rectangles, but wrap when they see the end of the line.
+The `<Text>` element is special relative to layout: everything inside is no longer using the Flexbox layout but using text layout. This means that elements inside of a `<Text>` are no longer rectangles, but wrap when they see the end of the line.
 
 ```jsx
 <Text>

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -148,7 +148,7 @@ Creates an object that represents ripple drawable with specified color (as a str
 | Name       | Type    | Required | Description                                  |
 | ---------- | ------- | -------- | -------------------------------------------- |
 | color      | string  | Yes      | The ripple color                             |
-| borderless | boolean | Yes      | If the ripple can render outside it's bounds |
+| borderless | boolean | Yes      | If the ripple can render outside its bounds |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -277,7 +277,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -288,7 +288,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/blog/2017-02-14-using-native-driver-for-animated.md
+++ b/website/blog/2017-02-14-using-native-driver-for-animated.md
@@ -159,7 +159,7 @@ After:
 
 ## Caveats
 
-Not everything you can do with Animated is currently supported in Native Animated. The main limitation is that you can only animate non-layout properties, things like `transform` and `opacity` will work but flexbox and position properties won't. Another one is with `Animated.event`, it will only work with direct events and not bubbling events. This means it does not work with `PanResponder` but does work with things like `ScrollView#onScroll`.
+Not everything you can do with Animated is currently supported in Native Animated. The main limitation is that you can only animate non-layout properties, things like `transform` and `opacity` will work but Flexbox and position properties won't. Another one is with `Animated.event`, it will only work with direct events and not bubbling events. This means it does not work with `PanResponder` but does work with things like `ScrollView#onScroll`.
 
 Native Animated has also been part of React Native for quite a while but has never been documented because it was considered experimental. Because of that make sure you are using a recent version (0.40+) of React Native if you want to use this feature.
 

--- a/website/versioned_docs/version-0.11/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.11/drawerlayoutandroid.md
@@ -125,8 +125,8 @@ Function called whenever there is an interaction with the navigation view.
 Function called when the drawer state has changed. The drawer can be in 3 states:
 
 - idle, meaning there is no interaction with the navigation view happening at the time
-- dragging, meaning there is currently an interation with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- dragging, meaning there is currently an interaction with the navigation view
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.12/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.12/drawerlayoutandroid.md
@@ -125,8 +125,8 @@ Function called whenever there is an interaction with the navigation view.
 Function called when the drawer state has changed. The drawer can be in 3 states:
 
 - idle, meaning there is no interaction with the navigation view happening at the time
-- dragging, meaning there is currently an interation with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- dragging, meaning there is currently an interaction with the navigation view
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.13/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.13/drawerlayoutandroid.md
@@ -129,8 +129,8 @@ Function called whenever there is an interaction with the navigation view.
 Function called when the drawer state has changed. The drawer can be in 3 states:
 
 - idle, meaning there is no interaction with the navigation view happening at the time
-- dragging, meaning there is currently an interation with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- dragging, meaning there is currently an interaction with the navigation view
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.16/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.16/drawerlayoutandroid.md
@@ -131,8 +131,8 @@ Function called whenever there is an interaction with the navigation view.
 Function called when the drawer state has changed. The drawer can be in 3 states:
 
 - idle, meaning there is no interaction with the navigation view happening at the time
-- dragging, meaning there is currently an interation with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- dragging, meaning there is currently an interaction with the navigation view
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.17/navigatorios.md
+++ b/website/versioned_docs/version-0.17/navigatorios.md
@@ -28,7 +28,7 @@ render: function() {
 },
 ```
 
-Now MyView will be rendered by the navigator. It will recieve the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
+Now MyView will be rendered by the navigator. It will receive the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
 
 See the initialRoute propType for a complete definition of a route.
 

--- a/website/versioned_docs/version-0.18/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.18/drawerlayoutandroid.md
@@ -132,7 +132,7 @@ Function called when the drawer state has changed. The drawer can be in 3 states
 
 - idle, meaning there is no interaction with the navigation view happening at the time
 - dragging, meaning there is currently an interaction with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.20/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.20/viewpagerandroid.md
@@ -104,7 +104,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.22/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.22/drawerlayoutandroid.md
@@ -147,7 +147,7 @@ Function called when the drawer state has changed. The drawer can be in 3 states
 
 - idle, meaning there is no interaction with the navigation view happening at the time
 - dragging, meaning there is currently an interaction with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.23/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.23/drawerlayoutandroid.md
@@ -147,7 +147,7 @@ Function called when the drawer state has changed. The drawer can be in 3 states
 
 - idle, meaning there is no interaction with the navigation view happening at the time
 - dragging, meaning there is currently an interaction with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.24/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.24/drawerlayoutandroid.md
@@ -148,7 +148,7 @@ Function called when the drawer state has changed. The drawer can be in 3 states
 
 - idle, meaning there is no interaction with the navigation view happening at the time
 - dragging, meaning there is currently an interaction with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.25/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.25/drawerlayoutandroid.md
@@ -149,7 +149,7 @@ Function called when the drawer state has changed. The drawer can be in 3 states
 
 - idle, meaning there is no interaction with the navigation view happening at the time
 - dragging, meaning there is currently an interaction with the navigation view
-- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the navigation view, and the navigation view is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.25/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.25/viewpagerandroid.md
@@ -105,7 +105,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.29/image.md
+++ b/website/versioned_docs/version-0.29/image.md
@@ -146,7 +146,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                | Required |
 | ----------------------------------- | -------- |

--- a/website/versioned_docs/version-0.30/image.md
+++ b/website/versioned_docs/version-0.30/image.md
@@ -146,7 +146,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                       | Required |
 | ---------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.30/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.30/viewpagerandroid.md
@@ -108,7 +108,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type                | Required |
 | ------------------- | -------- |

--- a/website/versioned_docs/version-0.31/image.md
+++ b/website/versioned_docs/version-0.31/image.md
@@ -146,7 +146,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                                 | Required |
 | -------------------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.32/image.md
+++ b/website/versioned_docs/version-0.32/image.md
@@ -177,7 +177,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                                 | Required |
 | -------------------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.32/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.32/viewpagerandroid.md
@@ -101,7 +101,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.34/image.md
+++ b/website/versioned_docs/version-0.34/image.md
@@ -187,7 +187,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                                 | Required |
 | -------------------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.35/image.md
+++ b/website/versioned_docs/version-0.35/image.md
@@ -188,7 +188,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                                 | Required |
 | -------------------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.37/image.md
+++ b/website/versioned_docs/version-0.37/image.md
@@ -188,7 +188,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.39/image.md
+++ b/website/versioned_docs/version-0.39/image.md
@@ -190,7 +190,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.41/image.md
+++ b/website/versioned_docs/version-0.41/image.md
@@ -190,7 +190,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.42/image.md
+++ b/website/versioned_docs/version-0.42/image.md
@@ -190,7 +190,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.43/image.md
+++ b/website/versioned_docs/version-0.43/image.md
@@ -190,7 +190,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.43/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.43/touchablenativefeedback.md
@@ -101,7 +101,7 @@ Creates an object that represents ripple drawable with specified color (as a str
 | Name       | Type    | Required | Description                                  |
 | ---------- | ------- | -------- | -------------------------------------------- |
 | color      | string  | Yes      | The ripple color                             |
-| borderless | boolean | Yes      | If the ripple can render outside it's bounds |
+| borderless | boolean | Yes      | If the ripple can render outside its bounds |
 
 ---
 

--- a/website/versioned_docs/version-0.44/flatlist.md
+++ b/website/versioned_docs/version-0.44/flatlist.md
@@ -83,7 +83,7 @@ More complex example demonstrating `PureComponent` usage for perf optimization a
       }
     }
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits it's props that aren't explicitly listed here along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props that aren't explicitly listed here along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.

--- a/website/versioned_docs/version-0.44/image.md
+++ b/website/versioned_docs/version-0.44/image.md
@@ -190,7 +190,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.44/view.md
+++ b/website/versioned_docs/version-0.44/view.md
@@ -278,7 +278,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -289,7 +289,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.45/flatlist.md
+++ b/website/versioned_docs/version-0.45/flatlist.md
@@ -83,7 +83,7 @@ More complex example demonstrating `PureComponent` usage for perf optimization a
       }
     }
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits it's props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.

--- a/website/versioned_docs/version-0.45/sectionlist.md
+++ b/website/versioned_docs/version-0.45/sectionlist.md
@@ -39,7 +39,7 @@ Simple Examples:
       ]}
     />
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits it's props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.

--- a/website/versioned_docs/version-0.45/view.md
+++ b/website/versioned_docs/version-0.45/view.md
@@ -279,7 +279,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -290,7 +290,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.46/flatlist.md
+++ b/website/versioned_docs/version-0.46/flatlist.md
@@ -83,7 +83,7 @@ More complex example demonstrating `PureComponent` usage for perf optimization a
       }
     }
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits it's props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.

--- a/website/versioned_docs/version-0.46/sectionlist.md
+++ b/website/versioned_docs/version-0.46/sectionlist.md
@@ -39,7 +39,7 @@ Simple Examples:
       ]}
     />
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits it's props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of `ScrollView`) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.

--- a/website/versioned_docs/version-0.47/view.md
+++ b/website/versioned_docs/version-0.47/view.md
@@ -291,7 +291,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -302,7 +302,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.47/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.47/viewpagerandroid.md
@@ -102,7 +102,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.48/image.md
+++ b/website/versioned_docs/version-0.48/image.md
@@ -251,7 +251,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.48/view.md
+++ b/website/versioned_docs/version-0.48/view.md
@@ -295,7 +295,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -306,7 +306,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.49/view.md
+++ b/website/versioned_docs/version-0.49/view.md
@@ -291,7 +291,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -302,7 +302,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.49/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.49/viewpagerandroid.md
@@ -102,7 +102,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.5/navigatorios.md
+++ b/website/versioned_docs/version-0.5/navigatorios.md
@@ -24,7 +24,7 @@ render: function() {
 },
 ```
 
-Now MyView will be rendered by the navigator. It will recieve the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
+Now MyView will be rendered by the navigator. It will receive the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
 
 See the initialRoute propType for a complete definition of a route.
 

--- a/website/versioned_docs/version-0.5/view.md
+++ b/website/versioned_docs/version-0.5/view.md
@@ -297,7 +297,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
   ```
   .box-none {
       pointer-events: none;
@@ -306,7 +306,7 @@ Controls whether the `View` can be the target of touch events.
       pointer-events: all;
   }
   ```
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
   ```
   .box-only {
       pointer-events: all;

--- a/website/versioned_docs/version-0.5/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.5/viewpagerandroid.md
@@ -104,7 +104,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.50/image.md
+++ b/website/versioned_docs/version-0.50/image.md
@@ -251,7 +251,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.50/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.50/viewpagerandroid.md
@@ -105,7 +105,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.51/image.md
+++ b/website/versioned_docs/version-0.51/image.md
@@ -251,7 +251,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.51/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.51/viewpagerandroid.md
@@ -105,7 +105,7 @@ Function called when the page scrolling state has changed. The page scrolling st
 
 - idle, meaning there is no interaction with the page scroller happening at the time
 - dragging, meaning there is currently an interaction with the page scroller
-- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing it's closing or opening animation
+- settling, meaning that there was an interaction with the page scroller, and the page scroller is now finishing its closing or opening animation
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.53/image.md
+++ b/website/versioned_docs/version-0.53/image.md
@@ -251,7 +251,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 | Type                                                    | Required |
 | ------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.54/image.md
+++ b/website/versioned_docs/version-0.54/image.md
@@ -255,7 +255,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 - `center`: Center the image in the view along both dimensions. If the image is larger than the view, scale it down uniformly so that it is contained in the view.
 

--- a/website/versioned_docs/version-0.55/image.md
+++ b/website/versioned_docs/version-0.55/image.md
@@ -256,7 +256,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 - `stretch`: Scale width and height independently, This may change the aspect ratio of the src.
 
-- `repeat`: Repeat the image to cover the frame of the view. The image will keep it's size and aspect ratio. (iOS only)
+- `repeat`: Repeat the image to cover the frame of the view. The image will keep its size and aspect ratio. (iOS only)
 
 - `center`: Center the image in the view along both dimensions. If the image is larger than the view, scale it down uniformly so that it is contained in the view.
 

--- a/website/versioned_docs/version-0.55/view.md
+++ b/website/versioned_docs/version-0.55/view.md
@@ -292,7 +292,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -303,7 +303,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.57/view.md
+++ b/website/versioned_docs/version-0.57/view.md
@@ -306,7 +306,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -317,7 +317,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.58/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.58/touchablenativefeedback.md
@@ -101,7 +101,7 @@ Creates an object that represents ripple drawable with specified color (as a str
 | Name       | Type    | Required | Description                                  |
 | ---------- | ------- | -------- | -------------------------------------------- |
 | color      | string  | Yes      | The ripple color                             |
-| borderless | boolean | Yes      | If the ripple can render outside it's bounds |
+| borderless | boolean | Yes      | If the ripple can render outside its bounds |
 
 ---
 

--- a/website/versioned_docs/version-0.59/view.md
+++ b/website/versioned_docs/version-0.59/view.md
@@ -317,7 +317,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'auto'`: The View can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
-- `'box-none'`: The View is never the target of touch events but it's subviews can be. It behaves like if the view had the following classes in CSS:
+- `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-none {
@@ -328,7 +328,7 @@ Controls whether the `View` can be the target of touch events.
 }
 ```
 
-- `'box-only'`: The view can be the target of touch events but it's subviews cannot be. It behaves like if the view had the following classes in CSS:
+- `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
 ```
 .box-only {

--- a/website/versioned_docs/version-0.60/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.60/touchablenativefeedback.md
@@ -149,7 +149,7 @@ Creates an object that represents ripple drawable with specified color (as a str
 | Name       | Type    | Required | Description                                  |
 | ---------- | ------- | -------- | -------------------------------------------- |
 | color      | string  | Yes      | The ripple color                             |
-| borderless | boolean | Yes      | If the ripple can render outside it's bounds |
+| borderless | boolean | Yes      | If the ripple can render outside its bounds |
 
 ---
 

--- a/website/versioned_docs/version-0.8/navigatorios.md
+++ b/website/versioned_docs/version-0.8/navigatorios.md
@@ -24,7 +24,7 @@ render: function() {
 },
 ```
 
-Now MyView will be rendered by the navigator. It will recieve the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
+Now MyView will be rendered by the navigator. It will receive the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
 
 See the initialRoute propType for a complete definition of a route.
 

--- a/website/versioned_docs/version-0.9/navigatorios.md
+++ b/website/versioned_docs/version-0.9/navigatorios.md
@@ -24,7 +24,7 @@ render: function() {
 },
 ```
 
-Now MyView will be rendered by the navigator. It will recieve the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
+Now MyView will be rendered by the navigator. It will receive the route object in the `route` prop, a navigator, and all of the props specified in `passProps`.
 
 See the initialRoute propType for a complete definition of a route.
 


### PR DESCRIPTION
Only small errors but copy-pasted multiple times in the various version docs, so looks like there are more changes than there are. Removal of apostrophes in possessive 'its', capitalised Flexbox and a couple of instances of 'interation' instead of 'interaction'.
