### PR TITLE
Adding the start of Object Types reference

### DIFF
--- a/docs/rectorsize.md
+++ b/docs/rectorsize.md
@@ -5,6 +5,8 @@ title: RectOrSize Object Type
 
 `RectOrSize` accepts numeric pixel values to describe how far to extend a rectangular area. These values are added to the original area's size to expand it.
 
+## Example
+
 ```js
 {
     bottom: 20,

--- a/docs/rectorsize.md
+++ b/docs/rectorsize.md
@@ -1,0 +1,41 @@
+---
+id: rectorsize
+title: RectOrSize Object Type
+---
+
+`RectOrSize` accepts numeric pixel values to describe how far to extend a rectangular area. These values are added to the original area's size to expand it.
+
+```js
+{
+    bottom: 20,
+    left: null,
+    right: undefined,
+    top: 50
+}
+```
+
+## Keys and values
+
+### `bottom`
+
+| Type                        | Required |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |
+
+### `left`
+
+| Type                        | Required |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |
+
+### `right`
+
+| Type                        | Required |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |
+
+### `top`
+
+| Type                        | Required |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -287,6 +287,9 @@
       "ram-bundles-inline-requires": {
         "title": "RAM Bundles and Inline Requires"
       },
+      "rectorsize": {
+        "title": "RectOrSize Object Type"
+      },
       "refreshcontrol": {
         "title": "RefreshControl"
       },
@@ -3977,6 +3980,7 @@
       "Core Components": "Core Components",
       "Props": "Props",
       "APIs": "APIs",
+      "Object Types": "Object Types",
       "Guides": "Guides",
       "Components": "Components",
       "Contributing": "Contributing"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -143,6 +143,7 @@
         "label": "iOS APIs",
         "ids": ["actionsheetios", "dynamiccolorios", "settings"]
       }
-    ]
+    ],
+    "Object Types": ["rectorsize"]
   }
 }


### PR DESCRIPTION
We have many shared complex object types that bloat component and API references. It's time to start cutting some up into handy to reference pages, starting with those in service of `Pressable`