### PR TITLE
Added missing argument in code snippet.

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -96,7 +96,7 @@ The final Java step is to register the ViewManager to the application, this happ
   public List<ViewManager> createViewManagers(
                             ReactApplicationContext reactContext) {
     return Arrays.<ViewManager>asList(
-      new ReactImageManager()
+      new ReactImageManager(reactContext)
     );
   }
 ```


### PR DESCRIPTION
ReactImageManager's constructer is 
```
  public ReactImageManager(ReactApplicationContext reactContext) {
    mCallerContext = reactContext;
  }
```
but while calling it in `ReactPackage` the code written is 
```
  @Override
  public List<ViewManager> createViewManagers(
                            ReactApplicationContext reactContext) {
    return Arrays.<ViewManager>asList(
      new ReactImageManager() **//Error here**
    );
  }
```
**Fix:**
```
  @Override
  public List<ViewManager> createViewManagers(
                            ReactApplicationContext reactContext) {
    return Arrays.<ViewManager>asList(
      new ReactImageManager(reactContext)
    );
  }
```

ReactImageManager 's constructer needs reactContext, so passing it solves the issue.