### PR TITLE
Fix `useWindowDimensions` page link

### DIFF
--- a/website/versioned_docs/version-0.61/dimensions.md
+++ b/website/versioned_docs/version-0.61/dimensions.md
@@ -4,7 +4,7 @@ title: Dimensions
 original_id: dimensions
 ---
 
-> [`useWindowDimensions`](useWindowDimensions) is the preffered API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions) is the preffered API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```jsx
 import {Dimensions} from 'react-native';


### PR DESCRIPTION
Small PR to fix the `useWindowDimensions` page link in the `Dimensions` documentation.