### PR TITLE
Update link on React Native homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -82,7 +82,7 @@ including [Callstack], [Expo], [Infinite Red], [Microsoft], and [Software Mansio
 Our community is always shipping exciting new projects and exploring platforms beyond Android and iOS
 with repos like React Native Windows and React Native Web.
 
-[2nd highest]: https://octoverse.github.com/projects#repositories
+[2nd highest]: https://octoverse.github.com/2018/projects.html#repositories
 [Callstack]: https://callstack.com/
 [Expo]: https://expo.io/
 [Infinite Red]: https://infinite.red/


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

A link on the React Native homepage leading to `https://octoverse.github.com/projects#repositories` is dead. I've updated it with a working one.