### PR TITLE
Update to pixelratio.md - getFontScale() returns value on iOS

### DIFF
--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -134,9 +134,9 @@ static getFontScale(): number
 Returns the scaling factor for font sizes. This is the ratio that is used to calculate the absolute font size, so any elements that heavily depend on that should use this to do calculations.
 
 * on Android value reflects the user preference set in **Settings > Display > Font size** 
-* on iOS value reflects the user preference set in **Settings > Accessibilty > Display & Test Size > Larger Text**
+* on iOS value reflects the user preference set in **Settings > Display & Brightness > Text Size**, value can also be updated in **Settings > Accessibilty > Display & Test Size > Larger Text**
 
-If a font scale is not set, this returns the device pixel ratio.
+If a font scale is not set, this returns the device pixel ratio. 
 
 ---
 

--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -134,7 +134,7 @@ static getFontScale(): number
 Returns the scaling factor for font sizes. This is the ratio that is used to calculate the absolute font size, so any elements that heavily depend on that should use this to do calculations.
 
 * on Android value reflects the user preference set in **Settings > Display > Font size** 
-* on iOS it will always return the default pixel ratio
+* on iOS value reflects the user preference set in **Settings > Accessibilty > Display & Test Size > Larger Text**
 
 If a font scale is not set, this returns the device pixel ratio.
 


### PR DESCRIPTION
iOS does return a user value using getFontScale

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
