### PR TITLE
add deprecation note to the Picker components

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -1,9 +1,11 @@
 ---
 id: picker
-title: Picker
+title: 🚧 Picker
 ---
 
-Renders the native picker component on Android and iOS. 
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+
+Renders the native picker component on Android and iOS.
 
 ## Example
 
@@ -125,4 +127,3 @@ Used to locate this view in end-to-end tests.
 | Type   | Required |
 | ------ | -------- |
 | string | No       |
-

--- a/docs/pickerios.md
+++ b/docs/pickerios.md
@@ -3,7 +3,7 @@ id: pickerios
 title: 🚧 PickerIOS
 ---
 
-> **Deprecated.** Use [Picker](picker.md) instead.
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
 
 ---
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -246,7 +246,7 @@
         "title": "Picker Style Props"
       },
       "picker": {
-        "title": "Picker"
+        "title": "🚧 Picker"
       },
       "pickerios": {
         "title": "🚧 PickerIOS"
@@ -3702,7 +3702,7 @@
         "title": "PermissionsAndroid"
       },
       "version-0.62/version-0.62-picker": {
-        "title": "Picker"
+        "title": "🚧 Picker"
       },
       "version-0.62/version-0.62-pixelratio": {
         "title": "PixelRatio"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -71,7 +71,6 @@
       "imagebackground",
       "keyboardavoidingview",
       "modal",
-      "picker",
       "refreshcontrol",
       "safeareaview",
       "scrollview",

--- a/website/versioned_docs/version-0.61/pickerios.md
+++ b/website/versioned_docs/version-0.61/pickerios.md
@@ -4,7 +4,7 @@ title: 🚧 PickerIOS
 original_id: pickerios
 ---
 
-> **Deprecated.** Use [Picker](picker.md) instead.
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
 
 ---
 

--- a/website/versioned_docs/version-0.62/picker.md
+++ b/website/versioned_docs/version-0.62/picker.md
@@ -1,8 +1,10 @@
 ---
 id: version-0.62-picker
-title: Picker
+title: 🚧 Picker
 original_id: picker
 ---
+
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
 
 Renders the native picker component on Android and iOS.
 

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -81,7 +81,6 @@
       "version-0.62-imagebackground",
       "version-0.62-keyboardavoidingview",
       "version-0.62-modal",
-      "version-0.62-picker",
       "version-0.62-refreshcontrol",
       "version-0.62-safeareaview",
       "version-0.62-scrollview",


### PR DESCRIPTION
This PR adds depreciation note to the `Picker` component page, updates depreciation note on the `PickerIOS` and removes `Picker` from the `0.62` and `next` sidebars (similar as all other deprecated components), fixes #1836.

Deprecation note can be found in the code here:
* https://github.com/facebook/react-native/blob/master/index.js#L163