### PR TITLE
Add warning about AAB and Hermes

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -3,9 +3,6 @@ id: hermes
 title: Using Hermes
 ---
 
-> ## Note about Android App Bundles
-> Android app bundles are not yet supported with hermes.
-
 <a href="https://hermesengine.dev">
   <img width="300" height="300" style="float: right; margin: -30px 4px 0;" src="/react-native/docs/assets/HermesLogo.svg"/>
 </a>
@@ -47,6 +44,9 @@ That's it! You should now be able to develop and deploy your app as normal:
 ```shell
 $ react-native run-android
 ```
+
+> ## Note about Android App Bundles
+> Android app bundles are not yet supported with hermes.
 
 ## Confirming Hermes is in use
 

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -3,6 +3,9 @@ id: hermes
 title: Using Hermes
 ---
 
+> ## Note about Android App Bundles
+> Android app bundles are not yet supported with hermes.
+
 <a href="https://hermesengine.dev">
   <img width="300" height="300" style="float: right; margin: -30px 4px 0;" src="/react-native/docs/assets/HermesLogo.svg"/>
 </a>


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
https://github.com/facebook/react-native/issues/26252

Currently Hermes does not support AAB, only APK for Android.

This update will add a warning to the documentation to help warn other developers when trying to build with Hermes and AAB.
