### PR TITLE
Fix missing "in" in intro-react.md

### DIFF
--- a/docs/intro-react.md
+++ b/docs/intro-react.md
@@ -229,7 +229,7 @@ export default Cat;
 
 <block class="endBlock devNotes" />
 
-You can render this component multiple times and multiple places without repeating your code by using `<Cat>`:
+You can render this component multiple times and in multiple places without repeating your code by using `<Cat>`:
 
 ```SnackPlayer name=Multiple%20Components
 import React from 'react';


### PR DESCRIPTION
Without the "multiple times" part, the correct phrase would be "You can render this component in multiple places".

This could also be reworked as "You can render this component in multiple places and multiple times without repeating your code...".

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
