### PR TITLE
update Readme file, add TOC, add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repo contains the website configuration and documentation powering the [Rea
 
 ## Contents
 
-- [Getting started](#-requirements)
-- [Overview](#-building-your-first-react-native-app)
-- [Website configuration](#-documentation)
-- [Contributing](#-upgrading)
+- [Getting started](#-getting-started)
+- [Overview](#-overview)
+- [Website configuration](#-website-configuration)
+- [Contributing](#-contributing)
 - [License](#-license)
 
 ## 📋 Getting started

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [reactnative.dev](https://reactnative.dev/) &middot; [![CC BY 4.0 license](https://img.shields.io/badge/license-CC%20BY%204.0-blue.svg)](LICENSE-docs.md) [![Circle CI Status](https://circleci.com/gh/facebook/react-native-website.svg?style=shield)](https://circleci.com/gh/facebook/react-native-website) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+# [reactnative.dev](https://reactnative.dev/) &middot; [![CC BY 4.0 license](https://img.shields.io/badge/license-CC%20BY%204.0-blue.svg)](LICENSE-docs) [![Circle CI Status](https://circleci.com/gh/facebook/react-native-website.svg?style=shield)](https://circleci.com/gh/facebook/react-native-website) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 This repo contains the website configuration and documentation powering the [React Native website](https://reactnative.dev/).
 

--- a/README.md
+++ b/README.md
@@ -10,32 +10,32 @@ This repo contains the website configuration and documentation powering the [Rea
 - [Contributing](#-contributing)
 - [License](#-license)
 
-## 📋 Getting started
+## ✈️ Getting started
 
 ### Prerequisites
 
-1.  [Git](https://git-scm.com/downloads)
-1.  [Node](https://nodejs.org/en/download/) (version 10 or greater).
-1.  [Yarn](https://yarnpkg.com/lang/en/docs/install/) (version 1.5 or greater).
-1.  A fork of the repo (for any contributions).
+1.  [Git](https://git-scm.com/downloads).
+1.  [Node](https://nodejs.org/en/download/) _(version 10 or greater)_.
+1.  [Yarn](https://yarnpkg.com/lang/en/docs/install/) _(version 1.5 or greater)_.
+1.  A fork of the repo _(for any contributions)_.
 1.  A clone of the `react-native-website` repo.
 
 ### Installation
 
 1.  `cd react-native-website` to go into the project root.
 1.  `cd website` to go into the website portion of the project.
-1.  `yarn` to install the website's npm dependencies (or `npm install`, if not using Yarn).
+1.  `yarn` or `npm install` to install the website's npm dependencies.
 
 ### Running locally
 
-1.  `yarn start` to start the development server (powered by Docusaurus) (or `npm start`, if not using Yarn).
+1.  `yarn start` or `npm start` to start the development server _(powered by [Docusaurus](https://docusaurus.io))_.
 1.  `open http://localhost:3000/` to open the site in your favorite browser.
 
 ## 📖 Overview
 
-If you would like to _contribute an edit or addition to the docs,_ read through our [style guide](STYLEGUIDE.md) before you write anything. All our content is generated from markdown files you can find in the `docs` directory.
+If you would like to **_contribute an edit or addition to the docs,_** read through our [style guide](STYLEGUIDE.md) before you write anything. All our content is generated from markdown files you can find in the `docs` directory.
 
-_To edit the internals of how the site is built,_ you may want to get familiarized with how the site is built. The React Native website is a static site generated using [Docusaurus](https://docusaurus.io). The website configuration can be found in the `website` directory. Visit the Docusaurus website to learn more about all the available configuration options.
+**_To edit the internals of how the site is built,_** you may want to get familiarized with how the site is built. The React Native website is a static site generated using [Docusaurus](https://docusaurus.io). The website configuration can be found in the `website` directory. Visit the Docusaurus website to learn more about all the available configuration options.
 
 ### Directory Structure
 
@@ -90,11 +90,13 @@ Docusaurus keeps track of the list of versions for the site in the `website/vers
 
 1.  `cd react-native-website` to go into the project root.
 1.  `cd website` to go into the website portion of the project.
-1.  Run `yarn run version <newVersion>` where `<newVersion>` is the new version being released.
+1.  Run `yarn run version <newVersion>` or `npm run version <newVersion>` where `<newVersion>` is the new version being released.
 
 ## 🔧 Website configuration
 
 The main config file for the website can be found at `website/siteConfig.js`. This file tells [Docusaurus how to build the website](http://docusaurus.io/docs/en/site-config.html). Edits to this file are rarely necessary.
+
+The `core` subdirectory contains JavaScript and React components that are the core part of the website, such as the SnackPlayer.
 
 The `pages` subdirectory contains the React components that make up the non-documentation pages of the site, such as the homepage.
 
@@ -110,25 +112,31 @@ The `showcase.json` file contains the list of users that are highlighted in the 
 
 ### Make the change
 
-1.  Follow the "Running locally" instructions.
+1.  Follow the "[Running locally](#running-locally)" instructions.
 1.  Save the files and check in the browser.
 1.  Some changes may require a server restart to generate new files. (Pages in `docs` always do!)
-1.  Edits to pages in `docs` will only be visible in the latest version of the documentation, called "Next", under `docs/next`. Visit **http://localhost:3000/docs/next/YOUR-DOCS-PAGE** to see your work.
+1.  Edits to pages in `docs` will only be visible in the latest version of the documentation, called "Next", under `docs/next`.
+
+Visit **http://localhost:3000/docs/next/YOUR-DOCS-PAGE** to see your work.
 
 > `open http://localhost:3000/versions.html` to see older versions of the docs.
 
 ### Test the change
 
-If possible, test any visual changes in all latest versions of Firefox and Chrome on desktop and Safari and Chrome on mobile.
+If possible, test any visual changes in all latest versions of the following browsers:
+
+- Chrome and Firefox on desktop.
+- Chrome and Safari on mobile.
 
 ### Push it
 
-1.  Run `yarn prettier` to ensure your changes are consistent with other files in the repo.
-1.  `git add -A && git commit -m "My message"` (replacing `My message` with a commit message, such as `Fixed header logo on Android`) to stage and commit your changes.
+1.  Run `yarn prettier` or `npm run prettier` to ensure your changes are consistent with other files in the repo.
+1.  `git add -A && git commit -m "My message"` to stage and commit your changes.
+    > replace `My message` with a commit message, such as `Fixed header logo on Android`
 1.  `git push my-fork-name the-name-of-my-branch`
 1.  Go to the [react-native-website repo](https://github.com/facebook/react-native-website) and you should see recently pushed branches.
 1.  Follow GitHub's instructions.
-1.  If possible, include screenshots of visual changes.
+1.  Describe briefly your changes (in case of visual changes, please include screenshots).
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-# [reactnative.dev](https://reactnative.dev/) &middot; [![Circle CI Status](https://circleci.com/gh/facebook/react-native-website.svg?style=shield)](https://circleci.com/gh/facebook/react-native-website) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+# [reactnative.dev](https://reactnative.dev/) &middot; [![CC BY 4.0 license](https://img.shields.io/badge/license-CC%20BY%204.0-blue.svg)](LICENSE-docs.md) [![Circle CI Status](https://circleci.com/gh/facebook/react-native-website.svg?style=shield)](https://circleci.com/gh/facebook/react-native-website) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 This repo contains the website configuration and documentation powering the [React Native website](https://reactnative.dev/).
 
-## Getting started
+## Contents
+
+- [Getting started](#-requirements)
+- [Overview](#-building-your-first-react-native-app)
+- [Website configuration](#-documentation)
+- [Contributing](#-upgrading)
+- [License](#-license)
+
+## 📋 Getting started
 
 ### Prerequisites
 
-1.  Git
-1.  Node: install version 8 or greater.
-1.  Yarn: See [Yarn website for installation instructions](https://yarnpkg.com/lang/en/docs/install/). (needs 1.5 or greater).
+1.  [Git](https://git-scm.com/downloads)
+1.  [Node](https://nodejs.org/en/download/) (version 10 or greater).
+1.  [Yarn](https://yarnpkg.com/lang/en/docs/install/) (version 1.5 or greater).
 1.  A fork of the repo (for any contributions).
 1.  A clone of the `react-native-website` repo.
 
@@ -23,13 +31,13 @@ This repo contains the website configuration and documentation powering the [Rea
 1.  `yarn start` to start the development server (powered by Docusaurus) (or `npm start`, if not using Yarn).
 1.  `open http://localhost:3000/` to open the site in your favorite browser.
 
-# Overview
+## 📖 Overview
 
 If you would like to _contribute an edit or addition to the docs,_ read through our [style guide](STYLEGUIDE.md) before you write anything. All our content is generated from markdown files you can find in the 'docs/' directory.
 
 _To edit the internals of how the site is built,_ you may want to get familiarized with how the site is built. The React Native website is a static site generated using [Docusaurus](https://docusaurus.io). The website configuration can be found in the 'website/' directory. Visit the Docusaurus website to learn more about all the available configuration options.
 
-## Directory Structure
+### Directory Structure
 
 The following is a high-level overview of relevant files and folders.
 
@@ -66,7 +74,7 @@ react-native-website/
     └── versions.json
 ```
 
-## Documentation sources
+### Documentation sources
 
 As mentioned above, the 'docs/' folder contains the source files for all of the docs in the React Native website. In most cases, you will want to edit the files within this directory. If you're adding a new doc or you need to alter the order the docs appear in the sidebar, take a look at the 'sidebars.json' file in the 'website/' directory. The sidebars file contains a list of document ids that should match those defined in the header metadata (aka frontmatter) of the docs markdown files.
 
@@ -84,7 +92,7 @@ Docusaurus keeps track of the list of versions for the site in the 'website/vers
 1.  `cd website` to go into the website portion of the project.
 1.  Run `yarn run version <newVersion>` where `<newVersion>` is the new version being released.
 
-## Website configuration
+## 🔧 Website configuration
 
 The main config file for the website can be found at 'website/siteConfig.js'. This file tells [Docusaurus how to build the website](http://docusaurus.io/docs/en/site-config.html). Edits to this file are rarely necessary.
 
@@ -92,7 +100,7 @@ The 'pages/' subdirectory contains the React components that make up the non-doc
 
 The 'showcase.json' file contains the list of users that are highlighted in the React Native showcase.
 
-## Contributing
+## 👏 Contributing
 
 ### Create a branch
 
@@ -122,9 +130,7 @@ If possible, test any visual changes in all latest versions of Firefox and Chrom
 1.  Follow GitHub's instructions.
 1.  If possible, include screenshots of visual changes.
 
----
-
-## License
+## 📄 License
 
 React Native is [MIT licensed](./LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ react-native-website/
     ├── core/
     ├── pages/
     │   └── en/
-    │       ├── ...
     │       ├── index.js
     │       └── ...
     ├── static/
@@ -68,6 +67,7 @@ react-native-website/
     ├── versioned_sidebars/
     │   ├── version-0.5-sidebars.json
     │   └── ...
+    ├── package.json
     ├── showcase.json
     ├── sidebars.json
     ├── siteConfig.js

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ This repo contains the website configuration and documentation powering the [Rea
 
 ## 📖 Overview
 
-If you would like to _contribute an edit or addition to the docs,_ read through our [style guide](STYLEGUIDE.md) before you write anything. All our content is generated from markdown files you can find in the 'docs/' directory.
+If you would like to _contribute an edit or addition to the docs,_ read through our [style guide](STYLEGUIDE.md) before you write anything. All our content is generated from markdown files you can find in the `docs` directory.
 
-_To edit the internals of how the site is built,_ you may want to get familiarized with how the site is built. The React Native website is a static site generated using [Docusaurus](https://docusaurus.io). The website configuration can be found in the 'website/' directory. Visit the Docusaurus website to learn more about all the available configuration options.
+_To edit the internals of how the site is built,_ you may want to get familiarized with how the site is built. The React Native website is a static site generated using [Docusaurus](https://docusaurus.io). The website configuration can be found in the `website` directory. Visit the Docusaurus website to learn more about all the available configuration options.
 
 ### Directory Structure
 
@@ -76,15 +76,15 @@ react-native-website/
 
 ### Documentation sources
 
-As mentioned above, the 'docs/' folder contains the source files for all of the docs in the React Native website. In most cases, you will want to edit the files within this directory. If you're adding a new doc or you need to alter the order the docs appear in the sidebar, take a look at the 'sidebars.json' file in the 'website/' directory. The sidebars file contains a list of document ids that should match those defined in the header metadata (aka frontmatter) of the docs markdown files.
+As mentioned above, the `docs` folder contains the source files for all of the docs in the React Native website. In most cases, you will want to edit the files within this directory. If you're adding a new doc or you need to alter the order the docs appear in the sidebar, take a look at the `sidebars.json` file in the `website` directory. The sidebars file contains a list of document ids that should match those defined in the header metadata (aka frontmatter) of the docs markdown files.
 
 ### Versioned docs
 
-The React Native website is versioned as to allow users to go back and see the API reference docs for any given release. A new version of the website is generally made whenever there is a new React Native release. When this happens, any changes made to the 'docs/' and 'website/sidebars.json' files will be copied over to the corresponding location within 'website/versioned_docs/' and 'website/versioned_sidebars/'.
+The React Native website is versioned as to allow users to go back and see the API reference docs for any given release. A new version of the website is generally generated whenever there is a new React Native release. When this happens, any changes made to the `docs` and `website/sidebars.json` files will be copied over to the corresponding location within `website/versioned_docs` and `website/versioned_sidebars`.
 
-> Do not edit the auto-generated files within 'versioned_docs/' or 'versioned_sidebars/' unless you are sure it is necessary. Edits made to older versions will not be propagated to newer versions of the docs.
+> **_Note:_** Do not edit the auto-generated files within `versioned_docs` or `versioned_sidebars` unless you are sure it is necessary. Edits made to older versions will not be propagated to newer versions of the docs.
 
-Docusaurus keeps track of the list of versions for the site in the 'website/versions.json' file. The ordering of the versions in this file should be in reverse chronological order.
+Docusaurus keeps track of the list of versions for the site in the `website/versions.json` file. The ordering of the versions in this file should be in reverse chronological order.
 
 #### Cutting a new version
 
@@ -94,11 +94,11 @@ Docusaurus keeps track of the list of versions for the site in the 'website/vers
 
 ## 🔧 Website configuration
 
-The main config file for the website can be found at 'website/siteConfig.js'. This file tells [Docusaurus how to build the website](http://docusaurus.io/docs/en/site-config.html). Edits to this file are rarely necessary.
+The main config file for the website can be found at `website/siteConfig.js`. This file tells [Docusaurus how to build the website](http://docusaurus.io/docs/en/site-config.html). Edits to this file are rarely necessary.
 
-The 'pages/' subdirectory contains the React components that make up the non-documentation pages of the site, such as the homepage.
+The `pages` subdirectory contains the React components that make up the non-documentation pages of the site, such as the homepage.
 
-The 'showcase.json' file contains the list of users that are highlighted in the React Native showcase.
+The `showcase.json` file contains the list of users that are highlighted in the React Native showcase.
 
 ## 👏 Contributing
 
@@ -112,8 +112,8 @@ The 'showcase.json' file contains the list of users that are highlighted in the 
 
 1.  Follow the "Running locally" instructions.
 1.  Save the files and check in the browser.
-1.  Some changes may require a server restart to generate new files. (Pages in **/docs** always do!)
-1.  Edits to pages in **/docs** will only be visible in the latest version of the documentation, called "Next," under **/docs/next**. Visit **http://localhost:3000/docs/next/YOUR-DOCS-PAGE** to see your work.
+1.  Some changes may require a server restart to generate new files. (Pages in `docs` always do!)
+1.  Edits to pages in `docs` will only be visible in the latest version of the documentation, called "Next", under `docs/next`. Visit **http://localhost:3000/docs/next/YOUR-DOCS-PAGE** to see your work.
 
 > `open http://localhost:3000/versions.html` to see older versions of the docs.
 


### PR DESCRIPTION
This PR updates the `README.md` file. The goal was to use similar, coherent structure to the `react-native` repository [Readme](https://github.com/facebook/react-native/blob/master/README.md). The following changes has been made:
* add `Contents` links at the top of file, just after description
* add links to the prerequisite software (also I have bumped recommended Node version)
 > Question here: Can we bump it even to 12 for the website since `next` [docs](https://reactnative.dev/docs/next/environment-setup) are recommending the latest LTS for RN?
* utilize emojis in main headers (most of emojis was taken straight from `react-native`  readme)
* add license badge
* use code formatting for the paths and files/folders names

### Preview can be viewed here:
* https://github.com/Simek/react-native-website/tree/readme-update