### PR TITLE
Add an ability to slide up announcement bar on scroll

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -237,6 +237,25 @@ input#search_input_react:focus {
   color: #fff;
 }
 
+.fixedHeaderContainer,
+.onPageNav,
+.docsNavContainer {
+  transition: top 0.35s;
+}
+
+.navPusher {
+  transition: top 0.35s, margin 0.35s;
+}
+
+/*
+Fix small mobile device overflow with sliding up banner
+(code is present on desktop and for larger devices)
+ */
+body {
+  display: flex;
+  flex-direction: column;
+}
+
 @media only screen and (max-width: 700px) {
   ul.nav-site.nav-site-internal {
     margin-top: 160px;

--- a/website/static/js/announcement.js
+++ b/website/static/js/announcement.js
@@ -12,41 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
 const scrollStartBoundary = 160;
 
 window.onscroll = () => {
-  const fixedHeaderContainer = document.querySelector('.fixedHeaderContainer');
-  const navPusher = document.querySelector('.navPusher');
+  // Simple check for mobile devices
+  if (typeof window.orientation !== 'undefined') {
+    const fixedHeaderContainer = document.querySelector(
+      '.fixedHeaderContainer'
+    );
+    const navPusher = document.querySelector('.navPusher');
 
-  if (
-    document.body.scrollTop > scrollStartBoundary ||
-    document.documentElement.scrollTop > scrollStartBoundary
-  ) {
-    fixedHeaderContainer.style.top = '-100px';
-    navPusher.style.top = '-100px';
-    navPusher.style.marginBottom = '-100px';
-
-    // Desktop layout
-    if (!document.querySelector('.navBreadcrumb').offsetParent) {
-      document.querySelector('.docsNavContainer').style.top = '60px';
-      document.querySelector('.onPageNav').style.top = '72px';
-      document.querySelector('.docsContainer').style.paddingTop = '100px';
+    if (
+      document.body.scrollTop > scrollStartBoundary ||
+      document.documentElement.scrollTop > scrollStartBoundary
+    ) {
+      fixedHeaderContainer.style.top = '-100px';
+      navPusher.style.top = '-100px';
+      navPusher.style.marginBottom = '-100px';
+    } else {
+      fixedHeaderContainer.style.top = '0';
+      navPusher.style.top = '0';
+      navPusher.style.marginBottom = '0';
     }
-  } else {
-    fixedHeaderContainer.style.top = '0';
-    navPusher.style.top = '0';
-    navPusher.style.marginBottom = '0';
-
-    // Desktop layout
-    if (!document.querySelector('.navBreadcrumb').offsetParent) {
-      document.querySelector('.docsNavContainer').style.top = '136px';
-      document.querySelector('.onPageNav').style.top = '172px';
-      document.querySelector('.docsContainer').style.paddingTop = '0';
-    }
-  }
-};
-
-window.onresize = () => {
-  // Fix desktop resizing
-  if (document.querySelector('.navBreadcrumb').offsetParent) {
-    document.querySelector('.docsNavContainer').style.top = 'initial';
-    document.querySelector('.docsContainer').style.paddingTop = 'auto';
   }
 };

--- a/website/static/js/announcement.js
+++ b/website/static/js/announcement.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', () => {
   const container = document.querySelector('.fixedHeaderContainer');
   if (container) {
     const announcement = document.createElement('div');
@@ -8,3 +8,45 @@ document.addEventListener('DOMContentLoaded', function() {
     container.insertBefore(announcement, container.firstChild);
   }
 });
+
+const scrollStartBoundary = 160;
+
+window.onscroll = () => {
+  const fixedHeaderContainer = document.querySelector('.fixedHeaderContainer');
+  const navPusher = document.querySelector('.navPusher');
+
+  if (
+    document.body.scrollTop > scrollStartBoundary ||
+    document.documentElement.scrollTop > scrollStartBoundary
+  ) {
+    fixedHeaderContainer.style.top = '-100px';
+    navPusher.style.top = '-100px';
+    navPusher.style.marginBottom = '-100px';
+
+    // Desktop layout
+    if (!document.querySelector('.navBreadcrumb').offsetParent) {
+      document.querySelector('.docsNavContainer').style.top = '60px';
+      document.querySelector('.onPageNav').style.top = '72px';
+      document.querySelector('.docsContainer').style.paddingTop = '100px';
+    }
+  } else {
+    fixedHeaderContainer.style.top = '0';
+    navPusher.style.top = '0';
+    navPusher.style.marginBottom = '0';
+
+    // Desktop layout
+    if (!document.querySelector('.navBreadcrumb').offsetParent) {
+      document.querySelector('.docsNavContainer').style.top = '136px';
+      document.querySelector('.onPageNav').style.top = '172px';
+      document.querySelector('.docsContainer').style.paddingTop = '0';
+    }
+  }
+};
+
+window.onresize = () => {
+  // Fix desktop resizing
+  if (document.querySelector('.navBreadcrumb').offsetParent) {
+    document.querySelector('.docsNavContainer').style.top = undefined;
+    document.querySelector('.docsContainer').style.paddingTop = undefined;
+  }
+};

--- a/website/static/js/announcement.js
+++ b/website/static/js/announcement.js
@@ -46,7 +46,7 @@ window.onscroll = () => {
 window.onresize = () => {
   // Fix desktop resizing
   if (document.querySelector('.navBreadcrumb').offsetParent) {
-    document.querySelector('.docsNavContainer').style.top = undefined;
-    document.querySelector('.docsContainer').style.paddingTop = undefined;
+    document.querySelector('.docsNavContainer').style.top = 'initial';
+    document.querySelector('.docsContainer').style.paddingTop = 'auto';
   }
 };


### PR DESCRIPTION
This PR adds an ability to slide up announcement bar on scroll (in a bit hacky, but working way). 

There were a lot of small UI/display glitches at the beginning, I have manage to fix most of them (I hope), but this solution is not ideal in any mean, it's just a temporary UX fix mainly for the small, mobile devices.

### Desktop preview
![500](https://user-images.githubusercontent.com/719641/86240463-93155900-bba1-11ea-8b67-64c2dc7fc765.gif)

### Mobile preview
![ezgif-1-fdf19ba5ebc8](https://user-images.githubusercontent.com/719641/86240684-eb4c5b00-bba1-11ea-8cd7-37b87d36dc47.gif)

