### PR TITLE
Image & View: add snack examples to use functional components

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -9,8 +9,6 @@ This example shows fetching and displaying an image from local storage as well a
 
 > Note that for network and data images, you will need to manually specify the dimensions of your image!
 
-
-```
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">
     <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
@@ -164,7 +162,7 @@ export default class DisplayAnImageWithStyle extends Component {
 ```
 
 <block class="endBlock syntax" />
-```
+
 
 
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -88,7 +88,7 @@ export default class DisplayAnImage extends Component {
 
 You can also add `style` to an image:
 
-```
+
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">
     <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">

--- a/docs/image.md
+++ b/docs/image.md
@@ -113,7 +113,6 @@ export default class DisplayAnImage extends Component {
 ```
 
 <block class="endBlock syntax" />
-```
 
 You can also add `style` to an image:
 
@@ -192,9 +191,6 @@ export default class DisplayAnImageWithStyle extends Component {
 ```
 
 <block class="endBlock syntax" />
-
-
-
 
 ### GIF and WebP support on Android
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -9,9 +9,43 @@ This example shows fetching and displaying an image from local storage as well a
 
 > Note that for network and data images, you will need to manually specify the dimensions of your image!
 
+<block class="functional syntax" />
+
 ```SnackPlayer name=Image
-import React, { Component } from 'react';
+import React from 'react';
 import { View, Image } from 'react-native';
+
+export default function DisplayAnImage() {
+  return (
+    <View style={{ paddingTop: 50 }}>
+      <Image
+        style={{ width: 50, height: 50 }}
+        source={require('@expo/snack-static/react-native-logo.png')}
+      />
+      <Image
+        style={{ width: 50, height: 50 }}
+        source={{
+          uri: 'https://facebook.github.io/react-native/img/tiny_logo.png',
+        }}
+      />
+      <Image
+        style={{ width: 66, height: 58 }}
+        source={{
+          uri:
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==',
+        }}
+      />
+    </View>
+  );
+}
+```
+
+<block class="classical syntax" />
+
+```SnackPlayer name=Image
+
+import React, { Component } from 'react';
+import { AppRegistry, View, Image } from 'react-native';
 
 export default class DisplayAnImage extends Component {
   render() {
@@ -35,7 +69,40 @@ export default class DisplayAnImage extends Component {
 }
 ```
 
+<block class="endBlock syntax" />
+
 You can also add `style` to an image:
+
+<block class="functional syntax" />
+
+```SnackPlayer name=Image
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 50,
+  },
+  stretch: {
+    width: 50,
+    height: 200,
+    resizeMode: 'stretch',
+  },
+});
+
+export default function DisplayAnImageWithStyle() {
+  return (
+    <View style={styles.container}>
+      <Image
+        style={styles.stretch}
+        source={require('@expo/snack-static/react-native-logo.png')}
+      />
+    </View>
+  );
+}
+```
+
+<block class="classical syntax" />
 
 ```SnackPlayer name=Image
 import React, { Component } from 'react';
@@ -62,6 +129,8 @@ export default class DisplayAnImageWithStyle extends Component {
   }
 }
 ```
+
+<block class="endBlock syntax" />
 
 ### GIF and WebP support on Android
 
@@ -156,6 +225,7 @@ blurRadius: the blur radius of the blur filter added to the image
 | number | No       |
 
 > Tip : IOS you will need to increase `blurRadius` more than `5`
+
 ---
 
 ### `onLayout`
@@ -308,9 +378,9 @@ When true, indicates the image is an accessibility element.
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
-| Type                                                               | Required | Platform |
-| ------------------------------------------------------------------ | -------- | -------- |
-| object: {top: number, left: number, bottom: number, right: number} | No       | iOS      |
+| Type | Required | Platform |
+| --- | --- | --- |
+| object: {top: number, left: number, bottom: number, right: number} | No | iOS |
 
 ---
 
@@ -389,11 +459,11 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| Name    | Type     | Required | Description                                                                                          |
-| ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri     | string   | Yes      | The location of the image.                                                                           |
-| success | function | Yes      | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure | function | No       | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| uri | string | Yes | The location of the image. |
+| success | function | Yes | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure | function | No | The function that will be called if there was an error, such as failing to retrieve the image. |
 
 ---
 
@@ -411,12 +481,12 @@ Does not work for static image resources.
 
 **Parameters:**
 
-| Name    | Type     | Required | Description                                                                                          |
-| ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri     | string   | Yes      | The location of the image.                                                                           |
-| headers | object   | Yes      | The headers for the request.                                                                         |
-| success | function | Yes      | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure | function | No       | The function that will be called if there was an error, such as failing toto retrieve the image.     |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| uri | string | Yes | The location of the image. |
+| headers | object | Yes | The headers for the request. |
+| success | function | Yes | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure | function | No | The function that will be called if there was an error, such as failing toto retrieve the image. |
 
 ---
 
@@ -478,8 +548,8 @@ Resolves an asset reference into an object which has the properties `uri`, `widt
 
 **Parameters:**
 
-| Name   | Type           | Required | Description                                                                  |
-| ------ | -------------- | -------- | ---------------------------------------------------------------------------- |
-| source | number, object | Yes      | A number (opaque type returned by require('./foo.png')) or an `ImageSource`. |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| source | number, object | Yes | A number (opaque type returned by require('./foo.png')) or an `ImageSource`. |
 
 > `ImageSource` is an object like `{ uri: '<http location || file path>' }`

--- a/docs/image.md
+++ b/docs/image.md
@@ -25,23 +25,37 @@ This example shows fetching and displaying an image from local storage as well a
 ```SnackPlayer name=Function%20Component%20Example
 
 import React from 'react';
-import { View, Image } from 'react-native';
+import { View, Image, StyleSheet } from 'react-native';
 
-export default function DisplayAnImage() {
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 50,
+  },
+  tinyLogo: {
+    width: 50, 
+    height: 50,
+  },
+  logo: {
+    width: 66, 
+    height: 58,
+  },
+});
+
+const DisplayAnImage = () => {
   return (
-    <View style={{ paddingTop: 50 }}>
+    <View style={styles.container}>
       <Image
-        style={{ width: 50, height: 50 }}
+        style={styles.tinyLogo}
         source={require('@expo/snack-static/react-native-logo.png')}
       />
       <Image
-        style={{ width: 50, height: 50 }}
+        style={styles.tinyLogo}
         source={{
           uri: 'https://facebook.github.io/react-native/img/tiny_logo.png',
         }}
       />
       <Image
-        style={{ width: 66, height: 58 }}
+        style={styles.logo}
         source={{
           uri:
             'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==',
@@ -51,6 +65,7 @@ export default function DisplayAnImage() {
   );
 }
 
+export default DisplayAnImage;
 ```
 
 <block class="classical syntax" />
@@ -58,22 +73,36 @@ export default function DisplayAnImage() {
 ```SnackPlayer name=Class%20Component%20Example
 
 import React, { Component } from 'react';
-import { AppRegistry, View, Image } from 'react-native';
+import { AppRegistry, View, Image, StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 50,
+  },
+  tinyLogo: {
+    width: 50, 
+    height: 50,
+  },
+  logo: {
+    width: 66, 
+    height: 58,
+  },
+});
 
 export default class DisplayAnImage extends Component {
   render() {
     return (
-      <View>
+      <View style={styles.container}>
         <Image
-          style={{width: 50, height: 50}}
+          style={styles.tinyLogo}
           source={require('@expo/snack-static/react-native-logo.png')}
         />
         <Image
-          style={{width: 50, height: 50}}
+          style={styles.tinyLogo}
           source={{uri: 'https://facebook.github.io/react-native/img/tiny_logo.png'}}
         />
         <Image
-          style={{width: 66, height: 58}}
+          style={styles.logo}
           source={{uri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg=='}}
         />
       </View>
@@ -118,7 +147,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function DisplayAnImageWithStyle() {
+const DisplayAnImageWithStyle = () => {
   return (
     <View style={styles.container}>
       <Image
@@ -129,6 +158,7 @@ export default function DisplayAnImageWithStyle() {
   );
 }
 
+export default DisplayAnImageWithStyle;
 ```
 
 <block class="classical syntax" />

--- a/docs/image.md
+++ b/docs/image.md
@@ -9,9 +9,23 @@ This example shows fetching and displaying an image from local storage as well a
 
 > Note that for network and data images, you will need to manually specify the dimensions of your image!
 
+
+```
+<div class="toggler">
+  <ul role="tablist" class="toggle-syntax">
+    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
+      Function Component Example
+    </li>
+    <li id="classical" class="button-classical" aria-selected="false" role="tab" tabindex="0" aria-controls="classicaltab" onclick="displayTabs('syntax', 'classical')">
+      Class Component Example
+    </li>
+  </ul>
+</div>
+
 <block class="functional syntax" />
 
-```SnackPlayer name=Image
+```SnackPlayer name=Function%20Component%20Example
+
 import React from 'react';
 import { View, Image } from 'react-native';
 
@@ -38,11 +52,12 @@ export default function DisplayAnImage() {
     </View>
   );
 }
+
 ```
 
 <block class="classical syntax" />
 
-```SnackPlayer name=Image
+```SnackPlayer name=Class%20Component%20Example
 
 import React, { Component } from 'react';
 import { AppRegistry, View, Image } from 'react-native';
@@ -67,15 +82,30 @@ export default class DisplayAnImage extends Component {
     );
   }
 }
+
 ```
 
 <block class="endBlock syntax" />
+```
 
 You can also add `style` to an image:
 
+```
+<div class="toggler">
+  <ul role="tablist" class="toggle-syntax">
+    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
+      Function Component Example
+    </li>
+    <li id="classical" class="button-classical" aria-selected="false" role="tab" tabindex="0" aria-controls="classicaltab" onclick="displayTabs('syntax', 'classical')">
+      Class Component Example
+    </li>
+  </ul>
+</div>
+
 <block class="functional syntax" />
 
-```SnackPlayer name=Image
+```SnackPlayer name=Function%20Component%20Example
+
 import React from 'react';
 import { View, Image, StyleSheet } from 'react-native';
 
@@ -100,11 +130,13 @@ export default function DisplayAnImageWithStyle() {
     </View>
   );
 }
+
 ```
 
 <block class="classical syntax" />
 
-```SnackPlayer name=Image
+```SnackPlayer name=Class%20Component%20Example
+
 import React, { Component } from 'react';
 import { View, Image, StyleSheet } from 'react-native';
 
@@ -128,9 +160,13 @@ export default class DisplayAnImageWithStyle extends Component {
     );
   }
 }
+
 ```
 
 <block class="endBlock syntax" />
+```
+
+
 
 ### GIF and WebP support on Android
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -9,22 +9,23 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-```jsx
-class ViewBoxesWithColorAndText extends Component {
-  render() {
-    return (
-      <View
-        style={{
-          flexDirection: 'row',
-          height: 100,
-          padding: 20,
-        }}>
-        <View style={{backgroundColor: 'blue', flex: 0.3}} />
-        <View style={{backgroundColor: 'red', flex: 0.5}} />
-        <Text>Hello World!</Text>
-      </View>
-    );
-  }
+```SnackPlayer name=Example%20Code
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function ViewBoxesWithColorAndText() {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        height: 100,
+        padding: 20,
+      }}>
+      <View style={{ backgroundColor: 'blue', flex: 0.3 }} />
+      <View style={{ backgroundColor: 'red', flex: 0.5 }} />
+      <Text>Hello World!</Text>
+    </View>
+  );
 }
 ```
 
@@ -139,9 +140,9 @@ Describes the current state of a component to the user of an assistive technolog
 
 See the [Accessibility guide](accessibility.md#accessibilitystate-ios-android) for more information.
 
-| Type                                                                                           | Required |
-| ---------------------------------------------------------------------------------------------- | -------- |
-| object: {disabled: bool, selected: bool, checked: bool or 'mixed', busy: bool, expanded: bool} | No       |
+| Type | Required |
+| --- | --- |
+| object: {disabled: bool, selected: bool, checked: bool or 'mixed', busy: bool, expanded: bool} | No |
 
 ---
 
@@ -290,9 +291,9 @@ For example, if a touchable view has a height of 20 the touchable height can be 
 
 > The touch area never extends past the parent view bounds and the Z-index of sibling views always takes precedence if a touch hits two overlapping views.
 
-| Type                                                               | Required |
-| ------------------------------------------------------------------ | -------- |
-| object: {top: number, left: number, bottom: number, right: number} | No       |
+| Type | Required |
+| --- | --- |
+| object: {top: number, left: number, bottom: number, right: number} | No |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -10,23 +10,24 @@ The most fundamental component for building a UI, `View` is a container that sup
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
 ```SnackPlayer name=Example%20Code
-import React from 'react';
-import { View, Text } from 'react-native';
+import React from "react";
+import { View, Text } from "react-native";
 
-const ViewBoxesWithColorAndText= () => {
+const ViewBoxesWithColorAndText = () => {
   return (
     <View
       style={{
-        flexDirection: 'row',
+        flexDirection: "row",
         height: 100,
-        padding: 20,
-      }}>
-      <View style={{ backgroundColor: 'blue', flex: 0.3 }} />
-      <View style={{ backgroundColor: 'red', flex: 0.5 }} />
+        padding: 20
+      }}
+    >
+      <View style={{ backgroundColor: "blue", flex: 0.3 }} />
+      <View style={{ backgroundColor: "red", flex: 0.5 }} />
       <Text>Hello World!</Text>
     </View>
   );
-}
+};
 
 export default ViewBoxesWithColorAndText;
 ```


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:
-->

In Reference to #1579 

This PR adds a Snack Example for `<Image/>` component with a use case for a functional component.


