### PR TITLE
Fix typo in javascript-environment.md

### DIFF
--- a/docs/javascript-environment.md
+++ b/docs/javascript-environment.md
@@ -60,7 +60,7 @@ Specific
 
 ## Polyfills
 
-Many standards functions are also available on all the supported JavaScript runtimes.
+Many standard functions are also available on all the supported JavaScript runtimes.
 
 Browser
 


### PR DESCRIPTION
Replace "standards functions" with "standard functions"

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
