### PR TITLE
Fix wrong endBlock in text.md

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -102,6 +102,8 @@ const styles = StyleSheet.create({
 export default TextInANest;
 ```
 
+<block class="endBlock syntax" />
+
 ## Nested text
 
 Both Android and iOS allow you to display formatted text by annotating ranges of a string with specific formatting like bold or colored text (`NSAttributedString` on iOS, `SpannableString` on Android). In practice, this is very tedious. For React Native, we decided to use web paradigm for this where you can nest text to achieve the same effect.
@@ -130,8 +132,6 @@ const styles = StyleSheet.create({
 
 export default BoldAndBeautiful;
 ```
-
-<block class="endBlock syntax" />
 
 Behind the scenes, React Native converts this to a flat `NSAttributedString` or `SpannableString` that contains the following information:
 

--- a/website/versioned_docs/version-0.62/text.md
+++ b/website/versioned_docs/version-0.62/text.md
@@ -101,6 +101,8 @@ const styles = StyleSheet.create({
 });
 ```
 
+<block class="endBlock syntax" />
+
 ## Nested text
 
 Both Android and iOS allow you to display formatted text by annotating ranges of a string with specific formatting like bold or colored text (`NSAttributedString` on iOS, `SpannableString` on Android). In practice, this is very tedious. For React Native, we decided to use web paradigm for this where you can nest text to achieve the same effect.
@@ -129,8 +131,6 @@ const styles = StyleSheet.create({
 
 export default BoldAndBeautiful;
 ```
-
-<block class="endBlock syntax" />
 
 Behind the scenes, React Native converts this to a flat `NSAttributedString` or `SpannableString` that contains the following information:
 


### PR DESCRIPTION
Because of this wrong endBlock you can not see the chapter `Nested text`(until you switch to class component example)