### PR TITLE
Update LaunchScreen pro tip to use Storyboard

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -290,9 +290,9 @@ As your App Bundle grows in size, you may start to see a blank screen flash betw
 
 ```objectivec
   // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIView* launchScreenView = [[[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil] objectAtIndex:0];
-  launchScreenView.frame = self.window.bounds;
-  rootView.loadingView = launchScreenView;
+  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
+  UIViewController *vc = [sb instantiateInitialViewController];
+  rootView.loadingView = vc.view;
 ```
 
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:


### PR DESCRIPTION
Change initialization of LaunchScreen in AppDelegate.m from using the XIB (which is now deprecated in 0.63) to the Storyboard file.
