### PR TITLE
Add `expo-secure-store` to a list of libraries to consider for secure storage

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -61,10 +61,10 @@ The [Android Keystore](https://developer.android.com/training/articles/keystore)
 
 In order to use iOS Keychain services or Android Secure Shared Preferences, you can either write a bridge yourself or use a library which wraps them for you and provides a unified API at your own risk. Some libraries to consider:
 
-- [react-native-keychain](https://github.com/oblador/react-native-keychain)
 - [expo-secure-store](https://docs.expo.io/versions/latest/sdk/securestore/)
-- [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [fork](https://github.com/mCodex/react-native-sensitive-info/tree/keystore)) that uses Android Keystore
-- [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info
+- [react-native-keychain](https://github.com/oblador/react-native-keychain)
+- [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [branch](https://github.com/mCodex/react-native-sensitive-info/tree/keystore) that uses Android Keystore.
+  - [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info for Redux.
 
 > **Be mindful of unintentionally storing or exposing sensitive info.** This could happen accidentally, for example saving sensitive form data in redux state and persisting the whole state tree in Async Storage. Or sending user tokens and personal info to an application monitoring service such as Sentry or Crashlytics.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -62,6 +62,7 @@ The [Android Keystore](https://developer.android.com/training/articles/keystore)
 In order to use iOS Keychain services or Android Secure Shared Preferences, you can either write a bridge yourself or use a library which wraps them for you and provides a unified API at your own risk. Some libraries to consider:
 
 - [react-native-keychain](https://github.com/oblador/react-native-keychain)
+- [expo-secure-store](https://docs.expo.io/versions/latest/sdk/securestore/)
 - [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [fork](https://github.com/mCodex/react-native-sensitive-info/tree/keystore)) that uses Android Keystore
 - [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Noticed this great page and thought `expo-secure-store`, using keychain services on iOS and SharedPreferences and Keystore on Android, is worth mentioning too. 🙂 