### PR TITLE
App crashes if marginBottom is a string

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -163,7 +163,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#DDDDDD',
     padding: 10,
-    marginBottom: '10'
+    marginBottom: 10
   }
 })
 

--- a/website/versioned_docs/version-0.62/tutorial.md
+++ b/website/versioned_docs/version-0.62/tutorial.md
@@ -164,7 +164,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#DDDDDD',
     padding: 10,
-    marginBottom: '10'
+    marginBottom: 10
   }
 })
 


### PR DESCRIPTION
The sample crashes if `marginBottom` is a String. Using a number solves the crash.
