### PR TITLE
Add instructions to link react-native-gesture-handler

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -42,6 +42,11 @@ Next, install the required peer dependencies. You need to run different commands
   pod install
   cd ..
   ```
+  
+  Link the `react-native-gesture-handler` library to the native application:
+  ```sh
+  react-native link react-native-gesture-handler
+  ```
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
 
@@ -50,6 +55,7 @@ To finalize installation of `react-native-gesture-handler`, add the following at
 ```js
 import 'react-native-gesture-handler';
 ```
+
 
 Now, you need to wrap the whole app in `NavigationContainer`. Usually you'd do this in your entry file, such as `index.js` or `App.js`:
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -56,7 +56,6 @@ To finalize installation of `react-native-gesture-handler`, add the following at
 import 'react-native-gesture-handler';
 ```
 
-
 Now, you need to wrap the whole app in `NavigationContainer`. Usually you'd do this in your entry file, such as `index.js` or `App.js`:
 
 ```jsx


### PR DESCRIPTION
**PR Motivation**
- the react-native-gesture-handler library needs to be linked with the native code
- the instructions for linking this library are lacking
- this commit aims to fit the gap by adding these instructions

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
