### PR TITLE
design: update 'onPageNav' style to mimic sidebar UI

### DIFF
--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -177,6 +177,10 @@ figcaption {
   color: #000;
 }
 
+.onPageNav a code {
+  padding: 0;
+}
+
 .onPageNav ul ul {
   padding: 8px 0 0 16px;
 }

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -163,3 +163,26 @@ figure {
 figcaption {
   margin: 1em 0 0 0;
 }
+
+/* Right side navigation */
+
+.onPageNav a,
+.onPageNav a:hover {
+  display: block;
+  background: none;
+  border-bottom: 0;
+}
+
+.onPageNav a:hover {
+  color: #000;
+}
+
+.onPageNav ul ul {
+  padding: 8px 0 0 16px;
+}
+
+.onPageNav .toc-headings > li > a.active {
+  border-left: 4px solid #61dafb;
+  margin-left: -15px;
+  padding-left: 11px;
+}


### PR DESCRIPTION
This small PR introduces design tweak to the `onPageNav` component (right sidebar). My goal  here was to mimic main sidebar design and improve readability. Preview demonstrate page scrolling with nested child and then hover effect and click.

* [Page used for the preview](https://reactnative.dev/docs/next/native-modules-ios)

### Preview
![Mar-05-2020 12-03-12](https://user-images.githubusercontent.com/719641/75975748-5f6b4080-5ed9-11ea-952e-9c7ae4af9232.gif)
