### PR TITLE
Remove type from alert.md

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -71,5 +71,5 @@ Alert.alert(
 ### `alert()`
 
 ```jsx
-static alert(title, message?, buttons?, options? type?)
+static alert(title, message?, buttons?, options?)
 ```


### PR DESCRIPTION
Type isn't just there in the sources anymore: https://github.com/facebook/react-native/blob/v0.61.2/Libraries/Alert/Alert.js#L42
