### PR TITLE
Upgrading docusaurus to fix JSX formatting incorrectly.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "alex": "^8.0.0",
-    "docusaurus": "1.14.3",
+    "docusaurus": "1.14.4",
     "highlight.js": "^9.15.10",
     "remarkable": "^2.0.0"
   },

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2298,10 +2298,10 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-docusaurus@1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.14.3.tgz#640ffc37ae14fe58c175fd14e66c3a2dd36e19a3"
-  integrity sha512-PoEB8uBLLVrWmv41Rvq9OqfOUUIk+tnscCNIuw/wI31tjALAfP3IfsliLc6ZBUvAtTF3S2Dk/quuzmdSCYgjaA==
+docusaurus@1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.14.4.tgz#1ef3ebe8c2aaaf1dec6c2e0e177e83be78aeaca3"
+  integrity sha512-KALmrlZBc0E+AB0ITR4POGKv8WcrcSSxvmgq7nC3TdpS+S2hrlXN/2tV3tVOZ8q8m+zhcMs7l9mAIhGFQyQwIw==
   dependencies:
     "@babel/core" "^7.7.4"
     "@babel/plugin-proposal-class-properties" "^7.7.4"


### PR DESCRIPTION
Docusaurus was having some issues with formatting JSX code blocks correctly. This was problematic in some of our examples. After working with them, they updated Docusaurus accordingly