### PR TITLE
update SegmentedControliOS page generated for 0.61

### DIFF
--- a/website/versioned_docs/version-0.61/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.61/segmentedcontrolios.md
@@ -14,17 +14,39 @@ The selected index can be changed on the fly by assigning the selectedIndex prop
 
 ## Example
 
-```jsx
-<SegmentedControlIOS
-  values={['One', 'Two']}
-  selectedIndex={this.state.selectedIndex}
-  onChange={(event) => {
-    this.setState({selectedIndex: event.nativeEvent.selectedSegmentIndex});
-  }}
-/>
-```
+```SnackPlayer name=SegmentedControlIOS%20Example&supportedPlatforms=ios
+import React, { useState } from "react";
+import { SegmentedControlIOS, StyleSheet, Text, View } from "react-native";
 
-<center><img src="/docs/assets/SegmentedControlIOS/example.gif" width="360"></img></center>
+export default App = () => {
+  const [index, setIndex] = useState(0);
+  return (
+    <View style={styles.container}>
+      <SegmentedControlIOS
+        values={['One', 'Two']}
+        selectedIndex={index}
+        onChange={(event) => {
+          setIndex(event.nativeEvent.selectedSegmentIndex);
+        }}
+      />
+      <Text style={styles.text}>
+        Selected index: {index}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    justifyContent: "center"
+  },
+  text: {
+    marginTop: 24
+  }
+});
+```
 
 ---
 
@@ -42,8 +64,6 @@ If false the user won't be able to interact with the control. Default value is t
 | ---- | -------- |
 | bool | No       |
 
-<center><img src="/docs/assets/SegmentedControlIOS/enabled.png" width="360"></img></center>
-
 ---
 
 ### `momentary`
@@ -53,8 +73,6 @@ If true, then selecting a segment won't persist visually. The `onValueChange` ca
 | Type | Required |
 | ---- | -------- |
 | bool | No       |
-
-<center><img src="/docs/assets/SegmentedControlIOS/momentary.gif" width="360"></img></center>
 
 ---
 
@@ -95,8 +113,6 @@ Accent color of the control.
 | Type   | Required |
 | ------ | -------- |
 | string | No       |
-
-<center><img src="/docs/assets/SegmentedControlIOS/tintColor.png" width="360"></img></center>
 
 ---
 


### PR DESCRIPTION
Initial PR #1774 was created before PR #1779 which added separate SegmentedControliOS page to the `0.61` version of docs. Without a PR rebase I was not able to access that file, sorry for that!

This PR fixes 404 images links on that page and replaces code block with a Snack example.