### PR TITLE
Need go back to project root before run testing

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -93,7 +93,7 @@ _Note: In order for Google Play to accept AAB format the App Signing by Google P
 
 ### Testing the release build of your app
 
-Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using(in project root):
+Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using the following command in the project root:
 
 ```sh
 $ npx react-native run-android --variant=release

--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -93,10 +93,9 @@ _Note: In order for Google Play to accept AAB format the App Signing by Google P
 
 ### Testing the release build of your app
 
-Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using:
+Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using(in project root):
 
 ```sh
-$ cd - # Go back to project root
 $ npx react-native run-android --variant=release
 ```
 

--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -96,6 +96,7 @@ _Note: In order for Google Play to accept AAB format the App Signing by Google P
 Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using:
 
 ```sh
+$ cd - # Go back to project root
 $ npx react-native run-android --variant=release
 ```
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Since the previous step is:
```
$ cd android
$ ./gradlew bundleRelease
```
so next step we need to go back to the project root folder 