### PR TITLE
Added information regarding fragments and components

### DIFF
--- a/docs/intro-react.md
+++ b/docs/intro-react.md
@@ -119,6 +119,8 @@ class Cat extends Component {
 }
 ```
 
+> React components must have one root JSX element or it will return an error. You can satisfy this rule by creating a root JSX element or by using Fragments, you can read more about this further in this document or in the [React Fragments documentation](https://reactjs.org/docs/fragments.html).
+
 And as with function components, you can export your class component:
 
 ```jsx


### PR DESCRIPTION
This PR was created regarding the suggestion #1892 
I've added a note informing the one root element rule for React components and a reference about Fragments.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
