### PR TITLE
fix: "refer to" rather than "refer"

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -12,7 +12,7 @@ React Native provides a number of built-in [Core Components](intro-react-native-
 - [Android-specific](components-and-apis#android-components-and-apis)
 - [Others](components-and-apis#others)
 
-You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, refer [this guide about finding libraries](libraries#finding-libraries).
+You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, please refer to [this guide about finding libraries](libraries#finding-libraries).
 
 ## Basic Components
 

--- a/website/versioned_docs/version-0.62/components-and-apis.md
+++ b/website/versioned_docs/version-0.62/components-and-apis.md
@@ -13,7 +13,7 @@ React Native provides a number of built-in [Core Components](intro-react-native-
 - [Android-specific](components-and-apis#android-components-and-apis)
 - [Others](components-and-apis#others)
 
-You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, refer [this guide about finding libraries](libraries#finding-libraries).
+You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, please refer to [this guide about finding libraries](libraries#finding-libraries).
 
 ## Basic Components
 


### PR DESCRIPTION
In https://github.com/facebook/react-native-website/pull/1902 I made a typo and wrote "refer this guide" rather than "refer to this guide". I also added "please" before "refer" to be more polite.