### PR TITLE
fix: Invalid DOM property and unique key warnings

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -136,7 +136,7 @@ function TwitterButton({showCount = false}) {
   return (
     <a
       href="https://twitter.com/reactnative?ref_src=twsrc%5Etfw"
-      class="twitter-follow-button"
+      className="twitter-follow-button"
       data-size="large"
       data-show-count={`${showCount}`}>
       Follow @reactnative
@@ -147,7 +147,7 @@ function TwitterButton({showCount = false}) {
 function GitHubButton() {
   return (
     <a
-      class="github-button"
+      className="github-button"
       href="https://github.com/facebook/react-native"
       data-icon="octicon-star"
       data-size="large"
@@ -226,7 +226,7 @@ function LogoAnimation() {
         className="base"
       />
       <ScreenRect className="background" stroke="none" />
-      <g clip-path="url(#screen)" className="logo">
+      <g clipPath="url(#screen)" className="logo">
         <g className="logoInner">
           <circle cx="0" cy="0" r="30" fill="#61dafb" />
           <g stroke="#61dafb" strokeWidth="15" fill="none" id="logo">
@@ -322,7 +322,11 @@ function NativeDevelopment() {
         columnTwo={
           <div className="dissection">
             {[0, 1, 2, 3].map(i => (
-              <img alt="" src={`${baseUrl}img/homepage/dissection/${i}.png`} />
+              <img
+                alt=""
+                key={i}
+                src={`${baseUrl}img/homepage/dissection/${i}.png`}
+              />
             ))}
           </div>
         }
@@ -466,7 +470,7 @@ function GetStarted() {
         <ol className="steps">
           <li>
             <p>Run this</p>
-            <div class="terminal">
+            <div className="terminal">
               <code>npx react-native init MyTestApp</code>
             </div>
           </li>


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Remove following warnings when running `yarn start`:

```
➜  website git:(master) yarn start
yarn run v1.19.1
$ docusaurus-start
LiveReload server started on port 35729
[BABEL] Note: The code generator has deoptimised the styling of /Users/haruelrovix/Projects/react-native-website/website/node_modules/docusaurus/lib/core/metadata.js as it exceeds the max of 500KB.
[BABEL] Note: The code generator has deoptimised the styling of /Users/haruelrovix/Projects/react-native-website/website/node_modules/docusaurus/lib/core/metadata.js as it exceeds the max of 500KB.
Docusaurus server started on port 3000
Warning: Invalid DOM property `class`. Did you mean `className`?
    in a
    in TwitterButton
    in div
    in section
    in Section
    in HeaderHero
    in main
    in Index
    in div
    in body
    in html
    in Site
Warning: Invalid DOM property `clip-path`. Did you mean `clipPath`?
    in g
    in svg
    in LogoAnimation
    in div
    in div
    in TwoColumns
    in section
    in Section
    in HeaderHero
    in main
    in Index
    in div
    in body
    in html
    in Site
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <div>. See https://fb.me/react-warning-keys for more information.
    in img
    in NativeDevelopment
    in main
    in Index
    in div
    in body
    in html
    in Site

```
