### PR TITLE
Fix types in Share module

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -136,20 +136,20 @@ At least one of URL and message is required.
 
 ---
 
-### `sharedAction()`
+### `sharedAction`
 
 ```jsx
-static sharedAction()
+static sharedAction
 ```
 
 The content was successfully shared.
 
 ---
 
-### `dismissedAction()`
+### `dismissedAction`
 
 ```jsx
-static dismissedAction()
+static dismissedAction
 ```
 
 _iOS Only_. The dialog has been dismissed.


### PR DESCRIPTION
This PR fixes the types of Share.sharedAction and Share.dismissedAction.

These two static properties are not callable, but these are strings. ref: https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L154
