### PR TITLE
update the headers for the better navigation and consistency

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -5,7 +5,7 @@ title: AccessibilityInfo
 
 Sometimes it's useful to know whether or not the device has a screen reader that is currently active. The `AccessibilityInfo` API is designed for this purpose. You can use it to query the current state of the screen reader as well as to register to be notified when the state of the screen reader changes.
 
-Here's a small example illustrating how to use `AccessibilityInfo`:
+## Example
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">

--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -5,7 +5,7 @@ title: ActionSheetIOS
 
 Displays native to iOS [Action Sheet](https://developer.apple.com/design/human-interface-guidelines/ios/views/action-sheets/) component.
 
-### Example
+## Example
 
 ```SnackPlayer name=ActionSheetIOS&supportedPlatforms=ios
 import React, { useState } from "react";

--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -5,7 +5,7 @@ title: ActivityIndicator
 
 Displays a circular loading indicator.
 
-### Example
+## Example
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -18,7 +18,7 @@ AppState is frequently used to determine the intent and proper behavior when han
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)
 
-### Basic Usage
+## Basic Usage
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 

--- a/docs/button.md
+++ b/docs/button.md
@@ -16,7 +16,7 @@ If this button doesn't look right for your app, you can build your own button us
 />
 ```
 
-### Example
+## Example
 
 ```SnackPlayer name=Buttons
 import React from 'react';

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -20,7 +20,7 @@ const windowHeight = Dimensions.get('window').height;
 
 If you are targeting foldable devices or devices which can change the screen size or app window size, you can use the event listener available in the Dimensions module as shown in the below example.
 
-### Example
+## Example
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">

--- a/docs/drawerlayoutandroid.md
+++ b/docs/drawerlayoutandroid.md
@@ -5,7 +5,7 @@ title: DrawerLayoutAndroid
 
 React component that wraps the platform `DrawerLayout` (Android only). The Drawer (typically used for navigation) is rendered with `renderNavigationView` and direct children are the main view (where your content goes). The navigation view is initially not visible on the screen, but can be pulled in from the side of the window specified by the `drawerPosition` prop and its width can be set by the `drawerWidth` prop.
 
-Example:
+## Example
 
 ```SnackPlayer name=DrawerLayoutAndroid%20Component%20Example&supportedPlatforms=android
 import React, { useState } from "react";

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -41,7 +41,7 @@ The following helpers are used to modify other easing functions.
 - [`inOut`](easing.md#inout) makes any easing function symmetrical
 - [`out`](easing.md#out) runs an easing function backwards
 
-### Example
+## Example
 
 ```SnackPlayer name=Easing%20Demo
 import React from "react";

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -18,7 +18,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 
 If you need section support, use [`<SectionList>`](sectionlist.md).
 
-### Basic Example:
+## Example
 
 ```SnackPlayer name=flatlist-simple
 import React from 'react';

--- a/docs/image.md
+++ b/docs/image.md
@@ -9,6 +9,8 @@ This example shows fetching and displaying an image from local storage as well a
 
 > Note that for network and data images, you will need to manually specify the dimensions of your image!
 
+## Examples
+
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">
     <li id="functional" class="button-functional" aria-selected="false" role="tab" tabindex="0" aria-controls="functionaltab" onclick="displayTabs('syntax', 'functional')">
@@ -191,7 +193,7 @@ export default class DisplayAnImageWithStyle extends Component {
 
 <block class="endBlock syntax" />
 
-### GIF and WebP support on Android
+## GIF and WebP support on Android
 
 When building your own native code, GIF and WebP are not supported by default on Android.
 

--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -5,7 +5,7 @@ title: KeyboardAvoidingView
 
 It is a component to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust either its height, position, or bottom padding based on the position of the keyboard.
 
-### Example usage
+## Example
 
 ```SnackPlayer name=KeyboardAvoidingView&supportedPlatforms=android,ios
 import React, { Component } from 'react';

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -5,7 +5,7 @@ title: Modal
 
 The Modal component is a basic way to present content above an enclosing view.
 
-### Example
+## Example
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -3,7 +3,9 @@ id: picker
 title: Picker
 ---
 
-Renders the native picker component on Android and iOS. Example:
+Renders the native picker component on Android and iOS. 
+
+## Example
 
 ```SnackPlayer name=picker
 import React, { useState } from "react";

--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -27,7 +27,7 @@ We have to be careful when to do this rounding. You never want to work with roun
 
 In React Native, everything in JavaScript and within the layout engine works with arbitrary precision numbers. It's only when we set the position and dimensions of the native element on the main thread that we round. Also, rounding is done relative to the root rather than the parent, again to avoid accumulating rounding errors.
 
-### Example
+## Example
 
 ```SnackPlayer name=PixelRatio%20Example
 import React from "react";

--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -5,7 +5,7 @@ title: RefreshControl
 
 This component is used inside a ScrollView or ListView to add pull to refresh functionality. When the ScrollView is at `scrollY: 0`, swiping down triggers an `onRefresh` event.
 
-### Example
+## Example
 
 ```SnackPlayer name=RefreshControl&supportedPlatforms=ios,android
 import React from 'react';

--- a/docs/safeareaview.md
+++ b/docs/safeareaview.md
@@ -7,7 +7,7 @@ The purpose of `SafeAreaView` is to render content within the safe area boundari
 
 `SafeAreaView` renders nested content and automatically applies padding to reflect the portion of the view that is not covered by navigation bars, tab bars, toolbars, and other ancestor views. Moreover, and most importantly, Safe Area's paddings reflect the physical limitation of the screen, such as rounded corners or camera notches (i.e. the sensor housing area on iPhone X).
 
-### Usage Example
+## Example
 
 To use, wrap your top level view with a `SafeAreaView` with a `flex: 1` style applied to it. You may also want to use a background color that matches your application's design.
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -19,7 +19,7 @@ This is where `FlatList` comes into play. `FlatList` renders items lazily, when 
 
 `FlatList` is also handy if you want to render separators between your items, multiple columns, infinite scroll loading, or any number of other features it supports out of the box.
 
-### Example
+## Example
 
 ```SnackPlayer name=ScrollView
 import React from 'react';

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -18,7 +18,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 
 If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
 
-### Example
+## Example
 
 ```SnackPlayer name=SectionList
 import React from 'react';
@@ -101,52 +101,13 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 - In order to constrain memory and enable smooth scrolling, content is rendered asynchronously offscreen. This means it's possible to scroll faster than the fill rate and momentarily see blank content. This is a tradeoff that can be adjusted to suit the needs of each application, and we are working on improving it behind the scenes.
 - By default, the list looks for a `key` prop on each item and uses that for the React key. Alternatively, you can provide a custom `keyExtractor` prop.
 
-### Props
-
-- [`ScrollView` props...](scrollview.md#props)
-
-Required props:
-
-- [`renderItem`](sectionlist.md#renderitem)
-- [`sections`](sectionlist.md#sections)
-
-Optional props:
-
-- [`extraData`](sectionlist.md#extradata)
-- [`initialNumToRender`](sectionlist.md#initialnumtorender)
-- [`inverted`](sectionlist.md#inverted)
-- [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent)
-- [`keyExtractor`](sectionlist.md#keyextractor)
-- [`legacyImplementation`](sectionlist.md#legacyimplementation)
-- [`ListEmptyComponent`](sectionlist.md#listemptycomponent)
-- [`ListFooterComponent`](sectionlist.md#listfootercomponent)
-- [`ListHeaderComponent`](sectionlist.md#listheadercomponent)
-- [`onEndReached`](sectionlist.md#onendreached)
-- [`onEndReachedThreshold`](sectionlist.md#onendreachedthreshold)
-- [`onRefresh`](sectionlist.md#onrefresh)
-- [`onViewableItemsChanged`](sectionlist.md#onviewableitemschanged)
-- [`refreshing`](sectionlist.md#refreshing)
-- [`removeClippedSubviews`](sectionlist.md#removeclippedsubviews)
-- [`renderSectionFooter`](sectionlist.md#rendersectionfooter)
-- [`renderSectionHeader`](sectionlist.md#rendersectionheader)
-- [`SectionSeparatorComponent`](sectionlist.md#sectionseparatorcomponent)
-- [`stickySectionHeadersEnabled`](sectionlist.md#stickysectionheadersenabled)
-
-### Methods
-
-- [`flashScrollIndicators`](sectionlist.md#flashscrollindicators)
-- [`recordInteraction`](sectionlist.md#recordinteraction)
-- [`scrollToLocation`](sectionlist.md#scrolltolocation)
-
-### Type Definitions
-
-- [`Section`](sectionlist.md#section)
-
 ---
 
 # Reference
 
 ## Props
+
+Inherits [ScrollView Props](scrollview.md#props).
 
 ### `renderItem`
 

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -7,6 +7,8 @@ Renders a boolean input.
 
 This is a controlled component that requires an `onValueChange` callback that updates the `value` prop in order for the component to reflect user actions. If the `value` prop is not updated, the component will continue to render the supplied `value` prop instead of the expected result of any user actions.
 
+## Example
+
 ```SnackPlayer name=Switch
 import React, { useState } from "react";
 import { View, Switch, StyleSheet } from "react-native";

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -26,7 +26,7 @@ function MyComponent(props) {
 </TouchableHighlight>
 ```
 
-### Example
+## Example
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">
@@ -141,23 +141,6 @@ const styles = StyleSheet.create({
 });
 ```
 <block class="endBlock syntax" />
-
-### Props
-
-- [TouchableWithoutFeedback props...](touchablewithoutfeedback.md#props)
-
-* [`activeOpacity`](touchablehighlight.md#activeopacity)
-* [`onHideUnderlay`](touchablehighlight.md#onhideunderlay)
-* [`onShowUnderlay`](touchablehighlight.md#onshowunderlay)
-* [`style`](touchablehighlight.md#style)
-* [`underlayColor`](touchablehighlight.md#underlaycolor)
-* [`hasTVPreferredFocus`](touchablehighlight.md#hastvpreferredfocus)
-* [`nextFocusDown`](touchablehighlight.md#nextFocusDown)
-* [`nextFocusForward`](touchablehighlight.md#nextFocusForward)
-* [`nextFocusLeft`](touchablehighlight.md#nextFocusLeft)
-* [`nextFocusRight`](touchablehighlight.md#nextFocusRight)
-* [`nextFocusUp`](touchablehighlight.md#nextFocusUp)
-* [`testOnly_pressed`](touchablehighlight.md#testOnly_pressed)
 
 ---
 

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -9,7 +9,7 @@ At the moment it only supports having a single View instance as a child node, as
 
 Background drawable of native feedback touchable can be customized with `background` property.
 
-Example:
+## Example
 
 ```SnackPlayer name=TouchableNativeFeedback%20Android%20Component%20Example&supportedPlatforms=android
 import React, { useState } from "react";

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -7,9 +7,7 @@ Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<S
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
----
-
-### Example usage
+## Example
 
 ```SnackPlayer name=VirtualizedListExample
 import React from 'react';


### PR DESCRIPTION
This PR focuses on updating the headers of several pages for better navigation (adjusting headers affects right sidebar content) and for the better consistency between documentation pages.

I have also removed in-content props/method link lists on the `SectionList` and `TouchableHighlight` pages. This was useful before, but currently it duplicates the function of the right sidebar.