### PR TITLE
Fix typos in KeyboardAvoidingView docs for 0.62

### DIFF
--- a/website/versioned_docs/version-0.62/keyboardavoidingview.md
+++ b/website/versioned_docs/version-0.62/keyboardavoidingview.md
@@ -4,7 +4,7 @@ title: KeyboardAvoidingView
 original_id: keyboardavoidingview
 ---
 
-It is a component to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust either its height, position, or bottom padding based on the position of the keyboard.
+It is a component to solve the common problem of views that need to move out of the way of the virtual keyboard. It can automatically adjust either its height, position, or bottom padding based on the keyboard height.
 
 ## Example
 
@@ -12,10 +12,10 @@ It is a component to solve the common problem of views that need to move out of 
 import React, { Component } from 'react';
 import { View, KeyboardAvoidingView, TextInput, StyleSheet, Text, Platform, TouchableWithoutFeedback, Button, Keyboard  } from 'react-native';
 
-const keyBoardAvoidingComponent = () => {
+const KeyboardAvoidingComponent = () => {
   return (
     <KeyboardAvoidingView
-      behavior={Platform.Os == "ios" ? "padding" : "height"}
+      behavior={Platform.OS == "ios" ? "padding" : "height"}
       style={styles.container}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
   }
 });
 
-export default keyBoardAvoidingComponent;
+export default KeyboardAvoidingComponent;
 ```
 
 ---


### PR DESCRIPTION
Basically a copy of #1803, but to 0.62 instead of master.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
