### PR TITLE
fix few invalid links on the website

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,7 +64,7 @@ If you have a problem with Expo, before creating a new issue, please see if ther
 - in the [Expo CLI issues](https://github.com/expo/expo-cli/issues) (for issues related to Expo CLI), or
 - in the [Expo issues](https://github.com/expo/expo/issues) (for issues about the Expo client or SDK).
 
-If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started.md).
+If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started).
 
 <h3>Running your app on a simulator or virtual device</h3>
 
@@ -617,7 +617,7 @@ Congratulations! You've successfully run and modified your first React Native ap
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
-If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started.md).
+If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started).
 
 <block class="native windows linux mac android" />
 
@@ -625,4 +625,4 @@ If you're curious to learn more about React Native, check out the [Introduction 
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
-If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started.md).
+If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started).

--- a/docs/intro-react-native-components.md
+++ b/docs/intro-react-native-components.md
@@ -19,7 +19,7 @@ In Android and iOS development, a **view** is the basic building block of UI: a 
 
 In Android development, you write views in Kotlin or Java; in iOS development, you use Swift or Objective-C. With React Native, you can invoke these views with JavaScript using React components. At runtime, React Native creates the corresponding Android and iOS views for those components. Because React Native components are backed by the same views as Android and iOS, React Native apps look, feel, and perform like any other apps. We call these platform-backed components **Native Components.**
 
-React Native lets you to build your own Native Components for [Android](native-components-android.md) and [iOS](native-components-ios.md) to suit your app’s unique needs. We also have a thriving ecosystem of these **community-contributed components.** Check out [Native Directory](https://www.native.directory/) to find what the community has been creating.
+React Native lets you to build your own Native Components for [Android](native-components-android.md) and [iOS](native-components-ios.md) to suit your app’s unique needs. We also have a thriving ecosystem of these **community-contributed components.** Check out [Native Directory](https://reactnative.directory) to find what the community has been creating.
 
 React Native also includes a set of essential, ready-to-use Native Components you can use to start building your app today. These are React Native's **Core Components**.
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -70,7 +70,7 @@ Usually libraries built _specifically for other platforms_ will not work with Re
 
 ### Does it work for the platforms that my app supports?
 
-[React Native Directory](https://reactnative.directory/) allows you to filter by platform compatibility, such as iOS, Android, Web, and Windows. If the library you would like to use is not currently listed there, refer to the README for the library to learn more.
+[React Native Directory](https://reactnative.directory) allows you to filter by platform compatibility, such as iOS, Android, Web, and Windows. If the library you would like to use is not currently listed there, refer to the README for the library to learn more.
 
 ### Does it work with my app version of React Native?
 

--- a/docs/more-resources.md
+++ b/docs/more-resources.md
@@ -38,6 +38,6 @@ Try out apps from the [Showcase](https://reactnative.dev/showcase) to see what R
 
 React Native has a community of thousands of developers like you making content, tools, tutorials—and Native Components!
 
-Can’t find what you’re looking for in the Core Components? Visit [Native Directory](https://www.native.directory/) to find what the community has been creating.
+Can’t find what you’re looking for in the Core Components? Visit [React Native Directory](https://reactnative.directory) to find what the community has been creating.
 
 Interested in making your own Native Component or Module? Making modules for your own use case and sharing them with others on NPM and GitHub helps grow the React Native ecosystem and community! Read the guides to making your own Native Modules ([Android](native-modules-android.md), [iOS](native-modules-ios.md)) and Native Components ([Android](native-components-android.md), [iOS](native-components-ios.md)).

--- a/website/versioned_docs/version-0.62/getting-started.md
+++ b/website/versioned_docs/version-0.62/getting-started.md
@@ -65,7 +65,7 @@ If you have a problem with Expo, before creating a new issue, please see if ther
 - in the [Expo CLI issues](https://github.com/expo/expo-cli/issues) (for issues related to Expo CLI), or
 - in the [Expo issues](https://github.com/expo/expo/issues) (for issues about the Expo client or SDK).
 
-If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started.md).
+If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started).
 
 <h3>Running your app on a simulator or virtual device</h3>
 
@@ -576,7 +576,7 @@ Congratulations! You've successfully run and modified your first React Native ap
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
-If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started.md).
+If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started).
 
 <block class="native windows linux mac android" />
 
@@ -584,4 +584,4 @@ If you're curious to learn more about React Native, check out the [Introduction 
 
 - If you want to add this new React Native code to an existing application, check out the [Integration guide](integration-with-existing-apps.md).
 
-If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started.md).
+If you're curious to learn more about React Native, check out the [Introduction to React Native](getting-started).

--- a/website/versioned_docs/version-0.62/intro-react-native-components.md
+++ b/website/versioned_docs/version-0.62/intro-react-native-components.md
@@ -20,7 +20,7 @@ In Android and iOS development, a **view** is the basic building block of UI: a 
 
 In Android development, you write views in Kotlin or Java; in iOS development, you use Swift or Objective-C. With React Native, you can invoke these views with JavaScript using React components. At runtime, React Native creates the corresponding Android and iOS views for those components. Because React Native components are backed by the same views as Android and iOS, React Native apps look, feel, and perform like any other apps. We call these platform-backed components **Native Components.**
 
-React Native lets you to build your own Native Components for [Android](native-components-android.md) and [iOS](native-components-ios.md) to suit your app’s unique needs. We also have a thriving ecosystem of these **community-contributed components.** Check out [Native Directory](https://www.native.directory/) to find what the community has been creating.
+React Native lets you to build your own Native Components for [Android](native-components-android.md) and [iOS](native-components-ios.md) to suit your app’s unique needs. We also have a thriving ecosystem of these **community-contributed components.** Check out [React Native Directory](https://reactnative.directory) to find what the community has been creating.
 
 React Native also includes a set of essential, ready-to-use Native Components you can use to start building your app today. These are React Native's **Core Components**.
 

--- a/website/versioned_docs/version-0.62/libraries.md
+++ b/website/versioned_docs/version-0.62/libraries.md
@@ -71,7 +71,7 @@ Usually libraries built _specifically for other platforms_ will not work with Re
 
 ### Does it work for the platforms that my app supports?
 
-[React Native Directory](https://reactnative.directory/) allows you to filter by platform compatibility, such as iOS, Android, Web, and Windows. If the library you would like to use is not currently listed there, refer to the README for the library to learn more.
+[React Native Directory](https://reactnative.directory) allows you to filter by platform compatibility, such as iOS, Android, Web, and Windows. If the library you would like to use is not currently listed there, refer to the README for the library to learn more.
 
 ### Does it work with my app version of React Native?
 

--- a/website/versioned_docs/version-0.62/more-resources.md
+++ b/website/versioned_docs/version-0.62/more-resources.md
@@ -39,6 +39,6 @@ Try out apps from the [Showcase](https://reactnative.dev/showcase) to see what R
 
 React Native has a community of thousands of developers like you making content, tools, tutorials—and Native Components!
 
-Can’t find what you’re looking for in the Core Components? Visit [Native Directory](https://www.native.directory/) to find what the community has been creating.
+Can’t find what you’re looking for in the Core Components? Visit [React Native Directory](https://reactnative.directory) to find what the community has been creating.
 
 Interested in making your own Native Component or Module? Making modules for your own use case and sharing them with others on NPM and GitHub helps grow the React Native ecosystem and community! Read the guides to making your own Native Modules ([Android](native-modules-android.md), [iOS](native-modules-ios.md)) and Native Components ([Android](native-components-android.md), [iOS](native-components-ios.md)).


### PR DESCRIPTION
Fixes #1975

This small PR fixes the two invalid links reported in the issues above in the current and 0.62 versioned docs. The reason why `getting-started.md` was converted to the same page link lies inside RNW custom redirects.