### PR TITLE
fix React Intro typo in 0.62

### DIFF
--- a/website/versioned_docs/version-0.62/intro-react.md
+++ b/website/versioned_docs/version-0.62/intro-react.md
@@ -298,7 +298,7 @@ You can build many things with props and the Core Components [`Text`](text), [`I
 
 ## State
 
-While you can think of props as arguments you use to configure how components render, **state** is like a component’s personal data storage. Sate is useful for handling data that changes over time or that comes from user interaction. State gives your components memory!
+While you can think of props as arguments you use to configure how components render, **state** is like a component’s personal data storage. State is useful for handling data that changes over time or that comes from user interaction. State gives your components memory!
 
 > As a general rule, use props to configure a component when it renders. Use state to keep track of any component data that you expect to change over time.
 


### PR DESCRIPTION
This small PR fixes typo on the versioned React Intro page for 0.62, fixes #1842.
