### PR TITLE
Minor wording changes in PlatformColor.md

### DIFF
--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -7,7 +7,15 @@ title: PlatformColor
 PlatformColor(color1, [color2, ...colorN]);
 ```
 
-You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function, and provided it exists on that platform, that native color will be applied to the control or Javascript component specified in your style. All native color logic also translates if applicable, meaning if the native color specified is themes and/or high contrast sensitive, that logic will also transfer to the JavaScript component being colored.
+You can use the `PlatformColor` function to access native colors on the target platform by supplying the native color’s corresponding string value. You pass a string to the `PlatformColor` function and, provided it exists on that platform, it will return the corresponding native color, which you can apply in any part of your application.
+
+If you pass more than one string value to the `PlatformColor` function, it will treat the first value as the default and the rest as fallback.
+
+```js
+PlatformColor('bogusName', 'linkColor');
+```
+
+Since native colors can be sensitive to themes and/or high contrast, this platform specific logic also translates inside your components.
 
 <div class="toggler">
   <span>Developer Notes</span>
@@ -64,6 +72,6 @@ const styles = StyleSheet.create({
 });
 ```
 
-The string value provided to the `PlatformColor` function must match and agree with the same string as it exists on the native platform the app is being run on. This means to avoid runtime errors the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.Select()`.
+The string value provided to the `PlatformColor` function must match the string as it exists on the native platform where the app is running. In order to avoid runtime errors, the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.Select()`, as shown on the example above.
 
 > **Note:** You can find a complete example that demonstrates proper, intended use of `PlatformColor` in [PlatformColorExample.js](https://github.com/facebook/react-native/blob/master/RNTester/js/examples/PlatformColor/PlatformColorExample.js).


### PR DESCRIPTION
I found this section specially hard to read, so I'm proposing some minor tweaks that I think will make it easier to understand. 

I also added a mention to the fallback values which the function can receive, taking from the original PR which introduced the changes (https://github.com/facebook/react-native/pull/27908)

I don't know what the exact policy is on this, but since this was introduced in RN 0.63.0, perhaps this could also be clarified on the docs, as using it from an older version will throw a `_reactNative.PlatformColor is not a function` error.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
