### PR TITLE
Switch: update Snack example

### DIFF
--- a/docs/switch.md
+++ b/docs/switch.md
@@ -9,17 +9,26 @@ This is a controlled component that requires an `onValueChange` callback that up
 
 ```SnackPlayer name=switch
 import React, { useState } from 'react';
-import { Text, View, Switch } from 'react-native';
+import { View, Switch } from 'react-native';
 
 export default function App() {
-  const [value, setValue] = useState(false);
+  const [isEnabled, setIsEnabled] = useState(false);
+  const toggleSwitch = () => setIsEnabled(previousState => !previousState);
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <View
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#cecece',
+      }}>
       <Switch
-        value={value}
-        onValueChange={v => {
-          setValue(v);
-        }}
+        trackColor={{ false: '#767577', true: '#81b0ff' }}
+        thumbColor={isEnabled ? '#f5dd4b' : '#f4f3f4'}
+        ios_backgroundColor="#3e3e3e"
+        onValueChange={toggleSwitch}
+        value={isEnabled}
       />
     </View>
   );

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -7,25 +7,19 @@ Renders a boolean input.
 
 This is a controlled component that requires an `onValueChange` callback that updates the `value` prop in order for the component to reflect user actions. If the `value` prop is not updated, the component will continue to render the supplied `value` prop instead of the expected result of any user actions.
 
-```SnackPlayer name=switch
-import React, { useState } from 'react';
-import { View, Switch } from 'react-native';
+```SnackPlayer name=Switch
+import React, { useState } from "react";
+import { View, Switch, StyleSheet } from "react-native";
 
 export default function App() {
   const [isEnabled, setIsEnabled] = useState(false);
   const toggleSwitch = () => setIsEnabled(previousState => !previousState);
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: '#cecece',
-      }}>
+    <View style={styles.container}>
       <Switch
-        trackColor={{ false: '#767577', true: '#81b0ff' }}
-        thumbColor={isEnabled ? '#f5dd4b' : '#f4f3f4'}
+        trackColor={{ false: "#767577", true: "#81b0ff" }}
+        thumbColor={isEnabled ? "#f5dd4b" : "#f4f3f4"}
         ios_backgroundColor="#3e3e3e"
         onValueChange={toggleSwitch}
         value={isEnabled}
@@ -33,6 +27,14 @@ export default function App() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  }
+});
 ```
 
 ---


### PR DESCRIPTION
Issue: #1579

- Updated snack and example.

I improved the example in order to explore more props, since there is a Snack example in the [`next` version of documentation](http://facebook.github.io/react-native/docs/next/switch).