### PR TITLE
onLayout does not provide pageX and pageY

### DIFF
--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -176,7 +176,7 @@ Determines the location on screen, width, and height of the given view and retur
 - pageX
 - pageY
 
-Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible, consider using the [`onLayout` prop](view.md#onlayout) instead.
+Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible and you don't need `pageX` and `pageY`, consider using the [`onLayout` prop](view.md#onlayout) instead.
 
 ### measureInWindow(callback)
 


### PR DESCRIPTION
This bit was confusing because originally I used `onLayout` to get `pageY` but then realized that `onLayout` doesn't provide that value (not sure why exactly). Therefore I looked around and `measure` seems to do so but its docs suggest to use `onLayout` at some point 🙃