### PR TITLE
Update FlatList removeClippedSubviews default props documentation

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -498,7 +498,7 @@ Set this true while waiting for new data from a refresh.
 
 ### `removeClippedSubviews`
 
-This may improve scroll performance for large lists.
+This may improve scroll performance for large lists. On Android the default value is true
 
 > Note: May have bugs (missing content) in some circumstances - use at your own risk.
 


### PR DESCRIPTION
https://github.com/facebook/react-native-website/issues/1579

After some digging i found that in FlatList since this commit facebook/react-native@1a499f4 the default value of `removeClippedSubviews` on Android is true. Because there is a mismatch between the docs and the actual implementation i think that the docs should be updated with the correct behaviour.

Referencing related issue https://github.com/facebook/react-native-website/issues/1648 