### PR TITLE
Picker: update Snack example

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -7,18 +7,20 @@ Renders the native picker component on Android and iOS. Example:
 
 ```SnackPlayer name=picker
 import React, { useState } from 'react';
-import { Picker } from 'react-native';
+import { View, Picker } from 'react-native';
 
 export default function App() {
   const [selectedValue, setSelectedValue] = useState('java');
   return (
-    <Picker
-      selectedValue={selectedValue}
-      style={{ height: 50, width: 150 }}
-      onValueChange={(itemValue, itemIndex) => setSelectedValue(itemValue)}>
-      <Picker.Item label="Java" value="java" />
-      <Picker.Item label="JavaScript" value="js" />
-    </Picker>
+    <View style={{ flex: 1, paddingTop: 40, alignItems: 'center' }}>
+      <Picker
+        selectedValue={selectedValue}
+        style={{ height: 50, width: 150 }}
+        onValueChange={(itemValue, itemIndex) => setSelectedValue(itemValue)}>
+        <Picker.Item label="Java" value="java" />
+        <Picker.Item label="JavaScript" value="js" />
+      </Picker>
+    </View>
   );
 }
 ```

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -6,23 +6,32 @@ title: Picker
 Renders the native picker component on Android and iOS. Example:
 
 ```SnackPlayer name=picker
-import React, { useState } from 'react';
-import { View, Picker } from 'react-native';
+import React, { useState } from "react";
+import { View, Picker, StyleSheet } from "react-native";
 
 export default function App() {
-  const [selectedValue, setSelectedValue] = useState('java');
+  const [selectedValue, setSelectedValue] = useState("java");
   return (
-    <View style={{ flex: 1, paddingTop: 40, alignItems: 'center' }}>
+    <View style={styles.container}>
       <Picker
         selectedValue={selectedValue}
         style={{ height: 50, width: 150 }}
-        onValueChange={(itemValue, itemIndex) => setSelectedValue(itemValue)}>
+        onValueChange={(itemValue, itemIndex) => setSelectedValue(itemValue)}
+      >
         <Picker.Item label="Java" value="java" />
         <Picker.Item label="JavaScript" value="js" />
       </Picker>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 40,
+    alignItems: "center"
+  }
+});
 ```
 
 ---


### PR DESCRIPTION
Issue: #1579

- Updated snack example.

As I mentioned in #1594 there is also a Snack example in the [`next` version of documentation](http://facebook.github.io/react-native/docs/next/picker) for this component. So I just improved the visibility of the component.