### PR TITLE
standardize CameraRoll page: add deprecation note, remove listing

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -2964,7 +2964,7 @@
         "title": "Button"
       },
       "version-0.58/version-0.58-cameraroll": {
-        "title": "CameraRoll"
+        "title": "🚧 CameraRoll"
       },
       "version-0.58/version-0.58-communication-android": {
         "title": "Communication between native and React Native"

--- a/website/versioned_docs/version-0.58/cameraroll.md
+++ b/website/versioned_docs/version-0.58/cameraroll.md
@@ -1,8 +1,10 @@
 ---
 id: version-0.58-cameraroll
-title: CameraRoll
+title: 🚧 CameraRoll
 original_id: cameraroll
 ---
+
+> **Deprecated.** Use [@react-native-community/cameraroll](https://github.com/react-native-community/react-native-cameraroll) instead.
 
 `CameraRoll` provides access to the local camera roll or photo library.
 
@@ -13,11 +15,6 @@ On iOS, the `CameraRoll` API requires the `RCTCameraRoll` library to be linked. 
 The user's permission is required in order to access the Camera Roll on devices running iOS 10 or later. Add the `NSPhotoLibraryUsageDescription` key in your `Info.plist` with a string that describes how your app will use this data. This key will appear as `Privacy - Photo Library Usage Description` in Xcode.
 
 If you are targeting devices running iOS 11 or later, you will also need to add the `NSPhotoLibraryAddUsageDescription` key in your `Info.plist`. Use this key to define a string that describes how your app will use this data. By adding this key to your `Info.plist`, you will be able to request write-only access permission from the user. If you try to save to the camera roll without this permission, your app will exit.
-
-### Methods
-
-- [`saveToCameraRoll`](#savetocameraroll)
-- [`getPhotos`](#getphotos)
 
 ---
 


### PR DESCRIPTION
Fixes #1503.

This small PR improves a bit the last version of CameraRoll component page and fixes the issue mentioned above. Summary of changes:

* deprecation note added,
* in content method listing removed (this functionality was replaced by the `onPageNav` component located on the right side of the screen).