### PR TITLE
update TouchableOpacity page

### DIFF
--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -220,7 +220,7 @@ TV next focus up (see documentation for the View component).
 
 | Type | Required | Platform |
 | ---- | -------- | -------- |
-| bool | No       | iOS      |
+| bool | No       | Android  |
 
 ## Methods
 

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -5,22 +5,7 @@ title: TouchableOpacity
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 
-Opacity is controlled by wrapping the children in an Animated.View, which is added to the view hierarchy. Be aware that this can affect layout.
-
-Example:
-
-```jsx
-renderButton: function() {
-  return (
-    <TouchableOpacity onPress={this._onPressButton}>
-      <Image
-        style={styles.button}
-        source={require('./myButton.png')}
-      />
-    </TouchableOpacity>
-  );
-},
-```
+Opacity is controlled by wrapping the children in an `Animated.View`, which is added to the view hierarchy. Be aware that this can affect layout.
 
 ### Example
 
@@ -37,105 +22,99 @@ renderButton: function() {
 
 <block class="functional syntax" />
 
-```SnackPlayer name=Function%20Component%20Example%20TouchableOpacity
-import React, { useState } from 'react';
-import { StyleSheet, TouchableOpacity, Text, View } from 'react-native';
+```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example
+import React, { useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
-export default function App() {
+export default App = () => {
   const [count, setCount] = useState(0);
-  const handleIncrementCount = () => setCount(prevState => prevState + 1);
+  const onPress = () => setCount(prevCount => prevCount + 1);
 
   return (
     <View style={styles.container}>
       <View style={styles.countContainer}>
         <Text>Count: {count}</Text>
       </View>
-      <TouchableOpacity style={styles.button} onPress={handleIncrementCount}>
-        <Text>Touch Here</Text>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={onPress}
+      >
+        <Text>Press Here</Text>
       </TouchableOpacity>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 10,
+    justifyContent: "center",
+    paddingHorizontal: 10
   },
   button: {
-    alignItems: 'center',
-    backgroundColor: '#DDDDDD',
-    padding: 10,
+    alignItems: "center",
+    backgroundColor: "#DDDDDD",
+    padding: 10
   },
   countContainer: {
-    alignItems: 'center',
-    padding: 10,
-  },
+    alignItems: "center",
+    padding: 10
+  }
 });
 ```
 
 <block class="classical syntax" />
 
-```SnackPlayer name=Class%20Component%20Example
-import React, { Component } from 'react'
-import {
-  StyleSheet,
-  TouchableOpacity,
-  Text,
-  View,
-} from 'react-native'
+```SnackPlayer name=TouchableOpacity%20Class%20Component%20Example
+import React, { Component } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 export default class App extends Component {
   constructor(props) {
-    super(props)
-    this.state = { count: 0 }
+    super(props);
+    this.state = { count: 0 };
   }
 
   onPress = () => {
     this.setState({
-      count: this.state.count+1
-    })
-  }
+      count: this.state.count + 1
+    });
+  };
 
- render() {
-   return (
-     <View style={styles.container}>
-       <TouchableOpacity
-         style={styles.button}
-         onPress={this.onPress}
-       >
-         <Text> Touch Here </Text>
-       </TouchableOpacity>
-       <View style={[styles.countContainer]}>
-         <Text style={[styles.countText]}>
-            { this.state.count !== 0 ? this.state.count: null}
-          </Text>
+  render() {
+    const { count } = this.state;
+    return (
+      <View style={styles.container}>
+        <View style={styles.countContainer}>
+          <Text>Count: {count}</Text>
         </View>
+        <TouchableOpacity 
+          style={styles.button}
+          onPress={this.onPress}
+        >
+          <Text>Press Here</Text>
+        </TouchableOpacity>
       </View>
-    )
+    );
   }
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: "center",
     paddingHorizontal: 10
   },
   button: {
-    alignItems: 'center',
-    backgroundColor: '#DDDDDD',
+    alignItems: "center",
+    backgroundColor: "#DDDDDD",
     padding: 10
   },
   countContainer: {
-    alignItems: 'center',
+    alignItems: "center",
     padding: 10
-  },
-  countText: {
-    color: '#FF00FF'
   }
-})
+});
 ```
 <block class="endBlock syntax" />
 
@@ -157,7 +136,7 @@ Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
 
 ### `activeOpacity`
 
-Determines what the opacity of the wrapped view should be when touch is active. Defaults to 0.2.
+Determines what the opacity of the wrapped view should be when touch is active. Defaults to `0.2`.
 
 | Type   | Required |
 | ------ | -------- |
@@ -169,7 +148,14 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 _(Apple TV only)_ Object with properties to control Apple TV parallax effects.
 
-enabled: If true, parallax effects are enabled. Defaults to true. shiftDistanceX: Defaults to 2.0. shiftDistanceY: Defaults to 2.0. tiltAngle: Defaults to 0.05. magnification: Defaults to 1.0. pressMagnification: Defaults to 1.0. pressDuration: Defaults to 0.3. pressDelay: Defaults to 0.0.
+* `enabled`: If true, parallax effects are enabled. Defaults to `true`. 
+* `shiftDistanceX`: Defaults to `2.0`. 
+* `shiftDistanceY`: Defaults to `2.0`. 
+* `tiltAngle`: Defaults to `0.05`. 
+* `magnification`: Defaults to `1.0`. 
+* `pressMagnification`: Defaults to `1.0`. 
+* `pressDuration`: Defaults to `0.3`. 
+* `pressDelay`: Defaults to `0.0`.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -88,7 +88,7 @@ export default class App extends Component {
         <View style={styles.countContainer}>
           <Text>Count: {count}</Text>
         </View>
-        <TouchableOpacity 
+        <TouchableOpacity
           style={styles.button}
           onPress={this.onPress}
         >
@@ -116,6 +116,7 @@ const styles = StyleSheet.create({
   }
 });
 ```
+
 <block class="endBlock syntax" />
 
 ---
@@ -148,14 +149,14 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 _(Apple TV only)_ Object with properties to control Apple TV parallax effects.
 
-* `enabled`: If true, parallax effects are enabled. Defaults to `true`. 
-* `shiftDistanceX`: Defaults to `2.0`. 
-* `shiftDistanceY`: Defaults to `2.0`. 
-* `tiltAngle`: Defaults to `0.05`. 
-* `magnification`: Defaults to `1.0`. 
-* `pressMagnification`: Defaults to `1.0`. 
-* `pressDuration`: Defaults to `0.3`. 
-* `pressDelay`: Defaults to `0.0`.
+- `enabled`: If `true`, parallax effects are enabled. Defaults to `true`.
+- `shiftDistanceX`: Defaults to `2.0`.
+- `shiftDistanceY`: Defaults to `2.0`.
+- `tiltAngle`: Defaults to `0.05`.
+- `magnification`: Defaults to `1.0`.
+- `pressMagnification`: Defaults to `1.0`.
+- `pressDuration`: Defaults to `0.3`.
+- `pressDelay`: Defaults to `0.0`.
 
 | Type   | Required | Platform |
 | ------ | -------- | -------- |

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -7,7 +7,7 @@ A wrapper for making views respond properly to touches. On press down, the opaci
 
 Opacity is controlled by wrapping the children in an `Animated.View`, which is added to the view hierarchy. Be aware that this can affect layout.
 
-### Example
+## Example
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">


### PR DESCRIPTION
Refs: #1579

This PR introduce few small changes to the TouchableOpacity page:
* old example removed
* examples code unified based on Functional Component
* example names updated
* Prettier run on examples
* adjusted formatting in Reference

Nothing major as seen above, just an overall cleanup.