### PR TITLE
fix Docusaurus warning

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,6 @@
 ---
 id: testing
 title: Testing
-hero: /docs/assets/diagram_react-native-components.svg
 author: Vojtech Novak
 authorURL: https://twitter.com/vonovak
 description: This guide introduces React Native developers to the key concepts behind testing, how to write good tests, and what kinds of tests you can incorporate into your workflow.


### PR DESCRIPTION
This small PR fixes Docusaurus warning related to invalid header field:
> Header field "hero" in ~/projects/react-native-website/docs/testing.md is not supported.

Image linked there was not displayed on the page.