### PR TITLE
updated default folder location for Android Sdk in Windows

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -338,7 +338,7 @@ Newer versions
 In older versions, the SDK is installed, by default, at the following location (replace [username] by your username):
 
 ```powershell
-C:\Users\[username]\AppData\Local\Android\Sdk
+%LOCALAPPDATA%\Android\Sdk
 ```
 
 You can find the actual location of the SDK in the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -333,10 +333,12 @@ Type `source $HOME/.bash_profile` to load the config into your current shell. Ve
 
 ![ANDROID_HOME Environment Variable](/docs/assets/GettingStartedAndroidEnvironmentVariableANDROID_HOME.png)
 
-The SDK is installed, by default, at the following location:
+Newer versions 
+
+In older versions, the SDK is installed, by default, at the following location (replace [username] by your username):
 
 ```powershell
-c:\Android\tools\bin
+C:\Users\[username]\AppData\Local\Android\Sdk
 ```
 
 You can find the actual location of the SDK in the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
@@ -359,7 +361,7 @@ Open a new Command Prompt window to ensure the new environment variable is loade
 The default location for this folder is:
 
 ```powershell
-C:\Android\tools\bin\platform-tools
+C:\Users\[your username]\AppData\Local\Android\Sdk\platform-tools
 ```
 
 <block class="native linux android" />

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -333,9 +333,7 @@ Type `source $HOME/.bash_profile` to load the config into your current shell. Ve
 
 ![ANDROID_HOME Environment Variable](/docs/assets/GettingStartedAndroidEnvironmentVariableANDROID_HOME.png)
 
-Newer versions 
-
-In older versions, the SDK is installed, by default, at the following location (replace [username] by your username):
+The SDK is installed, by default, at the following location:
 
 ```powershell
 %LOCALAPPDATA%\Android\Sdk
@@ -361,7 +359,7 @@ Open a new Command Prompt window to ensure the new environment variable is loade
 The default location for this folder is:
 
 ```powershell
-C:\Users\[your username]\AppData\Local\Android\Sdk\platform-tools
+%LOCALAPPDATA%\Android\Sdk\platform-tools
 ```
 
 <block class="native linux android" />


### PR DESCRIPTION
Matching the configuration screenshot of the default folder location. I had some trouble during environment configuration when I figured out that the location from the screenshot provided was the correct one (for the Sdk location).

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
