### PR TITLE
import missing style in example

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -26,26 +26,27 @@ one team can maintain two platforms and share a common technology—React.
 import React from 'react';
 import {Text, View} from 'react-native';
 import {Header} from './Header';
+import {heading} from './Typography';
 
 const WelcomeScreen = () => 
   <View>
     <Header title="Welcome to React Native"/>
-    <Text style={header}>Step One</Text>
+    <Text style={heading}>Step One</Text>
     <Text>
       Edit App.js to change this screen and turn it
       into your app.
     </Text>
-    <Text style={header}>See Your Changes</Text>
+    <Text style={heading}>See Your Changes</Text>
     <Text>
       Press Cmd + R inside the simulator to reload
       your app’s code.
     </Text>
-    <Text style={header}>Debug</Text>
+    <Text style={heading}>Debug</Text>
     <Text>
       Press Cmd + M or Shake your device to open the
       React Native Debug Menu.
     </Text>
-    <Text style={header}>Learn</Text>
+    <Text style={heading}>Learn</Text>
     <Text>
       Read the docs to discover what to do next:
     </Text>


### PR DESCRIPTION
I looked at the example and felt something was missing and realized `header` was not imported.

Since there was already an `Header` component imported, I felt it might make sense to rename the variable and then import it from something that relates to styling. I went with `./Typography`

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
