### PR TITLE
TextInput: Added new docs for PasswordRules Prop

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -756,6 +756,17 @@ Possible values for `textContentType` are:
 
 ---
 
+### `passwordRules`
+
+When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them.
+In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | iOS      |
+
+---
+
 ### `style`
 
 Note that not all Text styles are supported, an incomplete list of what is not supported includes:


### PR DESCRIPTION
This prop which was added on [here](https://github.com/facebook/react-native/pull/25407) wasn't documented in the docs nor in the API. Related with #1579 