### PR TITLE
Update docs: add missing onTextInput property to TextInput component

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -515,6 +515,16 @@ Callback that is called when the text input's submit button is pressed with the 
 
 ---
 
+### `onTextInput`
+
+Callback that is called on new text input with the argument `{ nativeEvent: { text, previousText, range: { start, end } } }`. This prop requires `multiline={true}` to be set.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
 ### `placeholder`
 
 The string that will be rendered before text input has been entered.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

It adds docs for missing `onTextInput` property.

`onTextInput` source: https://github.com/facebook/react-native/blob/v0.61.2/Libraries/Components/TextInput/TextInput.js#L565

`TextInputEvent`: https://github.com/facebook/react-native/blob/v0.61.2/Libraries/Components/TextInput/TextInput.js#L64 