### PR TITLE
deprecation indicator and deprecation notes standardization

### DIFF
--- a/docs/alertios.md
+++ b/docs/alertios.md
@@ -3,7 +3,7 @@ id: alertios
 title: 🚧 AlertIOS
 ---
 
-> **Deprecated.** `AlertIOS` has been moved to [`Alert`](alert.md)
+> **Deprecated.** Use [`Alert`](alert.md) instead.
 
 `AlertIOS` provides functionality to create an iOS alert dialog with a message or create a prompt for user input.
 

--- a/docs/alertios.md
+++ b/docs/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: AlertIOS
+title: 🚧 AlertIOS
 ---
 
 > **Deprecated.** `AlertIOS` has been moved to [`Alert`](alert.md)

--- a/docs/asyncstorage.md
+++ b/docs/asyncstorage.md
@@ -1,9 +1,9 @@
 ---
 id: asyncstorage
-title: AsyncStorage
+title: 🚧 AsyncStorage
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-async-storage](https://github.com/react-native-community/react-native-async-storage) instead.
+> **Deprecated.** Use [@react-native-community/async-storage](https://github.com/react-native-community/react-native-async-storage) instead.
 
 `AsyncStorage` is an unencrypted, asynchronous, persistent, key-value storage system that is global to the app. It should be used instead of LocalStorage.
 

--- a/docs/datepickerandroid.md
+++ b/docs/datepickerandroid.md
@@ -1,11 +1,11 @@
 ---
 id: datepickerandroid
-title: DatePickerAndroid
+title: 🚧 DatePickerAndroid
 ---
 
-Opens the standard Android date picker dialog.
+> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead. 
 
-> `DatePickerAndroid` has been merged with `DatePickerIOS` and `TimePickerAndroid` into a single component called [DateTimePicker](https://github.com/react-native-community/react-native-datetimepicker#react-native-datetimepicker) and will be removed in a future release.
+Opens the standard Android date picker dialog.
 
 ### Example
 

--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -1,11 +1,11 @@
 ---
 id: datepickerios
-title: DatePickerIOS
+title: 🚧 DatePickerIOS
 ---
 
-Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a controlled component, so you must hook in to the `onDateChange` callback and update the `date` prop in order for the component to update, otherwise the user's change will be reverted immediately to reflect `props.date` as the source of truth.
+> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead. 
 
-> `DatePickerIOS` has been merged with `TimePickerAndroid` and `DatePickerAndroid` into a single component called [DateTimePicker](https://github.com/react-native-community/react-native-datetimepicker#react-native-datetimepicker) and will be removed in a future release.
+Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a controlled component, so you must hook in to the `onDateChange` callback and update the `date` prop in order for the component to update, otherwise the user's change will be reverted immediately to reflect `props.date` as the source of truth.
 
 ### Example
 

--- a/docs/imageeditor.md
+++ b/docs/imageeditor.md
@@ -1,6 +1,6 @@
 ---
 id: imageeditor
-title: ImageEditor
+title: 🚧 ImageEditor
 ---
 
 > **Deprecated.** Use [@react-native-community/image-editor](https://github.com/react-native-community/react-native-image-editor) instead.

--- a/docs/imagepickerios.md
+++ b/docs/imagepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: imagepickerios
-title: ImagePickerIOS
+title: 🚧 ImagePickerIOS
 ---
 
 > **Deprecated.** Use [@react-native-community/image-picker-ios](https://github.com/react-native-community/react-native-image-picker-ios) instead.

--- a/docs/pickerios.md
+++ b/docs/pickerios.md
@@ -1,6 +1,6 @@
 ---
 id: pickerios
-title: PickerIOS
+title: 🚧 PickerIOS
 ---
 
 > **Deprecated.** Use [Picker](picker.md) instead.

--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -1,7 +1,9 @@
 ---
 id: progressbarandroid
-title: ProgressBarAndroid
+title: 🚧 ProgressBarAndroid
 ---
+
+> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-community/react-native-progress-bar-android) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/docs/progressviewios.md
+++ b/docs/progressviewios.md
@@ -1,7 +1,9 @@
 ---
 id: progressviewios
-title: ProgressViewIOS
+title: 🚧 ProgressViewIOS
 ---
+
+> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-community/react-native-progress-view) instead.
 
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: PushNotificationIOS
+title: 🚧 PushNotificationIOS
 ---
 
 > **Deprecated.** Use [@react-native-community/push-notification-ios](https://github.com/react-native-community/react-native-push-notification-ios) instead.

--- a/docs/segmentedcontrolios.md
+++ b/docs/segmentedcontrolios.md
@@ -1,9 +1,9 @@
 ---
 id: segmentedcontrolios
-title: SegmentedControlIOS
+title: 🚧 SegmentedControlIOS
 ---
 
-> **Deprecated.** Use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
+> **Deprecated.** Use [@react-native-community/segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 

--- a/docs/slider.md
+++ b/docs/slider.md
@@ -1,9 +1,9 @@
 ---
 id: slider
-title: Slider
+title: 🚧 Slider
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-slider](https://github.com/react-native-community/react-native-slider) instead.
+> **Deprecated.** Use [@react-native-community/slider](https://github.com/react-native-community/react-native-slider) instead.
 
 A component used to select a single value from a range of values.
 

--- a/docs/statusbarios.md
+++ b/docs/statusbarios.md
@@ -1,8 +1,8 @@
 ---
 id: statusbarios
-title: StatusBarIOS
+title: 🚧 StatusBarIOS
 ---
 
-> Use `StatusBar` for mutating the status bar.
+> **Deprecated.** Use [`StatusBar`](statusbar.md) for mutating the status bar.
 
 ---

--- a/docs/timepickerandroid.md
+++ b/docs/timepickerandroid.md
@@ -1,11 +1,11 @@
 ---
 id: timepickerandroid
-title: TimePickerAndroid
+title: 🚧 TimePickerAndroid
 ---
 
-Opens the standard Android time picker dialog.
+> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
 
-> `TimePickerAndroid` has been merged with `DatePickerIOS` and `DatePickerAndroid` into a single component called [DateTimePicker](https://github.com/react-native-community/react-native-datetimepicker#react-native-datetimepicker) and will be removed in a future release.
+Opens the standard Android time picker dialog.
 
 ### Example
 

--- a/docs/viewpagerandroid.md
+++ b/docs/viewpagerandroid.md
@@ -1,9 +1,9 @@
 ---
 id: viewpagerandroid
-title: ViewPagerAndroid
+title: 🚧 ViewPagerAndroid
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-viewpager](https://github.com/react-native-community/react-native-viewpager) instead.
+> **Deprecated.** Use [@react-native-community/viewpager](https://github.com/react-native-community/react-native-viewpager) instead.
 
 Container that allows to flip left and right between child views. Each child view of the `ViewPagerAndroid` will be treated as a separate page and will be stretched to fill the `ViewPagerAndroid`.
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -300,7 +300,7 @@
         "title": "StatusBar"
       },
       "statusbarios": {
-        "title": "StatusBarIOS"
+        "title": "🚧 StatusBarIOS"
       },
       "style": {
         "title": "Style"
@@ -324,7 +324,7 @@
         "title": "TextInput"
       },
       "timepickerandroid": {
-        "title": "TimePickerAndroid"
+        "title": "🚧 TimePickerAndroid"
       },
       "timers": {
         "title": "Timers"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -21,7 +21,7 @@
         "title": "Alert"
       },
       "alertios": {
-        "title": "AlertIOS"
+        "title": "🚧 AlertIOS"
       },
       "animated": {
         "title": "Animated"
@@ -45,7 +45,7 @@
         "title": "AppState"
       },
       "asyncstorage": {
-        "title": "AsyncStorage"
+        "title": "🚧 AsyncStorage"
       },
       "backhandler": {
         "title": "BackHandler"
@@ -81,10 +81,10 @@
         "title": "Custom WebView"
       },
       "datepickerandroid": {
-        "title": "DatePickerAndroid"
+        "title": "🚧 DatePickerAndroid"
       },
       "datepickerios": {
-        "title": "DatePickerIOS"
+        "title": "🚧 DatePickerIOS"
       },
       "debugging": {
         "title": "Debugging"
@@ -141,10 +141,10 @@
         "title": "ImageBackground"
       },
       "imageeditor": {
-        "title": "ImageEditor"
+        "title": "🚧 ImageEditor"
       },
       "imagepickerios": {
-        "title": "ImagePickerIOS"
+        "title": "🚧 ImagePickerIOS"
       },
       "images": {
         "title": "Images"
@@ -234,7 +234,7 @@
         "title": "Picker"
       },
       "pickerios": {
-        "title": "PickerIOS"
+        "title": "🚧 PickerIOS"
       },
       "pixelratio": {
         "title": "PixelRatio"
@@ -252,7 +252,7 @@
         "title": "Props"
       },
       "pushnotificationios": {
-        "title": "PushNotificationIOS"
+        "title": "🚧 PushNotificationIOS"
       },
       "refreshcontrol": {
         "title": "RefreshControl"
@@ -276,7 +276,7 @@
         "title": "SectionList"
       },
       "segmentedcontrolios": {
-        "title": "SegmentedControlIOS"
+        "title": "🚧 SegmentedControlIOS"
       },
       "settings": {
         "title": "Settings"
@@ -291,7 +291,7 @@
         "title": "Publishing to Google Play Store"
       },
       "slider": {
-        "title": "Slider"
+        "title": "🚧 Slider"
       },
       "state": {
         "title": "State"
@@ -378,7 +378,7 @@
         "title": "View"
       },
       "viewpagerandroid": {
-        "title": "ViewPagerAndroid"
+        "title": "🚧 ViewPagerAndroid"
       },
       "virtualizedlist": {
         "title": "VirtualizedList"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -243,10 +243,10 @@
         "title": "Platform Specific Code"
       },
       "progressbarandroid": {
-        "title": "ProgressBarAndroid"
+        "title": "🚧 ProgressBarAndroid"
       },
       "progressviewios": {
-        "title": "ProgressViewIOS"
+        "title": "🚧 ProgressViewIOS"
       },
       "props": {
         "title": "Props"


### PR DESCRIPTION
By deprecation notes standardization I have meant following changes:
* using current NPM package name
* using similar phrasing
* positioning deprecation note always on the top of the page

The rest of changes are basically a concept, which you might not like. 

I was aiming to clarify deprecation and discourage developers to use those parts of RN so I have added  🚧emoji to the title of pages marked as deprecated Component or API. (Of course I'm open to change selected emoji, this could be anything else.)

<img width="1415" alt="Screenshot 2019-12-03 at 14 59 41" src="https://user-images.githubusercontent.com/719641/70058405-215f3780-15df-11ea-8a8f-534f88e0df3a.png">

I can work further on this PR or on any other solution that help in the case mentioned above.