### PR TITLE
Update async storage link

### DIFF
--- a/docs/asyncstorage.md
+++ b/docs/asyncstorage.md
@@ -3,7 +3,7 @@ id: asyncstorage
 title: AsyncStorage
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-async-storage](https://github.com/react-native-community/react-native-async-storage) instead.
+> **Deprecated.** Use [react-native-community/async-storage](https://github.com/react-native-community/async-storage) instead.
 
 `AsyncStorage` is an unencrypted, asynchronous, persistent, key-value storage system that is global to the app. It should be used instead of LocalStorage.
 


### PR DESCRIPTION
Package is now called `react-native-community/async-storage` instead of `react-native-community/react-native-async-storage`.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
