### PR TITLE
fix: Right sidebar breaking when end of the page is reached

### DIFF
--- a/website/static/css/sidenav.css
+++ b/website/static/css/sidenav.css
@@ -1,0 +1,7 @@
+/* Right SideNav */
+
+@media only screen and (min-width: 1024px) {
+  .onPageNav {
+    margin-bottom: 120px;
+  }
+}


### PR DESCRIPTION
Fixed this issue: [#1358](https://github.com/facebook/react-native-website/issues/1358)

## Summary
The right SideNav overlaps the footer when you scroll all the way down.

## Changelog
I have a new css file for the sidenav and I added a `margin-bottom` property in order to fix this issue.

## A test plan
Go to the virtualizedlist page and scroll all the way down.

This is my user agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"

http://localhost:3000/react-native/docs/virtualizedlist