### PR TITLE
docs: update typescript template for 0.61

### DIFF
--- a/website/versioned_docs/version-0.61/typescript.md
+++ b/website/versioned_docs/version-0.61/typescript.md
@@ -1,0 +1,224 @@
+---
+id: version-0.61-typescript
+title: Using TypeScript with React Native
+original_id: typescript
+---
+
+[TypeScript][ts] is a language which extends JavaScript by adding type definitions, much like [Flow][flow]. While React Native is built in Flow, it supports both TypeScript _and_ Flow by default.
+
+## Getting Started with TypeScript
+
+If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
+
+```sh
+npx react-native init MyTSProject --template react-native-template-typescript
+```
+
+You can use [Expo][expo] which has two TypeScript templates:
+
+```sh
+npm install -g expo-cli
+expo init MyTSProject
+```
+
+Or you could use [Ignite][ignite], which also has a TypeScript template:
+
+```sh
+npm install -g ignite-cli
+ignite new MyTSProject
+```
+
+## Adding TypeScript to an Existing Project
+
+1. Add TypeScript and the types for React Native and Jest to your project.
+
+```sh
+yarn add typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+# or for npm
+npm install --save-dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+```
+
+2. Add a TypeScript config file. Create a `tsconfig.json` in the root of your project:
+
+```json
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["es6"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "target": "esnext"
+  },
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js"
+  ]
+}
+```
+
+3. Create a `jest.config.js` file to configure Jest to use TypeScript
+
+```js
+module.exports = {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};
+```
+
+4. Rename a JavaScript file to be `*.tsx`
+
+5. Run `yarn tsc` to type-check your new TypeScript files.
+
+## How TypeScript and React Native works
+
+Out of the box, transforming your files to JavaScript works via the same [Babel infrastructure][babel] as a non-TypeScript React Native project. We recommend that you use the TypeScript compiler only for type checking. If you have existing TypeScript code being ported to React Native, there are [one or two caveats][babel-7-caveats] to using Babel instead of TypeScript.
+
+## What does React Native + TypeScript look like
+
+You can provide an interface for a React Component's [Props][props] and [State][state] via `React.Component<Props, State>` which will provide type-checking and editor auto-completing when working with that component in JSX.
+
+```tsx
+// components/Hello.tsx
+import React from 'react';
+import {Button, StyleSheet, Text, View} from 'react-native';
+
+export interface Props {
+    name: string;
+    enthusiasmLevel?: number;
+}
+
+const Hello: React.FC<Props> = (props) => {
+    const [enthusiasmLevel, setEnthusiasmLevel] = React.useState(props.enthusiasmLevel);
+
+    const onIncrement = () => setEnthusiasmLevel((enthusiasmLevel || 0) + 1);
+    const onDecrement = () => setEnthusiasmLevel((enthusiasmLevel || 0) - 1);
+
+    const getExclamationMarks = (numChars: number) => Array(numChars + 1).join('!');
+    return (
+        <View style={styles.root}>
+        <Text style={styles.greeting}>
+            Hello{' '}
+            {props.name + getExclamationMarks(enthusiasmLevel || 0)}
+        </Text>
+
+        <View style={styles.buttons}>
+            <View style={styles.button}>
+            <Button
+                title="-"
+                onPress={onDecrement}
+                accessibilityLabel="decrement"
+                color="red"
+            />
+            </View>
+
+            <View style={styles.button}>
+            <Button
+                title="+"
+                onPress={onIncrement}
+                accessibilityLabel="increment"
+                color="blue"
+            />
+            </View>
+        </View>
+        </View>
+    );
+    }
+}
+
+// styles
+const styles = StyleSheet.create({
+    root: {
+        alignItems: 'center',
+        alignSelf: 'center',
+    },
+    buttons: {
+       flexDirection: 'row',
+        minHeight: 70,
+        alignItems: 'stretch',
+        alignSelf: 'center',
+        borderWidth: 5,
+    },
+    button: {
+        flex: 1,
+        paddingVertical: 0,
+    },
+    greeting: {
+        color: '#999',
+        fontWeight: 'bold',
+    },
+});
+```
+
+You can explore the syntax more in the [TypeScript playground][tsplay].
+
+## Where to Find Useful Advice
+
+- [TypeScript Handbook][ts-handbook]
+- [React's documentation on TypeScript][react-ts]
+- [React + TypeScript Cheatsheets][cheat] has a good overview on how to use React with TypeScript
+
+## Using Custom Path Aliases with TypeScript
+
+To use custom path aliases with TypeScript, you need to set the path aliases to work from both Babel and TypeScript. Here's how:
+
+1. Edit your `tsconfig.json` to have your [custom path mappings][path-map]. Set anything in the root of `src` to be available with no preceding path reference, and allow any test file to be accessed by using `test/File.tsx`:
+
+```diff
+    "target": "esnext",
++     "baseUrl": ".",
++     "paths": {
++       "*": ["src/*"],
++       "tests": ["tests/*"]
++     },
+    }
+```
+
+2. Configure the Babel side done by adding a new dependency, [`babel-plugin-module-resolver`][bpmr]:
+
+```sh
+yarn add --dev babel-plugin-module-resolver
+# or
+npm install --save-dev babel-plugin-module-resolver
+```
+
+3. Finally, configure your `babel.config.js` (note that the syntax for your `babel.config.js` is different from your `tsconfig.json`):
+
+```diff
+{
+  plugins: [
++    [
++       'module-resolver',
++       {
++         root: ['./src'],
++         extensions: ['.ios.js', '.android.js', '.js', '.ts', '.tsx', '.json'],
++         alias: {
++           "test/*": ["./test/"],
++         }
++       }
++     ]
+  ]
+}
+```
+
+[react-ts]: https://reactjs.org/docs/static-type-checking.html#typescript
+[ts]: https://www.typescriptlang.org/
+[flow]: https://flow.org
+[ts-template]: https://github.com/react-native-community/react-native-template-typescript
+[babel]: /docs/javascript-environment#javascript-syntax-transformers
+[babel-7-caveats]: https://babeljs.io/docs/en/next/babel-plugin-transform-typescript
+[cheats]: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#reacttypescript-cheatsheets
+[ts-handbook]: http://www.typescriptlang.org/docs/home.html
+[props]: /docs/props.html
+[state]: /docs/state.html
+[path-map]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping
+[bpmr]: https://github.com/tleunen/babel-plugin-module-resolver
+[expo]: https://expo.io
+[ignite]: https://infinite.red/ignite
+[tsplay]: https://www.typescriptlang.org/play/?strictNullChecks=false&esModuleInterop=true&jsx=3#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4BYAKFEljgG8AhAVxhggDsAaOAZRgCeAGyS8AFkiQweAFSQAPaXABqwJAHcAvnGy4CRdDAC0HFDGAA3JGSpUFteMA4wkUTOiRwACjjABnBio4YLhTECQALjg-GCgnAHMKShC4JGcxZj9gFD8QABkkKyEAfiiOZhAAI1ckzVtKNE4YuAAJJCEhCCjkQwA6ADEAYQAeHwh-AD44AF44AAowXz8AShmp+iCQxo5mgG00mAysnPzC9p4-KQBRdMzs3IKigF0ZxGIYXszRGDMkBaXegcjvdTkVlklNsFts1OABJDhoIjhZyvOaraZTS4wG6HO4nR7tOZzIF4h5nIRwAA+lLgAAZVgBqOAARnBkLg0PgnAAIkhEUhkfBZmi1tFrrdjmSikSSZLQe0qTT6XAjCy2ZR2Zy4PFrvI0EIUCAzMBOABZFBQADWAWF5RAgzEFr8ZQq1Sg6KmAEEoFAUAI5naHU64EzWb0AFYQJxzfAAQnw6pSRBgzCgHHm7JSw1UGmighE03oMWESD8vRwEBgmgmmZCwzkijzJcLxZEZfiRCkCWrtZSwTaHQg9HwBDqyT7E-oi3GZbCniZOuxeoNRvMZot1uJEpBBIp1LpyzHE+CwwA9A2YDWNeOJ9m1OomwWi-nS71Kqx2Dsezfjyecw-WyQFsXzLd82E4b9fyzFhwI4XsoPMGACwAIiMZD4N-TgfFLPxCx5PkkQOI8oIndA0Bw4BKmAIRgEEPIUGqIRpmQgATAiBQOdCfxIqEIE6KBmKIFiuJ4uBTyvUSz3-K8MLrf9HyA58S1Aj8IIknjhhgz9ZInRCUIZETRJCLCiD8XD6DhBFCOcYijLgMiKKomi6IY9pmKcflBUMuzGn45jKiEZgkG8qDxJ0uApPvdTb1PaT4MijRorgRMQjHMcqFPU8FL8KgtUAm0+BfcRJA+flfjmDYfwrGAokq38UBo+IOFhFwQGdAhyOcVx8C4eCGuAJreHaTAonwTqXCgHr2U0XqfzAz92rqidMBEeRuWAIgMBNDhRpwdQpu4kIQCcNoBrEGq4AAdlpWb6sa5rWva-AYmTNAxAOu6Bo4IahBGjqDm627j0qaA2KgAB1YAWMOKIAFYgeCGb2XmzhavglaFCiZkEb7MAUBYliEmUVxzDQBqohu6acY7EqEjRw7eP40aAGIAE52Y+49ME4GBwaQM6LvwEGhBYznEdmzRwSAA


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Currently, accessing the document for `typescript` https://reactnative.dev/docs/typescript leads to page for React Native v0.60, which specifies the template version to be v6.2.0, for RN 0.60.

To use the typescript-template with the latest version 0.61.5, user would want to use the current latest version of `react-native-typescript-template`.

The document for typescript that does not have a specified template version only exists in the `@next` version of the document, which I believe is more suited for the rc versions?

Once the React Native 0.62 gets released, the template version for 0.61 will need to be specified (I'm assuming it's going to be 6.3.x), but until then, the document for 0.61 should not specify any version for the typescript template.