### PR TITLE
Modify duplicate code block in intro-react.md

### DIFF
--- a/docs/intro-react.md
+++ b/docs/intro-react.md
@@ -66,8 +66,6 @@ Here the `Cat` component will render a `<Text>` element:
 const Cat = () => {
   return <Text>Hello, I am your cat!</Text>;
 };
-
-export default Cat;
 ```
 
 You can export your function component with JavaScript’s [`export default`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) for use throughout your app like so:


### PR DESCRIPTION
There are two examples placed one on top of the other where the code is exactly the same. 

This makes the docs harder to understand, as referencing the same exact code for pointing out two different things in consecutive paragraphs can be confusing to a newcomer. It feels like a mistake, even though it can be backed that it is not.

I suggest removing the `export default Cat;` from the first example, where introducing the concept of default exports is not necessary, and use it only on the second code block, where the complete function component is displayed and once the concept has been properly introduced in the previous paragraph. 

I think this makes more sense and avoids the duplicate.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
