### PR TITLE
Update slider.md

### DIFF
--- a/docs/slider.md
+++ b/docs/slider.md
@@ -4,6 +4,7 @@ title: Slider
 ---
 
 > **Deprecated.** Use [react-native-community/react-native-slider](https://github.com/react-native-community/react-native-slider) instead.
+> **But.** Expo platform is not corresponded to [react-native-community/react-native-slider](https://github.com/react-native-community/react-native-slider).
 
 A component used to select a single value from a range of values.
 


### PR DESCRIPTION
When I read the deprecated message in this document, I tried to use [react-native-community/react-native-slider](https://github.com/react-native-community/react-native-slider, but is not corresponded to Expo. 

This doc has not the message. So I wasted a lot of time.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
