### PR TITLE
disable web platform preview for the Switch component

### DIFF
--- a/docs/switch.md
+++ b/docs/switch.md
@@ -9,7 +9,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 
 ## Example
 
-```SnackPlayer name=Switch
+```SnackPlayer name=Switch&supportedPlatforms=android,ios
 import React, { useState } from "react";
 import { View, Switch, StyleSheet } from "react-native";
 

--- a/website/versioned_docs/version-0.62/switch.md
+++ b/website/versioned_docs/version-0.62/switch.md
@@ -10,7 +10,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 
 ## Example
 
-```SnackPlayer name=Switch
+```SnackPlayer name=Switch&supportedPlatforms=android,ios
 import React, { useState } from "react";
 import { View, Switch, StyleSheet } from "react-native";
 

--- a/website/versioned_docs/version-0.63/switch.md
+++ b/website/versioned_docs/version-0.63/switch.md
@@ -10,7 +10,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 
 ## Example
 
-```SnackPlayer name=Switch
+```SnackPlayer name=Switch&supportedPlatforms=android,ios
 import React, { useState } from "react";
 import { View, Switch, StyleSheet } from "react-native";
 


### PR DESCRIPTION
Fixes #2032.

Currently due to properties differences between core and out-of-tree `web` platform there are display issues with `Switch` component in the Snack Preview. This PR disables the `web` preview for the Switch to prevent causing unnecessary confusion for the website readers.
