### PR TITLE
add 'sh' and 'tsx' to the Prism highlighter config

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -143,7 +143,7 @@ You can view installation instructions [in the README](https://github.com/infini
 
 You can display the console logs for an iOS or Android app by using the following commands in a terminal while the app is running:
 
-```
+```sh
 $ npx react-native log-ios
 $ npx react-native log-android
 ```

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -36,13 +36,13 @@ Also, if you're using ProGuard, you will need to add these rules in `proguard-ru
 
 Next, if you've already built your app at least once, clean the build:
 
-```shell
+```sh
 $ cd android && ./gradlew clean
 ```
 
 That's it! You should now be able to develop and deploy your app as normal:
 
-```shell
+```sh
 $ npx react-native run-android
 ```
 
@@ -64,7 +64,7 @@ const isHermes = () => global.HermesInternal !== null;
 
 To see the benefits of Hermes, try making a release build/deployment of your app to compare. For example:
 
-```shell
+```sh
 $ npx react-native run-android --variant release
 ```
 

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -88,7 +88,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-```
+```sh
 $ yarn add react-native
 ```
 
@@ -98,7 +98,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-```
+```sh
 $ yarn add react@version_printed_above
 ```
 
@@ -114,7 +114,7 @@ Add `node_modules/` to your `.gitignore` file.
 
 We recommend installing CocoaPods using [Homebrew](http://brew.sh/).
 
-```
+```sh
 $ brew install cocoapods
 ```
 
@@ -150,7 +150,7 @@ The list of supported `subspec`s is available in [`/node_modules/react-native/Re
 
 You can specify which `subspec`s your app will depend on in a `Podfile` file. The easiest way to create a `Podfile` is by running the CocoaPods `init` command in the `/ios` subfolder of your project:
 
-```
+```sh
 $ pod init
 ```
 
@@ -240,7 +240,7 @@ end
 
 After you have created your `Podfile`, you are ready to install the React Native pod.
 
-```
+```sh
 $ pod install
 ```
 
@@ -470,7 +470,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-```
+```sh
 $ npm start
 ```
 
@@ -778,7 +778,7 @@ You have now done all the basic steps to integrate React Native with your curren
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-```
+```sh
 $ yarn start
 ```
 
@@ -794,7 +794,7 @@ Once you reach your React-powered activity inside the app, it should load the Ja
 
 You can use Android Studio to create your release builds too! It’s as quick as creating release builds of your previously-existing native Android app. There’s one additional step, which you’ll have to do before every release build. You need to execute the following to create a React Native bundle, which will be included with your native Android app:
 
-```
+```sh
 $ npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/com/your-company-name/app-package-name/src/main/assets/index.android.bundle --assets-dest android/com/your-company-name/app-package-name/src/main/res/
 ```
 

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -7,14 +7,14 @@ Native modules are usually distributed as npm packages, except that on top of th
 
 To get set up with the basic project structure for a native module we will use a third party tool [create-react-native-module](https://github.com/brodybits/create-react-native-module). You can go ahead further and dive deep into how that library works, for our needs we will only need:
 
-```
+```sh
 $ yarn global add create-react-native-module
 $ create-react-native-module MyLibrary
 ```
 
 Where MyLibrary is the name you would like for the new module. After doing this you will navigate into `MyLibrary` folder and install the npm package to be locally available for your computer by doing:
 
-```
+```sh
 $ yarn install
 ```
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -23,7 +23,7 @@ The first step for debugging this jank is to answer the fundamental question of 
 
 First, connect a device that exhibits the stuttering you want to investigate to your computer via USB and get it to the point right before the navigation/animation you want to profile. Run `systrace` as follows:
 
-```
+```sh
 $ <path_to_android_sdk>/platform-tools/systrace/systrace.py --time=10 -o trace.html sched gfx view -a <your_package_name>
 ```
 

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -287,7 +287,7 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
 
-```objc
+```objectivec
   // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
   UIView* launchScreenView = [[[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil] objectAtIndex:0];
   launchScreenView.frame = self.window.bounds;
@@ -296,7 +296,7 @@ As your App Bundle grows in size, you may start to see a blank screen flash betw
 
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
-```shell
+```sh
  if [ "${CONFIGURATION}" == "Debug" ]; then
   export SKIP_BUNDLING=true
  fi

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -130,7 +130,7 @@ Make sure that you replace `22b8` with the identifier you get in the above comma
 
 Now check that your device is properly connecting to ADB, the Android Debug Bridge, by running `adb devices`.
 
-```
+```sh
 $ adb devices
 List of devices attached
 emulator-5554 offline   # Google emulator
@@ -143,7 +143,7 @@ Seeing `device` in the right column means the device is connected. You must have
 
 Type the following in your command prompt to install and launch your app on the device:
 
-```
+```sh
 $ npx react-native run-android
 ```
 
@@ -218,13 +218,13 @@ You can use this method if your device is running Android 5.0 (Lollipop) or newe
 
 Run the following in a command prompt:
 
-```
+```sh
 $ adb -s <device name> reverse tcp:8081 tcp:8081
 ```
 
 To find the device name, run the following adb command:
 
-```
+```sh
 $ adb devices
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,13 +13,13 @@ The React Native packager runs on port 8081. If another process is already using
 
 Run the following command to find the id for the process that is listening on port 8081:
 
-```
+```sh
 $ sudo lsof -i :8081
 ```
 
 Then run the following to terminate the process:
 
-```
+```sh
 $ kill -9 <PID>
 ```
 
@@ -29,7 +29,7 @@ On Windows you can find the process using port 8081 using [Resource Monitor](htt
 
 You can configure the packager to use a port other than 8081 by using the `port` parameter:
 
-```
+```sh
 $ npx react-native start --port=8088
 ```
 

--- a/website/blog/2016-11-08-introducing-button-yarn-and-a-public-roadmap.md
+++ b/website/blog/2016-11-08-introducing-button-yarn-and-a-public-roadmap.md
@@ -42,7 +42,7 @@ Button is meant to work great and look native on every platform, so it won't sup
 
 You can now use [Yarn](https://yarnpkg.com/), the new package manager for JavaScript, to speed up `react-native init` significantly. To see the speedup please [install yarn](https://yarnpkg.com/en/docs/install) and upgrade your `react-native-cli` to 1.2.0:
 
-```
+```sh
 $ npm install -g react-native-cli
 ```
 

--- a/website/blog/2017-03-13-introducing-create-react-native-app.md
+++ b/website/blog/2017-03-13-introducing-create-react-native-app.md
@@ -15,7 +15,7 @@ Many developers struggle with installing and configuring React Native’s curren
 
 Try creating a new project (replace with suitable yarn commands if you have it installed):
 
-```
+```sh
 $ npm i -g create-react-native-app
 $ create-react-native-app my-project
 $ cd my-project

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -70,7 +70,16 @@ const siteConfig = {
     RemarkablePlugins.SnackPlayer,
     RemarkablePlugins.ReactNativeWebPlayer,
   ],
-  usePrism: ['javascript', 'js', 'jsx', 'java', 'objective-c', 'json'],
+  usePrism: [
+    'javascript',
+    'js',
+    'jsx',
+    'java',
+    'objective-c',
+    'json',
+    'sh',
+    'tsx',
+  ],
   highlight: {
     theme: 'solarized-dark',
   },


### PR DESCRIPTION
This PR adds two missing languages (Shell and TypeScript) used on the docs site to the Prism code highlighter config. This change improves the related code appearance.

### SH
<img width="664" alt="sh" src="https://user-images.githubusercontent.com/719641/76974863-087e5600-6932-11ea-8c59-a3f2a4683dfa.png">

### TSX
<img width="1333" alt="tsx" src="https://user-images.githubusercontent.com/719641/76974869-0ae0b000-6932-11ea-8b6b-1830e59b0455.png">