### PR TITLE
0.62 release blog post update

### DIFF
--- a/website/blog/2020-03-26-version-0.62.md
+++ b/website/blog/2020-03-26-version-0.62.md
@@ -36,7 +36,7 @@ For more information, check out the [Flipper documentation](https://fbflipper.co
 
 We’ve added a new `Appearance` module to provide access to the user's appearance preferences, such as their preferred color scheme (light or dark).
 
-```
+```js
 const colorScheme = Appearance.getColorScheme();
 if (colorScheme === 'dark') {
   // Use dark color scheme
@@ -45,7 +45,7 @@ if (colorScheme === 'dark') {
 
 We’ve also added a hook to subscribe to state updates to the users preferences:
 
-```
+```jsx
 import {Text, useColorScheme} from 'react-native';
 
 const MyComponent = () => {

--- a/website/blog/2020-03-26-version-0.62.md
+++ b/website/blog/2020-03-26-version-0.62.md
@@ -54,11 +54,11 @@ const MyComponent = () => {
 };
 ```
 
-See the docs for [Appearance](https://reactnative.dev/docs/appearance) and [useColorScheme](https://reactnative.dev/docs/usecolorscheme) for more information.
+See the docs for [Appearance](/docs/appearance) and [useColorScheme](/docs/usecolorscheme) for more information.
 
 ## Moving Apple TV to react-native-tvos
 
-As part of our [Lean Core effort](https://reactnative.dev/blog/#lean-core) and to bring Apple TV in line with other platforms like React Native Windows and React Native macOS, we’ve started to remove Apple TV specific code from core.
+As part of our [Lean Core effort](/blog/#lean-core) and to bring Apple TV in line with other platforms like React Native Windows and React Native macOS, we’ve started to remove Apple TV specific code from core.
 
 Going forward, Apple TV support for React Native will be maintained in [react-native-community/react-native-tvos](https://github.com/react-native-community/react-native-tvos) along with the corresponding `react-native-tvos` NPM package. This is a full fork of the main repository, with only the changes needed to support Apple TV.
 
@@ -66,9 +66,9 @@ Releases of `react-native-tvos` will be based on the public release of React Nat
 
 ## More upgrade support
 
-When 0.61 was released, the community introduced a new [upgrade helper](https://react-native-community.github.io/upgrade-helper/) tool to support developers upgrading to new versions of React Native. The upgrade helper provides a diff of changes from the version you're on to the version you're targeting, allowing you to see the changes that need to be made for your specific upgrace.
+When 0.61 was released, the community introduced a new [upgrade helper](https://react-native-community.github.io/upgrade-helper/) tool to support developers upgrading to new versions of React Native. The upgrade helper provides a diff of changes from the version you're on to the version you're targeting, allowing you to see the changes that need to be made for your specific upgrade.
 
-Even with this tool, issues come up when upgrading. Today we're introducting more dedicated upgrading support by announcing [Upgrade-Support](https://github.com/react-native-community/upgrade-support). Upgrade Support is a GitHub issue tracker where users can submit issues specific to upgrading their projects to receive help from the community.
+Even with this tool, issues come up when upgrading. Today we're introducing more dedicated upgrading support by announcing [Upgrade-Support](https://github.com/react-native-community/upgrade-support). Upgrade Support is a GitHub issue tracker where users can submit issues specific to upgrading their projects to receive help from the community.
 
 We're always working to improve the upgrade experience, and we hope that these tools give users the support they need in the edge cases we haven't covered yet.
 


### PR DESCRIPTION
This small PR improves code blocks syntax highlight in `0.62` release blog post, fixes two typos and updates the internal links.

### Preview
<img width="677" alt="Annotation 2020-04-04 225218" src="https://user-images.githubusercontent.com/719641/78461158-f426b100-76c6-11ea-8530-781f3fc62ad4.png">
