### PR TITLE
docs: Remove advice to enable Fast Refresh for new apps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -556,8 +556,6 @@ Congratulations! You've successfully run and modified your first React Native ap
 
 <h2>Now what?</h2>
 
-- Turn on [Fast Refresh](debugging.md#enabling-fast-refresh) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
-
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
 If you're curious to learn more about React Native, continue on to the [Tutorial](tutorial.md).
@@ -565,8 +563,6 @@ If you're curious to learn more about React Native, continue on to the [Tutorial
 <block class="native windows linux mac android" />
 
 <h2>Now what?</h2>
-
-- Turn on [Fast Refresh](debugging.md#enabling-fast-refresh) in the Developer Menu. Your app will now reload automatically whenever you save any changes!
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 


### PR DESCRIPTION
RN 0.61 enables Fast Refresh by default for new apps. There is no need to instruct users to manually enable it in the Getting Started guide.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
