### PR TITLE
improved labels design + ActivityIndicator and Button pages tweaks

### DIFF
--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -24,16 +24,14 @@ Displays a circular loading indicator.
 import React from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 
-const App = () => {
-  return (
-    <View style={[styles.container, styles.horizontal]}>
-      <ActivityIndicator size="large" color="#0000ff" />
-      <ActivityIndicator size="small" color="#00ff00" />
-      <ActivityIndicator size="large" color="#0000ff" />
-      <ActivityIndicator size="small" color="#00ff00" />
-    </View>
-  );
-}
+const App = () => (
+  <View style={[styles.container, styles.horizontal]}>
+    <ActivityIndicator />
+    <ActivityIndicator size="large" />
+    <ActivityIndicator size="small" color="#0000ff" />
+    <ActivityIndicator size="large" color="#00ff00" />
+  </View>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -60,10 +58,10 @@ class App extends Component {
   render() {
     return (
       <View style={[styles.container, styles.horizontal]}>
-        <ActivityIndicator size="large" color="#0000ff" />
-        <ActivityIndicator size="small" color="#00ff00" />
-        <ActivityIndicator size="large" color="#0000ff" />
-        <ActivityIndicator size="small" color="#00ff00" />
+      <ActivityIndicator />
+      <ActivityIndicator size="large" />
+      <ActivityIndicator size="small" color="#0000ff" />
+      <ActivityIndicator size="large" color="#00ff00" />
       </View>
     );
   }
@@ -92,40 +90,42 @@ export default App;
 
 Inherits [View Props](view#props).
 
+---
+
 ### `animating`
 
-Whether to show the indicator (true, the default) or hide it (false).
+Whether to show the indicator (`true`) or hide it (`false`).
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Required | Default |
+| ---- | -------- | ------- |
+| bool | No       | `true`  |
 
 ---
 
 ### `color`
 
-The foreground color of the spinner (default is gray on iOS and dark cyan on Android).
+The foreground color of the spinner.
 
-| Type            | Required |
-| --------------- | -------- |
-| [color](colors) | No       |
+| Type            | Required | Default                                                                                                                                                                             |
+| --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | No       | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style="background: #999" class="color-box"></ins>`'#999999'` <div class="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped`
+### `hidesWhenStopped` <div class="label ios">iOS</div>
 
-Whether the indicator should hide when not animating (true by default).
+Whether the indicator should hide when not animating.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Required | Default |
+| ---- | -------- | ------- |
+| bool | No       | `true`  |
 
 ---
 
 ### `size`
 
-Size of the indicator (default is 'small'). Passing a number to the size prop is only supported on Android.
+Size of the indicator.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| enum('small', 'large'), number | No       |
+| Type                                                                           | Required | Default   |
+| ------------------------------------------------------------------------------ | -------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | No       | `'small'` |

--- a/docs/button.md
+++ b/docs/button.md
@@ -18,76 +18,70 @@ If this button doesn't look right for your app, you can build your own button us
 
 ## Example
 
-```SnackPlayer name=Buttons
+```SnackPlayer name=Button%20Example
 import React from 'react';
 import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
-import Constants from 'expo-constants';
 
-const Separator = () => {
-  return <View style={styles.separator} />;
-}
+const Separator = () => (
+  <View style={styles.separator} />
+);
 
-const App = () => {
-  return (
-    <SafeAreaView style={styles.container}>
-      <View>
-        <Text style={styles.title}>
-          The title and onPress handler are required. It is recommended to set
-          accessibilityLabel to help make your app usable by everyone.
-        </Text>
+const App = () => (
+  <SafeAreaView style={styles.container}>
+    <View>
+      <Text style={styles.title}>
+        The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
+      </Text>
+      <Button
+        title="Press me"
+        onPress={() => Alert.alert('Simple Button pressed')}
+      />
+    </View>
+    <Separator />
+    <View>
+      <Text style={styles.title}>
+        Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
+      </Text>
+      <Button
+        title="Press me"
+        color="#f194ff"
+        onPress={() => Alert.alert('Button with adjusted color pressed')}
+      />
+    </View>
+    <Separator />
+    <View>
+      <Text style={styles.title}>
+        All interaction for the component are disabled.
+      </Text>
+      <Button
+        title="Press me"
+        disabled
+        onPress={() => Alert.alert('Cannot press this one')}
+      />
+    </View>
+    <Separator />
+    <View>
+      <Text style={styles.title}>
+        This layout strategy lets the title define the width of the button.
+      </Text>
+      <View style={styles.fixToText}>
         <Button
-          title="Press me"
-          onPress={() => Alert.alert('Simple Button pressed')}
+          title="Left button"
+          onPress={() => Alert.alert('Left button pressed')}
+        />
+        <Button
+          title="Right button"
+          onPress={() => Alert.alert('Right button pressed')}
         />
       </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          Adjust the color in a way that looks standard on each platform. On
-          iOS, the color prop controls the color of the text. On Android, the
-          color adjusts the background color of the button.
-        </Text>
-        <Button
-          title="Press me"
-          color="#f194ff"
-          onPress={() => Alert.alert('Button with adjusted color pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          All interaction for the component are disabled.
-        </Text>
-        <Button
-          title="Press me"
-          disabled
-          onPress={() => Alert.alert('Cannot press this one')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          This layout strategy lets the title define the width of the button.
-        </Text>
-        <View style={styles.fixToText}>
-          <Button
-            title="Left button"
-            onPress={() => Alert.alert('Left button pressed')}
-          />
-          <Button
-            title="Right button"
-            onPress={() => Alert.alert('Right button pressed')}
-          />
-        </View>
-      </View>
-    </SafeAreaView>
-  );
-}
+    </View>
+  </SafeAreaView>
+);
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    justifyContent: 'center',
     marginHorizontal: 16,
   },
   title: {
@@ -114,23 +108,23 @@ export default App;
 
 ## Props
 
-### `onPress`
+### **`onPress`**
 
 Handler to be called when the user taps the button. The first function argument is an event in form of [PressEvent](pressevent).
 
-| Type     | Required |
-| -------- | -------- |
-| function | Yes      |
+| Type     | Required                              |
+| -------- | ------------------------------------- |
+| function | <div class="label required">Yes</div> |
 
 ---
 
-### `title`
+### **`title`**
 
-Text to display inside the button.
+Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
-| Type   | Required |
-| ------ | -------- |
-| string | Yes      |
+| Type   | Required                              |
+| ------ | ------------------------------------- |
+| string | <div class="label required">Yes</div> |
 
 ---
 
@@ -148,19 +142,79 @@ Text to display for blindness accessibility features.
 
 Color of the text (iOS), or background color of the button (Android).
 
-| Type            | Required |
-| --------------- | -------- |
-| [color](colors) | No       |
+| Type            | Required | Default                                                                                                                                                                                                                 |
+| --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | No       | <ins style="background: #2196F3" class="color-box"></ins>`'#2196F3'` <div class="label android">Android</div><hr/><ins style="background: #007AFF" class="color-box"></ins>`'#007AFF'` <div class="label ios">iOS</div> |
 
 ---
 
 ### `disabled`
 
-If true, disable all interactions for this component.
+If `true`, disable all interactions for this component.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Required | Default |
+| ---- | -------- | ------- |
+| bool | No       | `false` |
+
+---
+
+### `hasTVPreferredFocus` <div class="label tv">TV</div>
+
+TV preferred focus.
+
+| Type | Required | Default |
+| ---- | -------- | ------- |
+| bool | No       | `false` |
+
+---
+
+### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+
+Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+---
+
+### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+
+Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+---
+
+### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+
+Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+---
+
+### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+
+Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
+---
+
+### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+
+Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
 
 ---
 
@@ -174,68 +228,10 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `hasTVPreferredFocus`
+### `touchSoundDisabled` <div class="label android">Android</div>
 
-_(Apple TV only)_ TV preferred focus (see documentation for the View component).
+If `true`, doesn't play system sound on touch.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
-
-### `nextFocusDown`
-
-Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `nextFocusForward`
-
-Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `nextFocusLeft`
-
-Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `nextFocusRight`
-
-Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `nextFocusUp`
-
-Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `touchSoundDisabled`
-
-If true, doesn't play system sound on touch.
-
-| Type    | Required | Platform |
-| ------- | -------- | -------- |
-| boolean | No       | Android  |
+| Type    | Required | Default |
+| ------- | -------- | ------- |
+| boolean | No       | `false` |

--- a/docs/button.md
+++ b/docs/button.md
@@ -112,9 +112,9 @@ export default App;
 
 Handler to be called when the user taps the button. The first function argument is an event in form of [PressEvent](pressevent).
 
-| Type     | Required                              |
-| -------- | ------------------------------------- |
-| function | <div class="label required">Yes</div> |
+| Type     | Required |
+| -------- | -------- |
+| function | Yes      |
 
 ---
 
@@ -122,9 +122,9 @@ Handler to be called when the user taps the button. The first function argument 
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
-| Type   | Required                              |
-| ------ | ------------------------------------- |
-| string | <div class="label required">Yes</div> |
+| Type   | Required |
+| ------ | -------- |
+| string | Yes      |
 
 ---
 

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -256,18 +256,11 @@ figcaption {
   border-right-color: #222;
 }
 
-.label.required {
-  background: #fa5035;
-}
-.label.required:before {
-  border-right-color: #fa5035;
-}
-
 .label.tv {
-  background: #7e70ce;
+  background: #6170af;
 }
 .label.tv:before {
-  border-right-color: #7e70ce;
+  border-right-color: #6170af;
 }
 
 h3 .label {

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -138,6 +138,7 @@ table tr td {
   line-height: 1.3em;
   padding: 10px;
   text-align: left;
+  vertical-align: middle;
 }
 table tr th:last-of-type,
 table tr td:last-of-type {
@@ -147,6 +148,7 @@ table tr th code,
 table tr td code {
   display: inline-block;
   font-size: 12px;
+  padding: 3.4px 6px 2px;
 }
 table tr th {
   color: #6e6d6d;
@@ -215,21 +217,83 @@ figcaption {
   font-size: 0.85rem;
   font-weight: 500;
   color: #fff;
-  padding: 4px 14px;
-  border-radius: 4px;
+  padding: 2px 12px;
+  border-radius: 0 2px 2px 0;
+}
+
+.label:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -12px;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 12px 12px 12px 0;
+}
+
+.label:after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  border-radius: 2px;
+  background: #fff;
 }
 
 .label.android {
   background: #a4c936;
 }
+.label.android:before {
+  border-right-color: #a4c936;
+}
 
 .label.ios {
   background: #222;
 }
+.label.ios:before {
+  border-right-color: #222;
+}
+
+.label.required {
+  background: #fa5035;
+}
+.label.required:before {
+  border-right-color: #fa5035;
+}
+
+.label.tv {
+  background: #7e70ce;
+}
+.label.tv:before {
+  border-right-color: #7e70ce;
+}
 
 h3 .label {
-  top: -1px;
-  margin-left: 12px;
+  top: -2px;
+  margin-left: 22px;
+  line-height: 20px;
+}
+
+td .label {
+  padding: 0 8px 0 10px;
+  font-size: 0.7rem;
+  margin-left: 14px;
+}
+
+td .label:before {
+  left: -8px;
+  border-width: 9px 8px 9px 0;
+}
+
+td .label:after {
+  top: 7.5px;
+}
+
+td .label.required {
+  margin-left: 8px;
+  letter-spacing: 0.03rem;
 }
 
 /* Label as dot in the right sidebar */

--- a/website/static/css/react-native.css
+++ b/website/static/css/react-native.css
@@ -252,6 +252,8 @@ article iframe {
   }
 }
 
+/* Color preview box */
+
 .color-box {
   float: left;
   width: 24px;
@@ -259,6 +261,12 @@ article iframe {
   margin: 2px 8px 0 0;
   border: 0.05rem solid $deepdark;
   border-radius: 3px;
+}
+
+td .color-box {
+  border-color: #6e6d6d;
+  width: 20px;
+  height: 20px;
 }
 
 /* "Native Code Required" banner */


### PR DESCRIPTION
This PR introduces improved labels design and updates the `ActivityIndicator` and `Button` pages code references according to the new "standard" based on `Pressable` docs.

I have also updated the examples a bit but mainly for the better readability.

### Preview
<img width="1088" alt="Annotation 2020-05-26 190029" src="https://user-images.githubusercontent.com/719641/82928955-3b247a80-9f83-11ea-881a-c8aa42ea9df4.png">
