### PR TITLE
AppState Function Component Example Fix: useRef instead of useState

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -40,7 +40,6 @@ import React, { useEffect, useRef } from "react";
 import { AppState, StyleSheet, Text, View } from "react-native";
 
 const AppStateExample = () => {
-
   const appState = useRef(AppState.currentState);
 
   useEffect(() => {
@@ -57,7 +56,7 @@ const AppStateExample = () => {
     }
     appState.current = nextAppState;
   };
-  
+
   return (
     <View style={styles.container}>
       <Text>Current state is: {appState.current}</Text>

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -60,7 +60,7 @@ const AppStateExample = () => {
   
   return (
     <View style={styles.container}>
-      <Text>Current state is: {appState}</Text>
+      <Text>Current state is: {appState.current}</Text>
     </View>
   );
 };

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -36,11 +36,12 @@ To see the current state, you can check `AppState.currentState`, which will be k
 <block class="functional syntax" />
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { AppState, StyleSheet, Text, View } from "react-native";
 
 const AppStateExample = () => {
-  const [appState, setAppState] = useState(AppState.currentState);
+
+  const appState = useRef(AppState.currentState);
 
   useEffect(() => {
     AppState.addEventListener("change", _handleAppStateChange);
@@ -50,13 +51,13 @@ const AppStateExample = () => {
     };
   }, []);
 
-  const _handleAppStateChange = nextAppState => {
-    if (appState.match(/inactive|background/) && nextAppState === "active") {
+  const _handleAppStateChange = (nextAppState) => {
+    if (appState.current.match(/inactive|background/) && nextAppState === "active") {
       console.log("App has come to the foreground!");
     }
-    setAppState(nextAppState);
+    appState.current = nextAppState;
   };
-
+  
   return (
     <View style={styles.container}>
       <Text>Current state is: {appState}</Text>


### PR DESCRIPTION
when appState was being created with useState, the _handleAppStateChange had the original appState reference at the time that the event listener was created, and therefore never updated and remained 'active'. Adding a useCallback also did not seem to update appState, even if appState was added as a dependency.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
