### PR TITLE
fix init typescript template

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -10,7 +10,7 @@ title: Using TypeScript with React Native
 If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
 
 ```sh
-npx react-native init MyApp --template react-native-template-typescript
+npx react-native init MyApp --template typescript
 ```
 
 > **Note** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your pc. Try uninstalling the cli and run the cli using `npx`.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

When I run the command as documented, I got the following error.

```
info Fetching template react-native-template-react-native-template-typescript...
yarn add v1.6.0
[1/4] 🔍  Resolving packages...
warning jest > jest-cli > jest-config > jest-environment-jsdom > jsdom > left-pad@1.3.0: use String.prototype.padStart()
warning jest > jest-cli > jest-config > jest-environment-jsdom > jsdom > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
error An unexpected error occurred: "https://registry.yarnpkg.com/react-native-template-react-native-template-typescript: Not found".
info If you think this is a bug, please open a bug report with the information provided in "/Users/toda/project/IfReward/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
yarn remove v1.6.0
[1/2] 🗑  Removing module react-native-template-react-native-template-typescript...
error This module isn't specified in a manifest.
info Visit https://yarnpkg.com/en/docs/cli/remove for documentation about this command.
warn Failed to clean up template temp files in node_modules/react-native-template-react-native-template-typescript. This is not a critical error, you can work on your app.
(node:42357) UnhandledPromiseRejectionWarning: Error: Command failed: yarn add react-native-template-react-native-template-typescript
    at makeError (/Users/toda/project/IfReward/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/Users/toda/project/IfReward/node_modules/execa/index.js:278:16)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:42357) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:42357) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

When you execute the changed command, the following log is output and init completes normally.