### PR TITLE
Add light background to the search bar

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -112,12 +112,14 @@ li.navSearchWrapper {
 @media only screen and (max-width: 1024px) {
   .reactNavSearchWrapper input#search_input_react {
     border-radius: 0.25rem;
-    background-color: $dark;
+    background-color: $tintColor;
+    color: $deepdark;
     height: 30px;
   }
 
   .reactNavSearchWrapper input#search_input_react:focus {
-    background-color: $light;
+    background-color: $tintColor;
+    color: $deepdark;
   }
 }
 
@@ -171,14 +173,27 @@ li.navSearchWrapper {
   box-sizing: initial;
 }
 
+.navSearchWrapper:before {
+  border: 3px solid #717171;
+}
+.navSearchWrapper::after {
+  background: #717171;
+}
+
 input#search_input_react {
   /* Make as wide as the expanded state in the docusaurus default */
   width: 220px;
-  background-color: $dark;
+  background-color: $tintColor;
+  color: $deepdark;
   border-radius: 0.25rem;
   transition: background-color 150ms ease-in-out;
 }
 
+input#search_input_react::placeholder {
+  color: #717171;
+}
+
 input#search_input_react:focus {
-  background-color: $light;
+  background-color: $tintColor;
+  color: $deepdark;
 }


### PR DESCRIPTION
This PR changes the background of the search bar from dark to light.

There have been quite a few instances recently where I really struggled to find the search bar on the site, as there is not a whole lot of contrast between the search bar and the rest of the header.

Current search bar: 
![image](https://user-images.githubusercontent.com/13405567/82619849-08563d00-9ba5-11ea-9ceb-9817c262bcd6.png)

Proposed search bar:
![image](https://user-images.githubusercontent.com/13405567/82620063-94686480-9ba5-11ea-91d1-beb9d23590bf.png)
