### PR TITLE
Removing references to next pages

### DIFF
--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -169,6 +169,6 @@ const styles = StyleSheet.create({
 });
 ```
 
-## Scrolling lists, swiping pages, and pinch-to-zoom
+## Scrolling and swiping
 
-Another gesture commonly used in mobile apps is the swipe or pan. This gesture allows the user to scroll through a list of items, or swipe through pages of content. In order to handle these and other gestures, we'll learn [how to use a ScrollView](using-a-scrollview.md) next.
+Gestures commonly used on devices with touchable screens include swipes and pans. These allow the user to scroll through a list of items, or swipe through pages of content. For these, check out the [ScrollView](scrollview.md) Core Component.


### PR DESCRIPTION
Since this page was moved out of the Getting Started docs and the ScrollView is being merged into a mini tutorial, this should link ahead to ScrollView's API docs.
