### PR TITLE
Update ScrollView docs to reflect that removeClippedSubviews no longer defaults to true

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -504,7 +504,7 @@ See [RefreshControl](refreshcontrol.md).
 
 ### `removeClippedSubviews`
 
-Experimental: When true, offscreen child views (whose `overflow` value is `hidden`) are removed from their native backing superview when offscreen. This can improve scrolling performance on long lists. The default value is true.
+Experimental: When true, offscreen child views (whose `overflow` value is `hidden`) are removed from their native backing superview when offscreen. This can improve scrolling performance on long lists.
 
 | Type | Required |
 | ---- | -------- |


### PR DESCRIPTION
#1579

As I mentioned in #1648, the `ScrollView` docs are out of date, stating that the `removeClippedSubviews` prop defaults to `true`. [This is no longer the case](https://github.com/facebook/react-native/blob/10254a900a2332fc87063d9287da2403abbdf5c3/Libraries/Components/ScrollView/ScrollView.js#L1085).

This PR just removes the out-of-date line from the docs.
