### PR TITLE
ui-ux: Fix header search right-margin

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -173,7 +173,8 @@ li.navSearchWrapper {
 
 input#search_input_react {
   /* Make as wide as the expanded state in the docusaurus default */
-  width: 220px;
+  width: 200px;
+  margin-right: 20px;
   background-color: $dark;
   border-radius: 0.25rem;
   transition: background-color 150ms ease-in-out;


### PR DESCRIPTION
This PR fixes #1237

## Quick Explanation
When hovering on the `GitHub` link, there's no margin/space gap between the `Search Input` and the `GitHub` link.

## UI Changes
| # | How it looks like |
| --- | ---|
| Before | ![fix-header-search-margin-before](https://user-images.githubusercontent.com/16986422/68672696-d0699f80-055a-11ea-8c84-771eed91d593.jpg) |
| After | ![fix-header-search-margin](https://user-images.githubusercontent.com/16986422/68672706-d790ad80-055a-11ea-8043-d1b9d11bc1fd.jpg) |