### PR TITLE
Update instructions for enabling developer options on Android.

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -73,7 +73,7 @@ If everything is set up correctly, your device will be listed as the build targe
 
 Most Android devices can only install and run apps downloaded from Google Play, by default. You will need to enable USB Debugging on your device in order to install your app during development.
 
-To enable USB debugging on your device, you will first need to enable the "Developer options" menu by going to **Settings** → **About phone** and then tapping the `Build number` row at the bottom seven times. You can then go back to **Settings** → **System** → **Developer options** to enable "USB debugging".
+To enable USB debugging on your device, you will first need to enable the "Developer options" menu by going to **Settings** → **About phone** → **Software information** and then tapping the `Build number` row at the bottom seven times. You can then go back to **Settings** → **Developer options** to enable "USB debugging".
 
 ### 2. Plug in your device via USB
 

--- a/website/versioned_docs/version-0.5/running-on-device.md
+++ b/website/versioned_docs/version-0.5/running-on-device.md
@@ -74,7 +74,7 @@ If everything is set up correctly, your device will be listed as the build targe
 
 Most Android devices can only install and run apps downloaded from Google Play, by default. You will need to enable USB Debugging on your device in order to install your app during development.
 
-To enable USB debugging on your device, you will first need to enable the "Developer options" menu by going to **Settings** → **About phone** and then tapping the `Build number` row at the bottom seven times. You can then go back to **Settings** → **Developer options** to enable "USB debugging".
+To enable USB debugging on your device, you will first need to enable the "Developer options" menu by going to **Settings** → **About phone** → **Software information** and then tapping the `Build number` row at the bottom seven times. You can then go back to **Settings** → **Developer options** to enable "USB debugging".
 
 ### 2. Plug in your device via USB
 


### PR DESCRIPTION
- `Build number` is now nested inside of `Software information`.
- `Developer Options` now resides at `Settings` root.

Screenshots:
![Screenshot_20200721-130316_Settings](https://user-images.githubusercontent.com/17093532/88101605-1a2b7080-cb53-11ea-8974-7ef9524058ab.jpg)
![20200721_130603](https://user-images.githubusercontent.com/17093532/88101629-1f88bb00-cb53-11ea-8984-ab2379923051.jpg)
