### PR TITLE
fix link in hermes docs, metro configuration link.

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -74,7 +74,7 @@ This will compile JavaScript to bytecode during build time which will improve yo
 
 Hermes supports the Chrome debugger by implementing the Chrome inspector protocol. This means Chrome's tools can be used to directly debug JavaScript running on Hermes, on an emulator or device.
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/getting-started#configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -74,7 +74,7 @@ This will compile JavaScript to bytecode during build time which will improve yo
 
 Hermes supports the Chrome debugger by implementing the Chrome inspector protocol. This means Chrome's tools can be used to directly debug JavaScript running on Hermes, on an emulator or device.
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/getting-started#configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/website/versioned_docs/version-0.62/hermes.md
+++ b/website/versioned_docs/version-0.62/hermes.md
@@ -71,7 +71,7 @@ This will compile JavaScript to bytecode during build time which will improve yo
 
 Hermes supports the Chrome debugger by implementing the Chrome inspector protocol. This means Chrome's tools can be used to directly debug JavaScript running on Hermes, on an emulator or device.
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/getting-started#configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/website/versioned_docs/version-0.62/hermes.md
+++ b/website/versioned_docs/version-0.62/hermes.md
@@ -71,7 +71,7 @@ This will compile JavaScript to bytecode during build time which will improve yo
 
 Hermes supports the Chrome debugger by implementing the Chrome inspector protocol. This means Chrome's tools can be used to directly debug JavaScript running on Hermes, on an emulator or device.
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/en/configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/getting-started#configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 


### PR DESCRIPTION
this PR fix link in Hermes docs, metro configuration link!!.

when you click this link, 404 appears.