### PR TITLE
fix: add missing Appearance module APIs

### DIFF
--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -66,3 +66,19 @@ Supported color schemes:
 See also: `useColorScheme` hook.
 
 > Note: `getColorScheme()` will always return `light` when debugging with Chrome.
+
+### `addChangeListener()`
+
+```jsx
+static addChangeListener(listener)
+```
+
+Add an event handler that is fired when appearance preferences change.
+
+### `removeChangeListener()`
+
+```jsx
+static removeChangeListener(listener)
+```
+
+Remove an event handler.

--- a/website/versioned_docs/version-0.62/appearance.md
+++ b/website/versioned_docs/version-0.62/appearance.md
@@ -67,3 +67,19 @@ Supported color schemes:
 See also: `useColorScheme` hook.
 
 > Note: `getColorScheme()` will always return `light` when debugging with Chrome.
+
+### `addChangeListener()`
+
+```jsx
+static addChangeListener(listener)
+```
+
+Add an event handler that is fired when appearance preferences change.
+
+### `removeChangeListener()`
+
+```jsx
+static removeChangeListener(listener)
+```
+
+Remove an event handler.


### PR DESCRIPTION
## Summary

Added missing `addChangeListener` and `removeChangeListener` APIs present in Appearance module: https://github.com/facebook/react-native/blob/0.62-stable/Libraries/Utilities/Appearance.js
Updated docs for 0.62 and current.
