### PR TITLE
add Snack example to PixelRatio page

### DIFF
--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -27,6 +27,51 @@ We have to be careful when to do this rounding. You never want to work with roun
 
 In React Native, everything in JavaScript and within the layout engine works with arbitrary precision numbers. It's only when we set the position and dimensions of the native element on the main thread that we round. Also, rounding is done relative to the root rather than the parent, again to avoid accumulating rounding errors.
 
+### Example
+
+```SnackPlayer name=PixelRatio%20Example
+import React from "react";
+import { PixelRatio, StyleSheet, Text, TextInput, View } from "react-native";
+
+export default App = () => {
+  const size = 234;
+  return (
+    <View style={styles.container}>
+      <Text>Current Pixel Ratio is:</Text>
+      <Text style={styles.value}>
+        {PixelRatio.get()}
+      </Text>
+      <Text>Current Font Scale is:</Text>
+      <Text style={styles.value}>
+        {PixelRatio.getFontScale()}
+      </Text>
+      <br />
+      <Text>On this device image in size of:</Text>
+      <Text style={styles.value}>
+        {size} px
+      </Text>
+      <Text>Will be rendered as:</Text>
+      <Text style={styles.value}>
+        {PixelRatio.getPixelSizeForLayoutSize(size)} px
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  value: {
+    fontSize: 24,
+    marginBottom: 12,
+    marginTop: 4
+  }
+});
+```
+
 ---
 
 # Reference

--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -33,42 +33,43 @@ In React Native, everything in JavaScript and within the layout engine works wit
 import React from "react";
 import { Image, PixelRatio, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 
-export default App = () => {
-  const length = 50;
-  return (
-    <ScrollView style={styles.scrollContainer}>
-      <View style={styles.container}>
-        <Text>Current Pixel Ratio is:</Text>
-        <Text style={styles.value}>{PixelRatio.get()}</Text>
-      </View>
-      <View style={styles.container}>
-        <Text>Current Font Scale is:</Text>
-        <Text style={styles.value}>{PixelRatio.getFontScale()}</Text>
-      </View>
-      <View style={styles.container}>      
-        <Text>On this device images with a layout width of</Text>
-      <Text style={styles.value}>{length} px</Text>
-      <Image
-        source={{ uri: "https://reactnative.dev/docs/assets/p_cat1.png" }}
-        style={{ width: length, height: length }}
-      />
-      </View>
-      <View style={styles.container}>      
-        <Text>require images with a pixel width of</Text>
-        <Text style={styles.value}>
-          {PixelRatio.getPixelSizeForLayoutSize(length)} px
-        </Text>
-        <Image
-          source={{ uri: "https://reactnative.dev/docs/assets/p_cat1.png" }}
-          style={{
-            width: PixelRatio.getPixelSizeForLayoutSize(length),
-            height: PixelRatio.getPixelSizeForLayoutSize(length)
-          }}
-        />
-      </View>
-    </ScrollView>
-  );
+const size = 50;
+const cat = {
+  uri: "https://reactnative.dev/docs/assets/p_cat1.png",
+  width: size,
+  height: size
 };
+
+export default App = () => (
+  <ScrollView style={styles.scrollContainer}>
+    <View style={styles.container}>
+      <Text>Current Pixel Ratio is:</Text>
+      <Text style={styles.value}>{PixelRatio.get()}</Text>
+    </View>
+    <View style={styles.container}>
+      <Text>Current Font Scale is:</Text>
+      <Text style={styles.value}>{PixelRatio.getFontScale()}</Text>
+    </View>
+    <View style={styles.container}>
+      <Text>On this device images with a layout width of</Text>
+      <Text style={styles.value}>{size} px</Text>
+      <Image source={cat} />
+    </View>
+    <View style={styles.container}>
+      <Text>require images with a pixel width of</Text>
+      <Text style={styles.value}>
+        {PixelRatio.getPixelSizeForLayoutSize(size)} px
+      </Text>
+      <Image
+        source={cat}
+        style={{
+          width: PixelRatio.getPixelSizeForLayoutSize(size),
+          height: PixelRatio.getPixelSizeForLayoutSize(size)
+        }}
+      />
+    </View>
+  </ScrollView>
+);
 
 const styles = StyleSheet.create({
   scrollContainer: {

--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -3,7 +3,7 @@ id: pixelratio
 title: PixelRatio
 ---
 
-`PixelRatio` gives you access to the device's pixel density and fontScales.
+`PixelRatio` gives you access to the device's pixel density and font scale.
 
 ## Fetching a correctly sized image
 
@@ -103,22 +103,22 @@ static get()
 
 Returns the device pixel density. Some examples:
 
-- PixelRatio.get() === 1
+- `PixelRatio.get() === 1`
   - [mdpi Android devices](https://material.io/tools/devices/)
-- PixelRatio.get() === 1.5
+- `PixelRatio.get() === 1.5`
   - [hdpi Android devices](https://material.io/tools/devices/)
-- PixelRatio.get() === 2
-  - iPhone 4, 4S
-  - iPhone 5, 5C, 5S
-  - iPhone 6, 7, 8
+- `PixelRatio.get() === 2`
+  - iPhone SE, 6S, 7, 8
   - iPhone XR
+  - iPhone 11
   - [xhdpi Android devices](https://material.io/tools/devices/)
-- PixelRatio.get() === 3
-  - iPhone 6 Plus, 7 Plus, 8 Plus
+- `PixelRatio.get() === 3`
+  - iPhone 6S Plus, 7 Plus, 8 Plus
   - iPhone X, XS, XS Max
+  - iPhone 11 Pro, 11 Pro Max
   - Pixel, Pixel 2
   - [xxhdpi Android devices](https://material.io/tools/devices/)
-- PixelRatio.get() === 3.5
+- `PixelRatio.get() === 3.5`
   - Nexus 6
   - Pixel XL, Pixel 2 XL
   - [xxxhdpi Android devices](https://material.io/tools/devices/)
@@ -128,21 +128,22 @@ Returns the device pixel density. Some examples:
 ### `getFontScale()`
 
 ```jsx
-static getFontScale()
+static getFontScale(): number
 ```
 
 Returns the scaling factor for font sizes. This is the ratio that is used to calculate the absolute font size, so any elements that heavily depend on that should use this to do calculations.
 
-If a font scale is not set, this returns the device pixel ratio.
+* on Android value reflects the user preference set in Settings > Display > Font size, 
+* on iOS it will always return the default pixel ratio.
 
-Currently this is only implemented on Android and reflects the user preference set in Settings > Display > Font size, on iOS it will always return the default pixel ratio. @platform android
+If a font scale is not set, this returns the device pixel ratio.
 
 ---
 
 ### `getPixelSizeForLayoutSize()`
 
 ```jsx
-static getPixelSizeForLayoutSize(layoutSize)
+static getPixelSizeForLayoutSize(layoutSize: number): number
 ```
 
 Converts a layout size (dp) to pixel size (px).
@@ -154,7 +155,7 @@ Guaranteed to return an integer number.
 ### `roundToNearestPixel()`
 
 ```jsx
-static roundToNearestPixel(layoutSize)
+static roundToNearestPixel(layoutSize: number): number
 ```
 
 Rounds a layout size (dp) to the nearest layout size that corresponds to an integer number of pixels. For example, on a device with a PixelRatio of 3, `PixelRatio.roundToNearestPixel(8.4) = 8.33`, which corresponds to exactly (8.33 \* 3) = 25 pixels.

--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -3,7 +3,7 @@ id: pixelratio
 title: PixelRatio
 ---
 
-PixelRatio class gives access to the device pixel density.
+`PixelRatio` gives you access to the device's pixel density and fontScales.
 
 ## Fetching a correctly sized image
 
@@ -31,36 +31,52 @@ In React Native, everything in JavaScript and within the layout engine works wit
 
 ```SnackPlayer name=PixelRatio%20Example
 import React from "react";
-import { PixelRatio, StyleSheet, Text, TextInput, View } from "react-native";
+import { Image, PixelRatio, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 
 export default App = () => {
-  const size = 234;
+  const length = 50;
   return (
-    <View style={styles.container}>
-      <Text>Current Pixel Ratio is:</Text>
-      <Text style={styles.value}>
-        {PixelRatio.get()}
-      </Text>
-      <Text>Current Font Scale is:</Text>
-      <Text style={styles.value}>
-        {PixelRatio.getFontScale()}
-      </Text>
-      <br />
-      <Text>On this device image in size of:</Text>
-      <Text style={styles.value}>
-        {size} px
-      </Text>
-      <Text>Will be rendered as:</Text>
-      <Text style={styles.value}>
-        {PixelRatio.getPixelSizeForLayoutSize(size)} px
-      </Text>
-    </View>
+    <ScrollView style={styles.scrollContainer}>
+      <View style={styles.container}>
+        <Text>Current Pixel Ratio is:</Text>
+        <Text style={styles.value}>{PixelRatio.get()}</Text>
+      </View>
+      <View style={styles.container}>
+        <Text>Current Font Scale is:</Text>
+        <Text style={styles.value}>{PixelRatio.getFontScale()}</Text>
+      </View>
+      <View style={styles.container}>      
+        <Text>On this device images with a layout width of</Text>
+      <Text style={styles.value}>{length} px</Text>
+      <Image
+        source={{ uri: "https://reactnative.dev/docs/assets/p_cat1.png" }}
+        style={{ width: length, height: length }}
+      />
+      </View>
+      <View style={styles.container}>      
+        <Text>require images with a pixel width of</Text>
+        <Text style={styles.value}>
+          {PixelRatio.getPixelSizeForLayoutSize(length)} px
+        </Text>
+        <Image
+          source={{ uri: "https://reactnative.dev/docs/assets/p_cat1.png" }}
+          style={{
+            width: PixelRatio.getPixelSizeForLayoutSize(length),
+            height: PixelRatio.getPixelSizeForLayoutSize(length)
+          }}
+        />
+      </View>
+    </ScrollView>
   );
 };
 
 const styles = StyleSheet.create({
+  scrollContainer: {
+    flext: 1,
+    marginTop: "2em",
+    justifyContent: "center",
+  },
   container: {
-    flex: 1,
     justifyContent: "center",
     alignItems: "center"
   },


### PR DESCRIPTION
Refs #1579.

This PR adds Snack example to the Pixel Ratio page.  This example is very simple and I have deliberate chosen text representation for the image/resource size calculation, mainly for the clarity what this API can do and which information it provides. But the phrasing might be the first thing to tweak here ; )

Preview:
<img width="320" alt="Screenshot 2020-03-01 at 20 50 10" src="https://user-images.githubusercontent.com/719641/75632634-4ecb7980-5bfe-11ea-8e1a-e1b488daf9db.png">
