### PR TITLE
move props related pages to separate section in sidebar

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3496,6 +3496,7 @@
       "Guides (iOS)": "Guides (iOS)",
       "Guides (Android)": "Guides (Android)",
       "Components": "Components",
+      "Props": "Props",
       "APIs": "APIs",
       "Contributing": "Contributing"
     }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -96,6 +96,13 @@
       "viewpagerandroid",
       "virtualizedlist"
     ],
+    "Props": [
+      "image-style-props",
+      "layout-props",
+      "shadow-props",
+      "text-style-props",
+      "view-style-props"
+    ],
     "APIs": [
       "accessibilityinfo",
       "actionsheetios",
@@ -112,10 +119,8 @@
       "easing",
       "imageeditor",
       "imagepickerios",
-      "image-style-props",
       "interactionmanager",
       "keyboard",
-      "layout-props",
       "layoutanimation",
       "linking",
       "panresponder",
@@ -123,17 +128,14 @@
       "pixelratio",
       "pushnotificationios",
       "settings",
-      "shadow-props",
       "share",
       "statusbarios",
       "stylesheet",
       "systrace",
-      "text-style-props",
       "timepickerandroid",
       "toastandroid",
       "transforms",
-      "vibration",
-      "view-style-props"
+      "vibration"
     ]
   }
 }


### PR DESCRIPTION
This PR adds new "Props" section to the "API" page sidebar which contains all props related pages earlier listed in section below. 

The order of sections can be changed, it's only a proposal aiming to tidy up the sidebar.

<img width="1429" alt="Screenshot 2019-12-04 at 14 08 16" src="https://user-images.githubusercontent.com/719641/70145175-c6d9e000-169f-11ea-8ce1-8f0fdfc8299d.png">
