### PR TITLE
Adding FlatList getNativeScrollRef() methods

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -686,6 +686,16 @@ Displays the scroll indicators momentarily.
 
 ---
 
+### `getNativeScrollRef()`
+
+```jsx
+getNativeScrollRef();
+```
+
+Provides a reference to the underlying scroll component
+
+---
+
 ### `getScrollResponder()`
 
 ```jsx


### PR DESCRIPTION
#1579

As per this commit https://github.com/facebook/react-native/commit/bde1d63 `FlatList` will get addtional props called `getNativeScrollRef` to get the underlying host component of `FlatList`. 

Because `getNativeScrollRef` will land on `v0.62` i think it's important to add it to the docs.
