### PR TITLE
update incorrect link to typescript

### DIFF
--- a/docs/javascript-environment.md
+++ b/docs/javascript-environment.md
@@ -55,7 +55,7 @@ Specific
 
 - [JSX](https://reactjs.org/docs/jsx-in-depth.html): `<View style={{color: 'red'}} />`
 - [Flow](https://flowtype.org/): `function foo(x: ?number): string {};`
-- [TypeScript](https://flowtype.org/): `function foo(x: number | undefined): string {};`
+- [TypeScript](https://www.typescriptlang.org/): `function foo(x: number | undefined): string {};`
 - [Babel Template](https://babeljs.io/docs/en/babel-template): allows AST templating
 
 ## Polyfills


### PR DESCRIPTION
TypeScript list item under Javascript Syntax Transformers section was pointing to the flow type web page instead of typescript.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
