### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -294,6 +294,16 @@ The React Native tools require some environment variables to be set up in order 
 
 <block class="native mac linux android" />
 
+Open the Terminal and open your `$HOME/.bash_profile` or `$HOME/.bashrc` using `GNU nano`.
+
+From your terminal, enter `nano` and the filename you want to edit.
+
+** For instance **
+
+```sh
+nano ~/.bash_profile
+```
+
 Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` config file:
 
 <block class="native mac android" />


### PR DESCRIPTION
Configure the ANDROID_HOME environment variable
Section doesn't mentions how to open or navigate to  $HOME/.bash_profile or $HOME/.bashrc files from Terminal.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
