### PR TITLE
No Intel HAXM when using Hyper-V

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -244,7 +244,8 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 - `Android SDK`
 - `Android SDK Platform`
-- `Performance (Intel ® HAXM)` ([See here for AMD](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
+- If not already using Hyper-V:
+  - `Performance (Intel ® HAXM)` ([See here for AMD or Hyper-V](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
 - `Android Virtual Device`
 
 <block class="native linux android" />

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -244,9 +244,8 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 - `Android SDK`
 - `Android SDK Platform`
-- If not already using Hyper-V:
-  - `Performance (Intel ® HAXM)` ([See here for AMD or Hyper-V](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
 - `Android Virtual Device`
+- If you are not already using Hyper-V: `Performance (Intel ® HAXM)` ([See here for AMD or Hyper-V](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
 
 <block class="native linux android" />
 


### PR DESCRIPTION
The docs [here](https://reactnative.dev/docs/getting-started) for Windows > Android lists the following package as a requirement;

* `Performance (Intel ® HAXM)`

However, in the case of having Hyper-V enabled, like for Docker, installing that package results in failure;

> This computer does not support Intel Virtualization Technology (VT-x) or it is being exclusively used by Hyper-V. HAXM cannot be installed. Please ensure Hyper-V is disabled in Windows Features, or refer to the Intel HAXM documentation for more information. 

The docs also link an article related to AMD, which also happens to mention Hyper-V;

> If you want to use Hyper-V at the same time as the Android Emulator on your Intel processor-based computer, you will also need the same Android Studio and Android Emulator versions as listed above, but with the additional requirements:
>
> * Enable via Windows Features: "Hyper-V" - Only available for Windows 10 Professional/Education/Enterprise
> * Intel Processor : Intel® Core™ processor that supports Virtualization Technology (VT-x), Extended Page Tables (EPT), and Unrestricted Guest (UG) features. Additionally VT-x needs to be enabled in the BIOS.

I've just learnt (via trial and error) that the latter means you don't need HAXM at all if you satisfy the above two.  When I originally read the article though, I thought it was implying I still need HAXM, and, the react-native docs are not clear on this.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
