### PR TITLE
Removed "Required" annotation of viewOffset in scrollToIndex

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -616,7 +616,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---

--- a/website/versioned_docs/version-0.52/flatlist.md
+++ b/website/versioned_docs/version-0.52/flatlist.md
@@ -491,7 +491,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---

--- a/website/versioned_docs/version-0.54/flatlist.md
+++ b/website/versioned_docs/version-0.54/flatlist.md
@@ -491,7 +491,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---

--- a/website/versioned_docs/version-0.55/flatlist.md
+++ b/website/versioned_docs/version-0.55/flatlist.md
@@ -539,7 +539,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---

--- a/website/versioned_docs/version-0.56/flatlist.md
+++ b/website/versioned_docs/version-0.56/flatlist.md
@@ -539,7 +539,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---

--- a/website/versioned_docs/version-0.58/flatlist.md
+++ b/website/versioned_docs/version-0.58/flatlist.md
@@ -540,7 +540,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---

--- a/website/versioned_docs/version-0.60/flatlist.md
+++ b/website/versioned_docs/version-0.60/flatlist.md
@@ -616,7 +616,7 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 - 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+- 'viewOffset' (number) - A fixed number of pixels to offset the final target position.
 - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/flatlist#scrolltoindex

The viewOffset property of Flatlist.scrolltoIndex is optional.
I think the "Required" Notation at the end is unnecessary.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
