### PR TITLE
add deprecation notice to the Geolocation page

### DIFF
--- a/website/versioned_docs/version-0.58/geolocation.md
+++ b/website/versioned_docs/version-0.58/geolocation.md
@@ -1,8 +1,10 @@
 ---
 id: version-0.58-geolocation
-title: Geolocation
+title: 🚧 Geolocation
 original_id: geolocation
 ---
+
+> **Deprecated.** Use [@react-native-community/geolocation](https://github.com/react-native-community/react-native-geolocation) instead.
 
 The Geolocation API extends the [Geolocation web spec](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation).
 


### PR DESCRIPTION
Refs #1554 

This small PR adds deprecation notice to the `Geolocation` page to prevent confusion and similar problems mentioned in issue linked above.

<img width="1440" alt="Screenshot 2020-02-27 at 10 30 03" src="https://user-images.githubusercontent.com/719641/75431099-a0e57400-594c-11ea-97dd-0f835f9c418f.png">
