### PR TITLE
update Text Style Props, replace inline listing with link on Text website

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -352,158 +352,160 @@ export default App;
 
 ## Props
 
-### `textShadowOffset`
-
-| Type                                   | Required |
-| -------------------------------------- | -------- |
-| object: {width: number,height: number} | No       |
-
----
-
 ### `color`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
-
----
-
-### `fontSize`
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `fontStyle`
-
-| Type                     | Required |
-| ------------------------ | -------- |
-| enum('normal', 'italic') | No       |
-
----
-
-### `fontWeight`
-
-Specifies font weight. The values 'normal' and 'bold' are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
-
-| Type                                                                                  | Required |
-| ------------------------------------------------------------------------------------- | -------- |
-| enum('normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900') | No       |
-
----
-
-### `lineHeight`
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `textAlign`
-
-Specifies text alignment. The value 'justify' is only supported on iOS and fallbacks to `left` on Android.
-
-| Type                                               | Required |
-| -------------------------------------------------- | -------- |
-| enum('auto', 'left', 'right', 'center', 'justify') | No       |
-
----
-
-### `textDecorationLine`
-
-| Type                                                                | Required |
-| ------------------------------------------------------------------- | -------- |
-| enum('none', 'underline', 'line-through', 'underline line-through') | No       |
-
----
-
-### `textShadowColor`
-
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `fontFamily`
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   |
+| ------ |
+| string |
 
 ---
 
-### `textShadowRadius`
+### `fontSize`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `includeFontPadding`
-
-Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`. Default is true.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   |
+| ------ |
+| number |
 
 ---
 
-### `textAlignVertical`
+### `fontStyle`
 
-| Type                                    | Required | Platform |
-| --------------------------------------- | -------- | -------- |
-| enum('auto', 'top', 'bottom', 'center') | No       | Android  |
+| Type                         |
+| ---------------------------- |
+| enum(`'normal'`, `'italic'`) |
+
+---
+
+### `fontWeight`
+
+Specifies font weight. The values `'normal'` and `'bold'` are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
+
+| Type                                                                                                        | Default    |
+| ----------------------------------------------------------------------------------------------------------- | ---------- |
+| enum(`'normal'`, `'bold'`, `'100'`, `'200'`, `'300'`, `'400'`, `'500'`, `'600'`, `'700'`, `'800'`, `'900'`) | `'normal'` |
+
+---
+
+### `includeFontPadding` <div class="label android">Android</div>
+
+Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
 ### `fontVariant`
 
-| Type                                                                                             | Required | Platform            |
-| ------------------------------------------------------------------------------------------------ | -------- | ------------------- |
-| array of enum('small-caps', 'oldstyle-nums', 'lining-nums', 'tabular-nums', 'proportional-nums') | No       | iOS, Android >= 5.0 |
+| Type                                                                                                       | Default |
+| ---------------------------------------------------------------------------------------------------------- | ------- |
+| array of enum(`'small-caps'`, `'oldstyle-nums'`, `'lining-nums'`, `'tabular-nums'`, `'proportional-nums'`) | `[]`    |
 
 ---
 
 ### `letterSpacing`
 
-| Type   | Required | Platform            |
-| ------ | -------- | ------------------- |
-| number | No       | iOS, Android >= 5.0 |
+Increase or decrease the spacing between characters. By default there is no extra letter spacing.
+
+| Type   |
+| ------ |
+| number |
 
 ---
 
-### `textDecorationColor`
+### `lineHeight`
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](colors.md) | No       | iOS      |
+| Type   |
+| ------ |
+| number |
 
 ---
 
-### `textDecorationStyle`
+### `textAlign`
 
-| Type                                        | Required | Platform |
-| ------------------------------------------- | -------- | -------- |
-| enum('solid', 'double', 'dotted', 'dashed') | No       | iOS      |
+Specifies text alignment. On Android, the value 'justify' is only supported on Oreo (8.0) or above (API level >= 26). The value will fallback to `left` on lower Android versions.
+
+| Type                                                         | Default  |
+| ------------------------------------------------------------ | -------- |
+| enum(`'auto'`, `'left'`, `'right'`, `'center'`, `'justify'`) | `'auto'` |
+
+---
+
+### `textAlignVertical` <div class="label android">Android</div>
+
+| Type                                            | Default  |
+| ----------------------------------------------- | -------- |
+| enum(`'auto'`, `'top'`, `'bottom'`, `'center'`) | `'auto'` |
+
+---
+
+### `textDecorationColor` <div class="label ios">iOS</div>
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `textDecorationLine`
+
+| Type                                                                        | Default  |
+| --------------------------------------------------------------------------- | -------- |
+| enum(`'none'`, `'underline'`, `'line-through'`, `'underline line-through'`) | `'none'` |
+
+---
+
+### `textDecorationStyle` <div class="label ios">iOS</div>
+
+| Type                                                | Default   |
+| --------------------------------------------------- | --------- |
+| enum(`'solid'`, `'double'`, `'dotted'`, `'dashed'`) | `'solid'` |
+
+---
+
+### `textShadowColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `textShadowOffset`
+
+| Type                                        |
+| ------------------------------------------- |
+| object: { width?: number, height?: number } |
+
+---
+
+### `textShadowRadius`
+
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `textTransform`
 
-| Type                                                 | Required |
-| ---------------------------------------------------- | -------- |
-| enum('none', 'uppercase', 'lowercase', 'capitalize') | No       |
+| Type                                                         | Default  |
+| ------------------------------------------------------------ | -------- |
+| enum(`'none'`, `'uppercase'`, `'lowercase'`, `'capitalize'`) | `'none'` |
 
 ---
 
-### `writingDirection`
+### `writingDirection` <div class="label ios">iOS</div>
 
-| Type                       | Required | Platform |
-| -------------------------- | -------- | -------- |
-| enum('auto', 'ltr', 'rtl') | No       | iOS      |
+| Type                             | Default  |
+| -------------------------------- | -------- |
+| enum(`'auto'`, `'ltr'`, `'rtl'`) | `'auto'` |

--- a/docs/text.md
+++ b/docs/text.md
@@ -609,61 +609,9 @@ The highlight color of the text.
 
 ### `style`
 
-| Type  | Required |
-| ----- | -------- |
-| style | No       |
-
-- [View Style Props...](view-style-props.md#style)
-
-- **`textShadowOffset`**: object: {width: number,height: number}
-
-- **`color`**: [color](colors.md)
-
-- **`fontSize`**: number
-
-- **`fontStyle`**: enum('normal', 'italic')
-
-- **`fontWeight`**: enum('normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900')
-
-  Specifies font weight. The values 'normal' and 'bold' are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
-
-- **`lineHeight`**: number
-
-- **`textAlign`**: enum('auto', 'left', 'right', 'center', 'justify')
-
-  Specifies text alignment. On Android, the value 'justify' is only supported on Oreo (8.0) or above (API level >= 26). The value will fallback to `left` on lower Android versions.
-
-- **`textDecorationLine`**: enum('none', 'underline', 'line-through', 'underline line-through')
-
-- **`textShadowColor`**: [color](colors.md)
-
-- **`fontFamily`**: string
-
-- **`textShadowRadius`**: number
-
-- **`includeFontPadding`**: bool (_Android_)
-
-  Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`. Default is true.
-
-* **`textAlignVertical`**: enum('auto', 'top', 'bottom', 'center') (_Android_)
-
-* **`fontVariant`**: array of enum('small-caps', 'oldstyle-nums', 'lining-nums', 'tabular-nums', 'proportional-nums') (_iOS_)
-
-* **`letterSpacing`**: number
-
-  Increase or decrease the spacing between characters. The default is 0, for no extra letter spacing.
-
-  iOS: The additional space will be rendered after each glyph.
-
-  Android: Only supported since Android 5.0 - older versions will ignore this attribute. Please note that additional space will be added _around_ the glyphs (half on each side), which differs from the iOS rendering. It is possible to emulate the iOS rendering by using layout attributes, e.g. negative margins, as appropriate for your situation.
-
-* **`textDecorationColor`**: [color](colors.md) (_iOS_)
-
-* **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
-
-* **`textTransform`**: enum('none', 'uppercase', 'lowercase', 'capitalize')
-
-* **`writingDirection`**: enum('auto', 'ltr', 'rtl') (_iOS_)
+| Type                                                                             | Required |
+| -------------------------------------------------------------------------------- | -------- |
+| [Text Style Props](text-style-props.md), [View Style Props](view-style-props.md) | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.60/text.md
+++ b/website/versioned_docs/version-0.60/text.md
@@ -543,61 +543,9 @@ The highlight color of the text.
 
 ### `style`
 
-| Type  | Required |
-| ----- | -------- |
-| style | No       |
-
-- [View Style Props...](view-style-props.md#style)
-
-- **`textShadowOffset`**: object: {width: number,height: number}
-
-- **`color`**: [color](colors.md)
-
-- **`fontSize`**: number
-
-- **`fontStyle`**: enum('normal', 'italic')
-
-- **`fontWeight`**: enum('normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900')
-
-  Specifies font weight. The values 'normal' and 'bold' are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
-
-- **`lineHeight`**: number
-
-- **`textAlign`**: enum('auto', 'left', 'right', 'center', 'justify')
-
-  Specifies text alignment. On Android, the value 'justify' is only supported on Oreo (8.0) or above (API level >= 26). The value will fallback to `left` on lower Android versions.
-
-- **`textDecorationLine`**: enum('none', 'underline', 'line-through', 'underline line-through')
-
-- **`textShadowColor`**: [color](colors.md)
-
-- **`fontFamily`**: string
-
-- **`textShadowRadius`**: number
-
-- **`includeFontPadding`**: bool (_Android_)
-
-  Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`. Default is true.
-
-* **`textAlignVertical`**: enum('auto', 'top', 'bottom', 'center') (_Android_)
-
-* **`fontVariant`**: array of enum('small-caps', 'oldstyle-nums', 'lining-nums', 'tabular-nums', 'proportional-nums') (_iOS_)
-
-* **`letterSpacing`**: number
-
-  Increase or decrease the spacing between characters. The default is 0, for no extra letter spacing.
-
-  iOS: The additional space will be rendered after each glyph.
-
-  Android: Only supported since Android 5.0 - older versions will ignore this attribute. Please note that additional space will be added _around_ the glyphs (half on each side), which differs from the iOS rendering. It is possible to emulate the iOS rendering by using layout attributes, e.g. negative margins, as appropriate for your situation.
-
-* **`textDecorationColor`**: [color](colors.md) (_iOS_)
-
-* **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
-
-* **`textTransform`**: enum('none', 'uppercase', 'lowercase', 'capitalize')
-
-* **`writingDirection`**: enum('auto', 'ltr', 'rtl') (_iOS_)
+| Type                                                                             | Required |
+| -------------------------------------------------------------------------------- | -------- |
+| [Text Style Props](text-style-props.md), [View Style Props](view-style-props.md) | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.62/text.md
+++ b/website/versioned_docs/version-0.62/text.md
@@ -608,61 +608,9 @@ The highlight color of the text.
 
 ### `style`
 
-| Type  | Required |
-| ----- | -------- |
-| style | No       |
-
-- [View Style Props...](view-style-props.md#style)
-
-- **`textShadowOffset`**: object: {width: number,height: number}
-
-- **`color`**: [color](colors.md)
-
-- **`fontSize`**: number
-
-- **`fontStyle`**: enum('normal', 'italic')
-
-- **`fontWeight`**: enum('normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900')
-
-  Specifies font weight. The values 'normal' and 'bold' are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
-
-- **`lineHeight`**: number
-
-- **`textAlign`**: enum('auto', 'left', 'right', 'center', 'justify')
-
-  Specifies text alignment. On Android, the value 'justify' is only supported on Oreo (8.0) or above (API level >= 26). The value will fallback to `left` on lower Android versions.
-
-- **`textDecorationLine`**: enum('none', 'underline', 'line-through', 'underline line-through')
-
-- **`textShadowColor`**: [color](colors.md)
-
-- **`fontFamily`**: string
-
-- **`textShadowRadius`**: number
-
-- **`includeFontPadding`**: bool (_Android_)
-
-  Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`. Default is true.
-
-* **`textAlignVertical`**: enum('auto', 'top', 'bottom', 'center') (_Android_)
-
-* **`fontVariant`**: array of enum('small-caps', 'oldstyle-nums', 'lining-nums', 'tabular-nums', 'proportional-nums') (_iOS_)
-
-* **`letterSpacing`**: number
-
-  Increase or decrease the spacing between characters. The default is 0, for no extra letter spacing.
-
-  iOS: The additional space will be rendered after each glyph.
-
-  Android: Only supported since Android 5.0 - older versions will ignore this attribute. Please note that additional space will be added _around_ the glyphs (half on each side), which differs from the iOS rendering. It is possible to emulate the iOS rendering by using layout attributes, e.g. negative margins, as appropriate for your situation.
-
-* **`textDecorationColor`**: [color](colors.md) (_iOS_)
-
-* **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
-
-* **`textTransform`**: enum('none', 'uppercase', 'lowercase', 'capitalize')
-
-* **`writingDirection`**: enum('auto', 'ltr', 'rtl') (_iOS_)
+| Type                                                                             | Required |
+| -------------------------------------------------------------------------------- | -------- |
+| [Text Style Props](text-style-props.md), [View Style Props](view-style-props.md) | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.63/text.md
+++ b/website/versioned_docs/version-0.63/text.md
@@ -610,61 +610,9 @@ The highlight color of the text.
 
 ### `style`
 
-| Type  | Required |
-| ----- | -------- |
-| style | No       |
-
-- [View Style Props...](view-style-props.md#style)
-
-- **`textShadowOffset`**: object: {width: number,height: number}
-
-- **`color`**: [color](colors.md)
-
-- **`fontSize`**: number
-
-- **`fontStyle`**: enum('normal', 'italic')
-
-- **`fontWeight`**: enum('normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900')
-
-  Specifies font weight. The values 'normal' and 'bold' are supported for most fonts. Not all fonts have a variant for each of the numeric values, in that case the closest one is chosen.
-
-- **`lineHeight`**: number
-
-- **`textAlign`**: enum('auto', 'left', 'right', 'center', 'justify')
-
-  Specifies text alignment. On Android, the value 'justify' is only supported on Oreo (8.0) or above (API level >= 26). The value will fallback to `left` on lower Android versions.
-
-- **`textDecorationLine`**: enum('none', 'underline', 'line-through', 'underline line-through')
-
-- **`textShadowColor`**: [color](colors.md)
-
-- **`fontFamily`**: string
-
-- **`textShadowRadius`**: number
-
-- **`includeFontPadding`**: bool (_Android_)
-
-  Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`. Default is true.
-
-* **`textAlignVertical`**: enum('auto', 'top', 'bottom', 'center') (_Android_)
-
-* **`fontVariant`**: array of enum('small-caps', 'oldstyle-nums', 'lining-nums', 'tabular-nums', 'proportional-nums') (_iOS_)
-
-* **`letterSpacing`**: number
-
-  Increase or decrease the spacing between characters. The default is 0, for no extra letter spacing.
-
-  iOS: The additional space will be rendered after each glyph.
-
-  Android: Only supported since Android 5.0 - older versions will ignore this attribute. Please note that additional space will be added _around_ the glyphs (half on each side), which differs from the iOS rendering. It is possible to emulate the iOS rendering by using layout attributes, e.g. negative margins, as appropriate for your situation.
-
-* **`textDecorationColor`**: [color](colors.md) (_iOS_)
-
-* **`textDecorationStyle`**: enum('solid', 'double', 'dotted', 'dashed') (_iOS_)
-
-* **`textTransform`**: enum('none', 'uppercase', 'lowercase', 'capitalize')
-
-* **`writingDirection`**: enum('auto', 'ltr', 'rtl') (_iOS_)
+| Type                                                                             | Required |
+| -------------------------------------------------------------------------------- | -------- |
+| [Text Style Props](text-style-props.md), [View Style Props](view-style-props.md) | No       |
 
 ---
 


### PR DESCRIPTION
This PR updates the Text Style Props page (alphabetical order, platform labels, default values and additional description) and removes in content styles listing on the Text page for the current and few newest, versioned docs.

Source: https://github.com/facebook/react-native/blob/master/Libraries/DeprecatedPropTypes/DeprecatedTextStylePropTypes.js

### Preview
<img width="1066" alt="Annotation 2020-07-21 205219" src="https://user-images.githubusercontent.com/719641/88094582-1c61ef00-cb94-11ea-889f-d258d2e4f681.png">
