### PR TITLE
design: use same color for tabs divider as used for TOC border

### DIFF
--- a/website/static/css/tabs.css
+++ b/website/static/css/tabs.css
@@ -5,9 +5,9 @@
   display: inline-block;
   top: 1px;
   padding: 10px;
-  margin: 0px 2px 0px 2px;
+  margin: 0 2px;
   border-bottom-color: transparent;
-  border-radius: 3px 3px 0px 0px;
+  border-radius: 3px 3px 0 0;
   font-size: 0.99em;
 }
 
@@ -59,21 +59,8 @@
   list-style-type: none;
   padding: 0;
   margin: 0;
-  border-bottom: 1px solid $subtle;
+  border-bottom: 1px solid $divider;
   cursor: default;
-}
-
-@media screen and (max-width: 960px) {
-  .toggler li,
-  .toggler li:first-child,
-  .toggler li:last-child {
-    border-bottom-color: $subtle;
-    border-radius: 3px;
-    margin: 2px 0px 2px 0px;
-  }
-  .toggler ul {
-    border-bottom: 0;
-  }
 }
 
 .toggler button {


### PR DESCRIPTION
This PR introduce small UI/design tweak which changes tabs divider color to the same used for TOC border (currently tabs border is dark gray):

<img width="1054" alt="a" src="https://user-images.githubusercontent.com/719641/74069711-57fe6780-49ff-11ea-9c92-bd71c9eb94dd.png">

Also I have made a small CSS cleanup and I have removed unnecessary code (probably leftover from the older design) for the vertical devices. As you can see below only visible change is that tabs divider is present now:

<img width="1097" alt="a2s" src="https://user-images.githubusercontent.com/719641/74070156-90eb0c00-4a00-11ea-92b1-3387fa0d6557.png">

