### PR TITLE
Fix Alert API docs

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -178,6 +178,7 @@ Alert.alert('Alert Title', 'My Alert Msg', [
   },
   { text: 'OK', onPress: () => console.log('OK Pressed') },
   {
+    // cancelable and onDismiss only work on Android.
     cancelable: true,
     onDismiss: () =>
       console.log(

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -161,7 +161,7 @@ On Android at most three buttons can be specified. Android has a concept of a ne
 
 Alerts on Android can be dismissed by tapping outside of the alert box. It is disabled by default and can be enabled by providing an optional `options` parameter with the cancelable property set to true i.e. `{ cancelable: true }`.
 
-The dismissed event can be handled by providing an `onDismiss` callback property `{ onDismiss: () => {} }` inside the `options` parameter.
+The cancel event can be handled by providing an `onDismiss` callback property `{ onDismiss: () => {} }` inside the `options` parameter.
 
 Example usage:
 

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -166,7 +166,6 @@ The cancel event can be handled by providing an `onDismiss` callback property `{
 Example usage:
 
 ```jsx
-// Works only on Android
 Alert.alert('Alert Title', 'My Alert Msg', [
   {
     text: 'Ask me later',

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -40,8 +40,7 @@ const App = () => {
           style: "cancel"
         },
         { text: "OK", onPress: () => console.log("OK Pressed") }
-      ],
-      { cancelable: false }
+      ]
     );
 
   const createThreeButtonAlert = () =>
@@ -59,8 +58,7 @@ const App = () => {
           style: "cancel"
         },
         { text: "OK", onPress: () => console.log("OK Pressed") }
-      ],
-      { cancelable: false }
+      ]
     );
 
   return (
@@ -101,8 +99,7 @@ class App extends Component {
           style: "cancel"
         },
         { text: "OK", onPress: () => console.log("OK Pressed") }
-      ],
-      { cancelable: false }
+      ]
     );
 
   createThreeButtonAlert = () =>
@@ -120,8 +117,7 @@ class App extends Component {
           style: "cancel"
         },
         { text: "OK", onPress: () => console.log("OK Pressed") }
-      ],
-      { cancelable: false }
+      ]
     );
 
   render() {
@@ -163,31 +159,33 @@ On Android at most three buttons can be specified. Android has a concept of a ne
 - Two buttons mean 'negative', 'positive' (such as 'Cancel', 'OK')
 - Three buttons mean 'neutral', 'negative', 'positive' (such as 'Later', 'Cancel', 'OK')
 
-By default alerts on Android can be dismissed by tapping outside of the alert box. This event can be handled by providing an optional `options` parameter, with an `onDismiss` callback property `{ onDismiss: () => {} }`.
+Alerts on Android can be dismissed by tapping outside of the alert box. It is disabled by default and can be enabled by providing an optional `options` parameter with the cancelable property set to true i.e. `{ cancelable: true }`.
 
-Alternatively, the dismissing behavior can be disabled altogether by providing an optional options parameter with the cancelable property set to false i.e. `{ cancelable: false }`.
+The dismissed event can be handled by providing an `onDismiss` callback property `{ onDismiss: () => {} }` inside the `options` parameter.
 
 Example usage:
 
 ```jsx
-// Works on both Android and iOS
-Alert.alert(
-  'Alert Title',
-  'My Alert Msg',
-  [
-    {
-      text: 'Ask me later',
-      onPress: () => console.log('Ask me later pressed')
-    },
-    {
-      text: 'Cancel',
-      onPress: () => console.log('Cancel Pressed'),
-      style: 'cancel'
-    },
-    { text: 'OK', onPress: () => console.log('OK Pressed') }
-  ],
-  { cancelable: false }
-);
+// Works only on Android
+Alert.alert('Alert Title', 'My Alert Msg', [
+  {
+    text: 'Ask me later',
+    onPress: () => console.log('Ask me later pressed')
+  },
+  {
+    text: 'Cancel',
+    onPress: () => console.log('Cancel Pressed'),
+    style: 'cancel'
+  },
+  { text: 'OK', onPress: () => console.log('OK Pressed') },
+  {
+    cancelable: true,
+    onDismiss: () =>
+      console.log(
+        'This alert was dismissed by tapping outside of the alert dialog.'
+      )
+  }
+]);
 ```
 
 ---


### PR DESCRIPTION
The `cancelable` property value is by default set to `false` in the source as can be seen [here](https://github.com/facebook/react-native/blob/master/Libraries/Alert/Alert.js#L61). I have updated the docs accordingly.

Please let me know if any changes are required.