### PR TITLE
Remove TODO showing in the docs of `AppState`

### DIFF
--- a/website/versioned_docs/version-0.28/appstate.md
+++ b/website/versioned_docs/version-0.28/appstate.md
@@ -74,7 +74,7 @@ Add a handler to AppState changes by listening to the `change` event type and pr
 | type    | string   | Yes      |             |
 | handler | function | Yes      |             |
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.42/appstate.md
+++ b/website/versioned_docs/version-0.42/appstate.md
@@ -86,7 +86,7 @@ Add a handler to AppState changes by listening to the `change` event type and pr
 | type    | string   | Yes      |             |
 | handler | function | Yes      |             |
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.46/appstate.md
+++ b/website/versioned_docs/version-0.46/appstate.md
@@ -86,7 +86,7 @@ Add a handler to AppState changes by listening to the `change` event type and pr
 | type    | string   | Yes      |             |
 | handler | function | Yes      |             |
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.53/appstate.md
+++ b/website/versioned_docs/version-0.53/appstate.md
@@ -84,7 +84,7 @@ addEventListener(type, handler);
 
 Add a handler to AppState changes by listening to the `change` event type and providing the handler
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.54/appstate.md
+++ b/website/versioned_docs/version-0.54/appstate.md
@@ -82,7 +82,7 @@ addEventListener(type, handler);
 
 Add a handler to AppState changes by listening to the `change` event type and providing the handler
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.55/appstate.md
+++ b/website/versioned_docs/version-0.55/appstate.md
@@ -82,7 +82,7 @@ addEventListener(type, handler);
 
 Add a handler to AppState changes by listening to the `change` event type and providing the handler
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.58/appstate.md
+++ b/website/versioned_docs/version-0.58/appstate.md
@@ -81,7 +81,7 @@ addEventListener(type, handler);
 
 Add a handler to AppState changes by listening to the `change` event type and providing the handler
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 

--- a/website/versioned_docs/version-0.60/appstate.md
+++ b/website/versioned_docs/version-0.60/appstate.md
@@ -86,7 +86,7 @@ addEventListener(type, handler);
 
 Add a handler to AppState changes by listening to the `change` event type and providing the handler
 
-TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique).
+<!-- TODO: now that AppState is a subclass of NativeEventEmitter, we could deprecate `addEventListener` and `removeEventListener` and use `addListener` and `listener.remove()` directly. That will be a breaking change though, as both the method and event names are different (addListener events are currently required to be globally unique). -->
 
 ---
 


### PR DESCRIPTION
The following _TODO_ comment is currently showing in the page of `AppState`:

![image](https://user-images.githubusercontent.com/6207220/70439277-f0c04780-1a8f-11ea-9739-83b03b0796bb.png)

Here's a PR to put it as code comment as I believe it is not supposed to be there.