### PR TITLE
Moving API and Components to their own sections

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3985,9 +3985,9 @@
       "Guides (Android)": "Guides (Android)",
       "Guides (iOS)": "Guides (iOS)",
       "APIs": "APIs",
-      "Object Types": "Object Types",
       "Core Components": "Core Components",
       "Props": "Props",
+      "Object Types": "Object Types",
       "Guides": "Guides",
       "Components": "Components",
       "Contributing": "Contributing"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3965,6 +3965,7 @@
     },
     "links": {
       "Docs": "Docs",
+      "Components": "Components",
       "API": "API",
       "Community": "Community",
       "Blog": "Blog",
@@ -3983,10 +3984,10 @@
       "Native Components and Modules": "Native Components and Modules",
       "Guides (Android)": "Guides (Android)",
       "Guides (iOS)": "Guides (iOS)",
-      "Core Components": "Core Components",
-      "Props": "Props",
       "APIs": "APIs",
       "Object Types": "Object Types",
+      "Core Components": "Core Components",
+      "Props": "Props",
       "Guides": "Guides",
       "Components": "Components",
       "Contributing": "Contributing"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -102,8 +102,7 @@
         "label": "iOS APIs",
         "ids": ["actionsheetios", "dynamiccolorios", "settings"]
       }
-    ],
-    "Object Types": ["pressevent", "react-node", "rect"]
+    ]
   },
   "components": {
     "Core Components": [
@@ -146,6 +145,7 @@
       "shadow-props",
       "text-style-props",
       "view-style-props"
-    ]
+    ],
+    "Object Types": ["pressevent", "react-node", "rect"]
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -63,47 +63,6 @@
     ]
   },
   "api": {
-    "Core Components": [
-      "components-and-apis",
-      "activityindicator",
-      "button",
-      "flatlist",
-      "image",
-      "imagebackground",
-      "keyboardavoidingview",
-      "modal",
-      "pressable",
-      "refreshcontrol",
-      "safeareaview",
-      "scrollview",
-      "sectionlist",
-      "statusbar",
-      "switch",
-      "text",
-      "textinput",
-      "touchablehighlight",
-      "touchableopacity",
-      "touchablewithoutfeedback",
-      "view",
-      "virtualizedlist",
-      {
-        "type": "subcategory",
-        "label": "Android Components",
-        "ids": ["drawerlayoutandroid", "touchablenativefeedback"]
-      },
-      {
-        "type": "subcategory",
-        "label": "iOS Components",
-        "ids": ["inputaccessoryview", "maskedviewios"]
-      }
-    ],
-    "Props": [
-      "image-style-props",
-      "layout-props",
-      "shadow-props",
-      "text-style-props",
-      "view-style-props"
-    ],
     "APIs": [
       "accessibilityinfo",
       "alert",
@@ -145,5 +104,48 @@
       }
     ],
     "Object Types": ["pressevent", "react-node", "rect"]
+  },
+  "components": {
+    "Core Components": [
+      "components-and-apis",
+      "activityindicator",
+      "button",
+      "flatlist",
+      "image",
+      "imagebackground",
+      "keyboardavoidingview",
+      "modal",
+      "pressable",
+      "refreshcontrol",
+      "safeareaview",
+      "scrollview",
+      "sectionlist",
+      "statusbar",
+      "switch",
+      "text",
+      "textinput",
+      "touchablehighlight",
+      "touchableopacity",
+      "touchablewithoutfeedback",
+      "view",
+      "virtualizedlist",
+      {
+        "type": "subcategory",
+        "label": "Android Components",
+        "ids": ["drawerlayoutandroid", "touchablenativefeedback"]
+      },
+      {
+        "type": "subcategory",
+        "label": "iOS Components",
+        "ids": ["inputaccessoryview", "maskedviewios"]
+      }
+    ],
+    "Props": [
+      "image-style-props",
+      "layout-props",
+      "shadow-props",
+      "text-style-props",
+      "view-style-props"
+    ]
   }
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -32,7 +32,8 @@ const siteConfig = {
   editUrl: 'https://github.com/facebook/react-native-website/blob/master/docs/',
   headerLinks: [
     {doc: 'getting-started', label: 'Docs'},
-    {doc: 'activityindicator', label: 'API'},
+    {doc: 'components-and-apis', label: 'Components'},
+    {doc: 'accessibilityinfo', label: 'API'},
     {page: 'help', label: 'Community'},
     {blog: true, label: 'Blog'},
     {search: true},

--- a/website/versioned_sidebars/version-0.59-sidebars.json
+++ b/website/versioned_sidebars/version-0.59-sidebars.json
@@ -54,8 +54,9 @@
       "version-0.59-removing-default-permissions"
     ]
   },
-  "version-0.59-api": {
+  "version-0.59-components": {
     "Components": [
+      "version-0.59-components-and-apis",
       "version-0.59-activityindicator",
       "version-0.59-button",
       "version-0.59-datepickerios",
@@ -92,7 +93,9 @@
       "version-0.59-viewpagerandroid",
       "version-0.59-virtualizedlist",
       "version-0.59-webview"
-    ],
+    ]
+  },
+  "version-0.59-api": {
     "APIs": [
       "version-0.59-accessibilityinfo",
       "version-0.59-actionsheetios",

--- a/website/versioned_sidebars/version-0.60-sidebars.json
+++ b/website/versioned_sidebars/version-0.60-sidebars.json
@@ -14,7 +14,6 @@
       "version-0.60-more-resources"
     ],
     "Guides": [
-      "version-0.60-components-and-apis",
       "version-0.60-platform-specific-code",
       "version-0.60-navigation",
       "version-0.60-images",
@@ -55,8 +54,9 @@
       "version-0.60-hermes"
     ]
   },
-  "version-0.60-api": {
+  "version-0.60-components": {
     "Components": [
+      "version-0.60-components-and-apis",
       "version-0.60-activityindicator",
       "version-0.60-button",
       "version-0.60-datepickerios",
@@ -92,7 +92,9 @@
       "version-0.60-view",
       "version-0.60-viewpagerandroid",
       "version-0.60-virtualizedlist"
-    ],
+    ]
+  },
+  "version-0.60-api": {
     "APIs": [
       "version-0.60-accessibilityinfo",
       "version-0.60-actionsheetios",

--- a/website/versioned_sidebars/version-0.61-sidebars.json
+++ b/website/versioned_sidebars/version-0.61-sidebars.json
@@ -17,7 +17,6 @@
     ],
     "Guides": [
       "version-0.61-fast-refresh",
-      "version-0.61-components-and-apis",
       "version-0.61-platform-specific-code",
       "version-0.61-navigation",
       "version-0.61-images",
@@ -58,8 +57,9 @@
       "version-0.61-hermes"
     ]
   },
-  "version-0.61-api": {
+  "version-0.61-components": {
     "Components": [
+      "version-0.61-components-and-apis",
       "version-0.61-activityindicator",
       "version-0.61-button",
       "version-0.61-checkbox",
@@ -96,7 +96,9 @@
       "version-0.61-view",
       "version-0.61-viewpagerandroid",
       "version-0.61-virtualizedlist"
-    ],
+    ]
+  },
+  "version-0.61-api": {
     "APIs": [
       "version-0.61-accessibilityinfo",
       "version-0.61-actionsheetios",

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -72,7 +72,7 @@
       "version-0.62-app-extensions"
     ]
   },
-  "version-0.62-api": {
+  "version-0.62-components": {
     "Core Components": [
       "version-0.62-components-and-apis",
       "version-0.62-activityindicator",
@@ -115,7 +115,9 @@
       "version-0.62-shadow-props",
       "version-0.62-text-style-props",
       "version-0.62-view-style-props"
-    ],
+    ]
+  },
+  "version-0.62-api": {
     "APIs": [
       "version-0.62-accessibilityinfo",
       "version-0.62-alert",


### PR DESCRIPTION
The Components and APIs docs have been growing: components have shared props, APIs have shared objects. There's a lot of content now! I was thinking perhaps it would make sense to split them into two sections in the navigation structure like so

<img width="1438" alt="Screenshot 2020-05-21 at 13 12 53" src="https://user-images.githubusercontent.com/236306/82558086-d91fdb80-9b64-11ea-9b5f-46fe85ed1e99.png">

<img width="1474" alt="Screenshot 2020-05-21 at 13 12 45" src="https://user-images.githubusercontent.com/236306/82558091-dcb36280-9b64-11ea-84ec-43fea55610e3.png">
