### PR TITLE
Update hermes.md

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -59,7 +59,7 @@ If you've recently created a new app from scratch, you should see if Hermes is e
 A `HermesInternal` global variable will be available in JavaScript that can be used to verify that Hermes is in use:
 
 ```jsx
-const isHermes = () => global.HermesInternal !== null;
+const isHermes = () => !!global.HermesInternal;
 ```
 
 To see the benefits of Hermes, try making a release build/deployment of your app to compare. For example:


### PR DESCRIPTION
Revert #1414

Initially this check was `!= null`, which is correct. Then #1414 changed it to `!== null`, which causes it to always return true since `HermesInternal` is either an object or `undefined`. `!!` fixes it and should avoid making people wanting to change it to `!==`.