### PR TITLE
Fix PushNotificationIOS fetchCompletionHandler documentation link

### DIFF
--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -422,7 +422,7 @@ You will never need to instantiate `PushNotificationIOS` yourself. Listening to 
 finish(fetchResult);
 ```
 
-This method is available for remote notifications that have been received via: `application:didReceiveRemoteNotification:fetchCompletionHandler:` https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:fetchCompletionHandler:
+This method is available for remote notifications that have been received via: `application:didReceiveRemoteNotification:fetchCompletionHandler:` https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application?language=objc
 
 Call this to execute when the remote notification handling is complete. When calling this block, pass in the fetch result value that best describes the results of your operation. You _must_ call this handler and should do so as soon as possible. For a list of possible values, see `PushNotificationIOS.FetchResult`.
 


### PR DESCRIPTION
There seems to be broken link to Apple's developers documentation in `finish()` function description (https://facebook.github.io/react-native/docs/pushnotificationios#finish). Current one redirects to main `UIApplicationDelegate` page.

This PR fixes that and points directly to `application:didReceiveRemoteNotification:fetchCompletionHandler:` instance method docs.
