### PR TITLE
Update fast-refresh.md

### DIFF
--- a/docs/fast-refresh.md
+++ b/docs/fast-refresh.md
@@ -35,14 +35,13 @@ In the longer term, as more of your codebase moves to function components and Ho
 
 - Fast Refresh preserves React local state in function components (and Hooks) by default.
 - Sometimes you might want to _force_ the state to be reset, and a component to be remounted. For example, this can be handy if you're tweaking an animation that only happens on mount. To do this, you can add `// @refresh reset` anywhere in the file you're editing. This directive is local to the file, and instructs Fast Refresh to remount components defined in that file on every edit.
-- You can put `console.log` or `debugger;` into the components you edit during a Fast Refresh session.
-- Technically all `useState` and `useRef` Hooks are preserved, while all other Hooks run as if the component were removed then added again. The following example gives you some idea of how a fast refresh affects the `useEffect` Hook:
 
-```js
-useEffect(() => { // runs once and also on fast refresh
+## Fast Refresh and Hooks
 
-  return () => {  // runs when the component is removed and also on fast refresh
-    // ..
-  }
-}, [])
-```
+When possible, Fast Refresh attempts to preserve the state of your component between edits. In particular, `useState` and `useRef` preserve their previous values as long as you don't change their arguments or the order of the Hook calls.
+
+Hooks with dependencies—such as `useEffect`, `useMemo`, and `useCallback`—will *always* update during Fast Refresh. Their list of dependencies will be ignored while Fast Refresh is happening.
+
+For example, when you edit `useMemo(() => x * 2, [x])` to `useMemo(() => x * 10, [x])`, it will re-run even though `x` (the dependency) has not changed. If React didn't do that, your edit wouldn't reflect on the screen!
+
+Sometimes, this can lead to unexpected results. For example, even a `useEffect` with an empty array of dependencies would still re-run once during Fast Refresh. However, writing code resilient to an occasional re-running of `useEffect` is a good practice even without Fast Refresh. This makes it easier for you to later introduce new dependencies to it.

--- a/docs/fast-refresh.md
+++ b/docs/fast-refresh.md
@@ -36,3 +36,13 @@ In the longer term, as more of your codebase moves to function components and Ho
 - Fast Refresh preserves React local state in function components (and Hooks) by default.
 - Sometimes you might want to _force_ the state to be reset, and a component to be remounted. For example, this can be handy if you're tweaking an animation that only happens on mount. To do this, you can add `// @refresh reset` anywhere in the file you're editing. This directive is local to the file, and instructs Fast Refresh to remount components defined in that file on every edit.
 - You can put `console.log` or `debugger;` into the components you edit during a Fast Refresh session.
+- Technically all **useState** and **useRef** hooks is preserved, while all other hooks runs as if the component is being removed and added again. The following example gives you some insight into how a fast refresh affects the **useEffect** hook:
+
+```js
+useEffect(() => {
+  // I ran the first time, but will also run on fast refresh
+  return () => {
+    // I will run when the component is removed, but will also run on fast refresh
+  }
+}, [])
+```

--- a/docs/fast-refresh.md
+++ b/docs/fast-refresh.md
@@ -36,13 +36,13 @@ In the longer term, as more of your codebase moves to function components and Ho
 - Fast Refresh preserves React local state in function components (and Hooks) by default.
 - Sometimes you might want to _force_ the state to be reset, and a component to be remounted. For example, this can be handy if you're tweaking an animation that only happens on mount. To do this, you can add `// @refresh reset` anywhere in the file you're editing. This directive is local to the file, and instructs Fast Refresh to remount components defined in that file on every edit.
 - You can put `console.log` or `debugger;` into the components you edit during a Fast Refresh session.
-- Technically all **useState** and **useRef** hooks is preserved, while all other hooks runs as if the component is being removed and added again. The following example gives you some insight into how a fast refresh affects the **useEffect** hook:
+- Technically all `useState` and `useRef` Hooks are preserved, while all other Hooks run as if the component were removed then added again. The following example gives you some idea of how a fast refresh affects the `useEffect` Hook:
 
 ```js
-useEffect(() => {
-  // I ran the first time, but will also run on fast refresh
-  return () => {
-    // I will run when the component is removed, but will also run on fast refresh
+useEffect(() => { // runs once and also on fast refresh
+
+  return () => {  // runs when the component is removed and also on fast refresh
+    // ..
   }
 }, [])
 ```


### PR DESCRIPTION
Hi there!

As a library author I found it puzzling how fast-refresh affects the hooks. It is nice to document how **useState** and **useRef** differs from the others. Also giving an example of how **useEffect** runs related to a fast-refresh. Because it runs as if the component was removed and added again, which is just nice to know 😄 

Awesome work on this!

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
