### PR TITLE
fix Android ripple property on the Pressable page

### DIFF
--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -113,13 +113,13 @@ If true, doesn't play Android system sound on press.
 | ------- | -------- | ------- |
 | boolean | No       | `false` |
 
-### `android_rippleColor` <div class="label android">Android</div>
+### `android_ripple` <div class="label android">Android</div>
 
-Enables the Android ripple effect and configures its color.
+Enables the Android ripple effect and configures its properties.
 
-| Type                                         | Required |
-| -------------------------------------------- | -------- |
-| [color](https://reactnative.dev/docs/colors) | No       |
+| Type                                   | Required |
+| -------------------------------------- | -------- |
+| [RippleConfig](pressable#rippleconfig) | No       |
 
 ### `children`
 
@@ -197,9 +197,9 @@ Additional distance outside of this view in which a touch is considered a press 
 
 Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.
 
-| Type                                                           | Required |
-| -------------------------------------------------------------- | -------- |
-| [ViewStyleProp](https://reactnative.dev/docs/view-style-props) | No       |
+| Type                              | Required |
+| --------------------------------- | -------- |
+| [ViewStyleProp](view-style-props) | No       |
 
 ### `testOnly_pressed`
 
@@ -208,3 +208,21 @@ Used only for documentation or testing (e.g. snapshot testing).
 | Type    | Required | Default |
 | ------- | -------- | ------- |
 | boolean | No       | `false` |
+
+## Type Definitions
+
+### RippleConfig
+
+Ripple effect configuration for the `android_ripple` property.
+
+| Type   |
+| ------ |
+| object |
+
+**Properties:**
+
+| Name       | Type            | Required | Description                                         |
+| ---------- | --------------- | -------- | --------------------------------------------------- |
+| color      | [color](colors) | No       | Defines the color of the ripple effect.             |
+| borderless | boolean         | No       | Defines if ripple effect should not include border. |
+| radius     | number          | No       | Defines the radius of the ripple effect.            |


### PR DESCRIPTION
This PR fixes the `Pressable` component ripple effect property on Android according to the latest code in the stable branch of 0.63 release. Color property has been replaced with the `RippleConfig` object which provides greater flexibility for the users.

Refs:
* https://github.com/facebook/react-native/blob/0.63-stable/Libraries/Components/Pressable/Pressable.js#L128 
* https://github.com/facebook/react-native/blob/0.63-stable/Libraries/Components/Pressable/useAndroidRippleForView.js#L28

Kudos @vonovak !
