### PR TITLE
Clarify Vibration iOS API

### DIFF
--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -3,57 +3,41 @@ id: vibration
 title: Vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
+The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately. There will be no effect on devices that do not support vibration, such as the iOS Simulator or Android emulator.
 
-There will be no effect on devices that do not support vibration, such as the iOS Simulator or Android emulator.
+The `vibrate()` method can take a duration or pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. On iOS, this argument will have no effect as the `vibrate()` method invokes a simple `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call (e.g. a fixed time vibration).
 
-<div class="toggler">
-  <span>Developer Notes</span>
-  <span role="tablist" class="toggle-devNotes">
-    <button role="tab" class="button-webNote" onclick="displayTabs('devNotes', 'webNote')">Android</button>
-    <button role="tab" class="button-iosNote" onclick="displayTabs('devNotes', 'iosNote')">iOS</button>
-  </span>
-</div>
+Repeatable vibration is also supported on Android, in which case the vibration will repeat with the defined pattern until `cancel()` is called.
 
-<block class="webNote devNotes" />
-
-> Add `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`
-
-In Android, if `pattern` is a number, it specifies the vibration duration in ms. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time.
-
-Repeatable vibration is also supported, the vibration will repeat with defined pattern until `cancel()` is called.
+> Android apps should request the `android.permission.VIBRATE` permission by adding `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`.
 
 **Example**
 
 ```jsx
-const DURATION = 10000;
-const PATTERN = [1000, 2000, 3000];
-
-Vibration.vibrate(DURATION);
-// Vibrate for 10s
-
-Vibration.vibrate(PATTERN);
-// Wait 1s -> vibrate 2s -> wait 3s
-
-Vibration.vibrate(PATTERN, true);
-// Wait 1s -> vibrate 2s -> wait 3s -> wait 1s -> vibrate 2s -> wait 3s -> ...
-
-Vibration.cancel();
-// Stop vibration.
-```
-
-<block class="iosNote devNotes" />
-
-> The vibration duration is not configurable on iOS. Invoking `vibrate(duration)` will ignore the duration, and vibrate for a fixed time. Vibrating with a pattern is not supported on iOS, either.
-
-**Example**
-
-```jsx
+// iOS and Android: Vibrate for a fixed time (about 500ms)
 Vibration.vibrate();
-// Vibrate for a fixed time (about 500ms)
-```
 
-<block class="endBlock devNotes" />
+// Android:
+const ONE_SECOND_IN_MS = 1000;
+
+const PATTERN = [
+  1 * ONE_SECOND_IN_MS,
+  2 * ONE_SECOND_IN_MS,
+  3 * ONE_SECOND_IN_MS,
+];
+
+// Vibrate for 10 seconds:
+Vibration.vibrate(10 * ONE_SECOND_IN_MS);
+
+// Wait one second, then vibrate for two seconds:
+Vibration.vibrate(PATTERN);
+
+// Wait one second, vibrate for two seconds, wait three seconds, repeat.
+Vibration.vibrate(PATTERN, true);
+
+// Stop vibration:
+Vibration.cancel();
+```
 
 ---
 
@@ -64,19 +48,21 @@ Vibration.vibrate();
 ### `vibrate()`
 
 ```jsx
-Vibration.vibrate(pattern: number, Array<number>, repeat: boolean)
+Vibration.vibrate(?pattern: number, Array<number>, ?repeat: boolean)
 ```
 
 Trigger a vibration.
 
-**On Android,** a pattern of vibrations can be specified, as well as whether to keep vibrating until cancelled.
+The `vibrate()` method can take a pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. You may set `repeat` to true to run through the vibration pattern in a loop until `cancel()` is called.
+
+> On iOS, passing any arguments to `vibrate()` will have no effect as the Vibration API is implemented as a `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call, which is of fixed time vibration.
 
 **Parameters:**
 
-| Name    | Type                    | Required | Description                                                                  | Platform |
-| ------- | ----------------------- | -------- | ---------------------------------------------------------------------------- | -------- |
-| pattern | number or Array<number> | Yes      | Vibration pattern, accept a number or an array of numbers. Default to 400ms. | Android  |
-| repeat  | boolean                 | No       | Repeat vibration pattern until cancel(), default to false.                   | Android  |
+| Name    | Type                    | Required | Description                                                                   | Platform |
+| ------- | ----------------------- | -------- | ----------------------------------------------------------------------------- | -------- |
+| pattern | number or Array<number> | No       | Vibration pattern, accept a number or an array of numbers. Defaults to 400ms. | Android  |
+| repeat  | boolean                 | No       | Repeat vibration pattern until cancel(), default to false.                    | Android  |
 
 ---
 
@@ -86,7 +72,7 @@ Trigger a vibration.
 Vibration.cancel();
 ```
 
-**Android-Only.** Stop vibration.
+Call this to stop vibrating after having invoked `vibrate()` with repetition enabled.
 
 | Platform |
 | -------- |

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -5,7 +5,7 @@ title: Vibration
 
 Vibrates the device.
 
-### Example
+## Example
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android
 import React from "react";

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -9,15 +9,7 @@ Vibrates the device.
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android
 import React from "react";
-import {
-  Button,
-  Platform,
-  Text,
-  Vibration,
-  View,
-  SafeAreaView,
-  StyleSheet
-} from "react-native";
+import { Button, Platform, Text, Vibration, View, SafeAreaView, StyleSheet } from "react-native";
 
 function Separator() {
   return <View style={Platform.OS === "android" ? styles.separator : null} />;

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -5,38 +5,55 @@ title: Vibration
 
 The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately.
 
-There will be no effect on devices that do not support Vibration, eg. the simulator.
+There will be no effect on devices that do not support vibration, such as the iOS Simulator or Android emulator.
 
-**Note for Android:** add `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`
+<div class="toggler">
+  <span>Developer Notes</span>
+  <span role="tablist" class="toggle-devNotes">
+    <button role="tab" class="button-webNote" onclick="displayTabs('devNotes', 'webNote')">Android</button>
+    <button role="tab" class="button-iosNote" onclick="displayTabs('devNotes', 'iosNote')">iOS</button>
+  </span>
+</div>
 
-**The vibration duration in iOS is not configurable**, so there are some differences with Android. In Android, if `pattern` is a number, it specifies the vibration duration in ms. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time.
+<block class="webNote devNotes" />
 
-In iOS, invoking `vibrate(duration)` will ignore the duration and vibrate for a fixed time. While the `pattern` array is used to define the duration between each vibration. See below example for more.
+> Add `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`
+
+In Android, if `pattern` is a number, it specifies the vibration duration in ms. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time.
 
 Repeatable vibration is also supported, the vibration will repeat with defined pattern until `cancel()` is called.
 
-Example:
+**Example**
 
 ```jsx
 const DURATION = 10000;
 const PATTERN = [1000, 2000, 3000];
 
 Vibration.vibrate(DURATION);
-// Android: vibrate for 10s
-// iOS: duration is not configurable, vibrate for fixed time (about 500ms)
+// Vibrate for 10s
 
 Vibration.vibrate(PATTERN);
-// Android: wait 1s -> vibrate 2s -> wait 3s
-// iOS: wait 1s -> vibrate -> wait 2s -> vibrate -> wait 3s -> vibrate
+// Wait 1s -> vibrate 2s -> wait 3s
 
 Vibration.vibrate(PATTERN, true);
-// Android: wait 1s -> vibrate 2s -> wait 3s -> wait 1s -> vibrate 2s -> wait 3s -> ...
-// iOS: wait 1s -> vibrate -> wait 2s -> vibrate -> wait 3s -> vibrate -> wait 1s -> vibrate -> wait 2s -> vibrate -> wait 3s -> vibrate -> ...
+// Wait 1s -> vibrate 2s -> wait 3s -> wait 1s -> vibrate 2s -> wait 3s -> ...
 
 Vibration.cancel();
-// Android: vibration stopped
-// iOS: vibration stopped
+// Stop vibration.
 ```
+
+<block class="iosNote devNotes" />
+
+> The vibration duration is not configurable on iOS. Invoking `vibrate(duration)` will ignore the duration, and vibrate for a fixed time. Vibrating with a pattern is not supported on iOS, either.
+
+**Example**
+
+```jsx
+Vibration.vibrate();
+// Vibrate for a fixed time (about 500ms)
+```
+
+<block class="endBlock devNotes" />
 
 ---
 
@@ -50,14 +67,16 @@ Vibration.cancel();
 Vibration.vibrate(pattern: number, Array<number>, repeat: boolean)
 ```
 
-Trigger a vibration with specified `pattern`.
+Trigger a vibration.
+
+**On Android,** a pattern of vibrations can be specified, as well as whether to keep vibrating until cancelled.
 
 **Parameters:**
 
-| Name    | Type                    | Required | Description                                                                  |
-| ------- | ----------------------- | -------- | ---------------------------------------------------------------------------- |
-| pattern | number or Array<number> | Yes      | Vibration pattern, accept a number or an array of numbers. Default to 400ms. |
-| repeat  | boolean                 | No       | Repeat vibration pattern until cancel(), default to false.                   |
+| Name    | Type                    | Required | Description                                                                  | Platform |
+| ------- | ----------------------- | -------- | ---------------------------------------------------------------------------- | -------- |
+| pattern | number or Array<number> | Yes      | Vibration pattern, accept a number or an array of numbers. Default to 400ms. | Android  |
+| repeat  | boolean                 | No       | Repeat vibration pattern until cancel(), default to false.                   | Android  |
 
 ---
 
@@ -67,8 +86,8 @@ Trigger a vibration with specified `pattern`.
 Vibration.cancel();
 ```
 
-Stop vibration.
+**Android-Only.** Stop vibration.
 
-```
-Vibration.cancel()
-```
+| Platform |
+| -------- |
+| Android  |

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -14,7 +14,7 @@ Repeatable vibration is also supported on Android, in which case the vibration w
 **Example**
 
 ```jsx
-// iOS and Android: Vibrate for a fixed time (about 500ms)
+// iOS and Android: Vibrate for a fixed time (400ms)
 Vibration.vibrate();
 
 // Android:

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -5,19 +5,18 @@ title: Vibration
 
 The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately. There will be no effect on devices that do not support vibration, such as the iOS Simulator or Android emulator.
 
-The `vibrate()` method can take a duration or pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. On iOS, this argument will have no effect as the vibration will always have a fixed duration.
+The `vibrate()` method can take a duration or pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds (the vibration is of fixed length on iOS). If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time.
 
-Repeatable vibration is also supported on Android, in which case the vibration will repeat with the defined pattern until `cancel()` is called.
+Repeatable vibration is also supported, in which case the vibration will repeat with the defined pattern until `cancel()` is called.
 
 > Android apps should request the `android.permission.VIBRATE` permission by adding `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`.
 
 **Example**
 
 ```jsx
-// iOS and Android: Vibrate for a fixed time (400ms)
+// Vibrate for a fixed time
 Vibration.vibrate();
 
-// Android:
 const ONE_SECOND_IN_MS = 1000;
 
 const PATTERN = [
@@ -26,16 +25,16 @@ const PATTERN = [
   3 * ONE_SECOND_IN_MS,
 ];
 
-// Vibrate for 10 seconds:
+// Vibrate for 10 seconds on Android (iOS will vibrate for a fixed time):
 Vibration.vibrate(10 * ONE_SECOND_IN_MS);
 
-// Wait one second, then vibrate for two seconds:
+// Wait one second, then vibrate for two seconds (see PATTERN above):
 Vibration.vibrate(PATTERN);
 
-// Wait one second, vibrate for two seconds, wait three seconds, repeat.
+// Perform the same vibration pattern, repeatedly, until cancel() is called.
 Vibration.vibrate(PATTERN, true);
 
-// Stop vibration:
+// Stop vibration pattern:
 Vibration.cancel();
 ```
 
@@ -48,21 +47,22 @@ Vibration.cancel();
 ### `vibrate()`
 
 ```jsx
-Vibration.vibrate(?pattern: number, Array<number>, ?repeat: boolean)
+Vibration.vibrate(?pattern: number | Array<number>, ?repeat: boolean)
 ```
 
 Trigger a vibration.
 
-The `vibrate()` method can take a pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. You may set `repeat` to true to run through the vibration pattern in a loop until `cancel()` is called.
+The `vibrate()` method can take a `pattern` argument. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. You may set `repeat` to true to run through the vibration pattern in a loop until `cancel()` is called. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds.
 
-> On iOS, passing any arguments to `vibrate()` will have no effect as the Vibration API is implemented as a `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call, which is of fixed time vibration.
+> The Vibration API is implemented as a `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call on iOS. The vibration time is roughly 400 milliseconds.
 
 **Parameters:**
 
-| Name    | Type                    | Required | Description                                                                   | Platform |
-| ------- | ----------------------- | -------- | ----------------------------------------------------------------------------- | -------- |
-| pattern | number or Array<number> | No       | Vibration pattern, accept a number or an array of numbers. Defaults to 400ms. | Android  |
-| repeat  | boolean                 | No       | Repeat vibration pattern until cancel(), default to false.                    | Android  |
+| Name    | Type          | Required | Description                                                | Platform      |
+| ------- | ------------- | -------- | ---------------------------------------------------------- | ------------- |
+| pattern | number        | No       | Vibration duration in milliseconds. Defaults to 400 ms.    | Android       |
+| pattern | Array<number> | No       | Vibration pattern as an array of numbers in milliseconds.  | Android, iOS  |
+| repeat  | boolean       | No       | Repeat vibration pattern until cancel(), default to false. | Android , iOS |
 
 ---
 
@@ -73,7 +73,3 @@ Vibration.cancel();
 ```
 
 Call this to stop vibrating after having invoked `vibrate()` with repetition enabled.
-
-| Platform |
-| -------- |
-| Android  |

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -3,40 +3,107 @@ id: vibration
 title: Vibration
 ---
 
-The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately. There will be no effect on devices that do not support vibration, such as the iOS Simulator or Android emulator.
+Vibrates the device.
 
-The `vibrate()` method can take a duration or pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds (the vibration is of fixed length on iOS). If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time.
+### Example
 
-Repeatable vibration is also supported, in which case the vibration will repeat with the defined pattern until `cancel()` is called.
+```SnackPlayer name=Vibration&supportedPlatforms=ios,android
+import React from "react";
+import {
+  Button,
+  Platform,
+  Text,
+  Vibration,
+  View,
+  SafeAreaView,
+  StyleSheet
+} from "react-native";
+
+function Separator() {
+  return <View style={Platform.OS === "android" ? styles.separator : null} />;
+}
+
+export default class App extends React.Component {
+  render() {
+    const ONE_SECOND_IN_MS = 1000;
+
+    const PATTERN = [
+      1 * ONE_SECOND_IN_MS,
+      2 * ONE_SECOND_IN_MS,
+      3 * ONE_SECOND_IN_MS
+    ];
+
+    const PATTERN_DESC =
+      Platform.OS === "android"
+        ? "wait 1s, vibrate 2s, wait 3s"
+        : "wait 1s, vibrate, wait 2s, vibrate, wait 3s";
+
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text style={[styles.header, styles.paragraph]}>Vibration API</Text>
+        <View>
+          <Button title="Vibrate once" onPress={() => Vibration.vibrate()} />
+        </View>
+        <Separator />
+        {Platform.OS == "android"
+          ? [
+              <View>
+                <Button
+                  title="Vibrate for 10 seconds"
+                  onPress={() => Vibration.vibrate(10 * ONE_SECOND_IN_MS)}
+                />
+              </View>,
+              <Separator />
+            ]
+          : null}
+        <Text style={styles.paragraph}>Pattern: {PATTERN_DESC}</Text>
+        <Button
+          title="Vibrate with pattern"
+          onPress={() => Vibration.vibrate(PATTERN)}
+        />
+        <Separator />
+        <Button
+          title="Vibrate with pattern until cancelled"
+          onPress={() => Vibration.vibrate(PATTERN, true)}
+        />
+        <Separator />
+        <Button
+          title="Stop vibration pattern"
+          onPress={() => Vibration.cancel()}
+          color="#FF0000"
+        />
+      </SafeAreaView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    paddingTop: 44,
+    padding: 8
+  },
+  header: {
+    fontSize: 18,
+    fontWeight: "bold",
+    textAlign: "center"
+  },
+  paragraph: {
+    margin: 24,
+    textAlign: "center"
+  },
+  separator: {
+    marginVertical: 8,
+    borderBottomColor: "#737373",
+    borderBottomWidth: StyleSheet.hairlineWidth
+  }
+});
+```
 
 > Android apps should request the `android.permission.VIBRATE` permission by adding `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`.
 
-**Example**
-
-```jsx
-// Vibrate for a fixed time
-Vibration.vibrate();
-
-const ONE_SECOND_IN_MS = 1000;
-
-const PATTERN = [
-  1 * ONE_SECOND_IN_MS,
-  2 * ONE_SECOND_IN_MS,
-  3 * ONE_SECOND_IN_MS,
-];
-
-// Vibrate for 10 seconds on Android (iOS will vibrate for a fixed time):
-Vibration.vibrate(10 * ONE_SECOND_IN_MS);
-
-// Wait one second, then vibrate for two seconds (see PATTERN above):
-Vibration.vibrate(PATTERN);
-
-// Perform the same vibration pattern, repeatedly, until cancel() is called.
-Vibration.vibrate(PATTERN, true);
-
-// Stop vibration pattern:
-Vibration.cancel();
-```
+> The Vibration API is implemented as a `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call on iOS.
 
 ---
 
@@ -50,19 +117,21 @@ Vibration.cancel();
 Vibration.vibrate(?pattern: number | Array<number>, ?repeat: boolean)
 ```
 
-Trigger a vibration.
+Triggers a vibration with a fixed duration.
 
-The `vibrate()` method can take a `pattern` argument. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. You may set `repeat` to true to run through the vibration pattern in a loop until `cancel()` is called. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds.
+**On Android,** the vibration duration defaults to 400 milliseconds, and an arbitrary vibration duration can be specified by passing a number as the value for the `pattern` argument. **On iOS,** the vibration duration is fixed at roughly 400 milliseconds.
 
-> The Vibration API is implemented as a `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call on iOS. The vibration time is roughly 400 milliseconds.
+The `vibrate()` method can take a `pattern` argument with an array of numbers that represent time in milliseconds. You may set `repeat` to true to run through the vibration pattern in a loop until `cancel()` is called.
+
+**On Android,** the odd indices of the `pattern` array represent the vibration duration, while the even ones represent the separation time. **On iOS,** the numbers in the `pattern` array represent the separation time, as the vibration duration is fixed.
 
 **Parameters:**
 
-| Name    | Type          | Required | Description                                                | Platform      |
-| ------- | ------------- | -------- | ---------------------------------------------------------- | ------------- |
-| pattern | number        | No       | Vibration duration in milliseconds. Defaults to 400 ms.    | Android       |
-| pattern | Array<number> | No       | Vibration pattern as an array of numbers in milliseconds.  | Android, iOS  |
-| repeat  | boolean       | No       | Repeat vibration pattern until cancel(), default to false. | Android , iOS |
+| Name    | Type             | Required | Description                                                | Platform     |
+| ------- | ---------------- | -------- | ---------------------------------------------------------- | ------------ |
+| pattern | number           | No       | Vibration duration in milliseconds. Defaults to 400 ms.    | Android      |
+| pattern | Array of numbers | No       | Vibration pattern as an array of numbers in milliseconds.  | Android, iOS |
+| repeat  | boolean          | No       | Repeat vibration pattern until cancel(), default to false. | Android, iOS |
 
 ---
 

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -5,7 +5,7 @@ title: Vibration
 
 The Vibration API is exposed at `Vibration.vibrate()`. The vibration is synchronous so this method will return immediately. There will be no effect on devices that do not support vibration, such as the iOS Simulator or Android emulator.
 
-The `vibrate()` method can take a duration or pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. On iOS, this argument will have no effect as the `vibrate()` method invokes a simple `AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)` call (e.g. a fixed time vibration).
+The `vibrate()` method can take a duration or pattern argument. On Android, if `pattern` is a number, it specifies the vibration duration in milliseconds. If `pattern` is an array, those odd indices are the vibration duration, while the even ones are the separation time. On iOS, this argument will have no effect as the vibration will always have a fixed duration.
 
 Repeatable vibration is also supported on Android, in which case the vibration will repeat with the defined pattern until `cancel()` is called.
 


### PR DESCRIPTION
Addresses https://github.com/facebook/react-native/issues/27920. Vibration on iOS only supports a plain `Vibration.vibrate()` call. 

Vibrating by pattern is not supported: https://github.com/facebook/react-native/blob/2f758c3abbef33a47cd3651e7213066f53fb373f/Libraries/Vibration/RCTVibration.mm#L39-L48 https://github.com/facebook/react-native/blob/2f758c3abbef33a47cd3651e7213066f53fb373f/Libraries/Vibration/RCTVibration.mm#L28-L31

Canceling vibration is not supported: https://github.com/facebook/react-native/blob/2f758c3abbef33a47cd3651e7213066f53fb373f/Libraries/Vibration/RCTVibration.mm#L39-L48

Intentionally used "webNote" for Android notes to force Android notes to show up by default. If no webNote is present, the notes block will default to empty as displaytabs() will hide everything that is not a webNote.

Test Plan:

```
yarn
yarn start
```

Verified Vibration API docs look good. 