### PR TITLE
Remove duplicate documentation property for statusBarTranslucent on Modal

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -326,16 +326,6 @@ Default is set to `overFullScreen` or `fullScreen` depending on `transparent` pr
 
 ---
 
-### `statusBarTranslucent`
-
-The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
-
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
-
----
-
 ### `supportedOrientations`
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field. When using `presentationStyle` of `pageSheet` or `formSheet`, this property will be ignored by iOS.

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -258,16 +258,6 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `statusBarTranslucent`
-
-The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
-
----
-
 ### `onDismiss`
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
@@ -323,6 +313,16 @@ Default is set to `overFullScreen` or `fullScreen` depending on `transparent` pr
 | Type                                                           | Required | Platform |
 | -------------------------------------------------------------- | -------- | -------- |
 | enum('fullScreen', 'pageSheet', 'formSheet', 'overFullScreen') | No       | iOS      |
+
+---
+
+### `statusBarTranslucent`
+
+The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
 
 ---
 


### PR DESCRIPTION
This property is already documented further up this page, in addition to this instance wasn't defined as being Android-only.