### PR TITLE
update step by step integration with react navigation

### DIFF
--- a/website/versioned_docs/version-0.5/navigation.md
+++ b/website/versioned_docs/version-0.5/navigation.md
@@ -12,7 +12,7 @@ If you'd like to achieve a native look and feel on both Android and iOS, or you'
 
 ## React Navigation
 
-The community solution to navigation is a standalone library that allows developers to set up the screens of an app with a few lines of code. Assuming you are on the latest react-native version.
+The community solution to navigation is a standalone library that allows developers to set up the screens of an app with a few lines of code.
 
 The first step is to install in your project:
 

--- a/website/versioned_docs/version-0.5/navigation.md
+++ b/website/versioned_docs/version-0.5/navigation.md
@@ -12,20 +12,84 @@ If you'd like to achieve a native look and feel on both Android and iOS, or you'
 
 ## React Navigation
 
-The community solution to navigation is a standalone library that allows developers to set up the screens of an app with a few lines of code.
+The community solution to navigation is a standalone library that allows developers to set up the screens of an app with a few lines of code. Assuming you are on the latest react-native version.
 
 The first step is to install in your project:
 
 ```
-npm install --save react-navigation
+yarn add react-navigation
+# or with npm
+# npm install react-navigation
 ```
 
-The second step is to install react-native-gesture-handler
+The second step is to install additional dependencies such as `react-native-gesture-handler`, `react-native-reanimated`, and `react-native-screens`:
 
 ```
 yarn add react-native-gesture-handler
 # or with npm
 # npm install --save react-native-gesture-handler
+```
+
+```
+yarn add react-native-reanimated
+# or with npm
+# npm install --save react-native-reanimated
+```
+
+```
+yarn add react-native-screens
+# or with npm
+# npm install --save react-native-screens
+```
+
+To complete your installation on **iOS**, make sure you have [Cocoapods](https://cocoapods.org/). Then run:
+
+```
+cd ios
+pod install
+cd ..
+```
+
+To Complete your installation on **Android**. Add the following two lines to dependencies section in `android/app/build.gradle`:
+
+```
+implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
+```
+
+And make the following modifications to `MainActivity.java`:
+
+```diff
+package com.reactnavigation.example;
+
+import com.facebook.react.ReactActivity;
++ import com.facebook.react.ReactActivityDelegate;
++ import com.facebook.react.ReactRootView;
++ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+public class MainActivity extends ReactActivity {
+
+  @Override
+  protected String getMainComponentName() {
+    return "Example";
+  }
+
++  @Override
++  protected ReactActivityDelegate createReactActivityDelegate() {
++    return new ReactActivityDelegate(this, getMainComponentName()) {
++      @Override
++      protected ReactRootView createRootView() {
++       return new RNGestureHandlerEnabledRootView(MainActivity.this);
++      }
++    };
++  }
+}
+```
+
+Then add the following at the top of your entry file, such as `index.js` or `App.js`:
+
+```
+import 'react-native-gesture-handler'
 ```
 
 The third step is to install react-navigation-stack

--- a/website/versioned_docs/version-0.5/navigation.md
+++ b/website/versioned_docs/version-0.5/navigation.md
@@ -22,24 +22,10 @@ yarn add react-navigation
 # npm install react-navigation
 ```
 
-The second step is to install additional dependencies such as `react-native-gesture-handler`, `react-native-reanimated`, and `react-native-screens`:
+The second step is to install additional dependencies such as `react-native-gesture-handler`, `react-native-reanimated`, `react-native-screens`, `react-native-safe-area-context`, and `@react-native-community/masked-view`:
 
 ```
-yarn add react-native-gesture-handler
-# or with npm
-# npm install --save react-native-gesture-handler
-```
-
-```
-yarn add react-native-reanimated
-# or with npm
-# npm install --save react-native-reanimated
-```
-
-```
-yarn add react-native-screens
-# or with npm
-# npm install --save react-native-screens
+npm install --save react-navigation react-native-reanimated react-native-gesture-handler react-native-screens react-native-safe-area-context @react-native-community/masked-view
 ```
 
 To complete your installation on **iOS**, make sure you have [Cocoapods](https://cocoapods.org/). Then run:


### PR DESCRIPTION
## Motivation

when i created fresh project with latest react-native version, and i wanted to integrate react navigation to my project, i followed step by step instruction from http://facebook.github.io/react-native/docs/navigation and it got an error. 

But i found out that the current documentation missed out some step.

here is my pull request give an additional steps with the current react navigation version.

and here is some screenshot of additional step in my changes:

**1. install dependencies**
![image](https://user-images.githubusercontent.com/27436728/70333251-ba0ee500-1875-11ea-9aa1-e9bf9f3fff72.png)

**2. finishing up with android or iOS development target**
![image](https://user-images.githubusercontent.com/27436728/70334007-263e1880-1877-11ea-8e9d-f108769eb4a9.png)
