### PR TITLE
small tweaks for the BLM banner

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -200,12 +200,11 @@ input#search_input_react:focus {
 
 /* Overrides for the announcement banner */
 .announcement {
-  background-color: #20232a;
+  background-color: #191b21;
   color: #fff;
   font-weight: bold;
   font-size: 24px;
   padding: 30px;
-  margin: 0 auto 28px;
   text-align: center;
   height: 100px;
 }
@@ -246,6 +245,12 @@ input#search_input_react:focus {
 @media only screen and (min-width: 1024px) {
   .navPusher {
     padding-top: 160px;
+  }
+  .docsNavContainer {
+    top: 136px;
+  }
+  .onPageNav {
+    top: 172px;
   }
 }
 


### PR DESCRIPTION
This small PR fixes a display issue with the sticky navs and BLM banner. 

Also the background color of the banner has be adjusted to stand out a bit more.

### Preview
#### Before
<img width="1064" alt="Annotation 2020-06-05 155218" src="https://user-images.githubusercontent.com/719641/83884156-c7355f80-a744-11ea-841d-a849d4109069.png">

#### After
<img width="1040" alt="Annotation 2020-06-05 155032" src="https://user-images.githubusercontent.com/719641/83884163-ca305000-a744-11ea-80a2-fa2ad46d3704.png">
