### PR TITLE
Removed margin-right from docs-next button

### DIFF
--- a/website/static/css/docs-prevnext.css
+++ b/website/static/css/docs-prevnext.css
@@ -53,7 +53,6 @@
 
 .button.docs-next {
   margin-left: auto;
-  margin-right: -1.6rem;
 }
 
 .docs-next span:first-child {


### PR DESCRIPTION
Removed margin-right from docs-next button because it goes little bit out of the screen while working on mobile and it's wasn't as far as on the right side as compare to the Getting Started button from it's left.