### PR TITLE
Fix typo in using libraries docs page

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -66,7 +66,7 @@ After React Native Directory, the [npm registry](https://www.npmjs.com/) is the 
 
 ### Does it work with React Native?
 
-Usually libraries built _specifically for other platforms_ will not work with React Native. Examples include `react-select` which is built for the web and specifically targets `react-dom`, and `rimraf` which is built for Node.js and interacts with your computer file system. Other libraries like `lodash` use only JavaScript langauge features and work in any environment. You will gain a sense for this over time, but until then the easiest way to find out is to try it yourself. You can remove packages using `npm uninstall` if it turns out that it does not work in React Native.
+Usually libraries built _specifically for other platforms_ will not work with React Native. Examples include `react-select` which is built for the web and specifically targets `react-dom`, and `rimraf` which is built for Node.js and interacts with your computer file system. Other libraries like `lodash` use only JavaScript language features and work in any environment. You will gain a sense for this over time, but until then the easiest way to find out is to try it yourself. You can remove packages using `npm uninstall` if it turns out that it does not work in React Native.
 
 ### Does it work for the platforms that my app supports?
 


### PR DESCRIPTION
Hi,

Noticed there is a small typo in the https://reactnative.dev/docs/libraries page, this fixes it.
