### PR TITLE
Docs |  IOS  blurRadius  > 5

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -155,6 +155,7 @@ blurRadius: the blur radius of the blur filter added to the image
 | ------ | -------- |
 | number | No       |
 
+> Tip : IOS you will need to increase `blurRadius` more than `5`
 ---
 
 ### `onLayout`


### PR DESCRIPTION
**IOS** : I found some issues of `blurRadius`. i tested on 38 devices, when i increase the number of `blurRadius` > `5` then its started applying on that. You can see [27905](https://github.com/facebook/react-native/issues/27905)  [16780](https://github.com/facebook/react-native/issues/16780) [20910](https://github.com/facebook/react-native/issues/20910)

**ANDROID** : `blurRadius` its working if `blurRadius` < `5`  or  >, 🎉

@gaearon @hramos   thanks. Please review this PR 🎉 that's my first PR in this repo 🙌

🙌Happy to contribute with your team🙌