### PR TITLE
add missing method to the DevSettings docs

### DIFF
--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -14,13 +14,25 @@ The `DevSettings` module exposes methods for customizing settings for developers
 ### `addMenuItem()`
 
 ```jsx
- addMenuItem(title: string, handler: () => )
+static addMenuItem(title: string, handler: function)
 ```
 
 Add a custom menu item to the developer menu:
 
 ```jsx
-DevSettings.addMenuItem('Show Secret Dev Screen', () => {
-  Alert.alert('Showing secret dev screen!');
+DevSettings.addMenuItem("Show Secret Dev Screen", () => {
+  Alert.alert("Showing secret dev screen!");
 });
+```
+
+### `reload()`
+
+```jsx
+static reload()
+```
+
+Reload the application. Can be invoked directly or on user interaction:
+
+```jsx
+<Button title="Reload" onPress={() => DevSettings.reload()} />
 ```


### PR DESCRIPTION
Refs #1523.

This PR adds basic documentation for the `DevSettings.reload()` method.

Source: [facebook/react-native/Libraries/Utilities/DevSettings.js](https://github.com/facebook/react-native/blob/d0324f693c6ba5cabc92902f801db8c55cf4200a/Libraries/Utilities/DevSettings.js)