### PR TITLE
docs: add deprecation notice for ProgressBars

### DIFF
--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -3,6 +3,8 @@ id: progressbarandroid
 title: ProgressBarAndroid
 ---
 
+> **Deprecated.** Use [@react-native-community/react-native-progress-bar-android](https://github.com/react-native-community/react-native-progress-bar-android) instead.
+
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 
 ### Example
@@ -110,9 +112,9 @@ Style of the ProgressBar. One of:
 - SmallInverse
 - LargeInverse
 
-| Type | Required |
-| --- | --- |
-| enum('Horizontal', 'Normal', 'Small', 'Large', 'Inverse', 'SmallInverse', 'LargeInverse') | No |
+| Type                                                                                      | Required |
+| ----------------------------------------------------------------------------------------- | -------- |
+| enum('Horizontal', 'Normal', 'Small', 'Large', 'Inverse', 'SmallInverse', 'LargeInverse') | No       |
 
 ---
 

--- a/docs/progressviewios.md
+++ b/docs/progressviewios.md
@@ -3,6 +3,8 @@ id: progressviewios
 title: ProgressViewIOS
 ---
 
+> **Deprecated.** Use [@react-native-community/react-native-progress-view](https://github.com/react-native-community/react-native-progress-view) instead.
+
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 
 ### Example


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Add deprecation notice for `ProgressViewIOS` and `ProgressbarAndroid` as those two components are deprecated.

ref: https://github.com/facebook/react-native/blob/master/index.js#L185-L202
