### PR TITLE
Refactor AccessibilityInfo Example into React Hooks

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -76,6 +76,75 @@ const styles = StyleSheet.create({
 });
 ```
 
+````SnackPlayer name=AccessibilityInfo%20Example
+import React, { useState, useEffect } from "react";
+import { AccessibilityInfo, View, Text, StyleSheet } from "react-native";
+
+export default function App() {
+  const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
+  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+
+  useEffect(() => {
+    AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      handleReduceMotionToggled
+    );
+    AccessibilityInfo.addEventListener(
+      "screenReaderChanged",
+      handleScreenReaderToggled
+    );
+
+    AccessibilityInfo.fetch().then(reduceMotionEnabled => {
+      setReduceMotionEnabled(reduceMotionEnabled);
+    });
+    AccessibilityInfo.fetch().then(screenReaderEnabled => {
+      setScreenReaderEnabled(screenReaderEnabled);
+    });
+    return () => {
+      AccessibilityInfo.removeEventListener(
+        "reduceMotionChanged",
+        handleReduceMotionToggled
+      );
+
+      AccessibilityInfo.removeEventListener(
+        "screenReaderChanged",
+        handleScreenReaderToggled
+      );
+    };
+  }, []);
+
+  const handleReduceMotionToggled = reduceMotionEnabled => {
+    setReduceMotionEnabled(reduceMotionEnabled);
+  };
+
+  const handleScreenReaderToggled = screenReaderEnabled => {
+    setScreenReaderEnabled(screenReaderEnabled);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.status}>
+        The reduce motion is {reduceMotionEnabled ? "enabled" : "disabled"}.
+      </Text>
+      <Text style={styles.status}>
+        The screen reader is {screenReaderEnabled ? "enabled" : "disabled"}.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  status: {
+    margin: 30
+  }
+});
+’’’
+
 ---
 
 # Reference
@@ -86,7 +155,7 @@ const styles = StyleSheet.create({
 
 ```jsx
 static isBoldTextEnabled()
-```
+````
 
 **iOS-Only.** Query whether a bold text is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when bold text is enabled and `false` otherwise.
 

--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -155,7 +155,7 @@ const styles = StyleSheet.create({
 
 ```jsx
 static isBoldTextEnabled()
-````
+```
 
 **iOS-Only.** Query whether a bold text is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when bold text is enabled and `false` otherwise.
 

--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -7,76 +7,21 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 Here's a small example illustrating how to use `AccessibilityInfo`:
 
-```jsx
-import React, {useState, useEffect} from 'react';
-import {AccessibilityInfo, View, Text, StyleSheet} from 'react-native';
+<div class="toggler">
+  <ul role="tablist" class="toggle-syntax">
+    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
+      Function Component Example
+    </li>
+    <li id="classical" class="button-classical" aria-selected="false" role="tab" tabindex="0" aria-controls="classicaltab" onclick="displayTabs('syntax', 'classical')">
+      Class Component Example
+    </li>
+  </ul>
+</div>
 
-export default function App() {
-  const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
-  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+<block class="functional syntax" />
 
-  useEffect(() => {
-    AccessibilityInfo.addEventListener(
-      'reduceMotionChanged',
-      handleReduceMotionToggled,
-    );
-    AccessibilityInfo.addEventListener(
-      'screenReaderChanged',
-      handleScreenReaderToggled,
-    );
+```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example
 
-    AccessibilityInfo.isReduceMotionEnabled().then((reduceMotionEnabled) => {
-      setReduceMotionEnabled(reduceMotionEnabled);
-    });
-    AccessibilityInfo.isScreenReaderEnabled().then((screenReaderEnabled) => {
-      setScreenReaderEnabled(screenReaderEnabled);
-    });
-    return () => {
-      AccessibilityInfo.removeEventListener(
-        'reduceMotionChanged',
-        handleReduceMotionToggled,
-      );
-
-      AccessibilityInfo.removeEventListener(
-        'screenReaderChanged',
-        handleScreenReaderToggled,
-      );
-    };
-  }, []);
-
-  const handleReduceMotionToggled = (reduceMotionEnabled) => {
-    setReduceMotionEnabled(reduceMotionEnabled);
-  };
-
-  const handleScreenReaderToggled = (screenReaderEnabled) => {
-    setScreenReaderEnabled(screenReaderEnabled);
-  };
-
-  return (
-    <View style={styles.container}>
-      <Text style={styles.status}>
-        The reduce motion is {reduceMotionEnabled ? 'enabled' : 'disabled'}.
-      </Text>
-      <Text style={styles.status}>
-        The screen reader is {screenReaderEnabled ? 'enabled' : 'disabled'}.
-      </Text>
-    </View>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  status: {
-    margin: 30,
-  },
-});
-```
-
-````SnackPlayer name=AccessibilityInfo%20Example
 import React, { useState, useEffect } from "react";
 import { AccessibilityInfo, View, Text, StyleSheet } from "react-native";
 
@@ -143,7 +88,87 @@ const styles = StyleSheet.create({
     margin: 30
   }
 });
-’’’
+```
+
+<block class="classical syntax" />
+
+```SnackPlayer name=AccessibilityInfo%20Class%20Component%20Example
+
+import React from 'react';
+import { AccessibilityInfo, View, Text, StyleSheet } from 'react-native';
+
+export default class AccessibilityStatusExample extends React.Component {
+  state = {
+    reduceMotionEnabled: false,
+    screenReaderEnabled: false,
+  };
+
+  componentDidMount() {
+    AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      this._handleReduceMotionToggled
+    );
+    AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      this._handleScreenReaderToggled
+    );
+
+    AccessibilityInfo.fetch().then(reduceMotionEnabled => {
+      this.setState({ reduceMotionEnabled });
+    });
+    AccessibilityInfo.fetch().then(screenReaderEnabled => {
+      this.setState({ screenReaderEnabled });
+    });
+  }
+
+  componentWillUnmount() {
+    AccessibilityInfo.removeEventListener(
+      'reduceMotionChanged',
+      this._handleReduceMotionToggled
+    );
+
+    AccessibilityInfo.removeEventListener(
+      'screenReaderChanged',
+      this._handleScreenReaderToggled
+    );
+  }
+
+  _handleReduceMotionToggled = reduceMotionEnabled => {
+    this.setState({ reduceMotionEnabled });
+  };
+
+  _handleScreenReaderToggled = screenReaderEnabled => {
+    this.setState({ screenReaderEnabled });
+  };
+
+  render() {
+    return (
+      <View style={this.styles.container}>
+        <Text style={this.styles.status}>
+          The reduce motion is{' '}
+          {this.state.reduceMotionEnabled ? 'enabled' : 'disabled'}.
+        </Text>
+        <Text style={this.styles.status}>
+          The screen reader is{' '}
+          {this.state.screenReaderEnabled ? 'enabled' : 'disabled'}.
+        </Text>
+      </View>
+    );
+  }
+
+  styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    status: {
+      margin: 30,
+    },
+  });
+}
+```
+<block class="endBlock syntax" />
 
 ---
 

--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -8,65 +8,72 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 Here's a small example illustrating how to use `AccessibilityInfo`:
 
 ```jsx
-class AccessibilityStatusExample extends React.Component {
-  state = {
-    reduceMotionEnabled: false,
-    screenReaderEnabled: false,
-  };
+import React, {useState, useEffect} from 'react';
+import {AccessibilityInfo, View, Text, StyleSheet} from 'react-native';
 
-  componentDidMount() {
+export default function App() {
+  const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
+  const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
+
+  useEffect(() => {
     AccessibilityInfo.addEventListener(
       'reduceMotionChanged',
-      this._handleReduceMotionToggled,
+      handleReduceMotionToggled,
     );
     AccessibilityInfo.addEventListener(
       'screenReaderChanged',
-      this._handleScreenReaderToggled,
+      handleScreenReaderToggled,
     );
 
     AccessibilityInfo.isReduceMotionEnabled().then((reduceMotionEnabled) => {
-      this.setState({reduceMotionEnabled});
+      setReduceMotionEnabled(reduceMotionEnabled);
     });
     AccessibilityInfo.isScreenReaderEnabled().then((screenReaderEnabled) => {
-      this.setState({screenReaderEnabled});
+      setScreenReaderEnabled(screenReaderEnabled);
     });
-  }
+    return () => {
+      AccessibilityInfo.removeEventListener(
+        'reduceMotionChanged',
+        handleReduceMotionToggled,
+      );
 
-  componentWillUnmount() {
-    AccessibilityInfo.removeEventListener(
-      'reduceMotionChanged',
-      this._handleReduceMotionToggled,
-    );
+      AccessibilityInfo.removeEventListener(
+        'screenReaderChanged',
+        handleScreenReaderToggled,
+      );
+    };
+  }, []);
 
-    AccessibilityInfo.removeEventListener(
-      'screenReaderChanged',
-      this._handleScreenReaderToggled,
-    );
-  }
-
-  _handleReduceMotionToggled = (reduceMotionEnabled) => {
-    this.setState({reduceMotionEnabled});
+  const handleReduceMotionToggled = (reduceMotionEnabled) => {
+    setReduceMotionEnabled(reduceMotionEnabled);
   };
 
-  _handleScreenReaderToggled = (screenReaderEnabled) => {
-    this.setState({screenReaderEnabled});
+  const handleScreenReaderToggled = (screenReaderEnabled) => {
+    setScreenReaderEnabled(screenReaderEnabled);
   };
 
-  render() {
-    return (
-      <View>
-        <Text>
-          The reduce motion is{' '}
-          {this.state.reduceMotionEnabled ? 'enabled' : 'disabled'}.
-        </Text>
-        <Text>
-          The screen reader is{' '}
-          {this.state.screenReaderEnabled ? 'enabled' : 'disabled'}.
-        </Text>
-      </View>
-    );
-  }
+  return (
+    <View style={styles.container}>
+      <Text style={styles.status}>
+        The reduce motion is {reduceMotionEnabled ? 'enabled' : 'disabled'}.
+      </Text>
+      <Text style={styles.status}>
+        The screen reader is {screenReaderEnabled ? 'enabled' : 'disabled'}.
+      </Text>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  status: {
+    margin: 30,
+  },
+});
 ```
 
 ---


### PR DESCRIPTION
Issue: #1579

- Updates jsx example with React Hooks
- Adds Snack example with React Hooks

Please note: I’ve tested with SnackPlayer and the version of React Native it uses underneath does not include the methods `isReduceMotionEnabled` and `isScreenReaderEnabled` from the AccessibilityInfo API. For that reason, I used `fetch` in the Snack example. 
