### PR TITLE
Clarify android environment variables for macOS and Linux

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -320,7 +320,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 
 > `.bash_profile` is specific to `bash`. If you're using another shell, you will need to edit the appropriate shell-specific config file.
 
-Type `source $HOME/.bash_profile` to load the config into your current shell. Verify that ANDROID_HOME has been added to your path by running `echo $PATH`.
+Type `source $HOME/.bash_profile` for `bash` or `source $HOME/.zprofile` to load the config into your current shell. Verify that ANDROID_HOME has been set by running `echo $ANDROID_HOME` and the appropriate directories have been added to your path by running `echo $PATH`.
 
 > Please make sure you use the correct Android SDK path. You can find the actual location of the SDK in the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
 


### PR DESCRIPTION
Just some quick clarifications to the Environment Setup section. Now that macOS defaults to `zsh`, I thought it might be useful to explicitly provide instructions for configuring with `zsh`.