### PR TITLE
Added npx prefix to react-native commands within docs

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -42,7 +42,7 @@ $ cd android && ./gradlew clean
 That's it! You should now be able to develop and deploy your app as normal:
 
 ```shell
-$ react-native run-android
+$ npx react-native run-android
 ```
 
 > ## Note about Android App Bundles
@@ -63,7 +63,7 @@ const isHermes = () => global.HermesInternal !== null;
 To see the benefits of Hermes, try making a release build/deployment of your app to compare. For example:
 
 ```shell
-$ react-native run-android --variant release
+$ npx react-native run-android --variant release
 ```
 
 This will compile JavaScript to bytecode during build time which will improve your app's startup speed on device.

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -480,7 +480,7 @@ If you are using Xcode or your favorite editor, build and run your native iOS ap
 
 ```
 # From the root of your project
-$ react-native run-ios
+$ npx react-native run-ios
 ```
 
 In our sample application, you should see the link to the "High Scores" and then when you click on that you will see the rendering of your React Native component.
@@ -795,7 +795,7 @@ Once you reach your React-powered activity inside the app, it should load the Ja
 You can use Android Studio to create your release builds too! It’s as quick as creating release builds of your previously-existing native Android app. There’s one additional step, which you’ll have to do before every release build. You need to execute the following to create a React Native bundle, which will be included with your native Android app:
 
 ```
-$ react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/com/your-company-name/app-package-name/src/main/assets/index.android.bundle --assets-dest android/com/your-company-name/app-package-name/src/main/res/
+$ npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/com/your-company-name/app-package-name/src/main/assets/index.android.bundle --assets-dest android/com/your-company-name/app-package-name/src/main/res/
 ```
 
 > Don’t forget to replace the paths with correct ones and create the assets folder if it doesn’t exist.

--- a/docs/linking-libraries-ios.md
+++ b/docs/linking-libraries-ios.md
@@ -30,12 +30,12 @@ $ npm install <library-with-native-dependencies> --save
 Link your native dependencies:
 
 ```bash
-$ react-native link
+$ npx react-native link
 ```
 
 Done! All libraries with native dependencies should be successfully linked to your iOS/Android project.
 
-> **_Note:_** If your iOS project is using CocoaPods (contains `Podfile`) and linked library has `podspec` file, then `react-native link` will link library using Podfile. To support non-trivial Podfiles add `# Add new pods below this line` comment to places where you expect pods to be added.
+> **_Note:_** If your iOS project is using CocoaPods (contains `Podfile`) and linked library has `podspec` file, then `npx react-native link` will link library using Podfile. To support non-trivial Podfiles add `# Add new pods below this line` comment to places where you expect pods to be added.
 
 ### Manual linking
 

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -18,7 +18,7 @@ Where MyLibrary is the name you would like for the new module. After doing this 
 $ yarn install
 ```
 
-After this is done you can go to your main react app folder (which you created by doing `react-native init MyApp`)
+After this is done you can go to your main react app folder (which you created by doing `npx react-native init MyApp`)
 
 - add your newly created module as a dependency in your package.json
 - run `yarn install` to bring it along from your local npm repository.

--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ Right now the process of creating a React Native platform from scratch is not ve
 
 ### Bundling
 
-As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
+As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
 
 To register your platform with RNPM, your module's name must match one of these patterns:
 

--- a/docs/removing-default-permissions.md
+++ b/docs/removing-default-permissions.md
@@ -15,7 +15,7 @@ The default permissions that get added are:
 
 1. Let's start by removing `READ_PHONE_STATE`, `WRITE_EXTERNAL_STORAGE`, and `READ_EXTERNAL_STORAGE` from both production and debug APKs, as it is not required in either. These storage permissions are still not needed if `AsyncStorage` module is in use, so it is safe to remove from both production and debug.
 2. Open your `android/app/src/main/AndroidManifest.xml` file.
-3. Even though these three permissions are not listed in the manifest they get added in. We add the three permissions with `tools:node="remove"` attribute, to make sure it gets removed during build. Note that the package identifier will be different, for below it is "com.myapp" because the project was created with `react-native init myapp`.
+3. Even though these three permissions are not listed in the manifest they get added in. We add the three permissions with `tools:node="remove"` attribute, to make sure it gets removed during build. Note that the package identifier will be different, for below it is "com.myapp" because the project was created with `npx react-native init myapp`.
 
    ```diff
    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -51,7 +51,7 @@ The default permissions that get added are:
    </manifest>
    ```
 
-That's it. We did not remove the `INTERNET` permission as pretty much all apps use it. Now whenever you create a production APK, these 3 permissions will be removed. When you create a debug APK (`react-native run-android`) it will install the APK with these permissions added.
+That's it. We did not remove the `INTERNET` permission as pretty much all apps use it. Now whenever you create a production APK, these 3 permissions will be removed. When you create a debug APK (`npx react-native run-android`) it will install the APK with these permissions added.
 
 ##Hint
 If your App is free to use in the App-Store and there is no "In-App-Purchase" possible in your App, you also can remove: 

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -144,14 +144,14 @@ Seeing `device` in the right column means the device is connected. You must have
 Type the following in your command prompt to install and launch your app on the device:
 
 ```
-$ react-native run-android
+$ npx react-native run-android
 ```
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
 > Hint
 >
-> You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `react-native run-android --variant=release`).
+> You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
 
 <block class="mac windows linux android ios" />
 
@@ -306,7 +306,7 @@ The static bundle is built every time you target a physical device, even in Debu
 
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
-> You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `react-native run-ios --configuration Release`).
+> You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
 
 <block class="mac windows linux android" />
 

--- a/docs/running-on-simulator-ios.md
+++ b/docs/running-on-simulator-ios.md
@@ -5,10 +5,10 @@ title: Running On Simulator
 
 ## Starting the simulator
 
-Once you have your React Native project initialized, you can run `react-native run-ios` inside the newly created project directory. If everything is set up correctly, you should see your new app running in the iOS Simulator shortly.
+Once you have your React Native project initialized, you can run `npx react-native run-ios` inside the newly created project directory. If everything is set up correctly, you should see your new app running in the iOS Simulator shortly.
 
 ## Specifying a device
 
-You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone X"`. If you wish to run your app on an iPhone 5s, run `react-native run-ios --simulator="iPhone 5s"`.
+You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone X"`. If you wish to run your app on an iPhone 5s, run `npx react-native run-ios --simulator="iPhone 5s"`.
 
 The device names correspond to the list of devices available in Xcode. You can check your available devices by running `xcrun simctl list devices` from the console.

--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -96,7 +96,7 @@ _Note: In order for Google Play to accept AAB format the App Signing by Google P
 Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using:
 
 ```sh
-$ react-native run-android --variant=release
+$ npx react-native run-android --variant=release
 ```
 
 Note that `--variant=release` is only available if you've set up signing as described above.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,7 +30,7 @@ On Windows you can find the process using port 8081 using [Resource Monitor](htt
 You can configure the packager to use a port other than 8081 by using the `port` parameter:
 
 ```
-$ react-native start --port=8088
+$ npx react-native start --port=8088
 ```
 
 You will also need to update your applications to load the JavaScript bundle from the new port. If running on device from Xcode, you can do this by updating occurrences of `8081` to your chosen port in the `node_modules/react-native/React/React.xcodeproj/project.pbxproj` file.
@@ -93,10 +93,10 @@ Try [downgrading your Gradle version to 1.2.3](https://github.com/facebook/react
 
 ## react-native init hangs
 
-If you run into issues where running `react-native init` hangs in your system, try running it again in verbose mode and referring to [#2797](https://github.com/facebook/react-native/issues/2797) for common causes:
+If you run into issues where running `npx react-native init` hangs in your system, try running it again in verbose mode and referring to [#2797](https://github.com/facebook/react-native/issues/2797) for common causes:
 
 ```
-react-native init --verbose
+npx react-native init --verbose
 ```
 
 ## Unable to start react-native package manager (on Linux)

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -26,13 +26,13 @@ The [React Native CLI](https://github.com/react-native-community/cli) comes with
 Run the following command to start the process of upgrading to the latest version:
 
 ```sh
-react-native upgrade
+npx react-native upgrade
 ```
 
 You may specify a React Native version by passing an argument, e.g. to upgrade to `0.61.0-rc.0` run:
 
 ```sh
-react-native upgrade 0.61.0-rc.0
+npx react-native upgrade 0.61.0-rc.0
 ```
 
 The project is upgraded using `git apply` with 3-way merge, it may happen that you'll need to resolve a few conflicts after it's finished.
@@ -88,12 +88,12 @@ yarn add react@{{REACT_VERSION}}
 
 #### 3. Upgrade your project files
 
-The new release may contain updates to other files that are generated when you run `react-native init`, those files are listed after the `package.json` in the Upgrade Helper page. If there aren't other changes then you only need to rebuild the project to continue developing.
+The new release may contain updates to other files that are generated when you run `npx react-native init`, those files are listed after the `package.json` in the Upgrade Helper page. If there aren't other changes then you only need to rebuild the project to continue developing.
 
 In case there are changes then you can either update them manually by copying and pasting from the changes in the page or you can do it with the React Native CLI upgrade command by running:
 
 ```sh
-react-native upgrade
+npx react-native upgrade
 ```
 
 This will check your files against the latest template and perform the following:
@@ -108,7 +108,7 @@ This will check your files against the latest template and perform the following
 
 #### I want to upgrade with React Native CLI but I don't use Git
 
-While your project does not have to be handled by the Git versioning system -- you can use Mercurial, SVN, or nothing -- you will still need to [install Git](https://git-scm.com/downloads) on your system in order to use `react-native upgrade`. Git will also need to be available in the `PATH`. If your project doesn't use Git, initialize it and commit:
+While your project does not have to be handled by the Git versioning system -- you can use Mercurial, SVN, or nothing -- you will still need to [install Git](https://git-scm.com/downloads) on your system in order to use `npx react-native upgrade`. Git will also need to be available in the `PATH`. If your project doesn't use Git, initialize it and commit:
 
 ```sh
 git init # Initialize a Git repository


### PR DESCRIPTION
I noticed that in the docs the 'react-native' command sometimes doesn't have the 'npx' prefix and sometimes it does.
Considering that we're using it with 'npx' on the front page, I believe it would be a good idea to stay consistent through all the docs with it.