### PR TITLE
docs: remove unused prop from TextInput docs

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -645,24 +645,6 @@ The highlight and cursor color of the text input.
 
 ---
 
-### `selectionState`
-
-An instance of `DocumentSelectionState`, this is some state that is responsible for maintaining selection information for a document.
-
-Some functionality that can be performed with this instance is:
-
-- `blur()`
-- `focus()`
-- `update()`
-
-> You can reference `DocumentSelectionState` in [`vendor/document/selection/DocumentSelectionState.js`](https://github.com/facebook/react-native/blob/master/Libraries/vendor/document/selection/DocumentSelectionState.js)
-
-| Type                   | Required | Platform |
-| ---------------------- | -------- | -------- |
-| DocumentSelectionState | No       | iOS      |
-
----
-
 ### `selectTextOnFocus`
 
 If `true`, all text will automatically be selected on focus.
@@ -703,9 +685,9 @@ Possible values for `textAlign` are:
 - `center`
 - `right`
 
-| Type | Required |
-| ---- | -------- |
-| enum('left', 'center', 'right') | No     |
+| Type                            | Required |
+| ------------------------------- | -------- |
+| enum('left', 'center', 'right') | No       |
 
 ---
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

-->
#1579 

removed `selectionState` props from `TextInput` as it is no longer used in the component.

ref: https://github.com/facebook/react-native/blob/master/Libraries/Components/TextInput/TextInput.js

