### PR TITLE
[docs] Getting Started - update CLI package name to current one

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -194,7 +194,7 @@ Node comes with npm, which lets you install the React Native command line interf
 Run the following command in a Terminal:
 
 ```
-npm install -g react-native-cli
+npm install -g @react-native-community/cli
 ```
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
@@ -208,7 +208,7 @@ Node comes with npm, which lets you install the React Native command line interf
 Run the following command in a Command Prompt or shell:
 
 ```powershell
-npm install -g react-native-cli
+npm install -g @react-native-community/cli
 ```
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.


### PR DESCRIPTION
`react-native-cli` has been deprecated in favor of `@react-native-community/cli` a while ago (https://facebook.github.io/react-native/blog/2019/03/12/releasing-react-native-059). 