### PR TITLE
fix overlap and BLM pointer events issue on mobile

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -199,9 +199,8 @@ input#search_input_react:focus {
 }
 
 /* Overrides for the announcement banner */
-.slidingNav {
-  /* On mobile, the nav needs pointer events to pass through to the banner. */
-  pointer-events: none;
+.navigationSlider .slidingNav {
+  height: 60px;
 }
 
 .announcement {


### PR DESCRIPTION
Fixes #1976

This small PR changes the approach to fixing the overlap and pointer events issues on mobile after introducing BLM banner. Previous fix breaks the main header pointer events on the desktop.