### PR TITLE
Document getColorScheme behavior while sync debugging

### DIFF
--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -64,3 +64,5 @@ Supported color schemes:
 - null: The user has not indicated a preferred color theme.
 
 See also: `useColorScheme` hook.
+
+> Note: `getColorScheme()` will always return `light` when debugging with Chrome.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3540,7 +3540,7 @@
         "title": "Button"
       },
       "version-0.62/version-0.62-checkbox": {
-        "title": "CheckBox"
+        "title": "🚧 CheckBox"
       },
       "version-0.62/version-0.62-clipboard": {
         "title": "🚧 Clipboard"

--- a/website/versioned_docs/version-0.62/appearance.md
+++ b/website/versioned_docs/version-0.62/appearance.md
@@ -65,3 +65,5 @@ Supported color schemes:
 - null: The user has not indicated a preferred color theme.
 
 See also: `useColorScheme` hook.
+
+> Note: `getColorScheme()` will always return `light` when debugging with Chrome.


### PR DESCRIPTION
Related to https://github.com/facebook/react-native/issues/26705.

A fix for https://github.com/facebook/react-native/issues/26705 will have the Appearance module return `light` if the app is being debugged using Chrome Debugger.

# Test Plan

```
yarn
yarn start
```
Verified Appearance page shows the callout.