### PR TITLE
fix SectionList example appearance on iOS

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -86,6 +86,7 @@ const styles = StyleSheet.create({
   },
   header: {
     fontSize: 32,
+    backgroundColor: '#fff'
   },
   title: {
     fontSize: 24,


### PR DESCRIPTION
By default, SectionList on iOS have property `stickySectionHeadersEnabled` set to `true` so header element should have any background to be displayed properly.

Before and after change:
<img width="421" alt="x" src="https://user-images.githubusercontent.com/719641/69502995-8054ea80-0f15-11ea-97e6-38db6f5e21c9.png">

Adding `backgroundColor` doesn't affect appearance of other examples.