### PR TITLE
Fixed DrawerLayoutAndroid padding syntax which was causing the Expo Snack to crash

### DIFF
--- a/docs/drawerlayoutandroid.md
+++ b/docs/drawerlayoutandroid.md
@@ -54,13 +54,13 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    paddingTop: "50px",
+    paddingTop: 50,
     backgroundColor: "#ecf0f1",
     padding: 8
   },
   navigationContainer: {
     flex: 1,
-    paddingTop:  "50px",
+    paddingTop: 50,
     backgroundColor: "#fff",
     padding: 8
   }

--- a/website/versioned_docs/version-0.62/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.62/drawerlayoutandroid.md
@@ -55,13 +55,13 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    paddingTop: "50px",
+    paddingTop: 50,
     backgroundColor: "#ecf0f1",
     padding: 8
   },
   navigationContainer: {
     flex: 1,
-    paddingTop:  "50px",
+    paddingTop: 50,
     backgroundColor: "#fff",
     padding: 8
   }


### PR DESCRIPTION
### Description

Fixes an issue where the Expo Snack crashes at runtime due to invalid styling syntax.

![Screen Shot 2020-06-12 at 5 12 32 PM](https://user-images.githubusercontent.com/36051536/84555079-a5a61c00-ace0-11ea-8f54-d2f5925d3f2a.png)
