### PR TITLE
chore: document rippleRadius in TouchableNativeFeedback

### DIFF
--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -149,37 +149,38 @@ TV next focus up (see documentation for the View component).
 ### `SelectableBackground()`
 
 ```jsx
-static SelectableBackground()
+static SelectableBackground(rippleRadius: ?number)
 ```
 
-Creates an object that represents android theme's default background for selectable elements (?android:attr/selectableItemBackground).
+Creates an object that represents android theme's default background for selectable elements (?android:attr/selectableItemBackground). `rippleRadius` parameter controls the radius of the ripple effect.
 
 ---
 
 ### `SelectableBackgroundBorderless()`
 
 ```jsx
-static SelectableBackgroundBorderless()
+static SelectableBackgroundBorderless(rippleRadius: ?number)
 ```
 
-Creates an object that represent android theme's default background for borderless selectable elements (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+.
+Creates an object that represent android theme's default background for borderless selectable elements (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+. `rippleRadius` parameter controls the radius of the ripple effect.
 
 ---
 
 ### `Ripple()`
 
 ```jsx
-static Ripple(color: string, borderless: boolean)
+static Ripple(color: string, borderless: boolean, rippleRadius: ?number)
 ```
 
 Creates an object that represents ripple drawable with specified color (as a string). If property `borderless` evaluates to true the ripple will render outside of the view bounds (see native actionbar buttons as an example of that behavior). This background type is available on Android API level 21+.
 
 **Parameters:**
 
-| Name       | Type    | Required | Description                                 |
-| ---------- | ------- | -------- | ------------------------------------------- |
-| color      | string  | Yes      | The ripple color                            |
-| borderless | boolean | Yes      | If the ripple can render outside its bounds |
+| Name         | Type    | Required | Description                                 |
+| ------------ | ------- | -------- | ------------------------------------------- |
+| color        | string  | Yes      | The ripple color                            |
+| borderless   | boolean | Yes      | If the ripple can render outside its bounds |
+| rippleRadius | ?number | No       | controls the radius of the ripple effect    |
 
 ---
 


### PR DESCRIPTION
This documents rippleRadius added to TouchableNativeFeedback which is & will be available in RN 0.63. See https://github.com/facebook/react-native/pull/28009/files