### PR TITLE
hermes: Fix ProGuard rules for 0.62.0

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -27,10 +27,11 @@ Edit your `android/app/build.gradle` file and make the change illustrated below:
   ]
 ```
 
-Also, if you're using ProGuard, you will need to add this rule in `proguard-rules.pro` :
+Also, if you're using ProGuard, you will need to add these rules in `proguard-rules.pro` :
 
 ```
 -keep class com.facebook.hermes.unicode.** { *; }
+-keep class com.facebook.jni.** { *; }
 ```
 
 Next, if you've already built your app at least once, clean the build:


### PR DESCRIPTION
In 0.62.0 another ProGuard rule is required for the build to work

Related to https://github.com/facebook/react-native/issues/28270.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
