### PR TITLE
docs: arrange Image Props in alphabetical order

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -32,11 +32,11 @@ const styles = StyleSheet.create({
     paddingTop: 50,
   },
   tinyLogo: {
-    width: 50, 
+    width: 50,
     height: 50,
   },
   logo: {
-    width: 66, 
+    width: 66,
     height: 58,
   },
 });
@@ -80,11 +80,11 @@ const styles = StyleSheet.create({
     paddingTop: 50,
   },
   tinyLogo: {
-    width: 50, 
+    width: 50,
     height: 50,
   },
   logo: {
-    width: 66, 
+    width: 66,
     height: 58,
   },
 });
@@ -115,7 +115,6 @@ export default class DisplayAnImage extends Component {
 <block class="endBlock syntax" />
 
 You can also add `style` to an image:
-
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">
@@ -276,6 +275,26 @@ dependencies {
 
 ---
 
+### `accessible`
+
+When true, indicates the image is an accessibility element.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | iOS      |
+
+---
+
+### `accessibilityLabel`
+
+The text that's read by the screen reader when the user interacts with the image.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| string | No       | iOS      |
+
+---
+
 ### `blurRadius`
 
 blurRadius: the blur radius of the blur filter added to the image
@@ -285,6 +304,71 @@ blurRadius: the blur radius of the blur filter added to the image
 | number | No       |
 
 > Tip : IOS you will need to increase `blurRadius` more than `5`
+
+---
+
+### `capInsets`
+
+When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
+
+| Type                                                               | Required | Platform |
+| ------------------------------------------------------------------ | -------- | -------- |
+| object: {top: number, left: number, bottom: number, right: number} | No       | iOS      |
+
+---
+
+### `defaultSource`
+
+A static image to display while loading the image source.
+
+| Type           | Required | Platform |
+| -------------- | -------- | -------- |
+| object, number | No       | iOS      |
+| number         | No       | Android  |
+
+If passing an object, the general shape is `{uri: string, width: number, height: number, scale: number}`:
+
+- `uri` - a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource (which should be wrapped in the `require('./path/to/image.png')` function).
+- `width`, `height` - can be specified if known at build time, in which case these will be used to set the default `<Image/>` component dimensions.
+- `scale` - used to indicate the scale factor of the image. Defaults to 1.0 if unspecified, meaning that one image pixel equates to one display point / DIP.
+
+If passing a number:
+
+- `number` - Opaque type returned by something like `require('./image.jpg')`.
+
+> **Note:** On Android, the default source prop is ignored on debug builds.
+
+---
+
+### `fadeDuration`
+
+Android only. By default, it is 300ms.
+
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
+
+---
+
+### `loadingIndicatorSource`
+
+Similarly to `source`, this property represents the resource used to render the loading indicator for the image, displayed until image is ready to be displayed, typically after when it got downloaded from network.
+
+| Type                                  | Required |
+| ------------------------------------- | -------- |
+| array of ImageSourcePropTypes, number | No       |
+
+> Can accept a number as returned by `require('./image.jpg')`
+
+---
+
+### `onError`
+
+Invoked on load error with `{nativeEvent: {error}}`.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
 
 ---
 
@@ -330,6 +414,54 @@ e.g., `onLoadStart={(e) => this.setState({loading: true})}`
 
 ---
 
+### `onPartialLoad`
+
+Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
+
+| Type     | Required | Platform |
+| -------- | -------- | -------- |
+| function | No       | iOS      |
+
+---
+
+### `onProgress`
+
+Invoked on download progress with `{nativeEvent: {loaded, total}}`.
+
+| Type     | Required | Platform |
+| -------- | -------- | -------- |
+| function | No       | iOS      |
+
+---
+
+### `progressiveRenderingEnabled`
+
+Android only. When true, enables progressive jpeg streaming. https://frescolib.org/docs/progressive-jpegs.html
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
+
+---
+
+### `resizeMethod`
+
+The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
+
+- `auto`: Use heuristics to pick between `resize` and `scale`.
+
+- `resize`: A software operation which changes the encoded image in memory before it gets decoded. This should be used instead of `scale` when the image is much larger than the view.
+
+- `scale`: The image gets drawn downscaled or upscaled. Compared to `resize`, `scale` is faster (usually hardware accelerated) and produces higher quality images. This should be used if the image is smaller than the view. It should also be used if the image is slightly bigger than the view.
+
+More details about `resize` and `scale` can be found at http://frescolib.org/docs/resizing.html.
+
+| Type                            | Required | Platform |
+| ------------------------------- | -------- | -------- |
+| enum('auto', 'resize', 'scale') | No       | Android  |
+
+---
+
 ### `resizeMode`
 
 Determines how to resize the image when the frame doesn't match the raw image dimensions. Defaults to `cover`.
@@ -364,28 +496,6 @@ The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp` (
 
 ---
 
-### `loadingIndicatorSource`
-
-Similarly to `source`, this property represents the resource used to render the loading indicator for the image, displayed until image is ready to be displayed, typically after when it got downloaded from network.
-
-| Type                                  | Required |
-| ------------------------------------- | -------- |
-| array of ImageSourcePropTypes, number | No       |
-
-> Can accept a number as returned by `require('./image.jpg')`
-
----
-
-### `onError`
-
-Invoked on load error with `{nativeEvent: {error}}`.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
 ### `testID`
 
 A unique identifier for this element to be used in UI Automation testing scripts.
@@ -393,117 +503,6 @@ A unique identifier for this element to be used in UI Automation testing scripts
 | Type   | Required |
 | ------ | -------- |
 | string | No       |
-
----
-
-### `resizeMethod`
-
-The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
-
-- `auto`: Use heuristics to pick between `resize` and `scale`.
-
-- `resize`: A software operation which changes the encoded image in memory before it gets decoded. This should be used instead of `scale` when the image is much larger than the view.
-
-- `scale`: The image gets drawn downscaled or upscaled. Compared to `resize`, `scale` is faster (usually hardware accelerated) and produces higher quality images. This should be used if the image is smaller than the view. It should also be used if the image is slightly bigger than the view.
-
-More details about `resize` and `scale` can be found at http://frescolib.org/docs/resizing.html.
-
-| Type                            | Required | Platform |
-| ------------------------------- | -------- | -------- |
-| enum('auto', 'resize', 'scale') | No       | Android  |
-
----
-
-### `accessibilityLabel`
-
-The text that's read by the screen reader when the user interacts with the image.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | iOS      |
-
----
-
-### `accessible`
-
-When true, indicates the image is an accessibility element.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
-
----
-
-### `capInsets`
-
-When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
-
-| Type | Required | Platform |
-| --- | --- | --- |
-| object: {top: number, left: number, bottom: number, right: number} | No | iOS |
-
----
-
-### `defaultSource`
-
-A static image to display while loading the image source.
-
-| Type           | Required | Platform |
-| -------------- | -------- | -------- |
-| object, number | No       | iOS      |
-| number         | No       | Android  |
-
-If passing an object, the general shape is `{uri: string, width: number, height: number, scale: number}`:
-
-- `uri` - a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource (which should be wrapped in the `require('./path/to/image.png')` function).
-- `width`, `height` - can be specified if known at build time, in which case these will be used to set the default `<Image/>` component dimensions.
-- `scale` - used to indicate the scale factor of the image. Defaults to 1.0 if unspecified, meaning that one image pixel equates to one display point / DIP.
-
-If passing a number:
-
-- `number` - Opaque type returned by something like `require('./image.jpg')`.
-
-> **Note:** On Android, the default source prop is ignored on debug builds.
-
----
-
-### `onPartialLoad`
-
-Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
-
-| Type     | Required | Platform |
-| -------- | -------- | -------- |
-| function | No       | iOS      |
-
----
-
-### `onProgress`
-
-Invoked on download progress with `{nativeEvent: {loaded, total}}`.
-
-| Type     | Required | Platform |
-| -------- | -------- | -------- |
-| function | No       | iOS      |
-
----
-
-### `fadeDuration`
-
-Android only. By default, it is 300ms.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `progressiveRenderingEnabled`
-
-Android only. When true, enables progressive jpeg streaming. https://frescolib.org/docs/progressive-jpegs.html
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
 
 ## Methods
 
@@ -519,11 +518,11 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| uri | string | Yes | The location of the image. |
-| success | function | Yes | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure | function | No | The function that will be called if there was an error, such as failing to retrieve the image. |
+| Name    | Type     | Required | Description                                                                                          |
+| ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri     | string   | Yes      | The location of the image.                                                                           |
+| success | function | Yes      | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure | function | No       | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -541,12 +540,12 @@ Does not work for static image resources.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| uri | string | Yes | The location of the image. |
-| headers | object | Yes | The headers for the request. |
-| success | function | Yes | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure | function | No | The function that will be called if there was an error, such as failing toto retrieve the image. |
+| Name    | Type     | Required | Description                                                                                          |
+| ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri     | string   | Yes      | The location of the image.                                                                           |
+| headers | object   | Yes      | The headers for the request.                                                                         |
+| success | function | Yes      | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure | function | No       | The function that will be called if there was an error, such as failing toto retrieve the image.     |
 
 ---
 
@@ -608,8 +607,8 @@ Resolves an asset reference into an object which has the properties `uri`, `widt
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| source | number, object | Yes | A number (opaque type returned by require('./foo.png')) or an `ImageSource`. |
+| Name   | Type           | Required | Description                                                                  |
+| ------ | -------------- | -------- | ---------------------------------------------------------------------------- |
+| source | number, object | Yes      | A number (opaque type returned by require('./foo.png')) or an `ImageSource`. |
 
 > `ImageSource` is an object like `{ uri: '<http location || file path>' }`


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
#1579 

Double checked `Image` API to see if there was a missing proptypes.
Turns out there are `height` and `width` prop in the Image component, but it doesn't seem to have any effect in the actual code. (Making a PR in the core to remove the props https://github.com/facebook/react-native/pull/28151)
All other props seems to be included in the docs.

I've also rearranged the props to be in alphabetical order so its easier for readers to keep track.
