### PR TITLE
docs: add information about useWindowDimensions Hook

### DIFF
--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -2,16 +2,32 @@
 id: dimensions
 title: Dimensions
 ---
+
 ```jsx
-import {Dimensions } from "react-native";
+import {useWindowDimensions} from 'react-native';
 ```
+
+You can use the useWindowDimensions hook to get device width and height as well as subscribe to dimension updates.
+
+```jsx
+const {width, height} = useWindowDimensions();
+```
+
+If you want to get the device width and height in a class component, you can use the `Dimensions` API instead.
+
+```jsx
+import {Dimensions} from 'react-native';
+```
+
 You can get device width and height using below :
 
 Get device screen width and height :
+
 ```jsx
 const screenWidth = Math.round(Dimensions.get('window').width);
 const screenHeight = Math.round(Dimensions.get('window').height);
 ```
+
 # Reference
 
 ## Methods
@@ -42,9 +58,9 @@ Example: `var {height, width} = Dimensions.get('window');`
 
 **Parameters:**
 
-| Name      | Type     | Required | Description                                                                                   |
-| ------    | ------   | -------- | ----------------------------------------------------------------------------------------------|
-| dim       | string   | Yes      | Name of dimension as defined when calling `set`. @returns {Object?} Value for the dimension.  | 
+| Name | Type   | Required | Description                                                                                  |
+| ---- | ------ | -------- | -------------------------------------------------------------------------------------------- |
+| dim  | string | Yes      | Name of dimension as defined when calling `set`. @returns {Object?} Value for the dimension. |
 
 > For Android the `window` dimension will exclude the size used by the `status bar` (if not translucent) and `bottom navigation bar`
 
@@ -70,6 +86,6 @@ This should only be called from native code by sending the didUpdateDimensions e
 
 **Parameters:**
 
-| Name      | Type     | Required | Description                               |
-| ------    | ------   | -------- | ------------------------------------------|
-| dims      | object   | Yes      | string-keyed object of dimensions to set  | 
+| Name | Type   | Required | Description                              |
+| ---- | ------ | -------- | ---------------------------------------- |
+| dims | object | Yes      | string-keyed object of dimensions to set |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#1315
-->

This PR addresses #1315

Added information about `useWindowDimensions` hook in the `Dimensions` page.
