### PR TITLE
Update link to origami and yoga

### DIFF
--- a/website/versioned_docs/version-0.43/animated.md
+++ b/website/versioned_docs/version-0.43/animated.md
@@ -187,7 +187,7 @@ Config is an object that may have the following options:
 static spring(value, config)
 ```
 
-Spring animation based on Rebound and [Origami](https://facebook.github.io/origami/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
+Spring animation based on Rebound and [Origami](https://origami.design/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
 
 Config is an object that may have the following options:
 

--- a/website/versioned_docs/version-0.43/layout-props.md
+++ b/website/versioned_docs/version-0.43/layout-props.md
@@ -556,7 +556,7 @@ On iOS, `zIndex` may require `View`s to be siblings of each other for it to work
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.44/animated.md
+++ b/website/versioned_docs/version-0.44/animated.md
@@ -191,7 +191,7 @@ Config is an object that may have the following options:
 static spring(value, config)
 ```
 
-Spring animation based on Rebound and [Origami](https://facebook.github.io/origami/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
+Spring animation based on Rebound and [Origami](https://origami.design/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
 
 Config is an object that may have the following options:
 

--- a/website/versioned_docs/version-0.45/layout-props.md
+++ b/website/versioned_docs/version-0.45/layout-props.md
@@ -556,7 +556,7 @@ On iOS, `zIndex` may require `View`s to be siblings of each other for it to work
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.46/animated.md
+++ b/website/versioned_docs/version-0.46/animated.md
@@ -191,7 +191,7 @@ Config is an object that may have the following options:
 static spring(value, config)
 ```
 
-Spring animation based on Rebound and [Origami](https://facebook.github.io/origami/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
+Spring animation based on Rebound and [Origami](https://origami.design/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
 
 Config is an object that may have the following options. Note that you can only define bounciness/speed or tension/friction but not both:
 

--- a/website/versioned_docs/version-0.46/layout-props.md
+++ b/website/versioned_docs/version-0.46/layout-props.md
@@ -556,7 +556,7 @@ On iOS, `zIndex` may require `View`s to be siblings of each other for it to work
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.47/layout-props.md
+++ b/website/versioned_docs/version-0.47/layout-props.md
@@ -556,7 +556,7 @@ On iOS, `zIndex` may require `View`s to be siblings of each other for it to work
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.48/animated.md
+++ b/website/versioned_docs/version-0.48/animated.md
@@ -191,7 +191,7 @@ Config is an object that may have the following options:
 static spring(value, config)
 ```
 
-Spring animation based on Rebound and [Origami](https://facebook.github.io/origami/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
+Spring animation based on Rebound and [Origami](https://origami.design/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
 
 Config is an object that may have the following options. Note that you can only define bounciness/speed or tension/friction but not both:
 

--- a/website/versioned_docs/version-0.48/layout-props.md
+++ b/website/versioned_docs/version-0.48/layout-props.md
@@ -556,7 +556,7 @@ On iOS, `zIndex` may require `View`s to be siblings of each other for it to work
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.49/animated.md
+++ b/website/versioned_docs/version-0.49/animated.md
@@ -185,7 +185,7 @@ Config is an object that may have the following options:
 static spring(value, config)
 ```
 
-Spring animation based on Rebound and [Origami](https://facebook.github.io/origami/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
+Spring animation based on Rebound and [Origami](https://origami.design/). Tracks velocity state to create fluid motions as the `toValue` updates, and can be chained together.
 
 Config is an object that may have the following options. Note that you can only define bounciness/speed or tension/friction but not both:
 

--- a/website/versioned_docs/version-0.51/layout-props.md
+++ b/website/versioned_docs/version-0.51/layout-props.md
@@ -648,7 +648,7 @@ On iOS, `zIndex` may require `View`s to be siblings of each other for it to work
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.52/layout-props.md
+++ b/website/versioned_docs/version-0.52/layout-props.md
@@ -198,7 +198,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.55/layout-props.md
+++ b/website/versioned_docs/version-0.55/layout-props.md
@@ -198,7 +198,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.56/layout-props.md
+++ b/website/versioned_docs/version-0.56/layout-props.md
@@ -198,7 +198,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.57/layout-props.md
+++ b/website/versioned_docs/version-0.57/layout-props.md
@@ -198,7 +198,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://facebook.github.io/yoga/docs/rtl/ for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction/ for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Fixed some links to `origami` and `yoga` that had old domain.
