### PR TITLE
Dimensions 📐 - updated Docs 📑 & new snack examples ✨

### DIFF
--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -127,16 +127,6 @@ const styles = StyleSheet.create({
 
 React native comes with `useWindowDimensions` which automatically updates the window size when screen size changes
 
-<div class="toggler">
-  <ul role="tablist" class="toggle-syntax">
-    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
-      Function Component Example
-    </li>
-  </ul>
-</div>
-
-<block class="functional syntax" />
-
 ```SnackPlayer name=useWindowDimensions&supportedPlatforms=ios,android
 import React from "react";
 import { View, StyleSheet, Text, useWindowDimensions } from "react-native";
@@ -159,8 +149,6 @@ const styles = StyleSheet.create({
   }
 });
 ```
-
-<block class="endBlock syntax" />
 
 - You can also try [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from [React native hooks](https://github.com/react-native-community/react-native-hooks) library which makes handling screen/window size changes much simpler.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -10,9 +10,11 @@ import {Dimensions} from 'react-native';
 You can get the application window's width and height using below code:
 
 ```jsx
-const windowWidth = Math.round(Dimensions.get('window').width);
-const windowHeight = Math.round(Dimensions.get('window').height);
+const windowWidth = Dimensions.get('window').width;
+const windowHeight = Dimensions.get('window').height;
 ```
+
+> Note: Although dimensions are available immediately, they may change (e.g due to device rotation, foldable devices etc) so any rendering logic or styles that depend on these constants should try to call this function on every render, rather than caching the value (for example, using inline styles rather than setting a value in a `StyleSheet`).
 
 If you are targeting foldable devices or devices which can change the screen size or app window size, you can use the event listener available in the Dimensions module as shown in the below example.
 
@@ -123,7 +125,45 @@ const styles = StyleSheet.create({
 
 ### React Native Hooks
 
-You can also try [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from [React native hooks](https://github.com/react-native-community/react-native-hooks) library which makes handling screen/window size changes much simpler.
+React native comes with `useWindowDimensions` which automatically updates the window size when screen size changes
+
+<div class="toggler">
+  <ul role="tablist" class="toggle-syntax">
+    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
+      Function Component Example
+    </li>
+  </ul>
+</div>
+
+<block class="functional syntax" />
+
+```SnackPlayer name=useWindowDimensions&supportedPlatforms=ios,android
+import React from "react";
+import { View, StyleSheet, Text, useWindowDimensions } from "react-native";
+
+export default function App() {
+  const window = useWindowDimensions();
+
+  return (
+    <View style={styles.container}>
+      <Text>{`Window Dimensions: height - ${window.height}, width - ${window.width}`}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  }
+});
+```
+
+<block class="endBlock syntax" />
+
+- You can also try [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from [React native hooks](https://github.com/react-native-community/react-native-hooks) library which makes handling screen/window size changes much simpler.
+- [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 # Reference
 
@@ -151,15 +191,13 @@ static get(dim)
 
 Initial dimensions are set before `runApplication` is called so they should be available before any other require's are run, but may be updated later.
 
-> Note: Although dimensions are available immediately, they may change (e.g due to device rotation) so any rendering logic or styles that depend on these constants should try to call this function on every render, rather than caching the value (for example, using inline styles rather than setting a value in a `StyleSheet`).
-
 Example: `const {height, width} = Dimensions.get('window');`
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| dim | string | Yes | Name of dimension as defined when calling `set`. @returns {Object?} Value for the dimension. |
+| Name | Type   | Required | Description                                                                                  |
+| ---- | ------ | -------- | -------------------------------------------------------------------------------------------- |
+| dim  | string | Yes      | Name of dimension as defined when calling `set`. @returns {Object?} Value for the dimension. |
 
 > For Android the `window` dimension will exclude the size used by the `status bar` (if not translucent) and `bottom navigation bar`
 

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -7,14 +7,123 @@ title: Dimensions
 import {Dimensions} from 'react-native';
 ```
 
-You can get device width and height using below :
-
-Get device screen width and height :
+You can get the application window's width and height using below code:
 
 ```jsx
-const screenWidth = Math.round(Dimensions.get('window').width);
-const screenHeight = Math.round(Dimensions.get('window').height);
+const windowWidth = Math.round(Dimensions.get('window').width);
+const windowHeight = Math.round(Dimensions.get('window').height);
 ```
+
+If you are targeting foldable devices or devices which can change the screen size or app window size, you can use the event listener available in the Dimensions module as shown in the below example.
+
+### Example
+
+<div class="toggler">
+  <ul role="tablist" class="toggle-syntax">
+    <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
+      Function Component Example
+    </li>
+    <li id="classical" class="button-classical" aria-selected="false" role="tab" tabindex="0" aria-controls="classicaltab" onclick="displayTabs('syntax', 'classical')">
+      Class Component Example
+    </li>
+  </ul>
+</div>
+
+<block class="functional syntax" />
+
+```SnackPlayer name=Dimensions
+import React, { useState, useEffect } from "react";
+import { View, StyleSheet, Text, Dimensions } from "react-native";
+
+const window = Dimensions.get("window");
+const screen = Dimensions.get("screen");
+
+export default function App() {
+  const [dimensions, setDimensions] = useState({ window, screen });
+
+  const onChange = ({ window, screen }) => {
+    setDimensions({ window, screen });
+  };
+
+  useEffect(() => {
+    Dimensions.addEventListener("change", onChange);
+    return () => {
+      Dimensions.removeEventListener("change", onChange);
+    };
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text>{`Window Dimensions: height - ${dimensions.window.height}, width - ${dimensions.window.width}`}</Text>
+      <Text>{`Screen Dimensions: height - ${dimensions.screen.height}, width - ${dimensions.screen.width}`}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  }
+});
+```
+
+<block class="classical syntax" />
+
+```SnackPlayer name=Dimensions
+import React, { Component } from "react";
+import { View, StyleSheet, Text, Dimensions } from "react-native";
+
+const window = Dimensions.get("window");
+const screen = Dimensions.get("screen");
+
+export default class App extends Component {
+  state = {
+    dimensions: {
+      window,
+      screen
+    }
+  };
+
+  onChange = ({ window, screen }) => {
+    this.setState({ dimensions: { window, screen } });
+  };
+
+  componentDidMount() {
+    Dimensions.addEventListener("change", this.onChange);
+  }
+
+  componentWillUnmount() {
+    Dimensions.removeEventListener("change", this.onChange);
+  }
+
+  render() {
+    const { dimensions } = this.state;
+
+    return (
+      <View style={styles.container}>
+        <Text>{`Window Dimensions: height - ${dimensions.window.height}, width - ${dimensions.window.width}`}</Text>
+        <Text>{`Screen Dimensions: height - ${dimensions.screen.height}, width - ${dimensions.screen.width}`}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  }
+});
+```
+
+<block class="endBlock syntax" />
+
+### React Native Hooks
+
+You can also try [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from [React native hooks](https://github.com/react-native-community/react-native-hooks) library which makes handling screen/window size changes much simpler.
 
 # Reference
 
@@ -29,6 +138,8 @@ static addEventListener(type, handler)
 Add an event handler. Supported events:
 
 - `change`: Fires when a property within the `Dimensions` object changes. The argument to the event handler is an object with `window` and `screen` properties whose values are the same as the return values of `Dimensions.get('window')` and `Dimensions.get('screen')`, respectively.
+  - `window` - Size of the visible Application window
+  - `screen` - Size of the device's screen
 
 ---
 
@@ -46,9 +157,9 @@ Example: `const {height, width} = Dimensions.get('window');`
 
 **Parameters:**
 
-| Name | Type   | Required | Description                                                                                  |
-| ---- | ------ | -------- | -------------------------------------------------------------------------------------------- |
-| dim  | string | Yes      | Name of dimension as defined when calling `set`. @returns {Object?} Value for the dimension. |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| dim | string | Yes | Name of dimension as defined when calling `set`. @returns {Object?} Value for the dimension. |
 
 > For Android the `window` dimension will exclude the size used by the `status bar` (if not translucent) and `bottom navigation bar`
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Belongs to https://github.com/facebook/react-native-website/issues/1579

Inspiration - To address this [stackoverflow question](https://stackoverflow.com/questions/44978804/whats-the-difference-between-window-and-screen-in-the-dimensions-api)

Contains the snack with both class & functional component examples and also a bit of update to the documentation regarding screen, window & event listener.

Pending items in this PR:
- [x] `useDimensions` hook - Done!
- [x] Info regarding scaling - Somehow this section itself is removed from docs...
- [x] Verify if rounding is necessary for using Dimensions - It's probably not necessary cuz we will eventually have to work with changing screen sizes and this helps to animate the dimensions.

Previously this was raised in https://github.com/facebook/react-native-website/pull/1601 but closing it cuz the older one has conflicts with master & It's easier to merge this one