### PR TITLE
update animated values pages, add them to the sidebar

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -582,11 +582,15 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
+You can read more about `Animated.Value` API on the separate [page](animatedvalue).
+
 ---
 
 ### `ValueXY`
 
 2D value class for driving 2D animations, such as pan gestures.
+
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy).
 
 ---
 

--- a/docs/animatedvalue.md
+++ b/docs/animatedvalue.md
@@ -1,29 +1,11 @@
 ---
 id: animatedvalue
-title: AnimatedValue
+title: Animated.Value
 ---
 
 Standard value for driving animations. One `Animated.Value` can drive multiple properties in a synchronized fashion, but can only be driven by one mechanism at a time. Using a new mechanism (e.g. starting a new animation, or calling `setValue`) will stop any previous ones.
 
 Typically initialized with `new Animated.Value(0);`
-
-See also [`Animated`](animated).
-
-### Methods
-
-- [`setValue`](animatedvalue#setvalue)
-- [`setOffset`](animatedvalue#setoffset)
-- [`flattenOffset`](animatedvalue#flattenoffset)
-- [`extractOffset`](animatedvalue#extractoffset)
-- [`addListener`](animatedvalue#addlistener)
-- [`removeListener`](animatedvalue#removelistener)
-- [`removeAllListeners`](animatedvalue#removealllisteners)
-- [`stopAnimation`](animatedvalue#stopanimation)
-- [`resetAnimation`](animatedvalue#resetanimation)
-- [`interpolate`](animatedvalue#interpolate)
-- [`animate`](animatedvalue#animate)
-- [`stopTracking`](animatedvalue#stoptracking)
-- [`track`](animatedvalue#track)
 
 ---
 

--- a/docs/animatedvaluexy.md
+++ b/docs/animatedvaluexy.md
@@ -1,63 +1,60 @@
 ---
 id: animatedvaluexy
-title: AnimatedValueXY
+title: Animated.ValueXY
 ---
 
 2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
-See also [`Animated`](animated).
-
 ## Example
 
-```jsx
-class DraggableView extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      pan: new Animated.ValueXY(), // inits to zero
-    };
-    this.state.panResponder = PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onPanResponderMove: Animated.event([
-        null,
-        {
-          dx: this.state.pan.x, // x,y are Animated.Value
-          dy: this.state.pan.y,
-        },
-      ]),
-      onPanResponderRelease: () => {
-        Animated.spring(
-          this.state.pan, // Auto-multiplexed
-          {toValue: {x: 0, y: 0}}, // Back to zero
-        ).start();
+```SnackPlayer name=Animated.ValueXY
+import React, { useRef } from "react";
+import { Animated, PanResponder, StyleSheet, View } from "react-native";
+
+export default DraggableView = () => {
+  const pan = useRef(new Animated.ValueXY()).current;
+
+  const panResponder = PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onPanResponderMove: Animated.event([
+      null,
+      {
+        dx: pan.x, // x,y are Animated.Value
+        dy: pan.y,
       },
-    });
-  }
-  render() {
-    return (
+    ]),
+    onPanResponderRelease: () => {
+      Animated.spring(
+        pan, // Auto-multiplexed
+        { toValue: { x: 0, y: 0 } } // Back to zero
+      ).start();
+    },
+  });
+
+  return (
+    <View style={styles.container}>
       <Animated.View
-        {...this.state.panResponder.panHandlers}
-        style={this.state.pan.getLayout()}>
-        {this.props.children}
-      </Animated.View>
-    );
-  }
-}
+        {...panResponder.panHandlers}
+        style={[pan.getLayout(), styles.box]}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  box: {
+    backgroundColor: "#61dafb",
+    width: 80,
+    height: 80,
+    borderRadius: 4,
+  },
+});
 ```
-
-### Methods
-
-- [`setValue`](animatedvaluexy#setvalue)
-- [`setOffset`](animatedvaluexy#setoffset)
-- [`flattenOffset`](animatedvaluexy#flattenoffset)
-- [`extractOffset`](animatedvaluexy#extractoffset)
-- [`addListener`](animatedvaluexy#addlistener)
-- [`removeListener`](animatedvaluexy#removelistener)
-- [`removeAllListeners`](animatedvaluexy#removealllisteners)
-- [`stopAnimation`](animatedvaluexy#stopanimation)
-- [`resetAnimation`](animatedvaluexy#resetanimation)
-- [`getLayout`](animatedvaluexy#getlayout)
-- [`getTranslateTransform`](animatedvaluexy#gettranslatetransform)
 
 ---
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -27,10 +27,10 @@
         "title": "Animated"
       },
       "animatedvalue": {
-        "title": "AnimatedValue"
+        "title": "Animated.Value"
       },
       "animatedvaluexy": {
-        "title": "AnimatedValueXY"
+        "title": "Animated.ValueXY"
       },
       "animations": {
         "title": "Animations"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -107,6 +107,8 @@
       "accessibilityinfo",
       "alert",
       "animated",
+      "animatedvalue",
+      "animatedvaluexy",
       "appearance",
       "appregistry",
       "appstate",


### PR DESCRIPTION
Refs #1801, #426

For unknown for me reason `Animated.Value` and `Animated.ValueXY` pages has been lost without a sidebar entries for the few releases. After a quick glance at the code those APIs docs seems up to date.

This PR updates both pages to roughly match current standards, `Animated.ValueXY` class component example has been replaced with functional example in Snack, both of them has been added to the sidebar and a mentions has been added to the `Animated` page.

I can also port those changes to the `0.62` branch if you think it would be helpful.

### Preview
<img width="1111" alt="Annotation 2020-03-31 190840" src="https://user-images.githubusercontent.com/719641/78054910-0f21ba00-7383-11ea-9284-7e160d8a42b2.png">

