### PR TITLE
fix link to 'useWindowDimensions' on the Dimensions page

### DIFF
--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](useWindowDimensions) is the preffered API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions) is the preffered API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```jsx
 import {Dimensions} from 'react-native';


### PR DESCRIPTION
Refs #1676.

Link used in notice to `useWindowDimensions` on the Dimensions page is incorrect (only on the `next` branch of docs). This is just a simple fix for this 404, problematic page:
* https://reactnative.dev/docs/next/dimensions 