### PR TITLE
missing Animated.Value.setValue method

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -580,7 +580,7 @@ Stops any running animation and resets the value to its original.
 
 ### `Value`
 
-Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
+Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`, which return an animated value with `setValue` methord, it's especially useful when you want to re-initialize it after complete an animate.
 
 ---
 


### PR DESCRIPTION
missing `Animated.Value.setValue` method, newbie don't know how to reset the value, they may try `v = new Animate.Value(0)` in `start`'s complete handler, but it does not work.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
