### PR TITLE
fix the missing line of run the metro server

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -393,7 +393,7 @@ npx react-native init AwesomeTSProject --template typescript
 > If you previously installed a global `react-native-cli` package, please remove it as it may cause unexpected issues.
 
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
-
+Make sure that you have run the metro server by executing  `npx react-native start` 
 ```sh
 npx react-native init AwesomeProject
 ```


### PR DESCRIPTION
Mention that to run metro server before execute " npx react-native run-android" command. If you guys not mention that line it will make conflicts for beginners.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
