### PR TITLE
📋 Clipboard - added snack examples [WIP] 👷🏽‍♂️👨🏽‍💻🕵🏽‍♂️

### DIFF
--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -7,6 +7,111 @@ title: Clipboard
 
 ---
 
+### Example
+
+<div class="toggler">
+  <ul role="tablist" class="toggle-syntax">
+    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
+      Function Component Example
+    </li>
+    <li id="classical" class="button-classical" aria-selected="false" role="tab" tabindex="0" aria-controls="classicaltab" onclick="displayTabs('syntax', 'classical')">
+      Class Component Example
+    </li>
+  </ul>
+</div>
+
+<block class="functional syntax" />
+
+```SnackPlayer name=Clipboard
+import React, {useState} from 'react';
+import {View, StyleSheet, Text, Button, Clipboard, TextInput} from 'react-native';
+
+export default function App () {
+
+  const [displayText, setDisplayText] = useState("");
+  const [inputText, setInputText] = useState("");
+
+  const copyText = async () => {
+    Clipboard.setString(inputText);
+
+    setDisplayText(await Clipboard.getString());
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>{`Text in Clipboard - ${displayText}`}</Text>
+
+      <TextInput
+        placeholder="Add Text here..."
+        value={inputText}
+        onChangeText={setInputText}
+      />
+
+      <Button title={"Copy Text"} onPress={copyText}/>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+    alignItems: 'center'
+  },
+});
+```
+
+<block class="classical syntax" />
+
+```SnackPlayer name=Clipboard
+import React, {Component} from 'react';
+import {View, StyleSheet, Text, Button, Clipboard, TextInput} from 'react-native';
+
+export default class App extends Component {
+
+  state = {
+    displayText: "",
+    inputText: ""
+  };
+
+  setInputText = inputText => this.setState({ inputText });
+
+  setDisplayText = displayText => this.setState({ displayText });
+
+  copyText = async () => {
+    Clipboard.setString(this.state.inputText);
+
+    this.setDisplayText(await Clipboard.getString());
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>{`Text in Clipboard - ${this.state.displayText}`}</Text>
+
+        <TextInput
+          placeholder="Add Text here..."
+          value={this.state.inputText}
+          onChangeText={this.setInputText}
+        />
+
+        <Button title={"Copy Text"} onPress={this.copyText}/>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+    alignItems: 'center'
+  },
+});
+```
+
+<block class="endBlock syntax" />
+
 # Reference
 
 ## Methods
@@ -40,11 +145,12 @@ _setContent() {
   Clipboard.setString('hello world');
 }
 ```
+
 **Parameters:**
 
-| Name      | Type     | Required | Description                                |
-| ------    | ------   | -------- | -------------------------------------------|
-| content   | string   | Yes      | The content to be stored in the clipboard  | 
+| Name    | Type   | Required | Description                               |
+| ------- | ------ | -------- | ----------------------------------------- |
+| content | string | Yes      | The content to be stored in the clipboard |
 
 _Notice_
 

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -22,7 +22,7 @@ title: Clipboard
 
 <block class="functional syntax" />
 
-```SnackPlayer name=Clipboard
+```SnackPlayer name=Clipboard&supportedPlatforms=ios,android
 import React, {useState} from 'react';
 import {View, StyleSheet, Text, Button, Clipboard, TextInput} from 'react-native';
 
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
 
 <block class="classical syntax" />
 
-```SnackPlayer name=Clipboard
+```SnackPlayer name=Clipboard&supportedPlatforms=ios,android
 import React, {Component} from 'react';
 import {View, StyleSheet, Text, Button, Clipboard, TextInput} from 'react-native';
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Belongs to https://github.com/facebook/react-native-website/issues/1579

Created snacks with both functional and class components. However, unable to get the snack working on the expo web player. Clipboard is implemented in react-native-web, hence could use a little help here...

Current issues preventing this PR from merging into the master:
- [ ] Unable to use clipboard on web snack 
  - Fix: Disabling web option in the snack (https://github.com/react-native-community/react-native-clipboard/issues/5) 
  - update: The above fix isn't the required fix ☹️