### PR TITLE
Update Typescript template name in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -399,7 +399,7 @@ npx react-native init AwesomeProject --version X.XX.X
 You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
 
 ```sh
-npx react-native init AwesomeTSProject --template react-native-template-typescript
+npx react-native init AwesomeTSProject --template typescript
 ```
 
 > **Note** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your pc. Try uninstalling the cli and run the cli using `npx`.
@@ -429,7 +429,7 @@ npx react-native init AwesomeProject --version X.XX.X
 You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
 
 ```sh
-npx react-native init AwesomeTSProject --template react-native-template-typescript
+npx react-native init AwesomeTSProject --template typescript
 ```
 
 <block class="native mac windows linux android" />


### PR DESCRIPTION
It seems that there was a change in the `react-native init` command when using a template argument, because it fails to me if I try the way it's written on the website.

```
$ npx react-native init projectname --template react-native-template-typescript
# ...
# omitting irrelevent lines
info Fetching template react-native-template-react-native-template-typescript...
yarn add v1.19.2
[1/4] 🔍  Resolving packages...
warning jest > jest-cli > jest-config > jest-environment-jsdom > jsdom > left-pad@1.3.0: use String.prototype.padStart()
warning jest > jest-cli > jest-config > jest-environment-jsdom > jsdom > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
error An unexpected error occurred: "https://registry.yarnpkg.com/react-native-template-react-native-template-typescript: Not found".
info If you think this is a bug, please open a bug report with the information provided in "projectname/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
yarn remove v1.19.2
[1/2] 🗑  Removing module react-native-template-react-native-template-typescript...
error This module isn't specified in a package.json file.
info Visit https://yarnpkg.com/en/docs/cli/remove for documentation about this command.
warn Failed to clean up template temp files in node_modules/react-native-template-react-native-template-typescript. This is not a critical error, you can work on your app.
(node:31885) UnhandledPromiseRejectionWarning: Error: Command failed: yarn add react-native-template-react-native-template-typescript
```

If you try with template name as `typescript` then it works:
```
$ npx react-native init projectname --template typescript 
```