### PR TITLE
Add new option to ActionSheetIOS called disabledButtonsIndices

### DIFF
--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -71,6 +71,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
 - `tintColor` (string) - the [color](colors) used for non-destructive button titles
+- `disabledButtonIndices` (array of numbers) - a list of button indices which should be disabled
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 


### PR DESCRIPTION
That PR is updating `ActionSheet` docs according to the change feature from [PR](https://github.com/facebook/react-native/pull/28792) which is adding a possibility to disable buttons.

~~Don't merge till https://github.com/facebook/react-native/pull/28792 will be merged.~~

EDIT: PR on RN is merged.
