### PR TITLE
feat: improve instructions around CLI and mention CocoaPods installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 We recommend installing Node, Watchman, and JDK using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
 
-```
+```sh
 brew install yarn
 brew install node
 brew install watchman
@@ -185,37 +185,9 @@ If you have already installed Node on your system, make sure it is Node 8.3 or n
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-<block class="native mac ios android" />
-
-<h3>The React Native CLI</h3>
-
-Node comes with npm, which lets you install the React Native command line interface.
-
-Run the following command in a Terminal:
-
-```
-npm install -g react-native-cli
-```
-
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
-
-<block class="native windows linux android" />
-
-<h3>The React Native CLI</h3>
-
-Node comes with npm, which lets you install the React Native command line interface.
-
-Run the following command in a Command Prompt or shell:
-
-```powershell
-npm install -g react-native-cli
-```
-
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
-
 <block class="native mac ios" />
 
-<h3>Xcode</h3>
+<h3>Xcode & CocoaPods</h3>
 
 The easiest way to install Xcode is via the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12). Installing Xcode will also install the iOS Simulator and all the necessary tools to build your iOS app.
 
@@ -230,6 +202,18 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 <h4>Installing an iOS Simulator in Xcode</h4>
 
 To install a simulator, open <strong>Xcode > Preferences...</strong> and select the <strong>Components</strong> tab. Select a simulator with the corresponding version of iOS you wish to use.
+
+<h4>CocoaPods</h4>
+
+[CocoaPods](https://cocoapods.org/) is built with Ruby and it will be installable with the default Ruby available on macOS. You can use a Ruby Version manager, however we recommend that you use the standard Ruby available on macOS unless you know what you're doing.
+
+Using the default Ruby install will require you to use `sudo` when installing gems. (This is only an issue for the duration of the gem installation, though.)
+
+```sh
+sudo gem install cocoapods
+```
+
+For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
 <block class="native linux android" />
 
@@ -307,7 +291,7 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` config 
 
 <block class="native mac android" />
 
-```
+```sh
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -317,7 +301,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 
 <block class="native linux android" />
 
-```
+```sh
 export ANDROID_HOME=$HOME/Android/Sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -371,48 +355,52 @@ Follow the [Watchman installation guide](https://facebook.github.io/watchman/doc
 
 <h2>Creating a new application</h2>
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
+React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
+```sh
+npx react-native init AwesomeProject
 ```
-react-native init AwesomeProject
-```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo (or Create React Native App), or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
-<h3>[Optional] Using a specific version</h3>
+<h3>[Optional] Using a specific version or template</h3>
 
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
-```
-react-native init AwesomeProject --version X.XX.X
+```sh
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
-```
-react-native init AwesomeProject --version react-native@next
+You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
+
+```sh
+npx react-native init TSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />
 
 <h2>Creating a new application</h2>
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
+React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
+```sh
+npx react-native init AwesomeProject
 ```
-react-native init AwesomeProject
-```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Create React Native App, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
-<h3>[Optional] Using a specific version</h3>
+<h3>[Optional] Using a specific version or template</h3>
 
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
-```
-react-native init AwesomeProject --version X.XX.X
+```sh
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
-```
-react-native init AwesomeProject --version react-native@next
+You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
+
+```sh
+npx react-native init TSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />
@@ -455,18 +443,20 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-ios` inside your React Native project folder:
+> If you use Yarn package manager, your can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-```
+Run `npx react-native run-ios` inside your React Native project folder:
+
+```sh
 cd AwesomeProject
-react-native run-ios
+npx react-native run-ios
 ```
 
 You should see your new app running in the iOS Simulator shortly.
 
 ![AwesomeProject on iOS](/react-native/docs/assets/GettingStartediOSSuccess.png)
 
-`react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
+`npx react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 
@@ -478,11 +468,13 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-android` inside your React Native project folder:
+> If you use Yarn package manager, your can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-```
+Run `npx react-native run-android` inside your React Native project folder:
+
+```sh
 cd AwesomeProject
-react-native run-android
+npx react-native run-android
 ```
 
 If everything is set up correctly, you should see your new app running in your Android emulator shortly.
@@ -497,7 +489,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 <block class="native mac windows linux android" />
 
-`react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
+`npx react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3227,6 +3227,9 @@
       "version-0.60/version-0.60-flatlist": {
         "title": "FlatList"
       },
+      "version-0.60/version-0.60-getting-started": {
+        "title": "Getting Started"
+      },
       "version-0.60/version-0.60-hermes": {
         "title": "Using Hermes"
       },
@@ -3394,6 +3397,9 @@
       },
       "version-0.61/version-0.61-fast-refresh": {
         "title": "Fast Refresh"
+      },
+      "version-0.61/version-0.61-getting-started": {
+        "title": "Getting Started"
       },
       "version-0.7/version-0.7-pushnotificationios": {
         "title": "PushNotificationIOS"

--- a/website/versioned_docs/version-0.60/getting-started.md
+++ b/website/versioned_docs/version-0.60/getting-started.md
@@ -1,5 +1,5 @@
 ---
-id: version-0.5-getting-started
+id: version-0.60-getting-started
 title: Getting Started
 original_id: getting-started
 ---
@@ -148,7 +148,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 We recommend installing Node, Watchman, and JDK using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
 
-```
+```sh
 brew install yarn
 brew install node
 brew install watchman
@@ -186,37 +186,9 @@ If you have already installed Node on your system, make sure it is Node 8.3 or n
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-<block class="native mac ios android" />
-
-<h3>The React Native CLI</h3>
-
-Node comes with npm, which lets you install the React Native command line interface.
-
-Run the following command in a Terminal:
-
-```
-npm install -g react-native-cli
-```
-
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
-
-<block class="native windows linux android" />
-
-<h3>The React Native CLI</h3>
-
-Node comes with npm, which lets you install the React Native command line interface.
-
-Run the following command in a Command Prompt or shell:
-
-```powershell
-npm install -g react-native-cli
-```
-
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
-
 <block class="native mac ios" />
 
-<h3>Xcode</h3>
+<h3>Xcode & CocoaPods</h3>
 
 The easiest way to install Xcode is via the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12). Installing Xcode will also install the iOS Simulator and all the necessary tools to build your iOS app.
 
@@ -227,6 +199,22 @@ If you have already installed Xcode on your system, make sure it is version 9.4 
 You will also need to install the Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 ![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
+
+<h4>Installing an iOS Simulator in Xcode</h4>
+
+To install a simulator, open <strong>Xcode > Preferences...</strong> and select the <strong>Components</strong> tab. Select a simulator with the corresponding version of iOS you wish to use.
+
+<h4>CocoaPods</h4>
+
+[CocoaPods](https://cocoapods.org/) is built with Ruby and it will be installable with the default Ruby available on macOS. You can use a Ruby Version manager, however we recommend that you use the standard Ruby available on macOS unless you know what you're doing.
+
+Using the default Ruby install will require you to use `sudo` when installing gems. (This is only an issue for the duration of the gem installation, though.)
+
+```sh
+sudo gem install cocoapods
+```
+
+For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
 <block class="native linux android" />
 
@@ -304,7 +292,7 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` config 
 
 <block class="native mac android" />
 
-```
+```sh
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -314,7 +302,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 
 <block class="native linux android" />
 
-```
+```sh
 export ANDROID_HOME=$HOME/Android/Sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -368,48 +356,52 @@ Follow the [Watchman installation guide](https://facebook.github.io/watchman/doc
 
 <h2>Creating a new application</h2>
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
+React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
+```sh
+npx react-native init AwesomeProject
 ```
-react-native init AwesomeProject
-```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo (or Create React Native App), or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
-<h3>[Optional] Using a specific version</h3>
+<h3>[Optional] Using a specific version or template</h3>
 
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
-```
-react-native init AwesomeProject --version X.XX.X
+```sh
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
-```
-react-native init AwesomeProject --version react-native@next
+You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
+
+```sh
+npx react-native init TSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />
 
 <h2>Creating a new application</h2>
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
+React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
+```sh
+npx react-native init AwesomeProject
 ```
-react-native init AwesomeProject
-```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Create React Native App, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
-<h3>[Optional] Using a specific version</h3>
+<h3>[Optional] Using a specific version or template</h3>
 
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
-```
-react-native init AwesomeProject --version X.XX.X
+```sh
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
-```
-react-native init AwesomeProject --version react-native@next
+You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
+
+```sh
+npx react-native init TSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />
@@ -452,18 +444,20 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-ios` inside your React Native project folder:
+> If you use Yarn package manager, your can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-```
+Run `npx react-native run-ios` inside your React Native project folder:
+
+```sh
 cd AwesomeProject
-react-native run-ios
+npx react-native run-ios
 ```
 
 You should see your new app running in the iOS Simulator shortly.
 
 ![AwesomeProject on iOS](/react-native/docs/assets/GettingStartediOSSuccess.png)
 
-`react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
+`npx react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 
@@ -475,11 +469,13 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-android` inside your React Native project folder:
+> If you use Yarn package manager, your can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-```
+Run `npx react-native run-android` inside your React Native project folder:
+
+```sh
 cd AwesomeProject
-react-native run-android
+npx react-native run-android
 ```
 
 If everything is set up correctly, you should see your new app running in your Android emulator shortly.
@@ -494,7 +490,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 <block class="native mac windows linux android" />
 
-`react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
+`npx react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 

--- a/website/versioned_docs/version-0.61/getting-started.md
+++ b/website/versioned_docs/version-0.61/getting-started.md
@@ -1,5 +1,5 @@
 ---
-id: version-0.5-getting-started
+id: version-0.61-getting-started
 title: Getting Started
 original_id: getting-started
 ---
@@ -148,7 +148,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 We recommend installing Node, Watchman, and JDK using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
 
-```
+```sh
 brew install yarn
 brew install node
 brew install watchman
@@ -186,37 +186,9 @@ If you have already installed Node on your system, make sure it is Node 8.3 or n
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-<block class="native mac ios android" />
-
-<h3>The React Native CLI</h3>
-
-Node comes with npm, which lets you install the React Native command line interface.
-
-Run the following command in a Terminal:
-
-```
-npm install -g react-native-cli
-```
-
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
-
-<block class="native windows linux android" />
-
-<h3>The React Native CLI</h3>
-
-Node comes with npm, which lets you install the React Native command line interface.
-
-Run the following command in a Command Prompt or shell:
-
-```powershell
-npm install -g react-native-cli
-```
-
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
-
 <block class="native mac ios" />
 
-<h3>Xcode</h3>
+<h3>Xcode & CocoaPods</h3>
 
 The easiest way to install Xcode is via the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12). Installing Xcode will also install the iOS Simulator and all the necessary tools to build your iOS app.
 
@@ -227,6 +199,22 @@ If you have already installed Xcode on your system, make sure it is version 9.4 
 You will also need to install the Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 ![Xcode Command Line Tools](/react-native/docs/assets/GettingStartedXcodeCommandLineTools.png)
+
+<h4>Installing an iOS Simulator in Xcode</h4>
+
+To install a simulator, open <strong>Xcode > Preferences...</strong> and select the <strong>Components</strong> tab. Select a simulator with the corresponding version of iOS you wish to use.
+
+<h4>CocoaPods</h4>
+
+[CocoaPods](https://cocoapods.org/) is built with Ruby and it will be installable with the default Ruby available on macOS. You can use a Ruby Version manager, however we recommend that you use the standard Ruby available on macOS unless you know what you're doing.
+
+Using the default Ruby install will require you to use `sudo` when installing gems. (This is only an issue for the duration of the gem installation, though.)
+
+```sh
+sudo gem install cocoapods
+```
+
+For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
 <block class="native linux android" />
 
@@ -304,7 +292,7 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` config 
 
 <block class="native mac android" />
 
-```
+```sh
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -314,7 +302,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 
 <block class="native linux android" />
 
-```
+```sh
 export ANDROID_HOME=$HOME/Android/Sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -368,48 +356,52 @@ Follow the [Watchman installation guide](https://facebook.github.io/watchman/doc
 
 <h2>Creating a new application</h2>
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
+React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
+```sh
+npx react-native init AwesomeProject
 ```
-react-native init AwesomeProject
-```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo (or Create React Native App), or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
-<h3>[Optional] Using a specific version</h3>
+<h3>[Optional] Using a specific version or template</h3>
 
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
-```
-react-native init AwesomeProject --version X.XX.X
+```sh
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
-```
-react-native init AwesomeProject --version react-native@next
+You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
+
+```sh
+npx react-native init TSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />
 
 <h2>Creating a new application</h2>
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject":
+React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
+```sh
+npx react-native init AwesomeProject
 ```
-react-native init AwesomeProject
-```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Create React Native App, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
 
-<h3>[Optional] Using a specific version</h3>
+<h3>[Optional] Using a specific version or template</h3>
 
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
-```
-react-native init AwesomeProject --version X.XX.X
+```sh
+npx react-native init AwesomeProject --version X.XX.X
 ```
 
-```
-react-native init AwesomeProject --version react-native@next
+You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
+
+```sh
+npx react-native init TSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />
@@ -452,18 +444,20 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-ios` inside your React Native project folder:
+> If you use Yarn package manager, your can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-```
+Run `npx react-native run-ios` inside your React Native project folder:
+
+```sh
 cd AwesomeProject
-react-native run-ios
+npx react-native run-ios
 ```
 
 You should see your new app running in the iOS Simulator shortly.
 
 ![AwesomeProject on iOS](/react-native/docs/assets/GettingStartediOSSuccess.png)
 
-`react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
+`npx react-native run-ios` is one way to run your app. You can also run it directly from within Xcode.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 
@@ -475,11 +469,13 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 <h2>Running your React Native application</h2>
 
-Run `react-native run-android` inside your React Native project folder:
+> If you use Yarn package manager, your can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-```
+Run `npx react-native run-android` inside your React Native project folder:
+
+```sh
 cd AwesomeProject
-react-native run-android
+npx react-native run-android
 ```
 
 If everything is set up correctly, you should see your new app running in your Android emulator shortly.
@@ -494,7 +490,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 <block class="native mac windows linux android" />
 
-`react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
+`npx react-native run-android` is one way to run your app - you can also run it directly from within Android Studio.
 
 > If you can't get this to work, see the [Troubleshooting](troubleshooting.md#content) page.
 
@@ -543,7 +539,7 @@ Congratulations! You've successfully run and modified your first React Native ap
 
 <h2>Now what?</h2>
 
-- Turn on [Live Reload](debugging.md#reloading-javascript) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
+- Turn on [Fast Refresh](debugging.md#enabling-fast-refresh) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
@@ -553,7 +549,7 @@ If you're curious to learn more about React Native, continue on to the [Tutorial
 
 <h2>Now what?</h2>
 
-- Turn on [Live Reload](debugging.md#reloading-javascript) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
+- Turn on [Fast Refresh](debugging.md#enabling-fast-refresh) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 


### PR DESCRIPTION
Hey 👋! I'm one of the maintainers of React Native CLI, and would like to make the docs up to date around it. The current Getting Started guide spread a bit of confusion, because it's not updated.

Things changed:

- added correct syntax highlighting to shell commands (which means less colors, because there's no colors in shell).
- added a section about installing CocoaPods
- added an example of `init` with `--template` flag
- removed "The React Native CLI" section, because we don't want users to install global CLI now.
- removed references to deprecated "Create React Native App" project
- created appropriate 0.60 and 0.61 versioned docs

Closes #1423 (superseded)
Closes #1422 (superseded)
Closes #1333 (superseded)
Closes #1294 (superseded)
Closes #1303 (superseded)
Closes #1185 (superseded)
Closes #1113 (superseded)

cc @alloy @cpojer @grabbou @charpeni 