### PR TITLE
add missing i18n strings after 0.62 cut

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3488,6 +3488,366 @@
       "version-0.61/version-0.61-viewpagerandroid": {
         "title": "🚧 ViewPagerAndroid"
       },
+      "version-0.62/version-0.62-accessibility": {
+        "title": "Accessibility"
+      },
+      "version-0.62/version-0.62-accessibilityinfo": {
+        "title": "AccessibilityInfo"
+      },
+      "version-0.62/version-0.62-actionsheetios": {
+        "title": "ActionSheetIOS"
+      },
+      "version-0.62/version-0.62-activityindicator": {
+        "title": "ActivityIndicator"
+      },
+      "version-0.62/version-0.62-alert": {
+        "title": "Alert"
+      },
+      "version-0.62/version-0.62-alertios": {
+        "title": "🚧 AlertIOS"
+      },
+      "version-0.62/version-0.62-animated": {
+        "title": "Animated"
+      },
+      "version-0.62/version-0.62-animatedvalue": {
+        "title": "AnimatedValue"
+      },
+      "version-0.62/version-0.62-animatedvaluexy": {
+        "title": "AnimatedValueXY"
+      },
+      "version-0.62/version-0.62-animations": {
+        "title": "Animations"
+      },
+      "version-0.62/version-0.62-appearance": {
+        "title": "Appearance"
+      },
+      "version-0.62/version-0.62-appregistry": {
+        "title": "AppRegistry"
+      },
+      "version-0.62/version-0.62-appstate": {
+        "title": "AppState"
+      },
+      "version-0.62/version-0.62-backhandler": {
+        "title": "BackHandler"
+      },
+      "version-0.62/version-0.62-building-for-apple-tv": {
+        "title": "Building For TV Devices"
+      },
+      "version-0.62/version-0.62-button": {
+        "title": "Button"
+      },
+      "version-0.62/version-0.62-checkbox": {
+        "title": "CheckBox"
+      },
+      "version-0.62/version-0.62-clipboard": {
+        "title": "🚧 Clipboard"
+      },
+      "version-0.62/version-0.62-colors": {
+        "title": "Color Reference"
+      },
+      "version-0.62/version-0.62-communication-android": {
+        "title": "Communication between native and React Native"
+      },
+      "version-0.62/version-0.62-communication-ios": {
+        "title": "Communication between native and React Native"
+      },
+      "version-0.62/version-0.62-components-and-apis": {
+        "title": "Core Components and APIs"
+      },
+      "version-0.62/version-0.62-datepickerandroid": {
+        "title": "🚧 DatePickerAndroid"
+      },
+      "version-0.62/version-0.62-datepickerios": {
+        "title": "🚧 DatePickerIOS"
+      },
+      "version-0.62/version-0.62-debugging": {
+        "title": "Debugging"
+      },
+      "version-0.62/version-0.62-devsettings": {
+        "title": "DevSettings"
+      },
+      "version-0.62/version-0.62-dimensions": {
+        "title": "Dimensions"
+      },
+      "version-0.62/version-0.62-direct-manipulation": {
+        "title": "Direct Manipulation"
+      },
+      "version-0.62/version-0.62-drawerlayoutandroid": {
+        "title": "DrawerLayoutAndroid"
+      },
+      "version-0.62/version-0.62-easing": {
+        "title": "Easing"
+      },
+      "version-0.62/version-0.62-fast-refresh": {
+        "title": "Fast Refresh"
+      },
+      "version-0.62/version-0.62-flatlist": {
+        "title": "FlatList"
+      },
+      "version-0.62/version-0.62-flexbox": {
+        "title": "Layout with Flexbox"
+      },
+      "version-0.62/version-0.62-environment-setup": {
+        "title": "Setting up the development environment"
+      },
+      "version-0.62/version-0.62-handling-text-input": {
+        "title": "Handling Text Input"
+      },
+      "version-0.62/version-0.62-handling-touches": {
+        "title": "Handling Touches"
+      },
+      "version-0.62/version-0.62-headless-js-android": {
+        "title": "Headless JS"
+      },
+      "version-0.62/version-0.62-height-and-width": {
+        "title": "Height and Width"
+      },
+      "version-0.62/version-0.62-hermes": {
+        "title": "Using Hermes"
+      },
+      "version-0.62/version-0.62-image-style-props": {
+        "title": "Image Style Props"
+      },
+      "version-0.62/version-0.62-image": {
+        "title": "Image"
+      },
+      "version-0.62/version-0.62-imagebackground": {
+        "title": "ImageBackground"
+      },
+      "version-0.62/version-0.62-inputaccessoryview": {
+        "title": "InputAccessoryView"
+      },
+      "version-0.62/version-0.62-integration-with-existing-apps": {
+        "title": "Integration with Existing Apps"
+      },
+      "version-0.62/version-0.62-interactionmanager": {
+        "title": "InteractionManager"
+      },
+      "version-0.62/version-0.62-intro-react-native-components": {
+        "title": "Core Components and Native Components"
+      },
+      "version-0.62/version-0.62-intro-react": {
+        "title": "React Fundamentals"
+      },
+      "version-0.62/version-0.62-getting-started": {
+        "title": "Introduction"
+      },
+      "version-0.62/version-0.62-javascript-environment": {
+        "title": "JavaScript Environment"
+      },
+      "version-0.62/version-0.62-keyboard": {
+        "title": "Keyboard"
+      },
+      "version-0.62/version-0.62-keyboardavoidingview": {
+        "title": "KeyboardAvoidingView"
+      },
+      "version-0.62/version-0.62-layout-props": {
+        "title": "Layout Props"
+      },
+      "version-0.62/version-0.62-layoutanimation": {
+        "title": "LayoutAnimation"
+      },
+      "version-0.62/version-0.62-linking-libraries-ios": {
+        "title": "Linking Libraries"
+      },
+      "version-0.62/version-0.62-linking": {
+        "title": "Linking"
+      },
+      "version-0.62/version-0.62-modal": {
+        "title": "Modal"
+      },
+      "version-0.62/version-0.62-more-resources": {
+        "title": "More Resources"
+      },
+      "version-0.62/version-0.62-native-components-android": {
+        "title": "Native UI Components"
+      },
+      "version-0.62/version-0.62-native-components-ios": {
+        "title": "Native UI Components"
+      },
+      "version-0.62/version-0.62-native-modules-android": {
+        "title": "Native Modules"
+      },
+      "version-0.62/version-0.62-native-modules-ios": {
+        "title": "Native Modules"
+      },
+      "version-0.62/version-0.62-native-modules-setup": {
+        "title": "Native Modules Setup"
+      },
+      "version-0.62/version-0.62-navigation": {
+        "title": "Navigating Between Screens"
+      },
+      "version-0.62/version-0.62-network": {
+        "title": "Networking"
+      },
+      "version-0.62/version-0.62-optimizing-flatlist-configuration": {
+        "title": "Optimizing Flatlist Configuration"
+      },
+      "version-0.62/version-0.62-out-of-tree-platforms": {
+        "title": "Out-of-Tree Platforms"
+      },
+      "version-0.62/version-0.62-panresponder": {
+        "title": "PanResponder"
+      },
+      "version-0.62/version-0.62-performance": {
+        "title": "Performance Overview"
+      },
+      "version-0.62/version-0.62-permissionsandroid": {
+        "title": "PermissionsAndroid"
+      },
+      "version-0.62/version-0.62-picker": {
+        "title": "Picker"
+      },
+      "version-0.62/version-0.62-pixelratio": {
+        "title": "PixelRatio"
+      },
+      "version-0.62/version-0.62-platform-specific-code": {
+        "title": "Platform Specific Code"
+      },
+      "version-0.62/version-0.62-profiling": {
+        "title": "Profiling"
+      },
+      "version-0.62/version-0.62-progressbarandroid": {
+        "title": "🚧 ProgressBarAndroid"
+      },
+      "version-0.62/version-0.62-progressviewios": {
+        "title": "🚧 ProgressViewIOS"
+      },
+      "version-0.62/version-0.62-props": {
+        "title": "Props"
+      },
+      "version-0.62/version-0.62-pushnotificationios": {
+        "title": "🚧 PushNotificationIOS"
+      },
+      "version-0.62/version-0.62-ram-bundles-inline-requires": {
+        "title": "RAM Bundles and Inline Requires"
+      },
+      "version-0.62/version-0.62-refreshcontrol": {
+        "title": "RefreshControl"
+      },
+      "version-0.62/version-0.62-removing-default-permissions": {
+        "title": "Removing Default Permissions"
+      },
+      "version-0.62/version-0.62-running-on-device": {
+        "title": "Running On Device"
+      },
+      "version-0.62/version-0.62-running-on-simulator-ios": {
+        "title": "Running On Simulator"
+      },
+      "version-0.62/version-0.62-safeareaview": {
+        "title": "SafeAreaView"
+      },
+      "version-0.62/version-0.62-scrollview": {
+        "title": "ScrollView"
+      },
+      "version-0.62/version-0.62-sectionlist": {
+        "title": "SectionList"
+      },
+      "version-0.62/version-0.62-security": {
+        "title": "Security"
+      },
+      "version-0.62/version-0.62-settings": {
+        "title": "Settings"
+      },
+      "version-0.62/version-0.62-shadow-props": {
+        "title": "Shadow Props"
+      },
+      "version-0.62/version-0.62-share": {
+        "title": "Share"
+      },
+      "version-0.62/version-0.62-signed-apk-android": {
+        "title": "Publishing to Google Play Store"
+      },
+      "version-0.62/version-0.62-slider": {
+        "title": "🚧 Slider"
+      },
+      "version-0.62/version-0.62-state": {
+        "title": "State"
+      },
+      "version-0.62/version-0.62-statusbar": {
+        "title": "StatusBar"
+      },
+      "version-0.62/version-0.62-style": {
+        "title": "Style"
+      },
+      "version-0.62/version-0.62-stylesheet": {
+        "title": "StyleSheet"
+      },
+      "version-0.62/version-0.62-switch": {
+        "title": "Switch"
+      },
+      "version-0.62/version-0.62-systrace": {
+        "title": "Systrace"
+      },
+      "version-0.62/version-0.62-testing": {
+        "title": "Testing"
+      },
+      "version-0.62/version-0.62-text-style-props": {
+        "title": "Text Style Props"
+      },
+      "version-0.62/version-0.62-text": {
+        "title": "Text"
+      },
+      "version-0.62/version-0.62-textinput": {
+        "title": "TextInput"
+      },
+      "version-0.62/version-0.62-timepickerandroid": {
+        "title": "🚧 TimePickerAndroid"
+      },
+      "version-0.62/version-0.62-toastandroid": {
+        "title": "ToastAndroid"
+      },
+      "version-0.62/version-0.62-touchablehighlight": {
+        "title": "TouchableHighlight"
+      },
+      "version-0.62/version-0.62-touchablenativefeedback": {
+        "title": "TouchableNativeFeedback"
+      },
+      "version-0.62/version-0.62-touchableopacity": {
+        "title": "TouchableOpacity"
+      },
+      "version-0.62/version-0.62-touchablewithoutfeedback": {
+        "title": "TouchableWithoutFeedback"
+      },
+      "version-0.62/version-0.62-transforms": {
+        "title": "Transforms"
+      },
+      "version-0.62/version-0.62-troubleshooting": {
+        "title": "Troubleshooting"
+      },
+      "version-0.62/version-0.62-tutorial": {
+        "title": "Learn the Basics"
+      },
+      "version-0.62/version-0.62-typescript": {
+        "title": "Using TypeScript with React Native"
+      },
+      "version-0.62/version-0.62-upgrading": {
+        "title": "Upgrading to new React Native versions"
+      },
+      "version-0.62/version-0.62-usecolorscheme": {
+        "title": "useColorScheme"
+      },
+      "version-0.62/version-0.62-usewindowdimensions": {
+        "title": "useWindowDimensions"
+      },
+      "version-0.62/version-0.62-using-a-listview": {
+        "title": "Using List Views"
+      },
+      "version-0.62/version-0.62-using-a-scrollview": {
+        "title": "Using a ScrollView"
+      },
+      "version-0.62/version-0.62-vibration": {
+        "title": "Vibration"
+      },
+      "version-0.62/version-0.62-view-style-props": {
+        "title": "View Style Props"
+      },
+      "version-0.62/version-0.62-view": {
+        "title": "View"
+      },
+      "version-0.62/version-0.62-virtualizedlist": {
+        "title": "VirtualizedList"
+      },
       "version-0.7/version-0.7-pushnotificationios": {
         "title": "PushNotificationIOS"
       },


### PR DESCRIPTION
Refs: #1782 

This small PR adds missing i18n (localization) strings generated while running Docusaurus after version `0.62` cut.