### PR TITLE
add issue templates and helpful links based on RN repository config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: '🐛 Website Bug Report'
+about: Report a bug or issue with React Native website.
+title: ''
+---
+
+<!-- Please provide all the information requested. Issues that do not follow this format are likely to stall. -->
+
+## Description
+
+<!-- Please provide a clear and concise description of what the bug is. Include screenshots if needed. Pro tip: try the format "As an <person>, trying to <action>, when I <action>, <this> happens. It would be better if <this> happens instead." Example: As an Android developer on a Windows machine, when I set up my environment, I get this error: ... If I used this command instead, I wouldn't get this error ... -->
+
+## Documentation version
+
+<!-- Please list the version or versions on which the issue occurs (including `next`). You can find the documentation version next to the React Native logo at the top of every page. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ⚛️ React Native Issue
+    url: https://github.com/facebook/react-native/issues
+    about: Please report bugs or issues in the React Native repository.
+  - name: ⤴️ Upgrade Issue
+    url: https://github.com/react-native-community/upgrade-support
+    about: Need help upgrading to a newer React Native version? Visit the Upgrade Support repository.
+  - name: 🤔 Questions and Help
+    url: https://reactnative.dev/help
+    about: Looking for help with your app? Please refer to the React Native community's support resources.
+  - name: 🚀 React Native Discussions and Feature Proposals
+    url: https://github.com/react-native-community/discussions-and-proposals
+    about: Discuss the future of React Native in the React Native community's discussions and proposals repository.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,27 @@
+---
+name: '💡 Website Other'
+about: Post an idea, propose improvement, start discussion or put a request according to React Native website.
+title: ''
+---
+
+## Description
+
+<!-- Please provide a clear and concise description of your idea, a "TLDR." You can go into more detail below—more details make issues more actionable for us and help us prioritize! Include screenshots if needed. -->
+
+## What is the problem?
+
+<!-- Does this solve a problem? If so, what is it? -->
+
+## How can we address it?
+
+<!-- Are there any actionable steps we can take to rectify the situation? -->
+
+## Why is it important?
+
+<!-- Make your case here! -->
+
+## Who needs this?
+
+<!-- Android devs? New learners? TypeScript users? -->
+
+## When should this happen (use version numbers if needed)?


### PR DESCRIPTION
This small PR adds issue templates (in short, "Bug" and "Other") and helpful links to the "New issue" flow on the GitHub. Files are heavily based on the React Native repository [config files](https://github.com/facebook/react-native/tree/master/.github/ISSUE_TEMPLATE). The main motivation behind those changes were to help newcomers and guide them in the correct place, to help reporters to create quality issues and requests and to streamline the whole process and make it more consistent with current React Native approach.

I would like also to thank @rachelnabors for the help and tweaks during the creation process of this PR.

## Preview
<img width="764" alt="Annotation 2020-04-30 195940" src="https://user-images.githubusercontent.com/719641/80743444-3f44b000-8b1d-11ea-8347-b4e54b0cd274.png">

