### PR TITLE
fix Hello World example in 0.62 docs

### DIFF
--- a/website/versioned_docs/version-0.62/tutorial.md
+++ b/website/versioned_docs/version-0.62/tutorial.md
@@ -19,7 +19,7 @@ import { Text, View } from 'react-native';
 function HelloWorldApp() {
   return (
     <View
-      style={{  }}
+      style={{
         flex: 1,
         justifyContent: "center",
         alignItems: "center"


### PR DESCRIPTION
Refs: #1802, #1804

This PR fixes `Hello World` example in `0.62` versioned docs. It's a backport of #1785.
