### PR TITLE
fix: update installation instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -294,7 +294,7 @@ The React Native tools require some environment variables to be set up in order 
 
 <block class="native mac linux android" />
 
-Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (`$HOME/.zprofile` on macOS Catalina) config file:
+Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you are using `zsh` then `~/.zprofile` or `~/.zshrc`) config file:
 
 <block class="native mac android" />
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -294,7 +294,7 @@ The React Native tools require some environment variables to be set up in order 
 
 <block class="native mac linux android" />
 
-Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` config file:
+Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (`$HOME/.zprofile` on macOS Catalina) config file:
 
 <block class="native mac android" />
 


### PR DESCRIPTION
- macOS Catalina now uses Zsh instead of Bash

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

It took me a while to figure this out when I was installing RN on a fresh OS. 🙂 You can find more information here: https://thenextweb.com/dd/2019/06/04/why-does-macos-catalina-use-zsh-instead-of-bash-licensing/