### PR TITLE
Add supportedPlatforms param to Snack embeds

### DIFF
--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -7,7 +7,7 @@ This component is used inside a ScrollView or ListView to add pull to refresh fu
 
 ### Example
 
-```SnackPlayer name=RefreshControl
+```SnackPlayer name=RefreshControl&supportedPlatforms=ios,android
 import React from 'react';
 import {
   ScrollView,

--- a/website/core/RemarkablePlugins.js
+++ b/website/core/RemarkablePlugins.js
@@ -83,6 +83,9 @@ function SnackPlayer(md) {
     const sampleCode = tokens[idx].content;
     const encodedSampleCode = encodeURIComponent(sampleCode);
     const platform = params.platform ? params.platform : 'ios';
+    const supportedPlatforms = params.supportedPlatforms
+      ? params.supportedPlatforms
+      : 'ios,android,web';
     const rnVersion = params.version ? params.version : 'next';
 
     return (
@@ -96,6 +99,7 @@ function SnackPlayer(md) {
         data-snack-description="${description}"
         data-snack-code="${encodedSampleCode}"
         data-snack-platform="${platform}"
+        data-snack-supported-platforms=${supportedPlatforms}
         data-snack-preview="true"
         style="
           overflow: hidden;

--- a/website/versioned_docs/version-0.60/refreshcontrol.md
+++ b/website/versioned_docs/version-0.60/refreshcontrol.md
@@ -8,7 +8,7 @@ This component is used inside a ScrollView or ListView to add pull to refresh fu
 
 ### Example
 
-```SnackPlayer name=RefreshControl
+```SnackPlayer name=RefreshControl&supportedPlatforms=ios,android
 import React from 'react';
 import {
   ScrollView,


### PR DESCRIPTION
At the request of @rachelnabors, I added support to Snack for the `supportedPlatforms` URL query param that lets you specify what platforms a Snack will run on. This PR integrates the param into the Snack Remarkable plugin used here and gives an example of using it on the RefreshControl API reference page.

Here is what it looks like with the web option disabled on the RefreshControl page:

<img width="765" alt="Screen Shot 2019-11-28 at 15 14 23" src="https://user-images.githubusercontent.com/90494/69834998-01043700-11f3-11ea-8813-1b91f71c8e68.png">
