### PR TITLE
Fix typo on Vibration API doc files

### DIFF
--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -3,7 +3,7 @@ id: vibration
 title: Vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.22/vibration.md
+++ b/website/versioned_docs/version-0.22/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.22/vibrationios.md
+++ b/website/versioned_docs/version-0.22/vibrationios.md
@@ -6,7 +6,7 @@ original_id: vibrationios
 
 NOTE: `VibrationIOS` is being deprecated. Use `Vibration` instead.
 
-The Vibration API is exposed at `VibrationIOS.vibrate()`. On iOS, calling this function will trigger a one second vibration. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `VibrationIOS.vibrate()`. On iOS, calling this function will trigger a one second vibration. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the iOS simulator.
 

--- a/website/versioned_docs/version-0.24/vibration.md
+++ b/website/versioned_docs/version-0.24/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.49/vibration.md
+++ b/website/versioned_docs/version-0.49/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.5/vibration.md
+++ b/website/versioned_docs/version-0.5/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.5/vibrationios.md
+++ b/website/versioned_docs/version-0.5/vibrationios.md
@@ -4,7 +4,7 @@ title: VibrationIOS
 original_id: vibrationios
 ---
 
-The Vibration API is exposed at `VibrationIOS.vibrate()`. On iOS, calling this function will trigger a one second vibration. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `VibrationIOS.vibrate()`. On iOS, calling this function will trigger a one second vibration. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the iOS simulator.
 

--- a/website/versioned_docs/version-0.54/vibration.md
+++ b/website/versioned_docs/version-0.54/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.56/vibration.md
+++ b/website/versioned_docs/version-0.56/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.58/vibration.md
+++ b/website/versioned_docs/version-0.58/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 

--- a/website/versioned_docs/version-0.60/vibration.md
+++ b/website/versioned_docs/version-0.60/vibration.md
@@ -4,7 +4,7 @@ title: Vibration
 original_id: vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is asynchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
 There will be no effect on devices that do not support Vibration, eg. the simulator.
 


### PR DESCRIPTION
This PR will correct the typo on `asynchronous` while it should mean `synchronous`.
