### PR TITLE
update Accessibility pages, tweak examples

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,7 +1,7 @@
 ---
 id: accessibility
 title: Accessibility
-description: "Create mobile apps accessible to assistive technology with React Native's suite of APIs designed to work with Android and iOS."
+description: Create mobile apps accessible to assistive technology with React Native's suite of APIs designed to work with Android and iOS.
 ---
 
 Both Android and iOS provide APIs for integrating apps with assistive technologies like the bundled screen readers VoiceOver (iOS) and Talkback (Android). React Native has complimentary APIs that let your app accommodate all users.
@@ -10,7 +10,7 @@ Both Android and iOS provide APIs for integrating apps with assistive technologi
 
 ## Accessibility properties
 
-### accessible (iOS, Android)
+### `accessible` (Android, iOS)
 
 When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
 
@@ -25,7 +25,7 @@ On Android, `accessible={true}` property for a react-native View will be transla
 
 In the above example, we can't get accessibility focus separately on 'text one' and 'text two'. Instead we get focus on a parent view with 'accessible' property.
 
-### accessibilityLabel (iOS, Android)
+### `accessibilityLabel` (Android, iOS)
 
 When a view is marked as accessible, it is a good practice to set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected. VoiceOver will read this string when a user selects the associated element.
 
@@ -35,7 +35,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 <TouchableOpacity
   accessible={true}
   accessibilityLabel="Tap me!"
-  onPress={this._onPress}>
+  onPress={onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Press me!</Text>
   </View>
@@ -44,7 +44,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### accessibilityHint (iOS, Android)
+### `accessibilityHint` (Android, iOS)
 
 An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not clear from the accessibility label.
 
@@ -55,7 +55,7 @@ To use, set the `accessibilityHint` property to a custom string on your View, Te
   accessible={true}
   accessibilityLabel="Go back"
   accessibilityHint="Navigates to the previous screen"
-  onPress={this._onPress}>
+  onPress={onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Back</Text>
   </View>
@@ -66,11 +66,11 @@ iOS In the above example, VoiceOver will read the hint after the label, if the u
 
 Android In the above example, Talkback will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### accessibilityIgnoresInvertColors(iOS)
+### `accessibilityIgnoresInvertColors` (iOS)
 
 Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be false so that these specific views won't have their colors inverted.
 
-### accessibilityRole (iOS, Android)
+### `accessibilityRole` (Android, iOS)
 
 `accessibilityRole` communicates the purpose of a component to the user of an assistive technology.
 
@@ -104,7 +104,7 @@ Inverting screen colors is an Accessibility feature that makes the iPhone and iP
 - **timer** Used to represent a timer.
 - **toolbar** Used to represent a tool bar (a container of action buttons or components).
 
-### accessibilityState (iOS, Android)
+### `accessibilityState` (Android, iOS)
 
 Describes the current state of a component to the user of an assistive technology.
 
@@ -120,7 +120,7 @@ Describes the current state of a component to the user of an assistive technolog
 
 To use, set the `accessibilityState` to an object with a specific definition.
 
-### accessibilityValue (iOS, Android)
+### `accessibilityValue` (Android, iOS)
 
 Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
 
@@ -133,31 +133,31 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### accessibilityViewIsModal (iOS)
+### `accessibilityViewIsModal` (iOS)
 
 A Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in the view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### accessibilityElementsHidden (iOS)
+### `accessibilityElementsHidden` (iOS)
 
 A Boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
-### onAccessibilityTap (iOS, Android)
+### `onAccessibilityTap` (Android, iOS)
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### onMagicTap (iOS)
+### `onMagicTap` (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call, or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
-### onAccessibilityEscape (iOS)
+### `onAccessibilityEscape` (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### accessibilityLiveRegion (Android)
+### `accessibilityLiveRegion` (Android)
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite` and `assertive`:
 
@@ -166,36 +166,38 @@ When components dynamically change, we want TalkBack to alert the end user. This
 - **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
 
 ```jsx
-<TouchableWithoutFeedback onPress={this._addOne}>
+<TouchableWithoutFeedback onPress={addOne}>
   <View style={styles.embedded}>
     <Text>Click me</Text>
   </View>
 </TouchableWithoutFeedback>
 <Text accessibilityLiveRegion="polite">
-  Clicked {this.state.count} times
+  Clicked {count} times
 </Text>
 ```
 
-In the above example method \_addOne changes the state.count variable. As soon as an end user clicks the TouchableWithoutFeedback, TalkBack reads text in the Text view because of its `accessibilityLiveRegion=”polite”` property.
+In the above example method `addOne` changes the state variable `count`. As soon as an end user clicks the TouchableWithoutFeedback, TalkBack reads text in the Text view because of its `accessibilityLiveRegion="polite"` property.
 
-### importantForAccessibility (Android)
+### `importantForAccessibility` (Android)
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
 ```jsx
 <View style={styles.container}>
-  <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'green'}} importantForAccessibility="yes">
-    <Text> First layout </Text>
+  <View
+    style={[styles.layout, {backgroundColor: 'green'}]}
+    importantForAccessibility="yes">
+    <Text>First layout</Text>
   </View>
-  <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'yellow'}} importantForAccessibility="no-hide-descendants">
-    <Text> Second layout </Text>
+  <View
+    style={[styles.layout, {backgroundColor: 'yellow'}]}
+    importantForAccessibility="no-hide-descendants">
+    <Text>Second layout</Text>
   </View>
 </View>
 ```
 
-In the above example, the yellow layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
+In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
 ## Accessibility Actions
 
@@ -259,13 +261,13 @@ The `AccessibilityInfo` API allows you to determine whether or not a screen read
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: view tag and a type of an event. The supported event types are `typeWindowStateChanged`, `typeViewFocused` and `typeViewClicked`.
 
 ```jsx
-import { Platform, UIManager, findNodeHandle } from 'react-native';
+import {Platform, UIManager, findNodeHandle} from 'react-native';
 
 if (Platform.OS === 'android') {
-    UIManager.sendAccessibilityEvent(
-      findNodeHandle(this),
-      UIManager.AccessibilityEventTypes.typeViewFocused);
-  }
+  UIManager.sendAccessibilityEvent(
+    findNodeHandle(this),
+    UIManager.AccessibilityEventTypes.typeViewFocused,
+  );
 }
 ```
 
@@ -292,7 +294,7 @@ To use the volume key shortcut, press both volume keys for 3 seconds to start an
 
 Additionally, if you prefer, you can toggle TalkBack via command line with:
 
-```
+```sh
 # disable
 adb shell settings put secure enabled_accessibility_services com.android.talkback/com.google.android.marvin.talkback.TalkBackService
 

--- a/website/versioned_docs/version-0.5/accessibility.md
+++ b/website/versioned_docs/version-0.5/accessibility.md
@@ -4,17 +4,13 @@ title: Accessibility
 original_id: accessibility
 ---
 
-## Native App Accessibility (Android and iOS)
+Both Android and iOS provide APIs for integrating apps with assistive technologies like the bundled screen readers VoiceOver (iOS) and Talkback (Android). React Native has complimentary APIs that let your app accommodate all users.
 
-Both Android and iOS provide APIs for making apps accessible to people with disabilities. In addition, both platforms provide bundled assistive technologies, like the screen readers VoiceOver (iOS) and TalkBack (Android) for the visually impaired. Similarly, in React Native we have included APIs designed to provide developers with support for making apps more accessible. Take note, Android and iOS differ slightly in their approaches, and thus the React Native implementations may vary by platform.
+> Android and iOS differ slightly in their approaches, and thus the React Native implementations may vary by platform.
 
-In addition to this documentation, you might find [this blog post](https://engineering.fb.com/ios/making-react-native-apps-accessible/) about React Native accessibility to be useful.
+## Accessibility properties
 
-## Making Apps Accessible
-
-### Accessibility properties
-
-#### accessible (iOS, Android)
+### `accessible` (Android, iOS)
 
 When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
 
@@ -29,7 +25,7 @@ On Android, `accessible={true}` property for a react-native View will be transla
 
 In the above example, we can't get accessibility focus separately on 'text one' and 'text two'. Instead we get focus on a parent view with 'accessible' property.
 
-#### accessibilityLabel (iOS, Android)
+### `accessibilityLabel` (Android, iOS)
 
 When a view is marked as accessible, it is a good practice to set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected. VoiceOver will read this string when a user selects the associated element.
 
@@ -39,7 +35,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 <TouchableOpacity
   accessible={true}
   accessibilityLabel="Tap me!"
-  onPress={this._onPress}>
+  onPress={onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Press me!</Text>
   </View>
@@ -48,9 +44,9 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-#### accessibilityHint (iOS, Android)
+### `accessibilityHint` (Android, iOS)
 
-An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not apparent from the accessibility label.
+An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not clear from the accessibility label.
 
 To use, set the `accessibilityHint` property to a custom string on your View, Text or Touchable:
 
@@ -59,7 +55,7 @@ To use, set the `accessibilityHint` property to a custom string on your View, Te
   accessible={true}
   accessibilityLabel="Go back"
   accessibilityHint="Navigates to the previous screen"
-  onPress={this._onPress}>
+  onPress={onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Back</Text>
   </View>
@@ -70,11 +66,11 @@ iOS In the above example, VoiceOver will read the hint after the label, if the u
 
 Android In the above example, Talkback will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-#### accessibilityIgnoresInvertColors(iOS)
+### `accessibilityIgnoresInvertColors` (iOS)
 
 Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be false so that these specific views won't have their colors inverted.
 
-#### accessibilityRole (iOS, Android)
+### `accessibilityRole` (Android, iOS)
 
 `accessibilityRole` communicates the purpose of a component to the user of an assistive technology.
 
@@ -108,106 +104,89 @@ Inverting screen colors is an Accessibility feature that makes the iPhone and iP
 - **timer** Used to represent a timer.
 - **toolbar** Used to represent a tool bar (a container of action buttons or components).
 
-#### accessibilityState (iOS, Android)
+### `accessibilityState` (Android, iOS)
 
 Describes the current state of a component to the user of an assistive technology.
 
 `accessibilityState` is an object. It contains the following fields:
 
-| Name     | Type               | Required |
-| -------- | ------------------ | -------- |
-| disabled | boolean            | No       |
-| selected | boolean            | No       |
-| checked  | boolean or 'mixed' | No       |
-| busy     | boolean            | No       |
-| expanded | boolean            | No       |
-
-- **disabled** Used to indicate whether the element is disabled or not. When `true`, the element cannot be interacted with.
-- **selected** Used to indicate whether a selectable element is currently selected or not.
-- **checked** Used to indicate the state of a checkable element. This field can either take a boolean or the "mixed" string to represent mixed checkboxes.
-- **busy** Used to indicate whether an element is currently busy or not.
-- **expanded** Used to indicate whether an expandable element is currently expanded or collapsed.
+| Name     | Description                                                                                                                           | Type               | Required |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | -------- |
+| disabled | Indicates whether the element is disabled or not.                                                                                     | boolean            | No       |
+| selected | Indicates whether a selectable element is currently selected or not.                                                                  | boolean            | No       |
+| checked  | Indicates the state of a checkable element. This field can either take a boolean or the "mixed" string to represent mixed checkboxes. | boolean or 'mixed' | No       |
+| busy     | Indicates whether an element is currently busy or not.                                                                                | boolean            | No       |
+| expanded | Indicates whether an expandable element is currently expanded or collapsed.                                                           | boolean            | No       |
 
 To use, set the `accessibilityState` to an object with a specific definition.
 
-#### accessibilityValue (iOS, Android)
-
-Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
-
-`accessibilityValue` is an object. It contains the following fields:
-
-| Name | Description                                                                                    | Type    | Required                  |
-| ---- | ---------------------------------------------------------------------------------------------- | ------- | ------------------------- |
-| min  | The minimum value of this component's range.                                                   | integer | Required if `now` is set. |
-| max  | The maximum value of this component's range.                                                   | integer | Required if `now` is set. |
-| now  | The current value of this component's range.                                                   | integer | No                        |
-| text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
-
-#### accessibilityViewIsModal (iOS)
+### `accessibilityViewIsModal` (iOS)
 
 A Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in the view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-#### accessibilityElementsHidden (iOS)
+### `accessibilityElementsHidden` (iOS)
 
 A Boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
-#### onAccessibilityTap (iOS, Android)
+### `onAccessibilityTap` (Android, iOS)
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-#### onMagicTap (iOS)
+### `onMagicTap` (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call, or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
-#### onAccessibilityEscape (iOS)
+### `onAccessibilityEscape` (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-#### accessibilityLiveRegion (Android)
+### `accessibilityLiveRegion` (Android)
 
-When components dynamically change, we want TalkBack to alert the end user. This is made possible by the ‘accessibilityLiveRegion’ property. It can be set to ‘none’, ‘polite’ and ‘assertive’:
+When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite` and `assertive`:
 
 - **none** Accessibility services should not announce changes to this view.
 - **polite** Accessibility services should announce changes to this view.
 - **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
 
 ```jsx
-<TouchableWithoutFeedback onPress={this._addOne}>
+<TouchableWithoutFeedback onPress={addOne}>
   <View style={styles.embedded}>
     <Text>Click me</Text>
   </View>
 </TouchableWithoutFeedback>
 <Text accessibilityLiveRegion="polite">
-  Clicked {this.state.count} times
+  Clicked {count} times
 </Text>
 ```
 
-In the above example method \_addOne changes the state.count variable. As soon as an end user clicks the TouchableWithoutFeedback, TalkBack reads text in the Text view because of its 'accessibilityLiveRegion=”polite”' property.
+In the above example method `addOne` changes the state variable `count`. As soon as an end user clicks the TouchableWithoutFeedback, TalkBack reads text in the Text view because of its `accessibilityLiveRegion="polite"` property.
 
-#### importantForAccessibility (Android)
+### `importantForAccessibility` (Android)
 
-In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The ‘importantForAccessibility’ property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to ‘auto’, ‘yes’, ‘no’ and ‘no-hide-descendants’ (the last value will force accessibility services to ignore the component and all of its children).
+In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
 ```jsx
 <View style={styles.container}>
-  <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'green'}} importantForAccessibility=”yes”>
-    <Text> First layout </Text>
+  <View
+    style={[styles.layout, {backgroundColor: 'green'}]}
+    importantForAccessibility="yes">
+    <Text>First layout</Text>
   </View>
-  <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'yellow'}} importantForAccessibility=”no-hide-descendants”>
-    <Text> Second layout </Text>
+  <View
+    style={[styles.layout, {backgroundColor: 'yellow'}]}
+    importantForAccessibility="no-hide-descendants">
+    <Text>Second layout</Text>
   </View>
 </View>
 ```
 
-In the above example, the yellow layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
+In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### Accessibility Actions
+## Accessibility Actions
 
 Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. In order to support accessibility actions, a component must do two things:
 
@@ -260,22 +239,22 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 />
 ```
 
-### Checking if a Screen Reader is Enabled
+## Checking if a Screen Reader is Enabled
 
-The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo.md) for details.
+The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-### Sending Accessibility Events (Android)
+## Sending Accessibility Events (Android)
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: view tag and a type of an event. The supported event types are `typeWindowStateChanged`, `typeViewFocused` and `typeViewClicked`.
 
 ```jsx
-import { Platform, UIManager, findNodeHandle } from 'react-native';
+import {Platform, UIManager, findNodeHandle} from 'react-native';
 
 if (Platform.OS === 'android') {
-    UIManager.sendAccessibilityEvent(
-      findNodeHandle(this),
-      UIManager.AccessibilityEventTypes.typeViewFocused);
-  }
+  UIManager.sendAccessibilityEvent(
+    findNodeHandle(this),
+    UIManager.AccessibilityEventTypes.typeViewFocused,
+  );
 }
 ```
 
@@ -302,10 +281,14 @@ To use the volume key shortcut, press both volume keys for 3 seconds to start an
 
 Additionally, if you prefer, you can toggle TalkBack via command line with:
 
-```
+```sh
 # disable
 adb shell settings put secure enabled_accessibility_services com.android.talkback/com.google.android.marvin.talkback.TalkBackService
 
 # enable
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
+
+## Additional Resources
+
+- [Making React Native Apps Accessible](https://engineering.fb.com/ios/making-react-native-apps-accessible/)

--- a/website/versioned_docs/version-0.62/accessibility.md
+++ b/website/versioned_docs/version-0.62/accessibility.md
@@ -1,7 +1,6 @@
 ---
 id: version-0.62-accessibility
 title: Accessibility
-description: Create mobile apps accessible to assistive technology with React Native's suite of APIs designed to work with Android and iOS.
 original_id: accessibility
 ---
 
@@ -11,7 +10,7 @@ Both Android and iOS provide APIs for integrating apps with assistive technologi
 
 ## Accessibility properties
 
-### accessible (iOS, Android)
+### `accessible` (Android, iOS)
 
 When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
 
@@ -26,7 +25,7 @@ On Android, `accessible={true}` property for a react-native View will be transla
 
 In the above example, we can't get accessibility focus separately on 'text one' and 'text two'. Instead we get focus on a parent view with 'accessible' property.
 
-### accessibilityLabel (iOS, Android)
+### `accessibilityLabel` (Android, iOS)
 
 When a view is marked as accessible, it is a good practice to set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected. VoiceOver will read this string when a user selects the associated element.
 
@@ -36,7 +35,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 <TouchableOpacity
   accessible={true}
   accessibilityLabel="Tap me!"
-  onPress={this._onPress}>
+  onPress={onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Press me!</Text>
   </View>
@@ -45,7 +44,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### accessibilityHint (iOS, Android)
+### `accessibilityHint` (Android, iOS)
 
 An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not clear from the accessibility label.
 
@@ -56,7 +55,7 @@ To use, set the `accessibilityHint` property to a custom string on your View, Te
   accessible={true}
   accessibilityLabel="Go back"
   accessibilityHint="Navigates to the previous screen"
-  onPress={this._onPress}>
+  onPress={onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Back</Text>
   </View>
@@ -67,11 +66,11 @@ iOS In the above example, VoiceOver will read the hint after the label, if the u
 
 Android In the above example, Talkback will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### accessibilityIgnoresInvertColors(iOS)
+### `accessibilityIgnoresInvertColors` (iOS)
 
 Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be false so that these specific views won't have their colors inverted.
 
-### accessibilityRole (iOS, Android)
+### `accessibilityRole` (Android, iOS)
 
 `accessibilityRole` communicates the purpose of a component to the user of an assistive technology.
 
@@ -105,7 +104,7 @@ Inverting screen colors is an Accessibility feature that makes the iPhone and iP
 - **timer** Used to represent a timer.
 - **toolbar** Used to represent a tool bar (a container of action buttons or components).
 
-### accessibilityState (iOS, Android)
+### `accessibilityState` (Android, iOS)
 
 Describes the current state of a component to the user of an assistive technology.
 
@@ -121,7 +120,7 @@ Describes the current state of a component to the user of an assistive technolog
 
 To use, set the `accessibilityState` to an object with a specific definition.
 
-### accessibilityValue (iOS, Android)
+### `accessibilityValue` (Android, iOS)
 
 Represents the current value of a component. It can be a textual description of a component's value, or for range-based components, such as sliders and progress bars, it contains range information (minimum, current, and maximum).
 
@@ -134,69 +133,71 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### accessibilityViewIsModal (iOS)
+### `accessibilityViewIsModal` (iOS)
 
 A Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in the view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### accessibilityElementsHidden (iOS)
+### `accessibilityElementsHidden` (iOS)
 
 A Boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
-### onAccessibilityTap (iOS, Android)
+### `onAccessibilityTap` (Android, iOS)
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### onMagicTap (iOS)
+### `onMagicTap` (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call, or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
-### onAccessibilityEscape (iOS)
+### `onAccessibilityEscape` (iOS)
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### accessibilityLiveRegion (Android)
+### `accessibilityLiveRegion` (Android)
 
-When components dynamically change, we want TalkBack to alert the end user. This is made possible by the ‘accessibilityLiveRegion’ property. It can be set to ‘none’, ‘polite’ and ‘assertive’:
+When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite` and `assertive`:
 
 - **none** Accessibility services should not announce changes to this view.
 - **polite** Accessibility services should announce changes to this view.
 - **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
 
 ```jsx
-<TouchableWithoutFeedback onPress={this._addOne}>
+<TouchableWithoutFeedback onPress={addOne}>
   <View style={styles.embedded}>
     <Text>Click me</Text>
   </View>
 </TouchableWithoutFeedback>
 <Text accessibilityLiveRegion="polite">
-  Clicked {this.state.count} times
+  Clicked {count} times
 </Text>
 ```
 
-In the above example method \_addOne changes the state.count variable. As soon as an end user clicks the TouchableWithoutFeedback, TalkBack reads text in the Text view because of its 'accessibilityLiveRegion=”polite”' property.
+In the above example method `addOne` changes the state variable `count`. As soon as an end user clicks the TouchableWithoutFeedback, TalkBack reads text in the Text view because of its `accessibilityLiveRegion="polite"` property.
 
-### importantForAccessibility (Android)
+### `importantForAccessibility` (Android)
 
-In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The ‘importantForAccessibility’ property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to ‘auto’, ‘yes’, ‘no’ and ‘no-hide-descendants’ (the last value will force accessibility services to ignore the component and all of its children).
+In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
 ```jsx
 <View style={styles.container}>
-  <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'green'}} importantForAccessibility=”yes”>
-    <Text> First layout </Text>
+  <View
+    style={[styles.layout, {backgroundColor: 'green'}]}
+    importantForAccessibility="yes">
+    <Text>First layout</Text>
   </View>
-  <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'yellow'}} importantForAccessibility=”no-hide-descendants”>
-    <Text> Second layout </Text>
+  <View
+    style={[styles.layout, {backgroundColor: 'yellow'}]}
+    importantForAccessibility="no-hide-descendants">
+    <Text>Second layout</Text>
   </View>
 </View>
 ```
 
-In the above example, the yellow layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
+In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
 ## Accessibility Actions
 
@@ -260,13 +261,13 @@ The `AccessibilityInfo` API allows you to determine whether or not a screen read
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: view tag and a type of an event. The supported event types are `typeWindowStateChanged`, `typeViewFocused` and `typeViewClicked`.
 
 ```jsx
-import { Platform, UIManager, findNodeHandle } from 'react-native';
+import {Platform, UIManager, findNodeHandle} from 'react-native';
 
 if (Platform.OS === 'android') {
-    UIManager.sendAccessibilityEvent(
-      findNodeHandle(this),
-      UIManager.AccessibilityEventTypes.typeViewFocused);
-  }
+  UIManager.sendAccessibilityEvent(
+    findNodeHandle(this),
+    UIManager.AccessibilityEventTypes.typeViewFocused,
+  );
 }
 ```
 
@@ -293,7 +294,7 @@ To use the volume key shortcut, press both volume keys for 3 seconds to start an
 
 Additionally, if you prefer, you can toggle TalkBack via command line with:
 
-```
+```sh
 # disable
 adb shell settings put secure enabled_accessibility_services com.android.talkback/com.google.android.marvin.talkback.TalkBackService
 


### PR DESCRIPTION
This PR updates all versions of Accessibility page and introduces following changes:
* remove `accessibilityValue` from `0.61` docs and below ( fixes #1489 )
* remove `this` to promote more functional components
* fix `sendAccessibilityEvent` example
* sort headers (Android before iOS)
* backport few formatting tweaks from the current version to the versioned docs
* replace "pretty" quotation marks with the regular double quotes