### PR TITLE
Platform labels and slim table headings

### DIFF
--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -115,7 +115,7 @@ table {
 }
 table thead tr {
   /* display: table-header-group; */
-  background: #dddddd;
+  background: #ececec;
 }
 
 table tbody {
@@ -149,10 +149,15 @@ table tr td code {
   font-size: 12px;
 }
 table tr th {
-  color: #000000;
+  color: #6e6d6d;
   font-weight: bold;
   font-family: "Helvetica Neue", Arial, sans-serif;
   text-transform: uppercase;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+table tr td hr {
+  margin: 10px 0;
 }
 
 figure {
@@ -193,6 +198,48 @@ figcaption {
   border-left: 4px solid #61dafb;
   margin-left: -15px;
   padding-left: 11px;
+}
+
+/* Labels */
+
+.label {
+  display: inline-block;
+  position: relative;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #fff;
+  padding: 4px 14px;
+  border-radius: 4px;
+}
+
+.label.android {
+  background: #a4c936;
+}
+
+.label.ios {
+  background: #222;
+}
+
+h3 .label {
+  top: -1px;
+  margin-left: 12px;
+}
+
+/* Label as dot in the right sidebar */
+
+.onPageNav .label {
+  display: inline-block;
+  padding: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 100%;
+  margin-left: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  color: transparent;
 }
 
 /* Custom */


### PR DESCRIPTION
This PR adds new platform labels for the props and methods (change cherry-picked from the `Pressable` PR) and updates the design of the table headings.

There were other colors tested for the iOS like shades of blue, violet and orange, but it ended as near black (`#222`) because of [this](https://developer.apple.com/app-store/marketing/guidelines/) Apple marketing guide. There is no official rules and guides according to the stand-alone iOS logo usage. There are also different versions of iOS logo used by Apple on the website:
* https://developer.apple.com/assets/elements/icons/ios/ios-128x128_2x.png
* https://www.apple.com/v/iphone/home/ah/images/chapternav/iphone_ios_light__jjio8uqmjxei_large.svg

### Preview

Screenshot below is only a mock to present the visual aspect of the tables and labels (content is incorrect):

<img width="1062" alt="Annotation 2020-05-15 223027" src="https://user-images.githubusercontent.com/719641/82093683-e15abf80-96fb-11ea-8d2f-3e204d6163ff.png">
