### PR TITLE
Fix scrolling bug in side nav

### DIFF
--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -178,6 +178,7 @@ figcaption {
 /* Right side navigation */
 .onPageNav {
   overflow: visible;
+  overflow-y: auto;
 }
 
 .onPageNav a,


### PR DESCRIPTION
Hello! Currently, when viewing the documentation in a desktop browser, if the right side navigation bar has more items than can fit within the page's height, there is no way to view these items. For example, users cannot navigate through all of the props of large components such as `View` or `FlatList` by using the right navigation bar. (https://reactnative.dev/docs/flatlist.html)

This pull requests adds a vertical scroll bar when there are more right nav items than can fit the screen. Otherwise, there is no scroll bar.
