### PR TITLE
docs: fix link for segmented control community package

### DIFF
--- a/docs/segmentedcontrolios.md
+++ b/docs/segmentedcontrolios.md
@@ -3,7 +3,7 @@ id: segmentedcontrolios
 title: 🚧 SegmentedControlIOS
 ---
 
-> **Deprecated.** Use [@react-native-community/segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
+> **Deprecated.** Use [@react-native-community/segmented-control](https://github.com/react-native-community/segmented-control) instead.
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 

--- a/website/versioned_docs/version-0.60/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.60/segmentedcontrolios.md
@@ -4,7 +4,7 @@ title: SegmentedControlIOS
 original_id: segmentedcontrolios
 ---
 
-> **Deprecated.** Use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
+> **Deprecated.** Use [@react-native-community/segmented-control](https://github.com/react-native-community/segmented-control) instead.
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
`@react-native-community/segmented-control` recently changed its repo name to `segmented-control`.
This PR fixes the link to the correct URL.