### PR TITLE
Remove unused Component import

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -21,7 +21,7 @@ The Modal component is a basic way to present content above an enclosing view.
 <block class="functional syntax" />
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios
-import React, { Component, useState } from "react";
+import React, { useState } from "react";
 import {
   Alert,
   Modal,


### PR DESCRIPTION
Component was being imported in the functional component example, but it was not used in the example.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
