### PR TITLE
docs: add deprecation notice for clipboard

### DIFF
--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -1,7 +1,9 @@
 ---
 id: clipboard
-title: Clipboard
+title: 🚧 Clipboard
 ---
+
+> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-community/react-native-clipboard) instead.
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS
 
@@ -40,11 +42,12 @@ _setContent() {
   Clipboard.setString('hello world');
 }
 ```
+
 **Parameters:**
 
-| Name      | Type     | Required | Description                                |
-| ------    | ------   | -------- | -------------------------------------------|
-| content   | string   | Yes      | The content to be stored in the clipboard  | 
+| Name    | Type   | Required | Description                               |
+| ------- | ------ | -------- | ----------------------------------------- |
+| content | string | Yes      | The content to be stored in the clipboard |
 
 _Notice_
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -60,7 +60,7 @@
         "title": "CheckBox"
       },
       "clipboard": {
-        "title": "Clipboard"
+        "title": "🚧 Clipboard"
       },
       "colors": {
         "title": "Color Reference"


### PR DESCRIPTION
Adding deprecation notice for the `Clipboard` module, as it is now moved to the [community](https://github.com/react-native-community/react-native-clipboard)

Ref: https://github.com/facebook/react-native/blob/master/index.js#L301-L309