### PR TITLE
add ability to highlight new pages in the sidebar

### DIFF
--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -229,3 +229,27 @@ figcaption {
   color: #134484;
   border-bottom-color: #134484;
 }
+
+/*
+  Mark pages as "new" using href attribute:
+  - to show badge in all versions use "PAGEID"
+  - to restrict badge only to the current/default version use "docs/PAGEID"
+  - to restrict badge only to the next version use "next/PAGEID"
+*/
+
+.navItem[href*="dynamiccolorios"]:after,
+.navItem[href*="platformcolor"]:after {
+  content: "new";
+  display: inline-block;
+  position: relative;
+  top: -1px;
+  margin: -1px 0 -1px 10px;
+  padding: 3px 6px;
+  border: 1px solid #ff5722;
+  border-radius: 3px;
+  color: #ff5723;
+  text-transform: uppercase;
+  font-size: 10px;
+  line-height: 10px;
+  font-weight: 600;
+}

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -245,9 +245,9 @@ figcaption {
   top: -1px;
   margin: -1px 0 -1px 10px;
   padding: 3px 6px;
-  border: 1px solid #ff5722;
+  border: 1px solid #86b300;
   border-radius: 3px;
-  color: #ff5723;
+  color: #86b300;
   text-transform: uppercase;
   font-size: 10px;
   line-height: 10px;


### PR DESCRIPTION
This PR introduces ability to mark pages in the main (left) sidebar as "New". This was a nice-to-have feature for a some time, but Docusaurs do not offer a build-in solution or feature for adding such marks and produced HTML do not have any common used anchors. 

To solve this issue I decided to use `href` attribute and "contain" [selector](https://www.w3schools.com/cssref/sel_attr_contain.asp) to match the desired pages. 

The downside of this solution is that the CSS should be updated at least on each version cut.

I have tested those changes with the latest browsers on Win (Chrome, FF, Edge), macOS (Chrome, Safari) and iOS (Chrome, Safari). Few CSS properties has been added to ensure that the design is similar everywhere.

## Preview
<img width="200" alt="Annotation 2020-05-05 235649" src="https://user-images.githubusercontent.com/719641/81120279-abb01c80-8f2c-11ea-8215-d7cc35ed6025.png">

