### PR TITLE
Update link to NativeAnimationsExample in animations.md

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -281,7 +281,7 @@ The native driver also works with `Animated.event`. This is especially useful fo
 </Animated.ScrollView>
 ```
 
-You can see the native driver in action by running the [RNTester app](https://github.com/facebook/react-native/blob/master/RNTester/), then loading the Native Animated Example. You can also take a look at the [source code](https://github.com/facebook/react-native/blob/master/RNTester/js/NativeAnimationsExample.js) to learn how these examples were produced.
+You can see the native driver in action by running the [RNTester app](https://github.com/facebook/react-native/blob/master/RNTester/), then loading the Native Animated Example. You can also take a look at the [source code](https://github.com/facebook/react-native/blob/master/RNTester/js/examples/NativeAnimation/NativeAnimationsExample.js) to learn how these examples were produced.
 
 #### Caveats
 


### PR DESCRIPTION
The file (`NativeAnimationsExample.js`) was moved by https://github.com/facebook/react-native/commit/3945f10561622a3e361190919d0a6d397f67ef8b#diff-b24b9172a3a7b428c3cd7066710a927f.