### PR TITLE
Updated getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -482,7 +482,14 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 > If you use the Yarn package manager, you can use `yarn` instead of `npx` when running React Native commands inside an existing project.
 
-Run `npx react-native run-android` inside your React Native project folder:
+Run `npx react-native start` inside your React Native project folder:
+
+```sh
+cd AwesomeProject
+npx react-native start
+```
+
+On another terminal, run `npx react-native run-android`:
 
 ```sh
 cd AwesomeProject


### PR DESCRIPTION
I've updated this file to let explicit that I need to run 'npx react-native start' before running 'npx react-native run-android', because I'm beginner on react-native and I got an error when I run for the first time. (e.g. https://stackoverflow.com/q/55441230/8447990)

Thank you in advance.