### PR TITLE
Correct mistakes in flexDirection description

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -23,11 +23,11 @@ In the following example, the red, yellow, and green views are all children in t
 
 - `row` Align children from left to right. If wrapping is enabled, then the next line will start under the first item on the left of the container.
 
-- `column` (**default value**) Align children from top to bottom. If wrapping is enabled, then the next line will start to the left first item on the top of the container.
+- `column` (**default value**) Align children from top to bottom. If wrapping is enabled, then the next line will start to the right of the first item on the top of the container.
 
 - `row-reverse` Align children from right to left. If wrapping is enabled, then the next line will start under the first item on the right of the container.
 
-- `column-reverse` Align children from bottom to top. If wrapping is enabled, then the next line will start to the left first item on the bottom of the container.
+- `column-reverse` Align children from bottom to top. If wrapping is enabled, then the next line will start to the right of the first item on the bottom of the container.
 
 You can learn more [here](https://yogalayout.com/docs/flex-direction).
 


### PR DESCRIPTION
The current descriptions of the behavior for 'column' and 'column-reverse'  when wrapping is enabled are incorrect. They state that the next line will start to the left of the first line. This PR edits these descriptions to say that the next line will start to the _right_ of the first line.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
