### PR TITLE
Fix "Showcase" link under "More Resources"

### DIFF
--- a/docs/more-resources.md
+++ b/docs/more-resources.md
@@ -32,7 +32,7 @@ We recommend using the [VS Code](https://code.visualstudio.com/) code editor and
 
 ## Example Apps
 
-Try out apps from the [Showcase](/showcase/) to see what React Native is capable of! Looking for something more hands on? Check out this [set of example apps on GitHub](https://github.com/ReactNativeNews/React-Native-Apps). You can look at their source code—try running one on a simulator or device.
+Try out apps from the [Showcase](https://reactnative.dev/showcase) to see what React Native is capable of! Looking for something more hands on? Check out this [set of example apps on GitHub](https://github.com/ReactNativeNews/React-Native-Apps). You can look at their source code—try running one on a simulator or device.
 
 ## Find, make, and share your own Native Components and Modules
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
The **Showcase** link under https://reactnative.dev/docs/more-resources#examples is currently pointing to https://reactnative.dev/docs/showcase/, which results in a 404 Not Found.

This change points it to the correct one under https://reactnative.dev/showcase.