### PR TITLE
Fix Platform.OS reference

### DIFF
--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -14,7 +14,7 @@ import { View, KeyboardAvoidingView, TextInput, StyleSheet, Text, Platform, Touc
 const keyBoardAvoidingComponent = () => {
   return (
     <KeyboardAvoidingView
-      behavior={Platform.Os == "ios" ? "padding" : "height"}
+      behavior={Platform.OS == "ios" ? "padding" : "height"}
       style={styles.container}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
The reference to `Platform.Os` is incorrect, it should be `Platform.OS`. It is a small one, but it costed me some time (I thought that `KeyboardAvoidingView` is not working, but it just used a wrong setting for iOS, because of this typo ;) ).