### PR TITLE
Fix bug in example of AppState functional component

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -48,7 +48,7 @@ const AppStateExample = () => {
     return () => {
       AppState.removeEventListener("change", _handleAppStateChange);
     };
-  }, []);
+  }, [_handleAppStateChange]);
 
   const _handleAppStateChange = (nextAppState) => {
     if (appState.current.match(/inactive|background/) && nextAppState === "active") {


### PR DESCRIPTION
I found out that when _handleAppStateChange is triggered, appState is still "active". Therefore, ```appState.match(/inactive|background/)``` always return null. I believe this because _handleAppStateChange passed to useEffect was not updated. I propose a fix that is to add _handleAppStateChange to dependencies list of useEffect.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
