### PR TITLE
fix JDK8 installation command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -152,7 +152,7 @@ brew install yarn
 brew install node
 brew install watchman
 brew tap AdoptOpenJDK/openjdk
-brew cask install adoptopenjdk8
+brew cask install adoptopenjdk/openjdk/adoptopenjdk8
 ```
 
 If you have already installed Node on your system, make sure it is Node 8.3 or newer.


### PR DESCRIPTION
Currently, there are duplicate formulas on cask, so this command fails to install.

![名称未設定](https://user-images.githubusercontent.com/7282145/67002552-22afd000-f117-11e9-8552-67bba54506fd.png)

Please see related issue: https://github.com/AdoptOpenJDK/homebrew-openjdk/issues/106

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
