### PR TITLE
We can do better - show banner on every page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -255,15 +255,6 @@ function LogoAnimation() {
 function HeaderHero() {
   return (
     <Section background="dark" className="HeaderHero">
-      <div className="announcement">
-        <div className="announcement-inner">
-          Black Lives Matter.{' '}
-          <a href="https://support.eji.org/give/153413/#!/donation/checkout">
-            Support the Equal Justice Initiative
-          </a>
-          .
-        </div>
-      </div>
       <div className="socialLinks">
         <TwitterButton />
         <GitHubButton />

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -95,6 +95,7 @@ const siteConfig = {
     baseUrl + 'js/codeblocks.js',
     baseUrl + 'js/tabs.js',
     baseUrl + 'js/docs-rating.js',
+    baseUrl + 'js/announcement.js',
   ],
   cleanUrl: true,
   scrollToTop: true,

--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -197,3 +197,64 @@ input#search_input_react:focus {
   background-color: $tintColor;
   color: $deepdark;
 }
+
+/* Overrides for the announcement banner */
+.announcement {
+  background-color: #20232a;
+  color: #fff;
+  font-weight: bold;
+  font-size: 24px;
+  padding: 30px;
+  margin: 0 auto 28px;
+  text-align: center;
+  height: 100px;
+}
+
+.announcement-inner {
+  margin: 0 auto;
+  max-width: 768px;
+}
+
+.announcement-inner a {
+  text-decoration: underline;
+  display: inline-block;
+  color: $brand;
+}
+
+.announcement-inner a:hover {
+  color: #fff;
+}
+
+@media only screen and (max-width: 700px) {
+  ul.nav-site.nav-site-internal {
+    margin-top: 160px;
+  }
+  .navPusher {
+    padding-top: 210px;
+  }
+  .announcement {
+    padding: 10px;
+  }
+}
+
+@media only screen and (max-width: 500px) {
+  .announcement {
+    font-size: 18px;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .navPusher {
+    padding-top: 160px;
+  }
+}
+
+@media only screen and (max-width: 1023px) {
+  ul.nav-site.nav-site-internal {
+    margin-top: 160px;
+  }
+  .navPusher {
+    padding-top: 210px;
+  }
+}
+/* End announcement banner override */

--- a/website/static/css/homepage/HeaderHero.css
+++ b/website/static/css/homepage/HeaderHero.css
@@ -49,36 +49,6 @@
   justify-content: center;
 }
 
-/* Override for the announcement banner */
-.HeaderHero.HeaderHero {
-  padding-top: 0;
-}
-
-.HeaderHero .announcement {
-  background-color: #20232a;
-  color: #fff;
-  font-weight: bold;
-  font-size: 24px;
-  padding: 48px;
-  margin: 0 auto 28px;
-  text-align: center;
-}
-
-.HeaderHero .announcement-inner {
-  margin: 0 auto;
-  max-width: 768px;
-}
-
-.HeaderHero .announcement-inner a {
-  text-decoration: underline;
-}
-
-.HeaderHero .announcement-inner a:hover {
-  color: $brand;
-}
-
-/* End announcement banner override */
-
 @media only screen and (min-width: 961px) {
   .HeaderHero .TwoColumns {
     grid-template-columns: 3fr 1fr;

--- a/website/static/js/announcement.js
+++ b/website/static/js/announcement.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const container = document.querySelector('.fixedHeaderContainer');
+  if (container) {
+    const div = document.createElement('div');
+    div.innerHTML =
+      '<div class="announcement"><div class="announcement-inner">Black Lives Matter. <a href="https://support.eji.org/give/153413/#!/donation/checkout">Support the Equal Justice Initiative</a>.</div></div>';
+    const content = div.childNodes[0];
+    container.insertBefore(content, container.childNodes[0].nextSibling);
+  }
+});


### PR DESCRIPTION
## Overview

Adds the banner added in https://github.com/facebook/react-native-website/pull/1971 to every page.

Black lives matter.

## Screens

### Mobile
<img width="1680" alt="Screen Shot 2020-06-04 at 9 17 08 PM" src="https://user-images.githubusercontent.com/2440089/83826185-45442880-a6a9-11ea-969a-a4226794574a.png">

### Desktop Small
<img width="1680" alt="Screen Shot 2020-06-04 at 9 16 51 PM" src="https://user-images.githubusercontent.com/2440089/83826187-47a68280-a6a9-11ea-9509-11d28f76f8ba.png">

### Desktop Large
<img width="1680" alt="Screen Shot 2020-06-04 at 9 16 43 PM" src="https://user-images.githubusercontent.com/2440089/83826192-4bd2a000-a6a9-11ea-88f5-05b2ccad2b00.png">

