### PR TITLE
Fix getting started typescript command

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -10,7 +10,7 @@ title: Using TypeScript with React Native
 If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
 
 ```sh
-npx react-native init MyApp --template react-native-template-typescript
+npx react-native init MyApp --template typescript
 ```
 
 You can use [Expo][expo] which has two TypeScript templates:


### PR DESCRIPTION
The previous command failed to complete successfully and in the error log seemed to be trying to check-out `react-native-template-react-native-template-typescript`. So I think some kind of refactor in the template param of the cli caused that and tried `npx react-native init MyApp --template typescript` which worked properly.