### PR TITLE
Add two words to platform-specific-code.md

### DIFF
--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-This will result in a container having `flex: 1` on both platforms, a red background color on iOS, a green background color on Android, and a blue background on other platforms.
+This will result in a container having `flex: 1` on all platforms, a red background color on iOS, a green background color on Android, and a blue background color on other platforms.
 
 Since it accepts `any` value, you can also use it to return platform specific component, like below:
 


### PR DESCRIPTION
I think the documentation used to describe only two platform options in the paragraph I've changed. I've added two words to make it slightly more accurate and consistent.