### PR TITLE
replace state usage comparison image with the code blocks

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -116,6 +116,7 @@ In a React component, the props are the variables that we pass from a parent com
 import React, { useState } from 'react';
 
 
+
 const App = () => {
   const [count, setCount] = useState(0);
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -108,9 +108,71 @@ In a React component, the props are the variables that we pass from a parent com
 
 #### There are differences between React and React Native to handle the state?
 
-![image](https://user-images.githubusercontent.com/20761166/61405629-48270680-a8a8-11e9-906e-aa80d51e51e3.png)
+<div class="two-columns">
 
-As shown in the image, there is no difference in handling the `state` between [React](https://reactjs.org/docs/state-and-lifecycle.html) and `React Native`. You can use the state of your components both in classes and in functional components using [hooks](https://reactjs.org/docs/hooks-intro.html)!
+```jsx
+// ReactJS Counter Example using Hooks!
+
+import React, { useState } from 'react';
+
+
+const App = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="container">
+      <p>You clicked {count} times</p>
+      <button
+        onClick={() => setCount(count + 1)}>
+        Click me!
+      </button>
+    </div>
+  );
+};
+
+
+// CSS
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+```
+
+```jsx
+// React Native Counter Example using Hooks!
+
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+const App = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <Text>You clicked {count} times</Text>
+      <Button
+        onPress={() => setCount(count + 1)}
+        titles="Click me!"
+      />
+    </View>
+  );
+};
+
+// React Native Styles
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+});
+```
+
+</div>
+
+As shown above, there is no difference in handling the `state` between [React](https://reactjs.org/docs/state-and-lifecycle.html) and `React Native`. You can use the state of your components both in classes and in functional components using [hooks](https://reactjs.org/docs/hooks-intro.html)!
 
 In the following example we will show the same above counter example using classes.
 

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -368,3 +368,21 @@ td .label.required {
   line-height: 10px;
   font-weight: 600;
 }
+
+/* Two columns */
+.two-columns {
+  display: grid;
+  gap: 0 2%;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: ". .";
+}
+
+@media only screen and (max-width: 960px) {
+  .two-columns {
+    gap: 0;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+    grid-template-areas: "." ".";
+  }
+}

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -378,7 +378,11 @@ td .label.required {
   grid-template-areas: ". .";
 }
 
-@media only screen and (max-width: 960px) {
+.two-columns pre code {
+  white-space: pre-wrap;
+}
+
+@media only screen and (max-width: 1023px) {
   .two-columns {
     gap: 0;
     grid-template-columns: 1fr;


### PR DESCRIPTION
Fixes #2014 

This PR replaces the React and React Native state usage comparison image on the Tutorial page with the two code block arranged in the column (also the problem from the issue above has been fixed). On the small devices blocks are stacked in rows.

Live preview: https://deploy-preview-2026--react-native.netlify.app/docs/next/tutorial#state

### Preview
<img width="799" alt="Annotation 2020-07-06 223146" src="https://user-images.githubusercontent.com/719641/86638994-84330a00-bfd8-11ea-9960-e1acf7816159.png">

