### PR TITLE
Add npx to getting started instructions

### DIFF
--- a/website/versioned_docs/version-0.5/getting-started.md
+++ b/website/versioned_docs/version-0.5/getting-started.md
@@ -371,7 +371,7 @@ Follow the [Watchman installation guide](https://facebook.github.io/watchman/doc
 Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
 
 ```
-react-native init AwesomeProject
+npx react-native init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo (or Create React Native App), or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -381,11 +381,11 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```
-react-native init AwesomeProject --version X.XX.X
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
 ```
-react-native init AwesomeProject --version react-native@next
+npx react-native init AwesomeProject --version react-native@next
 ```
 
 <block class="native mac windows linux android" />
@@ -395,7 +395,7 @@ react-native init AwesomeProject --version react-native@next
 Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
 
 ```
-react-native init AwesomeProject
+npx react-native init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Create React Native App, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -405,11 +405,11 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```
-react-native init AwesomeProject --version X.XX.X
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
 ```
-react-native init AwesomeProject --version react-native@next
+npx react-native init AwesomeProject --version react-native@next
 ```
 
 <block class="native mac windows linux android" />
@@ -452,18 +452,18 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-ios` inside your React Native project folder:
+Run `npx react-native run-ios` inside your React Native project folder:
 
 ```
 cd AwesomeProject
-react-native run-ios
+npx react-native run-ios
 ```
 
 You should see your new app running in the iOS Simulator shortly.
 
 ![AwesomeProject on iOS](/react-native/docs/assets/GettingStartediOSSuccess.png)
 
-`react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
+`npx react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 
@@ -475,11 +475,11 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-android` inside your React Native project folder:
+Run `npx react-native run-android` inside your React Native project folder:
 
 ```
 cd AwesomeProject
-react-native run-android
+npx react-native run-android
 ```
 
 If everything is set up correctly, you should see your new app running in your Android emulator shortly.
@@ -494,7 +494,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 <block class="native mac windows linux android" />
 
-`react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
+`npx react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 


### PR DESCRIPTION
[react-native-cli](https://github.com/react-native-community/cli/pull/817) recommend `npx react-native` to use the local react-native binary.