### PR TITLE
🐛Fix erroneous use of absoluteFill

### DIFF
--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -150,11 +150,9 @@ A line with hairline width may not be visible if your simulator is downscaled.
 A very common pattern is to create overlays with position absolute and zero positioning (`position: 'absolute', left: 0, right: 0, top: 0, bottom: 0`), so `absoluteFill` can be used for convenience and to reduce duplication of these repeated styles. If you want, absoluteFill can be used to create a customized entry in a StyleSheet, e.g.:
 
 ```jsx
-const styles = StyleSheet.create({
-  wrapper: {
-    ...StyleSheet.absoluteFill,
-  },
-});
+<View style={StyleSheet.absoluteFill}>
+  <SomeOtherView />
+</View>
 ```
 
 ---


### PR DESCRIPTION
`StyleSheet.absoluteFill `cannot be spread into an object.