### PR TITLE
Update two page titles (remove "React Native")

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,6 +1,6 @@
 ---
 id: typescript
-title: Using TypeScript with React Native
+title: Using TypeScript
 ---
 
 [TypeScript][ts] is a language which extends JavaScript by adding type definitions, much like [Flow][flow]. While React Native is built in Flow, it supports both TypeScript _and_ Flow by default.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,6 +1,6 @@
 ---
 id: upgrading
-title: Upgrading to new React Native versions
+title: Upgrading to new versions
 ---
 
 Upgrading to new versions of React Native will give you access to more APIs, views, developer tools and other goodies. Upgrading requires a small amount of effort, but we try to make it straightforward for you.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -390,10 +390,10 @@
         "title": "Learn the Basics"
       },
       "typescript": {
-        "title": "Using TypeScript with React Native"
+        "title": "Using TypeScript"
       },
       "upgrading": {
-        "title": "Upgrading to new React Native versions"
+        "title": "Upgrading to new versions"
       },
       "usecolorscheme": {
         "title": "useColorScheme"


### PR DESCRIPTION
This small PR tweaks titles of the two following pages for the sake of simplicity:
* `Using TypeScript with React Native` -> `Using TypeScript`
* `Upgrading to new React Native versions` -> `Upgrading to new versions`