### PR TITLE
add correct 'supportedPlatforms' param to the few examples

### DIFF
--- a/docs/inputaccessoryview.md
+++ b/docs/inputaccessoryview.md
@@ -7,7 +7,7 @@ A component which enables customization of the keyboard input accessory view on 
 
 To use this component wrap your custom toolbar with the InputAccessoryView component, and set a `nativeID`. Then, pass that `nativeID` as the `inputAccessoryViewID` of whatever `TextInput` you desire. A basic example:
 
-```SnackPlayer name=InputAccessoryView&supportedPlatforms=ios,web
+```SnackPlayer name=InputAccessoryView&supportedPlatforms=ios
 import React, { useState } from 'react';
 import { Button, InputAccessoryView, ScrollView, TextInput } from 'react-native';
 
@@ -15,7 +15,7 @@ export default App = () => {
   const inputAccessoryViewID = 'uniqueID';
   const initialText = 'Placeholder Text';
   const [text, setText] = useState(initialText);
-  
+
   return (
     <>
       <ScrollView keyboardDismissMode="interactive">

--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -7,7 +7,7 @@ It is a component to solve the common problem of views that need to move out of 
 
 ### Example usage
 
-```SnackPlayer name=KeyboardAvoidingView
+```SnackPlayer name=KeyboardAvoidingView&supportedPlatforms=android,ios
 import React, { Component } from 'react';
 import { View, KeyboardAvoidingView, TextInput, StyleSheet, Text, Platform, TouchableWithoutFeedback, Button, Keyboard  } from 'react-native';
 

--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -9,7 +9,7 @@ Android-only React component used to indicate that the app is loading or there i
 
 ### Example
 
-```SnackPlayer name=ProgressBarAndroid platform=android
+```SnackPlayer name=ProgressBarAndroid&supportedPlatforms=android
 import React from 'react';
 import {View, StyleSheet, ProgressBarAndroid, Text} from 'react-native';
 

--- a/docs/progressviewios.md
+++ b/docs/progressviewios.md
@@ -9,7 +9,7 @@ Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 
 ### Example
 
-```SnackPlayer name=ProgressViewIOS platform=ios
+```SnackPlayer name=ProgressViewIOS&supportedPlatforms=ios
 import React from 'react';
 import {View, StyleSheet, ProgressViewIOS, Text} from 'react-native';
 


### PR DESCRIPTION
Refs #1579 

This small PR adds correct `supportedPlatforms` param to the few Snack examples.  Some of them were using old  `platform` parameter, some were missing it at all.