### PR TITLE
docs: specify typescript template version

### DIFF
--- a/website/versioned_docs/version-0.60/typescript.md
+++ b/website/versioned_docs/version-0.60/typescript.md
@@ -11,6 +11,7 @@ original_id: typescript
 If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
 
 ```sh
+# Template version is specifically for React Native 0.60
 npx react-native init MyTSProject --template react-native-template-typescript@6.2.0
 ```
 
@@ -33,7 +34,7 @@ ignite new MyTSProject
 1. Add TypeScript and the types for React Native and Jest to your project.
 
 ```sh
-yarn add --dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer 
+yarn add --dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
 # or for npm
 npm install --save-dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
 ```

--- a/website/versioned_docs/version-0.61/typescript.md
+++ b/website/versioned_docs/version-0.61/typescript.md
@@ -11,7 +11,8 @@ original_id: typescript
 If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
 
 ```sh
-npx react-native init MyTSProject --template react-native-template-typescript
+# Template version is specifically for React Native 0.61
+npx react-native init MyTSProject --template react-native-template-typescript@6.3.16
 ```
 
 You can use [Expo][expo] which has two TypeScript templates:


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Specified the version of typescript template to use for starting up RN project in typescript, as specified in https://github.com/react-native-community/react-native-template-typescript