### PR TITLE
Update the support of percentage in documentation of Height And Width file

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -7,7 +7,7 @@ A component's height and width determine its size on the screen.
 
 ## Fixed Dimensions
 
-The general way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are not unitless it support percentage, and represent density-independent pixels.
+The general way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are not unitless its support percentage and represent density-independent pixels.
 
 ```SnackPlayer name=Height%20and%20Width
 import React from 'react';

--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -7,7 +7,7 @@ A component's height and width determine its size on the screen.
 
 ## Fixed Dimensions
 
-The general way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are not unitless its support percentage and represent density-independent pixels.
+The general way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are not unitless it supports percentage and represents density-independent pixels.
 
 ```SnackPlayer name=Height%20and%20Width
 import React from 'react';

--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -7,7 +7,7 @@ A component's height and width determine its size on the screen.
 
 ## Fixed Dimensions
 
-The general way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are unitless, and represent density-independent pixels.
+The general way to set the dimensions of a component is by adding a fixed `width` and `height` to style. All dimensions in React Native are not unitless it support percentage, and represent density-independent pixels.
 
 ```SnackPlayer name=Height%20and%20Width
 import React from 'react';


### PR DESCRIPTION
The support of percentage is added two years ago
Update the support of percentage in documentation of Height And Width file
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#2071

-->
