### PR TITLE
mimic more reactjs.org BLM banner style, add grayscale filter

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -199,18 +199,33 @@ input#search_input_react:focus {
 }
 
 /* Overrides for the announcement banner */
+.navPusher,
+header a,
+header li:after {
+  filter: grayscale();
+}
+
+.fixedHeaderContainer {
+  height: auto;
+}
+
+.headerWrapper.wrapper {
+  padding-top: 100px;
+}
+
 .navigationSlider .slidingNav {
   height: 60px;
 }
 
 .announcement {
-  background-color: #191b21;
   color: #fff;
   font-weight: bold;
   font-size: 24px;
   padding: 30px;
   text-align: center;
   height: 100px;
+  position: absolute;
+  width: 100%;
 }
 
 .announcement-inner {
@@ -264,6 +279,9 @@ input#search_input_react:focus {
   }
   .navPusher {
     padding-top: 210px;
+  }
+  .navSearchWrapper {
+    top: 114px;
   }
 }
 /* End announcement banner override */

--- a/website/static/js/announcement.js
+++ b/website/static/js/announcement.js
@@ -1,10 +1,10 @@
 document.addEventListener('DOMContentLoaded', function() {
   const container = document.querySelector('.fixedHeaderContainer');
   if (container) {
-    const div = document.createElement('div');
-    div.innerHTML =
-      '<div class="announcement"><div class="announcement-inner">Black Lives Matter. <a href="https://support.eji.org/give/153413/#!/donation/checkout">Support the Equal Justice Initiative</a>.</div></div>';
-    const content = div.childNodes[0];
-    container.insertBefore(content, container.childNodes[0].nextSibling);
+    const announcement = document.createElement('div');
+    announcement.className = 'announcement';
+    announcement.innerHTML =
+      '<div class="announcement-inner">Black Lives Matter. <a href="https://support.eji.org/give/153413/#!/donation/checkout">Support the Equal Justice Initiative.</a></div>';
+    container.insertBefore(announcement, container.firstChild);
   }
 });


### PR DESCRIPTION
This PR is an attempt to mimic more reactjs.org style of BLM banner and small design changes on the reactnative.dev. The changes includes banner at the top, content grayscale filter and some minor improvements to prevent white background before the BLM banner loads and jumping of the header after the BLM banner loads (this problem has occured when components switched their places).

### Preview
<img width="1093" alt="Annotation 2020-06-06 000313" src="https://user-images.githubusercontent.com/719641/83926816-3c2b8800-a78b-11ea-9fab-9169d09a79c8.png">
