### PR TITLE
Update default version to 0.62

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -15,7 +15,7 @@ try {
   // We don't care if there are no repos synced locally
   // We only care if we are on the CI server and about to deploy
 }
-const defaultVersionShown = '0.61';
+const defaultVersionShown = '0.62';
 const baseUrl = '/';
 const repoUrl = 'https://github.com/facebook/react-native';
 const siteConfig = {


### PR DESCRIPTION
This is a followup PR to #1782.
Now that that is merged, we can bump the default version to be 0.62 - which as far as I can see from previous commits (https://github.com/facebook/react-native-website/commit/5a0f9d26acd484212debc0d11971c1a4fbb649fc#diff-c272134cac3612b41f93893bbaa34d24) it's just this change.

We will need to merge this **only** when 0.62.0 is out.