### PR TITLE
fix onPageNav height with announcement

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -264,6 +264,7 @@ input#search_input_react:focus {
   }
   .onPageNav {
     top: 172px;
+    max-height: calc(100vh - 172px);
   }
 }
 


### PR DESCRIPTION
Fixes #2003

The `onPageNav` after an announcement addition has invalid height which caused scrolling issues. 

This PR adds the correct `max-height` attribute which fixes the the problems.
