### PR TITLE
Fixing the broken link for the RTL Example

### DIFF
--- a/website/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
+++ b/website/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
@@ -211,6 +211,6 @@ The RTL support should cover most of the UX in your app; however, there are some
 
 ## Try it Out!
 
-Check out the [`RTLExample`](https://github.com/facebook/react-native/blob/master/RNTester/js/RTLExample.js) in the `RNTester` to understand more about RTL support, and let us know how it works for you!
+Check out the [`RTLExample`](https://github.com/facebook/react-native/blob/master/RNTester/js/examples/RTL/RTLExample.js) in the `RNTester` to understand more about RTL support, and let us know how it works for you!
 
 Finally, thank you for reading! We hope that the RTL support for React Native helps you grow your apps for international audience!


### PR DESCRIPTION
Fixing the broken link for the RTL Example in the blog post.

https://reactnative.dev/blog/2016/08/19/right-to-left-support-for-react-native-apps