### PR TITLE
disable web platform in Modal functional example

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -20,7 +20,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 <block class="functional syntax" />
 
-```SnackPlayer name=Modal
+```SnackPlayer name=Modal&supportedPlatforms=android,ios
 import React, { Component, useState } from "react";
 import {
   Alert,


### PR DESCRIPTION
This small PR disables `web` platform in Modal functional example because this component it's not working correctly in browser right now. Class component had `web` platform disabled earlier.