### PR TITLE
fix grammar - add 'will'

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -17,7 +17,7 @@ Open a dialog to share text content.
 
 In iOS, Returns a Promise which will be invoked with an object containing `action` and `activityType`. If the user dismissed the dialog, the Promise will still be resolved with action being `Share.dismissedAction` and all the other keys being undefined. Note that some share options will not appear or work on the iOS simulator.
 
-In Android, Returns a Promise which always be resolved with action being `Share.sharedAction`.
+In Android, Returns a Promise which will always be resolved with action being `Share.sharedAction`.
 
 ### Content
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -15,9 +15,9 @@ static share(content, options)
 
 Open a dialog to share text content.
 
-In iOS, Returns a Promise which will be invoked with an object containing `action` and `activityType`. If the user dismissed the dialog, the Promise will still be resolved with action being `Share.dismissedAction` and all the other keys being undefined. Note that some share options will not appear or work on the iOS simulator.
+In iOS, returns a Promise which will be invoked with an object containing `action` and `activityType`. If the user dismissed the dialog, the Promise will still be resolved with action being `Share.dismissedAction` and all the other keys being undefined. Note that some share options will not appear or work on the iOS simulator.
 
-In Android, Returns a Promise which will always be resolved with action being `Share.sharedAction`.
+In Android, returns a Promise which will always be resolved with action being `Share.sharedAction`.
 
 ### Content
 


### PR DESCRIPTION
Hi,

Just wanted to point out a tiny word that was missing in the docs that messed up the grammar.

The page on [Share](https://facebook.github.io/react-native/docs/share) currently states:

> In Android, Returns a Promise which always be resolved with action being `Share.sharedAction`.

This PR adds the word _will_ to the above sentence, leading to this improved sentence:

> In Android, Returns a Promise which will always be resolved with action being `Share.sharedAction`.

It's a small issue but having perfect docs is always nice :)