### PR TITLE
update Platform Color usage on iOS, add Android R.color

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -3,9 +3,21 @@ id: colors
 title: Color Reference
 ---
 
-Components in React Native are [styled using JavaScript](style). Color properties usually match how [CSS works on the web](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
+Components in React Native are [styled using JavaScript](style). Color properties usually match how [CSS works on the web](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value). General guides on the color usage on each platform could be found below:
 
-## Red Green Blue (RGB)
+- [Android](https://material.io/design/color/color-usage.html)
+- [iOS](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/)
+
+## Color APIs
+
+React Native has several color APIs designed to allow you to take full advantage of your platform's design and user preferences.
+
+- [PlatformColor](platformcolor) lets you reference the platform's color system.
+- [DynamicColorIOS](dynamiccolorios) is iOS specific and allows you to specify which colors should be used in light or Dark Mode.
+
+## Color representations
+
+### Red Green Blue (RGB)
 
 React Native supports `rgb()` and `rgba()` in both hexadecimal and functional notation:
 
@@ -16,14 +28,14 @@ React Native supports `rgb()` and `rgba()` in both hexadecimal and functional no
 - `'rgb(255, 0, 255)'`
 - `'rgba(255, 0, 255, 1.0)'`
 
-## Hue Saturation Lightness (HSL)
+### Hue Saturation Lightness (HSL)
 
 React Native supports `hsl()` and `hsla()` in functional notation:
 
 - `'hsl(360, 100%, 100%)'`
 - `'hsla(360, 100%, 100%, 1.0)'`
 
-## Color ints
+### Color ints
 
 React Native supports also colors as an `int` values (in RGB color mode):
 
@@ -31,24 +43,17 @@ React Native supports also colors as an `int` values (in RGB color mode):
 
 > **_Note:_** This might appear similar to the Android [Color](https://developer.android.com/reference/android/graphics/Color) ints representation but on Android values are stored in SRGB color mode (0xaarrggbb).
 
-## Color APIs
-
-React Native has several color APIs designed to allow you to take full advantage of your platform's design and user preferences.
-
-- [PlatformColor](platformcolor) lets you reference the platform's color system.
-- [DynamicColorIOS](dynamiccolorios) is iOS specific and allows you to specify which colors should be used in light or dark mode.
-
-## Named colors
+### Named colors
 
 In React Native you can also use color name strings as values.
 
 > **_Note:_** React Native only supports lowercase color names. Uppercase color names are not supported.
 
-### `transparent`
+#### `transparent`
 
 This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
-### Color keywords
+#### Color keywords
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 

--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -24,8 +24,10 @@ You can use the `PlatformColor` function to access native colors on the target p
 
 For a full list of the types of system colors supported, see:
 
-- [Android R.attr](https://developer.android.com/reference/android/R.attr)
-- [iOS Color](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors?language=objc)
+- Android:
+  - [R.attr](https://developer.android.com/reference/android/R.attr) - `?attr` prefix
+  - [R.color](https://developer.android.com/reference/android/R.color) - `@android:color` prefix
+- [iOS UIColor](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors)
 
 ## Example
 
@@ -46,7 +48,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'stretch',
     ...Platform.select({
-      ios: { color: PlatformColor('labelColor') },
+      ios: { color: PlatformColor('label') },
       android: { color: PlatformColor('?attr/colorControlNormal') },
       default: { color: 'black' },
     }),


### PR DESCRIPTION
This PR updates `Platform Color` API page according to the changes introduced in facebook/react-native#28703. It also adds `R.color` link for Android and information about prefixes to both sources.
