### PR TITLE
Added yarn command

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -17,6 +17,8 @@ The first step is to install in your project:
 
 ```
 npm install --save react-navigation
+# or with yarn
+# yarn add react-navigation
 ```
 
 The second step is to install react-native-gesture-handler


### PR DESCRIPTION
It's not huge but since react-native uses yarn package manager to manage libraries, I thought it would be nice if we get to see yarn command to install react-native-navigation.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
