### PR TITLE
docs: add npx in front of react-native command

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -42,7 +42,7 @@ $ cd android && ./gradlew clean
 That's it! You should now be able to develop and deploy your app as normal:
 
 ```shell
-$ react-native run-android
+$ npx react-native run-android
 ```
 
 > ## Note about Android App Bundles

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -480,7 +480,7 @@ If you are using Xcode or your favorite editor, build and run your native iOS ap
 
 ```
 # From the root of your project
-$ react-native run-ios
+$ npx react-native run-ios
 ```
 
 In our sample application, you should see the link to the "High Scores" and then when you click on that you will see the rendering of your React Native component.

--- a/docs/removing-default-permissions.md
+++ b/docs/removing-default-permissions.md
@@ -15,7 +15,7 @@ The default permissions that get added are:
 
 1. Let's start by removing `READ_PHONE_STATE`, `WRITE_EXTERNAL_STORAGE`, and `READ_EXTERNAL_STORAGE` from both production and debug APKs, as it is not required in either. These storage permissions are still not needed if `AsyncStorage` module is in use, so it is safe to remove from both production and debug.
 2. Open your `android/app/src/main/AndroidManifest.xml` file.
-3. Even though these three permissions are not listed in the manifest they get added in. We add the three permissions with `tools:node="remove"` attribute, to make sure it gets removed during build. Note that the package identifier will be different, for below it is "com.myapp" because the project was created with `react-native init myapp`.
+3. Even though these three permissions are not listed in the manifest they get added in. We add the three permissions with `tools:node="remove"` attribute, to make sure it gets removed during build. Note that the package identifier will be different, for below it is "com.myapp" because the project was created with `npx react-native init myapp`.
 
    ```diff
    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -51,7 +51,7 @@ The default permissions that get added are:
    </manifest>
    ```
 
-That's it. We did not remove the `INTERNET` permission as pretty much all apps use it. Now whenever you create a production APK, these 3 permissions will be removed. When you create a debug APK (`react-native run-android`) it will install the APK with these permissions added.
+That's it. We did not remove the `INTERNET` permission as pretty much all apps use it. Now whenever you create a production APK, these 3 permissions will be removed. When you create a debug APK (`npx react-native run-android`) it will install the APK with these permissions added.
 
 ##Hint
 If your App is free to use in the App-Store and there is no "In-App-Purchase" possible in your App, you also can remove: 

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -144,14 +144,14 @@ Seeing `device` in the right column means the device is connected. You must have
 Type the following in your command prompt to install and launch your app on the device:
 
 ```
-$ react-native run-android
+$ npx react-native run-android
 ```
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
 > Hint
 >
-> You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `react-native run-android --variant=release`).
+> You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
 
 <block class="mac windows linux android ios" />
 
@@ -306,7 +306,7 @@ The static bundle is built every time you target a physical device, even in Debu
 
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
-> You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `react-native run-ios --configuration Release`).
+> You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
 
 <block class="mac windows linux android" />
 

--- a/docs/running-on-simulator-ios.md
+++ b/docs/running-on-simulator-ios.md
@@ -5,10 +5,10 @@ title: Running On Simulator
 
 ## Starting the simulator
 
-Once you have your React Native project initialized, you can run `react-native run-ios` inside the newly created project directory. If everything is set up correctly, you should see your new app running in the iOS Simulator shortly.
+Once you have your React Native project initialized, you can run `npx react-native run-ios` inside the newly created project directory. If everything is set up correctly, you should see your new app running in the iOS Simulator shortly.
 
 ## Specifying a device
 
-You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone X"`. If you wish to run your app on an iPhone 5s, run `react-native run-ios --simulator="iPhone 5s"`.
+You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone X"`. If you wish to run your app on an iPhone 5s, run `npx react-native run-ios --simulator="iPhone 5s"`.
 
 The device names correspond to the list of devices available in Xcode. You can check your available devices by running `xcrun simctl list devices` from the console.

--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -96,7 +96,7 @@ _Note: In order for Google Play to accept AAB format the App Signing by Google P
 Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using:
 
 ```sh
-$ react-native run-android --variant=release
+$ npx react-native run-android --variant=release
 ```
 
 Note that `--variant=release` is only available if you've set up signing as described above.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

-->
#1630 

There are some react-native command examples that were missing `npx`, which is the preferred method to use the react-native cli.