### PR TITLE
Fix broken links

### DIFF
--- a/website/blog/2016-03-24-introducing-hot-reloading.md
+++ b/website/blog/2016-03-24-introducing-hot-reloading.md
@@ -39,7 +39,7 @@ Hot reloading is available as of 0.22, you can enable it:
 
 Now that we've seen why we want it and how to use it, the fun part begins: how it actually works.
 
-Hot Reloading is built on top of a feature [Hot Module Replacement](https://webpack.github.io/hot-module-replacement-with-webpack.md), or HMR. It was first introduced by Webpack and we implemented it inside of React Native Packager. HMR makes the Packager watch for file changes and send HMR updates to a thin HMR runtime included on the app.
+Hot Reloading is built on top of a feature [Hot Module Replacement](https://webpack.js.org/guides/hot-module-replacement/), or HMR. It was first introduced by Webpack and we implemented it inside of React Native Packager. HMR makes the Packager watch for file changes and send HMR updates to a thin HMR runtime included on the app.
 
 In a nutshell, the HMR update contains the new code of the JS modules that changed. When the runtime receives them, it replaces the old modules' code with the new one:
 

--- a/website/blog/2017-06-21-react-native-monthly-1.md
+++ b/website/blog/2017-06-21-react-native-monthly-1.md
@@ -52,7 +52,7 @@ As teams' plans might be of interest to a broader audience, we'll be sharing the
 ### Expo
 
 - Working on making it possible to install npm modules in [Snack](https://snack.expo.io/), will be useful for libraries to add examples to documentation.
-- Working with [Krzysztof](https://github.com/kmagiera) and other people at [Software Mansion](https://github.com/softwaremansion) on a JSC update on Android and a gesture handling library.
+- Working with [Krzysztof](https://github.com/kmagiera) and other people at [Software Mansion](https://github.com/software-mansion) on a JSC update on Android and a gesture handling library.
 - [Adam Miskiewicz](https://github.com/skevy) is transitioning his focus towards [react-navigation](https://github.com/react-community/react-navigation).
 - [Create React Native App](https://github.com/react-community/create-react-native-app) is in the [Getting Started guide](/docs/getting-started) in the docs. Expo wants to encourage library authors to explain clearly whether their lib works with CRNA or not, and if so, explain how to set it up.
 

--- a/website/blog/2017-08-30-react-native-monthly-3.md
+++ b/website/blog/2017-08-30-react-native-monthly-3.md
@@ -14,7 +14,7 @@ The React Native monthly meeting continues! This month's meeting was a bit short
 
 On this third meeting, we had 5 teams join us:
 
-- [Callstack](https://github.com/callstack-io)
+- [Callstack](https://github.com/callstack)
 - [Expo](https://github.com/expo)
 - [Facebook](https://github.com/facebook)
 - [Microsoft](https://github.com/microsoft)
@@ -47,7 +47,7 @@ Here are the notes from each team:
 
 - The new Skype app is built on top of React Native in order to facilitate sharing as much code between platforms as possible. The React Native-based Skype app is currently available in the Android and iOS app stores.
 - While building the Skype app on React Native, we send pull requests to React Native in order to address bugs and missing features that we come across. So far, we've gotten about [70 pull requests merged](https://github.com/facebook/react-native/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Arigdern%20).
-- React Native enabled us to power both the Android and iOS Skype apps from the same codebase. We also want to use that codebase to power the Skype web app. To help us achieve that goal, we built and open sourced a thin layer on top of React/React Native called [ReactXP](https://microsoft.github.io/reactxp/blog/2017/04/06/introducing-reactxp.html). ReactXP provides a set of cross platform components that get mapped to React Native when targeting iOS/Android and to react-dom when targeting the web. ReactXP's goals are similar to another open source library called React Native for Web. There's a brief description of how the approaches of these libraries differ in the [ReactXP FAQ](https://microsoft.github.io/reactxp/faq.md).
+- React Native enabled us to power both the Android and iOS Skype apps from the same codebase. We also want to use that codebase to power the Skype web app. To help us achieve that goal, we built and open sourced a thin layer on top of React/React Native called [ReactXP](https://microsoft.github.io/reactxp/blog/2017/04/06/introducing-reactxp.html). ReactXP provides a set of cross platform components that get mapped to React Native when targeting iOS/Android and to react-dom when targeting the web. ReactXP's goals are similar to another open source library called React Native for Web. There's a brief description of how the approaches of these libraries differ in the [ReactXP FAQ](https://microsoft.github.io/reactxp/docs/faq.html).
 
 ### Shoutem
 


### PR DESCRIPTION
- `https://webpack.github.io/hot-module-replacement-with-webpack.md`
moved to  `https://webpack.js.org/guides/hot-module-replacement`
- `https://github.com/softwaremansion` should be
`https://github.com/software-mansion`
- `https://github.com/callstack-io` should be
`https://github.com/callstack`
- `https://microsoft.github.io/reactxp/faq.md` moved to
`https://microsoft.github.io/reactxp/docs/faq.html`