### PR TITLE
Update AccessibilityInfo.setAccessibilityFocus()

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -151,7 +151,9 @@ Add an event handler. Supported events:
 static setAccessibilityFocus(reactTag)
 ```
 
-Set accessibility focus to a React component. On Android, this is equivalent to `UIManager.sendAccessibilityEvent(reactTag, UIManager.AccessibilityEventTypes.typeViewFocused);`.
+Set accessibility focus to a React component. On Android, this calls `UIManager.sendAccessibilityEvent(reactTag, UIManager.AccessibilityEventTypes.typeViewFocused);`.
+
+> **Note**: Make sure that any `View` you want to receive the accessibility focus has `accessible={true}`.
 
 ---
 


### PR DESCRIPTION
Add a warning about needing `accessible={true}` for `setAccessibilityFocus` to work correctly on Android.

The accessible prop on View sets the underlying Android view as focusable, which is needed for accessibility focus to work correctly. If you forget to set that prop on the View you want to receive the a11y focus, it will just fail silently on Android. Adding a warning here so that it's harder for people to make that mistake, hopefully.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
