### PR TITLE
Add workflow page "Using Libraries"

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -12,7 +12,7 @@ React Native provides a number of built-in [Core Components](intro-react-native-
 - [Android-specific](components-and-apis#android-components-and-apis)
 - [Others](components-and-apis#others)
 
-You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, search the npm registry for packages mentioning [react-native](https://www.npmjs.com/search?q=react-native&page=1&ranking=optimal) or check out [Awesome React Native](http://www.awesome-react-native.com/) for a curated list.
+You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, refer [this guide about finding libraries](libraries#finding-libraries).
 
 ## Basic Components
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -24,7 +24,7 @@ To install a library in your project, navigate to your project directory in your
 npm install react-native-webview
 ```
 
-The library that we have just installed includes native code, and we need to link to our app before we use it.
+The library that we installed includes native code, and we need to link to our app before we use it.
 
 ## Linking Native Code on iOS
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,0 +1,77 @@
+---
+id: libraries
+title: Using Libraries
+author: Brent Vatne
+authorURL: https://twitter.com/notbrent
+description: This guide introduces React Native developers to finding, installing, and using third-party libraries in their apps.
+---
+
+React Native provides a set of built-in [Core Components and APIs](./components-and-apis) ready to use in your app. You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If the Core Components and APIs don't have what you are looking for, you may be able to find and install a library from the community to add the functionality to your app.
+
+## Selecting a Package Manager
+
+React Native libraries are typically installed from the [npm registry](https://www.npmjs.com/) using a Node.js package manager such as [npm CLI](https://docs.npmjs.com/cli/npm) or [Yarn Classic](https://classic.yarnpkg.com/).
+
+If you have Node.js installed on your computer then you already have the npm CLI installed. Some developers prefer to use Yarn Classic for slightly faster install times and additional advanced features like Workspaces. Both tools work great with React Native. We will assume npm for the rest of this guide for simplicity of explanation.
+
+> 💡 The terms "library" and "package" are used interchangably in the JavaScript community.
+
+## Installing a Library
+
+To install a library in your project, navigate to your project directory in your terminal and run `npm install <name-of-the-library>`. Let's try this with `react-native-webview`:
+
+```bash
+npm install react-native-webview
+```
+
+The library that we have just installed includes native code, and we need to link to our app before we use it.
+
+## Linking Native Code on iOS
+
+React Native uses CocoaPods to manage iOS project dependencies and most React Native libraries follow this same convention. If a library you are using does not, then please refer to their README for additional instruction. In most cases, the following instructions will apply.
+
+Run `pod install` in our `ios` directory in order to link it to our native iOS project. A shortcut for doing this without switching to the `ios` directory is to run `npx pod-install`.
+
+```bash
+npx pod-install
+```
+
+Once this is complete, re-build the app binary to start using your new library:
+
+```bash
+npx react-native run-ios
+```
+
+## Linking Native Code on Android
+
+React Native uses Gradle to manage Android project dependencies. After you install a library with native dependencies, you will need to re-build the app binary to use your new library:
+
+```bash
+npx react-native run-android
+```
+
+## Finding Libraries
+
+[React Native Directory](https://reactnative.directory) is a searchable database of libraries built specifically for React Native. This is the first place to look for a library for your React Native app.
+
+Many of the libraries you will find on the directory are from [React Native Community](https://github.com/react-native-community/) or [Expo](https://docs.expo.io/versions/latest/).
+
+Libraries built by the React Native Community are driven by volunteers and individuals at companies that depend on React Native. They often support iOS, tvOS, Android, Windows, but this varies across projects. Many of the libraries in this organization were once React Native Core Components and APIs.
+
+Libraries built by Expo are all written in TypeScript and support iOS, Android, and react-native-web wherever possible. They usually require that you first install [react-native-unimodules](https://github.com/unimodules/react-native-unimodules) in order to use in your React Native app.
+
+After React Native Directory, the [npm registry](https://www.npmjs.com/) is the next best place if you can't find a library specifically for React Native on the directory. The npm registry is the definitive source for JavaScript libraries, but the libraries that it lists may not all be compatible with React Native. React Native is one of many JavaScript programming environments, including Node.js, web browsers, Electron, and more, and npm includes libraries that work for all of these environments.
+
+## Determining Library Compatibility
+
+### Does it work with React Native?
+
+Usually libraries built _specifically for other platforms_ will not work with React Native. Examples include `react-select` which is built for the web and specifically targets `react-dom`, and `rimraf` which is built for Node.js and interacts with your computer file system. Other libraries like `lodash` use only JavaScript langauge features and work in any environment. You will gain a sense for this over time, but until then the easiest way to find out is to try it yourself. You can remove packages using `npm uninstall` if it turns out that it does not work in React Native.
+
+### Does it work for the platforms that my app supports?
+
+[React Native Directory](https://reactnative.directory/) allows you to filter by platform compatibility, such as iOS, Android, Web, and Windows. If the library you would like to use is not currently listed there, refer to the README for the library to learn more.
+
+### Does it work with my app version of React Native?
+
+The latest version of a library is typically compatible with the latest version of React Native. If you are using an older version, you should refer to the README to know which version of the library you should install. You can install a particular version of the library by running `npm install <library-name>@<version-number>`, for example: `npm install @react-native-community/netinfo@^2.0.0`.

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -10,7 +10,7 @@ React Native provides a set of built-in [Core Components and APIs](./components-
 
 ## Selecting a Package Manager
 
-React Native libraries are typically installed from the [npm registry](https://www.npmjs.com/) using a Node.js package manager such as [npm CLI](https://docs.npmjs.com/cli/npm) or [Yarn Classic](https://classic.yarnpkg.com/).
+React Native libraries are typically installed from the [npm registry](https://www.npmjs.com/) using a Node.js package manager such as [npm CLI](https://docs.npmjs.com/cli/npm) or [Yarn Classic](https://classic.yarnpkg.com/en/).
 
 If you have Node.js installed on your computer then you already have the npm CLI installed. Some developers prefer to use Yarn Classic for slightly faster install times and additional advanced features like Workspaces. Both tools work great with React Native. We will assume npm for the rest of this guide for simplicity of explanation.
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -194,6 +194,9 @@
       "layoutanimation": {
         "title": "LayoutAnimation"
       },
+      "libraries": {
+        "title": "Finding and Using Libraries"
+      },
       "linking-libraries-ios": {
         "title": "Linking Libraries"
       },
@@ -3658,6 +3661,9 @@
       },
       "version-0.62/version-0.62-layoutanimation": {
         "title": "LayoutAnimation"
+      },
+      "version-0.62/version-0.62-libraries": {
+        "title": "Using Libraries"
       },
       "version-0.62/version-0.62-linking-libraries-ios": {
         "title": "Linking Libraries"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -195,7 +195,7 @@
         "title": "LayoutAnimation"
       },
       "libraries": {
-        "title": "Finding and Using Libraries"
+        "title": "Using Libraries"
       },
       "linking-libraries-ios": {
         "title": "Linking Libraries"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,6 +22,7 @@
       "fast-refresh",
       "debugging",
       "testing-overview",
+      "libraries",
       "typescript",
       "upgrading"
     ],

--- a/website/versioned_docs/version-0.62/components-and-apis.md
+++ b/website/versioned_docs/version-0.62/components-and-apis.md
@@ -13,7 +13,7 @@ React Native provides a number of built-in [Core Components](intro-react-native-
 - [Android-specific](components-and-apis#android-components-and-apis)
 - [Others](components-and-apis#others)
 
-You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, search the npm registry for packages mentioning [react-native](https://www.npmjs.com/search?q=react-native&page=1&ranking=optimal) or check out [Awesome React Native](http://www.awesome-react-native.com/) for a curated list.
+You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, refer [this guide about finding libraries](libraries#finding-libraries).
 
 ## Basic Components
 

--- a/website/versioned_docs/version-0.62/libraries.md
+++ b/website/versioned_docs/version-0.62/libraries.md
@@ -1,0 +1,77 @@
+---
+id: libraries
+title: Using Libraries
+author: Brent Vatne
+authorURL: https://twitter.com/notbrent
+description: This guide introduces React Native developers to finding, installing, and using third-party libraries in their apps.
+---
+
+React Native provides a set of built-in [Core Components and APIs](./components-and-apis) ready to use in your app. You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If the Core Components and APIs don't have what you are looking for, you may be able to find and install a library from the community to add the functionality to your app.
+
+## Selecting a Package Manager
+
+React Native libraries are typically installed from the [npm registry](https://www.npmjs.com/) using a Node.js package manager such as [npm CLI](https://docs.npmjs.com/cli/npm) or [Yarn Classic](https://classic.yarnpkg.com/).
+
+If you have Node.js installed on your computer then you already have the npm CLI installed. Some developers prefer to use Yarn Classic for slightly faster install times and additional advanced features like Workspaces. Both tools work great with React Native. We will assume npm for the rest of this guide for simplicity of explanation.
+
+> 💡 The terms "library" and "package" are used interchangably in the JavaScript community.
+
+## Installing a Library
+
+To install a library in your project, navigate to your project directory in your terminal and run `npm install <name-of-the-library>`. Let's try this with `react-native-webview`:
+
+```bash
+npm install react-native-webview
+```
+
+The library that we have just installed includes native code, and we need to link to our app before we use it.
+
+## Linking Native Code on iOS
+
+React Native uses CocoaPods to manage iOS project dependencies and most React Native libraries follow this same convention. If a library you are using does not, then please refer to their README for additional instruction. In most cases, the following instructions will apply.
+
+Run `pod install` in our `ios` directory in order to link it to our native iOS project. A shortcut for doing this without switching to the `ios` directory is to run `npx pod-install`.
+
+```bash
+npx pod-install
+```
+
+Once this is complete, re-build the app binary to start using your new library:
+
+```bash
+npx react-native run-ios
+```
+
+## Linking Native Code on Android
+
+React Native uses Gradle to manage Android project dependencies. After you install a library with native dependencies, you will need to re-build the app binary to use your new library:
+
+```bash
+npx react-native run-android
+```
+
+## Finding Libraries
+
+[React Native Directory](https://reactnative.directory) is a searchable database of libraries built specifically for React Native. This is the first place to look for a library for your React Native app.
+
+Many of the libraries you will find on the directory are from [React Native Community](https://github.com/react-native-community/) or [Expo](https://docs.expo.io/versions/latest/).
+
+Libraries built by the React Native Community are driven by volunteers and individuals at companies that depend on React Native. They often support iOS, tvOS, Android, Windows, but this varies across projects. Many of the libraries in this organization were once React Native Core Components and APIs.
+
+Libraries built by Expo are all written in TypeScript and support iOS, Android, and react-native-web wherever possible. They usually require that you first install [react-native-unimodules](https://github.com/unimodules/react-native-unimodules) in order to use in your React Native app.
+
+After React Native Directory, the [npm registry](https://www.npmjs.com/) is the next best place if you can't find a library specifically for React Native on the directory. The npm registry is the definitive source for JavaScript libraries, but the libraries that it lists may not all be compatible with React Native. React Native is one of many JavaScript programming environments, including Node.js, web browsers, Electron, and more, and npm includes libraries that work for all of these environments.
+
+## Determining Library Compatibility
+
+### Does it work with React Native?
+
+Usually libraries built _specifically for other platforms_ will not work with React Native. Examples include `react-select` which is built for the web and specifically targets `react-dom`, and `rimraf` which is built for Node.js and interacts with your computer file system. Other libraries like `lodash` use only JavaScript langauge features and work in any environment. You will gain a sense for this over time, but until then the easiest way to find out is to try it yourself. You can remove packages using `npm uninstall` if it turns out that it does not work in React Native.
+
+### Does it work for the platforms that my app supports?
+
+[React Native Directory](https://reactnative.directory/) allows you to filter by platform compatibility, such as iOS, Android, Web, and Windows. If the library you would like to use is not currently listed there, refer to the README for the library to learn more.
+
+### Does it work with my app version of React Native?
+
+The latest version of a library is typically compatible with the latest version of React Native. If you are using an older version, you should refer to the README to know which version of the library you should install. You can install a particular version of the library by running `npm install <library-name>@<version-number>`, for example: `npm install @react-native-community/netinfo@^2.0.0`.

--- a/website/versioned_docs/version-0.62/libraries.md
+++ b/website/versioned_docs/version-0.62/libraries.md
@@ -1,9 +1,10 @@
 ---
-id: libraries
+id: version-0.62-libraries
 title: Using Libraries
 author: Brent Vatne
 authorURL: https://twitter.com/notbrent
 description: This guide introduces React Native developers to finding, installing, and using third-party libraries in their apps.
+original_id: libraries
 ---
 
 React Native provides a set of built-in [Core Components and APIs](./components-and-apis) ready to use in your app. You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If the Core Components and APIs don't have what you are looking for, you may be able to find and install a library from the community to add the functionality to your app.
@@ -24,7 +25,7 @@ To install a library in your project, navigate to your project directory in your
 npm install react-native-webview
 ```
 
-The library that we have just installed includes native code, and we need to link to our app before we use it.
+The library that we installed includes native code, and we need to link to our app before we use it.
 
 ## Linking Native Code on iOS
 

--- a/website/versioned_docs/version-0.62/libraries.md
+++ b/website/versioned_docs/version-0.62/libraries.md
@@ -11,7 +11,7 @@ React Native provides a set of built-in [Core Components and APIs](./components-
 
 ## Selecting a Package Manager
 
-React Native libraries are typically installed from the [npm registry](https://www.npmjs.com/) using a Node.js package manager such as [npm CLI](https://docs.npmjs.com/cli/npm) or [Yarn Classic](https://classic.yarnpkg.com/).
+React Native libraries are typically installed from the [npm registry](https://www.npmjs.com/) using a Node.js package manager such as [npm CLI](https://docs.npmjs.com/cli/npm) or [Yarn Classic](https://classic.yarnpkg.com/en/).
 
 If you have Node.js installed on your computer then you already have the npm CLI installed. Some developers prefer to use Yarn Classic for slightly faster install times and additional advanced features like Workspaces. Both tools work great with React Native. We will assume npm for the rest of this guide for simplicity of explanation.
 

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -22,6 +22,7 @@
       "version-0.62-fast-refresh",
       "version-0.62-debugging",
       "version-0.62-testing-overview",
+      "version-0.62-libraries",
       "version-0.62-typescript",
       "version-0.62-upgrading"
     ],


### PR DESCRIPTION
- It's a safe bet to say that every React Native project ever shipped contains some kind of third party JavaScript library, and so we should help users to understand this and to learn how they can integrate libraries into their projects. This came up in a discussion with several folks interested in https://reactnative.directory/
- In my mind, this is the first step towards creating a first-class section on the topic, similar to the [flutter.dev Packages & Plugins section](https://flutter.dev/docs/development/packages-and-plugins/using-packages) (shout-out to Flutter folks, nice work).
- I included a backport to 0.62 docs because this isn't tied to a specific React Native version and would be immediately useful. Feedback is probably best kept to just docs/libraries.md as the versioned copy is identical.
- This was really hard to write, feedback much appreciated.