### PR TITLE
remove DocumentSelectionState link textinput docs #1518

### DIFF
--- a/website/versioned_docs/version-0.60/textinput.md
+++ b/website/versioned_docs/version-0.60/textinput.md
@@ -644,8 +644,6 @@ Some functionality that can be performed with this instance is:
 - `focus()`
 - `update()`
 
-> You can reference `DocumentSelectionState` in [`vendor/document/selection/DocumentSelectionState.js`](https://github.com/facebook/react-native/blob/master/Libraries/vendor/document/selection/DocumentSelectionState.js)
-
 | Type                   | Required | Platform |
 | ---------------------- | -------- | -------- |
 | DocumentSelectionState | No       | iOS      |


### PR DESCRIPTION
i try to find this file in react-native repository, i think this file it's deprecated.
if you click in the link appears 404 not found.