### PR TITLE
Remove unnecessary import (Handling Text Input)

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -8,7 +8,7 @@ title: Handling Text Input
 For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
 
 ```SnackPlayer name=Handling%20Text%20Input
-import React, { Component, useState } from 'react';
+import React, { useState } from 'react';
 import { Text, TextInput, View } from 'react-native';
 
 export default function PizzaTranslator() {


### PR DESCRIPTION
Import (Component) removed because there is no use in the example.

```javascript
import React, { Component, useState } from 'react';
```