### PR TITLE
[DOC]: API Reference for DevSettings.addMenuItem() #1523

### DIFF
--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -3,7 +3,7 @@ id: devsettings
 title: DevSettings
 ---
 
-`DevSettings`
+The `DevSettings` module exposes methods for customizing settings in for developers in development.
 
 ---
 
@@ -16,10 +16,11 @@ title: DevSettings
 ```jsx
  addMenuItem(title: string, handler: () => )
 ```
-It allows users to add additional dev menu options to their app, so you can use following code to show secret dev screen
+
+Add a custom menu item to the developer menu:
 
 ```jsx
 DevSettings.addMenuItem('Show Secret Dev Screen', () => {
-             Alert.alert('Showing secret dev screen!');
-           });
+  Alert.alert('Showing secret dev screen!');
+});
 ```

--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -3,7 +3,7 @@ id: devsettings
 title: DevSettings
 ---
 
-The `DevSettings` module exposes methods for customizing settings in for developers in development.
+The `DevSettings` module exposes methods for customizing settings for developers in development.
 
 ---
 

--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -1,7 +1,10 @@
-
 ---
 id: devsettings
 title: DevSettings
+---
+
+`DevSettings`
+
 ---
 
 # Reference
@@ -10,4 +13,13 @@ title: DevSettings
 
 ### `addMenuItem()`
 
-`addMenuItem()` allows users to add additional dev menu options to their app.
+```jsx
+ addMenuItem(title: string, handler: () => )
+```
+It allows users to add additional dev menu options to their app, so you can use following code to show secret dev screen
+
+```jsx
+DevSettings.addMenuItem('Show Secret Dev Screen', () => {
+             Alert.alert('Showing secret dev screen!');
+           });
+```

--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -1,0 +1,13 @@
+
+---
+id: devsettings
+title: DevSettings
+---
+
+# Reference
+
+## Methods
+
+### `addMenuItem()`
+
+`addMenuItem()` allows users to add additional dev menu options to their app.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -107,6 +107,7 @@
       "backhandler",
       "clipboard",
       "datepickerandroid",
+      "devsettings",
       "dimensions",
       "easing",
       "imageeditor",


### PR DESCRIPTION
Started writing the doc for addMenuItem() as DevSettingsModule.
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
