### PR TITLE
fix: fix wrong testing guide redirect

### DIFF
--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -1,5 +1,5 @@
 ---
-id: testing
+id: testing-overview
 title: Testing
 author: Vojtech Novak
 authorURL: https://twitter.com/vonovak

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -338,7 +338,7 @@
       "systrace": {
         "title": "Systrace"
       },
-      "testing": {
+      "testing-overview": {
         "title": "Testing"
       },
       "text-style-props": {
@@ -3779,7 +3779,7 @@
       "version-0.62/version-0.62-systrace": {
         "title": "Systrace"
       },
-      "version-0.62/version-0.62-testing": {
+      "version-0.62/version-0.62-testing-overview": {
         "title": "Testing"
       },
       "version-0.62/version-0.62-text-style-props": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -21,7 +21,7 @@
       "running-on-device",
       "fast-refresh",
       "debugging",
-      "testing",
+      "testing-overview",
       "typescript",
       "upgrading"
     ],

--- a/website/versioned_docs/version-0.62/testing-overview.md
+++ b/website/versioned_docs/version-0.62/testing-overview.md
@@ -1,10 +1,10 @@
 ---
-id: version-0.62-testing
+id: version-0.62-testing-overview
 title: Testing
 author: Vojtech Novak
 authorURL: https://twitter.com/vonovak
 description: This guide introduces React Native developers to the key concepts behind testing, how to write good tests, and what kinds of tests you can incorporate into your workflow.
-original_id: testing
+original_id: testing-overview
 ---
 
 As your codebase expands, small errors and edge cases you don’t expect can cascade into larger failures. Bugs lead to bad user experience and ultimately, business losses. One way to prevent fragile programming is to test your code before releasing it into the wild.

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -21,7 +21,7 @@
       "version-0.62-running-on-device",
       "version-0.62-fast-refresh",
       "version-0.62-debugging",
-      "version-0.62-testing",
+      "version-0.62-testing-overview",
       "version-0.62-typescript",
       "version-0.62-upgrading"
     ],


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->


if you take a look at the current public docs, the testing guide link in the sidebar redirects to a wiki page at https://github.com/facebook/react-native/wiki/Tests

I'm not 100% sure where the problem is but this solution works without breaking anything.


let me just add that the testing docs should probably not be versioned, and there is a tooling for this (versionedDocsBlacklist.json) but I don't have time to dig into that now. Thanks.