### PR TITLE
Typo fix Erorrs -> Errors debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -47,7 +47,7 @@ LogBox.ignoreAllLogs();
 
 Unhanded JavaScript errors such as `undefined is not a function` will automatically open a full screen LogBox error with the source of the error. These errors are dismissable and minimizable so that you can see the state of your app when these errors occur, but should always be addressed.
 
-### Syntax Erorrs
+### Syntax Errors
 
 Syntax errors will automatically open a full screen LogBox error with the source of the syntax error. This error is not dismissable because it represents invalid JavaScript execution that must be fixed before continuing with your app. To dismiss these errors, fix the syntax error and either save to automatically dismiss (with Fast Refresh enabled) or cmd+r to reload (with Fast Refresh disabled).
 


### PR DESCRIPTION
Fixing a typo in  debugging.md the header "Syntax Erorrs" -> "Syntax Errors"

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
