### PR TITLE
Update typescipt docs with explicit babel config

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -34,9 +34,9 @@ ignite new MyTSProject
 1. Add TypeScript and the types for React Native and Jest to your project.
 
 ```sh
-yarn add --dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+yarn add --dev typescript @babel/plugin-transform-typescript @types/jest @types/react @types/react-native @types/react-test-renderer 
 # or for npm
-npm install --save-dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+npm install --save-dev typescript @babel/plugin-transform-typescript @types/jest @types/react @types/react-native @types/react-test-renderer
 ```
 
 2. Add a TypeScript config file. Create a `tsconfig.json` in the root of your project:
@@ -64,7 +64,17 @@ npm install --save-dev typescript @types/jest @types/react @types/react-native @
 }
 ```
 
-3. Create a `jest.config.js` file to configure Jest to use TypeScript
+3. Update your `babel.config.js` file with the Babel Plugin
+
+```diff
+module.exports = {
++  plugins: ['module:@babel/plugin-transform-typescript'],
+  presets: ['module:metro-react-native-babel-preset'],
+};
+
+```
+
+4. Create a `jest.config.js` file to configure Jest to use TypeScript
 
 ```js
 module.exports = {
@@ -73,11 +83,11 @@ module.exports = {
 };
 ```
 
-4. Rename a JavaScript file to be `*.tsx`
+5. Rename a JavaScript file to be `*.tsx`
 
 > You should leave the `./index.js` entrypoint file as it is otherwise you may run into an issue when it comes to bundling a production build.
 
-5. Run `yarn tsc` to type-check your new TypeScript files.
+6. Run `tsc --noEmit` to type-check your new TypeScript files.
 
 ## How TypeScript and React Native works
 


### PR DESCRIPTION
Currently it's a bit bare bones and doesn't really mention how to set it up. Since Babel is already configured and able to parse TypeScript it's probably the easiest way forward.

Happy to make any changes if needed. I'm currently [trying out a "hello world"](https://twitter.com/itsmadou/status/1263229434640740352) with React Native MacOS. So I basically bootstraped with their getting started here... https://microsoft.github.io/react-native-windows/docs/rnm-getting-started and ended up wanting TypeScript.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
