### PR TITLE
Warn about using uppercase color names

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -35,6 +35,8 @@ This is a shortcut for `rgba(0,0,0,0)`:
 
 You can also use color names as values. React Native follows the [CSS3 specification](http://www.w3.org/TR/css3-color/#svg-color):
 
+> Beware that React Native only supports lowercase color names. Uppercase color names are not supported.
+
 <!-- alex disable black white -->
 
 - ![#f0f8ff](https://placehold.it/15/f0f8ff/000000?text=+) <color aliceblue /> aliceblue (#f0f8ff)


### PR DESCRIPTION
RN doesn't support uppercase named colors. Add to the doc, so web developers, can know the difference and prevent unexpected behaviour.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
