### PR TITLE
docs: fix template

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -389,8 +389,10 @@ npx react-native init AwesomeProject --version X.XX.X
 You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
 
 ```sh
-npx react-native init AwesomeTSProject --template typescript
+npx react-native init AwesomeTSProject --template react-native-template-typescript
 ```
+
+> **Note** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your pc. Try uninstalling the cli and run the cli using `npx`.
 
 <block class="native mac windows linux android" />
 
@@ -417,7 +419,7 @@ npx react-native init AwesomeProject --version X.XX.X
 You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
 
 ```sh
-npx react-native init AwesomeTSProject --template typescript
+npx react-native init AwesomeTSProject --template react-native-template-typescript
 ```
 
 <block class="native mac windows linux android" />

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -10,8 +10,10 @@ title: Using TypeScript with React Native
 If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
 
 ```sh
-npx react-native init MyApp --template typescript
+npx react-native init MyApp --template react-native-template-typescript
 ```
+
+> **Note** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your pc. Try uninstalling the cli and run the cli using `npx`.
 
 You can use [Expo][expo] which has two TypeScript templates:
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Fixed the usage of the typescript template and added a note.

This change has been going back and forth in the document, and I can understand why it can be confusing, since the behavior changes depending on which version of the cli they're using.

In `react-native-cli` version 2 and older (and the globally installed `react-native` before the cli got its own repository), the cli required you to get rid of the prefix `react-native-template-`, but starting from version 3 of the `react-native-cli` the behavior changed to type the whole template name.