### PR TITLE
Fix banner links not clickable on mobile

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -199,6 +199,11 @@ input#search_input_react:focus {
 }
 
 /* Overrides for the announcement banner */
+.slidingNav {
+  /* On mobile, the nav needs pointer events to pass through to the banner. */
+  pointer-events: none;
+}
+
 .announcement {
   background-color: #20232a;
   color: #fff;


### PR DESCRIPTION
## Overview

The banner is not clickable on mobile because the pointer events are blocked by nav.
