### PR TITLE
add deprecation note to the Apple TV (tvOS) guide

### DIFF
--- a/docs/building-for-apple-tv.md
+++ b/docs/building-for-apple-tv.md
@@ -3,6 +3,8 @@ id: building-for-apple-tv
 title: Building For TV Devices
 ---
 
+> **Deprecated.** Use [react-native-tvos](https://github.com/react-native-community/react-native-tvos) instead. For the details please check the [0.62 release blog post](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos).
+
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
 <div class="toggler">

--- a/docs/building-for-tv.md
+++ b/docs/building-for-tv.md
@@ -1,25 +1,24 @@
 ---
-id: version-0.62-building-for-apple-tv
+id: building-for-tv
 title: Building For TV Devices
-original_id: building-for-apple-tv
 ---
-
-> **Deprecated.** Use [react-native-tvos](https://github.com/react-native-community/react-native-tvos) instead. For the details please check the [0.62 release blog post](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos).
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
 <div class="toggler">
   <ul role="tablist" id="toggle-platform">
-    <li id="ios" class="button-ios" aria-selected="false" role="tab" tabindex="0" aria-controls="iostab" onclick="displayTab('platform', 'ios')">
-      iOS
-    </li>
     <li id="android" class="button-android" aria-selected="false" role="tab" tabindex="0" aria-controls="androidtab" onclick="displayTab('platform', 'android')">
       Android
+    </li>
+    <li id="ios" class="button-ios" aria-selected="false" role="tab" tabindex="0" aria-controls="iostab" onclick="displayTab('platform', 'ios')">
+      iOS
     </li>
   </ul>
 </div>
 
 <block class="ios" />
+
+> **Deprecated.** Use [react-native-tvos](https://github.com/react-native-community/react-native-tvos) instead. For the details please check the [0.62 release blog post](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos).
 
 The RNTester app supports Apple TV; use the `RNTester-tvOS` build target to build for tvOS.
 

--- a/docs/building-for-tv.md
+++ b/docs/building-for-tv.md
@@ -11,7 +11,7 @@ TV devices support has been implemented with the intention of making existing Re
       Android
     </li>
     <li id="ios" class="button-ios" aria-selected="false" role="tab" tabindex="0" aria-controls="iostab" onclick="displayTab('platform', 'ios')">
-      iOS
+      🚧 iOS
     </li>
   </ul>
 </div>

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -53,7 +53,7 @@
       "backhandler": {
         "title": "BackHandler"
       },
-      "building-for-apple-tv": {
+      "building-for-tv": {
         "title": "Building For TV Devices"
       },
       "button": {
@@ -3536,7 +3536,7 @@
       "version-0.62/version-0.62-backhandler": {
         "title": "BackHandler"
       },
-      "version-0.62/version-0.62-building-for-apple-tv": {
+      "version-0.62/version-0.62-building-for-tv": {
         "title": "Building For TV Devices"
       },
       "version-0.62/version-0.62-button": {

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -2108,7 +2108,7 @@
       "version-0.5/version-0.5-backhandler": {
         "title": "BackHandler"
       },
-      "version-0.5/version-0.5-building-for-apple-tv": {
+      "version-0.5/version-0.5-building-for-tv": {
         "title": "Building For TV Devices"
       },
       "version-0.5/version-0.5-button": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,7 +14,7 @@
     "Environment setup": [
       "environment-setup",
       "integration-with-existing-apps",
-      "building-for-apple-tv",
+      "building-for-tv",
       "out-of-tree-platforms"
     ],
     "Workflow": [

--- a/website/static/docs/building-for-apple-tv.html
+++ b/website/static/docs/building-for-apple-tv.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=building-for-tv.html">
+    <script type="text/javascript">
+      window.location.href = 'building-for-tv.html';
+    </script>
+    <title>React Native · A framework for building native apps using React</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow this <a href="building-for-tv.html">link</a>.
+  </body>
+</html>

--- a/website/versioned_docs/version-0.5/building-for-tv.md
+++ b/website/versioned_docs/version-0.5/building-for-tv.md
@@ -1,7 +1,7 @@
 ---
-id: version-0.5-building-for-apple-tv
+id: version-0.5-building-for-tv
 title: Building For TV Devices
-original_id: building-for-apple-tv
+original_id: building-for-tv
 ---
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.

--- a/website/versioned_docs/version-0.62/building-for-apple-tv.md
+++ b/website/versioned_docs/version-0.62/building-for-apple-tv.md
@@ -4,6 +4,8 @@ title: Building For TV Devices
 original_id: building-for-apple-tv
 ---
 
+> **Deprecated.** Use [react-native-tvos](https://github.com/react-native-community/react-native-tvos) instead. For the details please check the [0.62 release blog post](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos).
+
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
 <div class="toggler">

--- a/website/versioned_docs/version-0.62/building-for-tv.md
+++ b/website/versioned_docs/version-0.62/building-for-tv.md
@@ -1,24 +1,25 @@
 ---
-id: building-for-apple-tv
+id: version-0.62-building-for-tv
 title: Building For TV Devices
+original_id: building-for-tv
 ---
-
-> **Deprecated.** Use [react-native-tvos](https://github.com/react-native-community/react-native-tvos) instead. For the details please check the [0.62 release blog post](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos).
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
 <div class="toggler">
   <ul role="tablist" id="toggle-platform">
-    <li id="ios" class="button-ios" aria-selected="false" role="tab" tabindex="0" aria-controls="iostab" onclick="displayTab('platform', 'ios')">
-      iOS
-    </li>
     <li id="android" class="button-android" aria-selected="false" role="tab" tabindex="0" aria-controls="androidtab" onclick="displayTab('platform', 'android')">
       Android
+    </li>
+    <li id="ios" class="button-ios" aria-selected="false" role="tab" tabindex="0" aria-controls="iostab" onclick="displayTab('platform', 'ios')">
+      iOS
     </li>
   </ul>
 </div>
 
 <block class="ios" />
+
+> **Deprecated.** Use [react-native-tvos](https://github.com/react-native-community/react-native-tvos) instead. For the details please check the [0.62 release blog post](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos).
 
 The RNTester app supports Apple TV; use the `RNTester-tvOS` build target to build for tvOS.
 

--- a/website/versioned_docs/version-0.62/building-for-tv.md
+++ b/website/versioned_docs/version-0.62/building-for-tv.md
@@ -12,7 +12,7 @@ TV devices support has been implemented with the intention of making existing Re
       Android
     </li>
     <li id="ios" class="button-ios" aria-selected="false" role="tab" tabindex="0" aria-controls="iostab" onclick="displayTab('platform', 'ios')">
-      iOS
+      🚧 iOS
     </li>
   </ul>
 </div>

--- a/website/versioned_sidebars/version-0.10-sidebars.json
+++ b/website/versioned_sidebars/version-0.10-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.10-linking-libraries-ios",
       "version-0.10-running-on-simulator-ios",
       "version-0.10-communication-ios",
-      "version-0.10-building-for-apple-tv",
+      "version-0.10-building-for-tv",
       "version-0.10-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.11-sidebars.json
+++ b/website/versioned_sidebars/version-0.11-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.11-linking-libraries-ios",
       "version-0.11-running-on-simulator-ios",
       "version-0.11-communication-ios",
-      "version-0.11-building-for-apple-tv",
+      "version-0.11-building-for-tv",
       "version-0.11-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.12-sidebars.json
+++ b/website/versioned_sidebars/version-0.12-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.12-linking-libraries-ios",
       "version-0.12-running-on-simulator-ios",
       "version-0.12-communication-ios",
-      "version-0.12-building-for-apple-tv",
+      "version-0.12-building-for-tv",
       "version-0.12-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.13-sidebars.json
+++ b/website/versioned_sidebars/version-0.13-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.13-linking-libraries-ios",
       "version-0.13-running-on-simulator-ios",
       "version-0.13-communication-ios",
-      "version-0.13-building-for-apple-tv",
+      "version-0.13-building-for-tv",
       "version-0.13-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.14-sidebars.json
+++ b/website/versioned_sidebars/version-0.14-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.14-linking-libraries-ios",
       "version-0.14-running-on-simulator-ios",
       "version-0.14-communication-ios",
-      "version-0.14-building-for-apple-tv",
+      "version-0.14-building-for-tv",
       "version-0.14-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.15-sidebars.json
+++ b/website/versioned_sidebars/version-0.15-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.15-linking-libraries-ios",
       "version-0.15-running-on-simulator-ios",
       "version-0.15-communication-ios",
-      "version-0.15-building-for-apple-tv",
+      "version-0.15-building-for-tv",
       "version-0.15-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.18-sidebars.json
+++ b/website/versioned_sidebars/version-0.18-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.18-linking-libraries-ios",
       "version-0.18-running-on-simulator-ios",
       "version-0.18-communication-ios",
-      "version-0.18-building-for-apple-tv",
+      "version-0.18-building-for-tv",
       "version-0.18-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.19-sidebars.json
+++ b/website/versioned_sidebars/version-0.19-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.19-linking-libraries-ios",
       "version-0.19-running-on-simulator-ios",
       "version-0.19-communication-ios",
-      "version-0.19-building-for-apple-tv",
+      "version-0.19-building-for-tv",
       "version-0.19-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.20-sidebars.json
+++ b/website/versioned_sidebars/version-0.20-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.20-linking-libraries-ios",
       "version-0.20-running-on-simulator-ios",
       "version-0.20-communication-ios",
-      "version-0.20-building-for-apple-tv",
+      "version-0.20-building-for-tv",
       "version-0.20-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.22-sidebars.json
+++ b/website/versioned_sidebars/version-0.22-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.22-linking-libraries-ios",
       "version-0.22-running-on-simulator-ios",
       "version-0.22-communication-ios",
-      "version-0.22-building-for-apple-tv",
+      "version-0.22-building-for-tv",
       "version-0.22-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.24-sidebars.json
+++ b/website/versioned_sidebars/version-0.24-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.24-linking-libraries-ios",
       "version-0.24-running-on-simulator-ios",
       "version-0.24-communication-ios",
-      "version-0.24-building-for-apple-tv",
+      "version-0.24-building-for-tv",
       "version-0.24-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.26-sidebars.json
+++ b/website/versioned_sidebars/version-0.26-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.26-linking-libraries-ios",
       "version-0.26-running-on-simulator-ios",
       "version-0.26-communication-ios",
-      "version-0.26-building-for-apple-tv",
+      "version-0.26-building-for-tv",
       "version-0.26-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.28-sidebars.json
+++ b/website/versioned_sidebars/version-0.28-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.28-linking-libraries-ios",
       "version-0.28-running-on-simulator-ios",
       "version-0.28-communication-ios",
-      "version-0.28-building-for-apple-tv",
+      "version-0.28-building-for-tv",
       "version-0.28-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.29-sidebars.json
+++ b/website/versioned_sidebars/version-0.29-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.29-linking-libraries-ios",
       "version-0.29-running-on-simulator-ios",
       "version-0.29-communication-ios",
-      "version-0.29-building-for-apple-tv",
+      "version-0.29-building-for-tv",
       "version-0.29-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.32-sidebars.json
+++ b/website/versioned_sidebars/version-0.32-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.32-linking-libraries-ios",
       "version-0.32-running-on-simulator-ios",
       "version-0.32-communication-ios",
-      "version-0.32-building-for-apple-tv",
+      "version-0.32-building-for-tv",
       "version-0.32-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.33-sidebars.json
+++ b/website/versioned_sidebars/version-0.33-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.33-linking-libraries-ios",
       "version-0.33-running-on-simulator-ios",
       "version-0.33-communication-ios",
-      "version-0.33-building-for-apple-tv",
+      "version-0.33-building-for-tv",
       "version-0.33-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.36-sidebars.json
+++ b/website/versioned_sidebars/version-0.36-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.36-linking-libraries-ios",
       "version-0.36-running-on-simulator-ios",
       "version-0.36-communication-ios",
-      "version-0.36-building-for-apple-tv",
+      "version-0.36-building-for-tv",
       "version-0.36-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.37-sidebars.json
+++ b/website/versioned_sidebars/version-0.37-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.37-linking-libraries-ios",
       "version-0.37-running-on-simulator-ios",
       "version-0.37-communication-ios",
-      "version-0.37-building-for-apple-tv",
+      "version-0.37-building-for-tv",
       "version-0.37-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.43-sidebars.json
+++ b/website/versioned_sidebars/version-0.43-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.43-linking-libraries-ios",
       "version-0.43-running-on-simulator-ios",
       "version-0.43-communication-ios",
-      "version-0.43-building-for-apple-tv",
+      "version-0.43-building-for-tv",
       "version-0.43-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.44-sidebars.json
+++ b/website/versioned_sidebars/version-0.44-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.44-linking-libraries-ios",
       "version-0.44-running-on-simulator-ios",
       "version-0.44-communication-ios",
-      "version-0.44-building-for-apple-tv",
+      "version-0.44-building-for-tv",
       "version-0.44-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.46-sidebars.json
+++ b/website/versioned_sidebars/version-0.46-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.46-linking-libraries-ios",
       "version-0.46-running-on-simulator-ios",
       "version-0.46-communication-ios",
-      "version-0.46-building-for-apple-tv",
+      "version-0.46-building-for-tv",
       "version-0.46-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.48-sidebars.json
+++ b/website/versioned_sidebars/version-0.48-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.48-linking-libraries-ios",
       "version-0.48-running-on-simulator-ios",
       "version-0.48-communication-ios",
-      "version-0.48-building-for-apple-tv",
+      "version-0.48-building-for-tv",
       "version-0.48-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.5-sidebars.json
+++ b/website/versioned_sidebars/version-0.5-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.5-linking-libraries-ios",
       "version-0.5-running-on-simulator-ios",
       "version-0.5-communication-ios",
-      "version-0.5-building-for-apple-tv",
+      "version-0.5-building-for-tv",
       "version-0.5-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.50-sidebars.json
+++ b/website/versioned_sidebars/version-0.50-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.50-linking-libraries-ios",
       "version-0.50-running-on-simulator-ios",
       "version-0.50-communication-ios",
-      "version-0.50-building-for-apple-tv",
+      "version-0.50-building-for-tv",
       "version-0.50-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.52-sidebars.json
+++ b/website/versioned_sidebars/version-0.52-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.52-direct-manipulation",
       "version-0.52-colors",
       "version-0.52-integration-with-existing-apps",
-      "version-0.52-building-for-apple-tv",
+      "version-0.52-building-for-tv",
       "version-0.52-running-on-device",
       "version-0.52-upgrading",
       "version-0.52-troubleshooting",

--- a/website/versioned_sidebars/version-0.53-sidebars.json
+++ b/website/versioned_sidebars/version-0.53-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.53-direct-manipulation",
       "version-0.53-colors",
       "version-0.53-integration-with-existing-apps",
-      "version-0.53-building-for-apple-tv",
+      "version-0.53-building-for-tv",
       "version-0.53-running-on-device",
       "version-0.53-upgrading",
       "version-0.53-troubleshooting",

--- a/website/versioned_sidebars/version-0.54-sidebars.json
+++ b/website/versioned_sidebars/version-0.54-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.54-direct-manipulation",
       "version-0.54-colors",
       "version-0.54-integration-with-existing-apps",
-      "version-0.54-building-for-apple-tv",
+      "version-0.54-building-for-tv",
       "version-0.54-running-on-device",
       "version-0.54-upgrading",
       "version-0.54-troubleshooting",

--- a/website/versioned_sidebars/version-0.55-sidebars.json
+++ b/website/versioned_sidebars/version-0.55-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.55-direct-manipulation",
       "version-0.55-colors",
       "version-0.55-integration-with-existing-apps",
-      "version-0.55-building-for-apple-tv",
+      "version-0.55-building-for-tv",
       "version-0.55-running-on-device",
       "version-0.55-upgrading",
       "version-0.55-troubleshooting",

--- a/website/versioned_sidebars/version-0.56-sidebars.json
+++ b/website/versioned_sidebars/version-0.56-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.56-direct-manipulation",
       "version-0.56-colors",
       "version-0.56-integration-with-existing-apps",
-      "version-0.56-building-for-apple-tv",
+      "version-0.56-building-for-tv",
       "version-0.56-running-on-device",
       "version-0.56-upgrading",
       "version-0.56-troubleshooting",

--- a/website/versioned_sidebars/version-0.57-sidebars.json
+++ b/website/versioned_sidebars/version-0.57-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.57-direct-manipulation",
       "version-0.57-colors",
       "version-0.57-integration-with-existing-apps",
-      "version-0.57-building-for-apple-tv",
+      "version-0.57-building-for-tv",
       "version-0.57-running-on-device",
       "version-0.57-upgrading",
       "version-0.57-troubleshooting",

--- a/website/versioned_sidebars/version-0.59-sidebars.json
+++ b/website/versioned_sidebars/version-0.59-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.59-direct-manipulation",
       "version-0.59-colors",
       "version-0.59-integration-with-existing-apps",
-      "version-0.59-building-for-apple-tv",
+      "version-0.59-building-for-tv",
       "version-0.59-running-on-device",
       "version-0.59-upgrading",
       "version-0.59-troubleshooting",

--- a/website/versioned_sidebars/version-0.6-sidebars.json
+++ b/website/versioned_sidebars/version-0.6-sidebars.json
@@ -42,7 +42,7 @@
       "version-0.6-linking-libraries-ios",
       "version-0.6-running-on-simulator-ios",
       "version-0.6-communication-ios",
-      "version-0.6-building-for-apple-tv",
+      "version-0.6-building-for-tv",
       "version-0.6-app-extensions"
     ],
     "Guides (Android)": [

--- a/website/versioned_sidebars/version-0.60-sidebars.json
+++ b/website/versioned_sidebars/version-0.60-sidebars.json
@@ -31,7 +31,7 @@
       "version-0.60-direct-manipulation",
       "version-0.60-colors",
       "version-0.60-integration-with-existing-apps",
-      "version-0.60-building-for-apple-tv",
+      "version-0.60-building-for-tv",
       "version-0.60-running-on-device",
       "version-0.60-upgrading",
       "version-0.60-troubleshooting",

--- a/website/versioned_sidebars/version-0.61-sidebars.json
+++ b/website/versioned_sidebars/version-0.61-sidebars.json
@@ -34,7 +34,7 @@
       "version-0.61-direct-manipulation",
       "version-0.61-colors",
       "version-0.61-integration-with-existing-apps",
-      "version-0.61-building-for-apple-tv",
+      "version-0.61-building-for-tv",
       "version-0.61-running-on-device",
       "version-0.61-upgrading",
       "version-0.61-troubleshooting",

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -14,7 +14,7 @@
     "Environment setup": [
       "version-0.62-environment-setup",
       "version-0.62-integration-with-existing-apps",
-      "version-0.62-building-for-apple-tv",
+      "version-0.62-building-for-tv",
       "version-0.62-out-of-tree-platforms"
     ],
     "Workflow": [


### PR DESCRIPTION
This PR adds deprecation note to the `Building For TV Devices` guide according to `0.62` [release blog](https://reactnative.dev/blog/#moving-apple-tv-to-react-native-tvos) post, refs #1279.
