### PR TITLE
Remove empty h2

### DIFF
--- a/website/versioned_docs/version-0.62/textinput.md
+++ b/website/versioned_docs/version-0.62/textinput.md
@@ -782,7 +782,9 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 | ----------------------------------------- | -------- | -------- |
 | enum('simple', 'highQuality', 'balanced') | No       | Android  |
 
-## <!-- alex enable simple -->
+<!-- alex enable simple -->
+
+---
 
 ### `underlineColorAndroid`
 


### PR DESCRIPTION
Remove empty h2 that is between textBreakStrategy and underlineColorAndroid

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
