### PR TITLE
Add reserved method name note to iOS module docs

### DIFF
--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -498,3 +498,9 @@ For those of you new to Swift and Objective-C, whenever you [mix the two languag
 You can also use `RCT_EXTERN_REMAP_MODULE` and `_RCT_EXTERN_REMAP_METHOD` to alter the JavaScript name of the module or methods you are exporting. For more information see [`RCTBridgeModule`](https://github.com/facebook/react-native/blob/master/React/Base/RCTBridgeModule.h).
 
 > **Important when making third party modules**: Static libraries with Swift are only supported in Xcode 9 and later. In order for the Xcode project to build when you use Swift in the iOS static library you include in the module, your main app project must contain Swift code and a bridging header itself. If your app project does not contain any Swift code, a workaround can be a single empty .swift file and an empty bridging header.
+
+## Reserved Method Names
+
+### invalidate()
+
+Native modules can conform to the [RCTInvalidating](https://github.com/facebook/react-native/blob/aa0ef15335fe27c0c193e3e968789886d82e82ed/React/Base/RCTInvalidating.h) protocol on iOS by implementing the `invalidate` method. This method [can be invoked](https://github.com/facebook/react-native/blob/18e3303cd46a72668caae46e28c7c6ae69fbf8f8/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm#L456) when the native bridge is invalidated (ie: on devmode reload). You should avoid implementing this method in general, as this mechanism exists for backwards compatibility and may be removed in the future.


### PR DESCRIPTION
In our project we accidentally implemented the `invalidate` method on a native module we wrote to control a user's session. `SessionCacheModule.invalidate` was being called every time we triggered a dev mode reload, which would log us out :(

<img width="380" alt="Screen Shot 2020-01-13 at 3 54 19 PM" src="https://user-images.githubusercontent.com/1047502/72347009-223abd00-36a5-11ea-94de-87ea631f5611.png">

I'm adding cautionary notes to the docs in case someone encounters this footgun as well