### PR TITLE
Fix outdated links in `getting-started.md` page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -364,9 +364,9 @@ C:\Android\tools\bin\platform-tools
 
 <h3>Watchman</h3>
 
-Follow the [Watchman installation guide](https://facebook.github.io/watchman/docs/install.html#buildinstall) to compile and install Watchman from source.
+Follow the [Watchman installation guide](https://facebook.github.io/watchman/docs/install/#buildinstall) to compile and install Watchman from source.
 
-> [Watchman](https://facebook.github.io/watchman/docs/install.html) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance and increased compatibility in certain edge cases (translation: you may be able to get by without installing this, but your mileage may vary; installing this now may save you from a headache later).
+> [Watchman](https://facebook.github.io/watchman/docs/install/) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance and increased compatibility in certain edge cases (translation: you may be able to get by without installing this, but your mileage may vary; installing this now may save you from a headache later).
 
 <block class="native mac windows linux ios android" />
 


### PR DESCRIPTION
Motivation:
* It seems that some of external links to `Watchman` are outdated.

Modification:
* Fix broken links

Result:
* The page is updated with the correct links.