### PR TITLE
remove MaskedViewIOS from 0.62 sidebar

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3129,7 +3129,7 @@
         "title": "Linking"
       },
       "version-0.59/version-0.59-maskedviewios": {
-        "title": "MaskedViewIOS"
+        "title": "🚧 MaskedViewIOS"
       },
       "version-0.59/version-0.59-netinfo": {
         "title": "NetInfo"

--- a/website/versioned_docs/version-0.59/maskedviewios.md
+++ b/website/versioned_docs/version-0.59/maskedviewios.md
@@ -1,10 +1,10 @@
 ---
 id: version-0.59-maskedviewios
-title: MaskedViewIOS
+title: 🚧 MaskedViewIOS
 original_id: maskedviewios
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-masked-view](https://github.com/react-native-community/react-native-masked-view) instead.
+> **Deprecated.** Use [@react-native-community/masked-view](https://github.com/react-native-community/react-native-masked-view) instead.
 
 Renders the child view with a mask specified in the `maskElement` prop.
 

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -106,7 +106,7 @@
       {
         "type": "subcategory",
         "label": "iOS Components",
-        "ids": ["version-0.62-inputaccessoryview", "version-0.62-maskedviewios"]
+        "ids": ["version-0.62-inputaccessoryview"]
       }
     ],
     "Props": [


### PR DESCRIPTION
This PR removes `MaskedViewIOS` from `0.62` sidebar (it's a deprecated component and according to latest decisions deprecated pages should not be a part of the sidebar). I have also updated the repository name in deprecation notice and added deprecation mark to the page title.