### PR TITLE
remove duplicate statusBarTranslucent from Modal Docs  

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -326,16 +326,6 @@ Default is set to `overFullScreen` or `fullScreen` depending on `transparent` pr
 
 ---
 
-### `statusBarTranslucent`
-
-The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
-
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
-
----
-
 ### `supportedOrientations`
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field. When using `presentationStyle` of `pageSheet` or `formSheet`, this property will be ignored by iOS.


### PR DESCRIPTION
Removed the duplicate statusBarTranslucent doc from the documentation body.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Fixes #2016
