### PR TITLE
Fix the spacing on the footer of prev/next buttons

### DIFF
--- a/website/static/css/docs-prevnext.css
+++ b/website/static/css/docs-prevnext.css
@@ -6,8 +6,10 @@
 
 @media only screen and (min-width: 1024px) {
   .docs-prevnext {
-    margin: 0 -9999px 0 -3rem;
-    padding: 2rem 9999px 2rem 3rem;
+    /* margin: 0 -9999px 0 -3rem;
+    padding: 2rem 9999px 2rem 3rem; */
+    padding: 2rem 3rem;
+    margin: 0px -24px 0px -48px;
   }
 }
 
@@ -46,10 +48,12 @@
 
 .button.docs-prev {
   margin-right: auto;
+  margin-left: -0.1rem;
 }
 
 .button.docs-next {
   margin-left: auto;
+  margin-right: -1.6rem;
 }
 
 .docs-next span:first-child {


### PR DESCRIPTION
This PR fixes an issue with the bottom of the prev/next buttons passing the sidebar.

Before:

![image](https://user-images.githubusercontent.com/6207220/70624776-41b37580-1c21-11ea-9451-29f6d84122e1.png)

After:

![image](https://user-images.githubusercontent.com/6207220/70624806-54c64580-1c21-11ea-8465-f3c97b16289a.png)
