### PR TITLE
add Snack example to Easing page

### DIFF
--- a/docs/easing.md
+++ b/docs/easing.md
@@ -122,9 +122,9 @@ const SECTIONS = [
   {
     title: "Additional functions",
     data: [
-      { 
-        title: "Bezier", 
-        easing: Easing.bezier(0, 2, 1, -1) 
+      {
+        title: "Bezier",
+        easing: Easing.bezier(0, 2, 1, -1)
       },
       { title: "Circle", easing: Easing.circle },
       { title: "Sin", easing: Easing.sin },

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -359,7 +359,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```jsx
-static in easing;
+static in(easing);
 ```
 
 Runs an easing function forwards.

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -156,7 +156,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#20232a"
   },
   title: {
-    lineHeight: 32,
+    marginTop: 10,
     textAlign: "center",
     color: "#61dafb"
   },
@@ -165,7 +165,7 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   box: {
-    marginTop: 30,
+    marginTop: 32,
     borderRadius: 4,
     backgroundColor: "#61dafb"
   },
@@ -173,9 +173,8 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff"
   },
   listHeader: {
-    height: 24,
-    lineHeight: 24,
     paddingHorizontal: 8,
+    paddingVertical: 4,
     backgroundColor: "#f4f4f4",
     color: "#999",
     fontSize: 12,

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -45,7 +45,7 @@ The following helpers are used to modify other easing functions.
 
 ```SnackPlayer name=Easing%20Demo
 import React from "react";
-import { Animated, Button, Easing, SectionList, StatusBar, StyleSheet, Text, View } from "react-native";
+import { Animated, Easing, SectionList, StatusBar, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 export default App = () => {
   let opacity = new Animated.Value(0);
@@ -77,7 +77,7 @@ export default App = () => {
     <View style={styles.container}>
       <StatusBar hidden={true} />
       <Text style={styles.title}>
-        Click buttons below to see the Easing!
+        Press rows below to preview the Easing!
       </Text>
       <View style={styles.boxContainer}>
         <Animated.View style={animatedStyles} />
@@ -87,12 +87,12 @@ export default App = () => {
         sections={SECTIONS}
         keyExtractor={(item) => item.title}
         renderItem={({ item }) => (
-          <View style={styles.button}>
-            <Button
-              title={item.title}
-              onPress={() => animate(item.easing)}
-            />
-          </View>
+          <TouchableOpacity 
+            onPress={() => animate(item.easing)} 
+            style={styles.listRow}
+          >
+            <Text>{item.title}</Text>
+          </TouchableOpacity>
         )}
         renderSectionHeader={({ section: { title } }) => (
           <Text style={styles.listHeader}>{title}</Text>
@@ -177,11 +177,12 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     paddingHorizontal: 8,
     backgroundColor: "#f4f4f4",
+    color: "#999",
+    fontSize: 12,
     textTransform: "uppercase"
   },
-  button: {
-    marginHorizontal: 4,
-    marginVertical: 2
+  listRow: {
+    padding: 8
   }
 });
 ```

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -41,6 +41,151 @@ The following helpers are used to modify other easing functions.
 - [`inOut`](easing.md#inout) makes any easing function symmetrical
 - [`out`](easing.md#out) runs an easing function backwards
 
+### Example
+
+```SnackPlayer name=Easing%20Demo
+import React from "react";
+import { Animated, Button, Easing, SectionList, StatusBar, StyleSheet, Text, View } from "react-native";
+
+export default App = () => {
+  let opacity = new Animated.Value(0);
+
+  const animate = easing => {
+    opacity.setValue(0);
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 1200,
+      easing
+    }).start();
+  };
+
+  const size = opacity.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 80]
+  });
+
+  const animatedStyles = [
+    styles.box,
+    {
+      opacity,
+      width: size,
+      height: size
+    }
+  ];
+
+  return (
+    <View style={styles.container}>
+      <StatusBar hidden={true} />
+      <Text style={styles.title}>
+        Click buttons below to see the Easing!
+      </Text>
+      <View style={styles.boxContainer}>
+        <Animated.View style={animatedStyles} />
+      </View>
+      <SectionList
+        style={styles.list}
+        sections={SECTIONS}
+        keyExtractor={(item) => item.title}
+        renderItem={({ item }) => (
+          <View style={styles.button}>
+            <Button
+              title={item.title}
+              onPress={() => animate(item.easing)}
+            />
+          </View>
+        )}
+        renderSectionHeader={({ section: { title } }) => (
+          <Text style={styles.listHeader}>{title}</Text>
+        )}
+      />
+    </View>
+  );
+};
+
+const SECTIONS = [
+  {
+    title: "Predefined animations",
+    data: [
+      { title: "Bounce", easing: Easing.bounce },
+      { title: "Ease", easing: Easing.ease },
+      { title: "Elastic", easing: Easing.elastic(4) }
+    ]
+  },
+  {
+    title: "Standard functions",
+    data: [
+      { title: "Linear", easing: Easing.linear },
+      { title: "Quad", easing: Easing.quad },
+      { title: "Cubic", easing: Easing.cubic }
+    ]
+  },
+  {
+    title: "Additional functions",
+    data: [
+      { 
+        title: "Bezier", 
+        easing: Easing.bezier(0, 2, 1, -1) 
+      },
+      { title: "Circle", easing: Easing.circle },
+      { title: "Sin", easing: Easing.sin },
+      { title: "Exp", easing: Easing.exp }
+    ]
+  },
+  {
+    title: "Combinations",
+    data: [
+      {
+        title: "In + Bounce",
+        easing: Easing.in(Easing.bounce)
+      },
+      {
+        title: "Out + Exp",
+        easing: Easing.out(Easing.exp)
+      },
+      {
+        title: "InOut + Elastic",
+        easing: Easing.inOut(Easing.elastic(1))
+      }
+    ]
+  }
+];
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#20232a"
+  },
+  title: {
+    lineHeight: 32,
+    textAlign: "center",
+    color: "#61dafb"
+  },
+  boxContainer: {
+    height: 160,
+    alignItems: "center"
+  },
+  box: {
+    marginTop: 30,
+    borderRadius: 4,
+    backgroundColor: "#61dafb"
+  },
+  list: {
+    backgroundColor: "#fff"
+  },
+  listHeader: {
+    height: 24,
+    lineHeight: 24,
+    paddingHorizontal: 8,
+    backgroundColor: "#f4f4f4",
+    textTransform: "uppercase"
+  },
+  button: {
+    marginHorizontal: 4,
+    marginVertical: 2
+  }
+});
+```
+
 ---
 
 # Reference
@@ -214,7 +359,7 @@ A useful tool to visualize cubic bezier curves can be found at http://cubic-bezi
 ### `in()`
 
 ```jsx
-static in(easing);
+static in easing;
 ```
 
 Runs an easing function forwards.


### PR DESCRIPTION
Refs #1579.

This PR adds Snack example to the Easing page. I was trying not to overcomplicate this example but at the same time make it meaningful, hope I have achieved that. I'm open to any suggestions or corrections.

@rachelnabors Also this example has not a perfect UX on the `web` due to the way in which Scroll/Flat/Section Lists components has been implemented there, but is working. Please let me know if you want to disable this platform.