### PR TITLE
fix title style in the first example in text component API docs

### DIFF
--- a/website/versioned_docs/version-0.60/text.md
+++ b/website/versioned_docs/version-0.60/text.md
@@ -40,7 +40,7 @@ export default class TextInANest extends Component {
 const styles = StyleSheet.create({
   baseText: {
     fontFamily: 'Cochin',
-    marginVertical:20
+    marginVertical: 20,
   },
   titleText: {
     fontSize: 20,

--- a/website/versioned_docs/version-0.60/text.md
+++ b/website/versioned_docs/version-0.60/text.md
@@ -40,6 +40,7 @@ export default class TextInANest extends Component {
 const styles = StyleSheet.create({
   baseText: {
     fontFamily: 'Cochin',
+    marginVertical:20
   },
   titleText: {
     fontSize: 20,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36824170/71789162-b3979880-2fee-11ea-9a55-6d29b842bc9e.png)

the title style looks up the header phone so i fix that.

![image](https://user-images.githubusercontent.com/36824170/71789209-36205800-2fef-11ea-919b-6162e6a98c9c.png)


