### PR TITLE
Fix cli to be installed in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -194,7 +194,7 @@ Node comes with npm, which lets you install the React Native command line interf
 Run the following command in a Terminal:
 
 ```
-npm install -g react-native-cli
+npm install -g @react-native-community/cli
 ```
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
@@ -208,7 +208,7 @@ Node comes with npm, which lets you install the React Native command line interf
 Run the following command in a Command Prompt or shell:
 
 ```powershell
-npm install -g react-native-cli
+npm install -g @react-native-community/cli
 ```
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.


### PR DESCRIPTION
Currently 'Getting Started' provides wrong information by asking users to install an old version of CLI package, i.e. `react-native-cli` which has not been updated for several years. The correct one to use is `@react-native-community/cli`.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
