### PR TITLE
update RefreshControl page, fix minor platform labels display issues

### DIFF
--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -9,19 +9,10 @@ This component is used inside a ScrollView or ListView to add pull to refresh fu
 
 ```SnackPlayer name=RefreshControl&supportedPlatforms=ios,android
 import React from 'react';
-import {
-  ScrollView,
-  RefreshControl,
-  StyleSheet,
-  Text,
-  SafeAreaView,
-} from 'react-native';
-import Constants from 'expo-constants';
+import { RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text } from 'react-native';
 
 const wait = (timeout) => {
-  return new Promise(resolve => {
-    setTimeout(resolve, timeout);
-  });
+  return new Promise(resolve => setTimeout(resolve, timeout));
 }
 
 const App = () => {
@@ -29,7 +20,6 @@ const App = () => {
 
   const onRefresh = React.useCallback(() => {
     setRefreshing(true);
-
     wait(2000).then(() => setRefreshing(false));
   }, []);
 
@@ -38,7 +28,10 @@ const App = () => {
       <ScrollView
         contentContainerStyle={styles.scrollView}
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+          />
         }
       >
         <Text>Pull down to see RefreshControl indicator</Text>
@@ -50,7 +43,6 @@ const App = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
   },
   scrollView: {
     flex: 1,
@@ -63,7 +55,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-**Note:** `refreshing` is a controlled prop, this is why it needs to be set to true in the `onRefresh` function otherwise the refresh indicator will stop immediately.
+> Note: `refreshing` is a controlled prop, this is why it needs to be set to `true` in the `onRefresh` function otherwise the refresh indicator will stop immediately.
 
 ---
 
@@ -73,13 +65,35 @@ export default App;
 
 Inherits [View Props](view.md#props).
 
-### `refreshing`
+---
+
+### <div class="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
-| Type | Required |
-| ---- | -------- |
-| bool | Yes      |
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `colors` <div class="label android">Android</div>
+
+The colors (at least one) that will be used to draw the refresh indicator.
+
+| Type                         |
+| ---------------------------- |
+| array of [colors](colors.md) |
+
+---
+
+### `enabled` <div class="label android">Android</div>
+
+Whether the pull to refresh functionality is enabled.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | `true`  |
 
 ---
 
@@ -87,86 +101,83 @@ Whether the view should be indicating an active refresh.
 
 Called when the view starts refreshing.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
-### `colors`
-
-The colors (at least one) that will be used to draw the refresh indicator.
-
-| Type                        | Required | Platform |
-| --------------------------- | -------- | -------- |
-| array of [color](colors.md) | No       | Android  |
-
----
-
-### `enabled`
-
-Whether the pull to refresh functionality is enabled.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
-
----
-
-### `progressBackgroundColor`
+### `progressBackgroundColor` <div class="label android">Android</div>
 
 The background color of the refresh indicator.
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](colors.md) | No       | Android  |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
-### `progressViewOffset`
+### `progressViewOffset` <div class="label android">Android</div>
 
-Progress view top offset
+Progress view top offset.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
-
----
-
-### `size`
-
-Size of the refresh indicator, see RefreshControl.SIZE.
-
-| Type                                                                   | Required | Platform |
-| ---------------------------------------------------------------------- | -------- | -------- |
-| enum(RefreshLayoutConsts.SIZE.DEFAULT, RefreshLayoutConsts.SIZE.LARGE) | No       | Android  |
+| Type   | Default |
+| ------ | ------- |
+| number | `0`     |
 
 ---
 
-### `tintColor`
+### `size` <div class="label android">Android</div>
+
+Size of the refresh indicator.
+
+| Type                                                             | Default                          |
+| ---------------------------------------------------------------- | -------------------------------- |
+| [RefreshControl.SIZE](refreshcontrol.md#refreshlayoutconstssize) | RefreshLayoutConsts.SIZE.DEFAULT |
+
+---
+
+### `tintColor` <div class="label ios">iOS</div>
 
 The color of the refresh indicator.
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](colors.md) | No       | iOS      |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
-### `title`
+### `title` <div class="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | iOS      |
+| Type   |
+| ------ |
+| string |
 
 ---
 
-### `titleColor`
+### `titleColor` <div class="label ios">iOS</div>
 
-Title color.
+The color of the refresh indicator title.
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](colors.md) | No       | iOS      |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+## Type Definitions
+
+### RefreshLayoutConsts.SIZE
+
+The SwipeRefreshLayout Android component constants. The acctual component size may vary between devices. You can read more about the native component in the [Android documentation](https://developer.android.com/reference/androidx/swiperefreshlayout/widget/SwipeRefreshLayout).
+
+| Type |
+| ---- |
+| enum |
+
+**Constants:**
+
+| Name    | Type | Value | Description                 |
+| ------- | ---- | ----- | --------------------------- |
+| DEFAULT | int  | `1`   | Default RefreshControl size |
+| LARGE   | int  | `0`   | Large RefreshControl size   |

--- a/website/static/css/docs.css
+++ b/website/static/css/docs.css
@@ -177,8 +177,7 @@ figcaption {
 
 /* Right side navigation */
 .onPageNav {
-  overflow: visible;
-  overflow-y: auto;
+  flex: 0 0 246px;
 }
 
 .onPageNav a,
@@ -197,7 +196,7 @@ figcaption {
 }
 
 .onPageNav ul ul {
-  padding: 8px 0 0 16px;
+  padding: 8px 0 0 14px;
 }
 
 .onPageNav ul ul li {
@@ -335,7 +334,6 @@ td .label.required {
   height: 6px;
   border-radius: 100%;
   margin-left: 2px;
-  margin-right: -12px;
   white-space: nowrap;
   overflow: hidden;
   color: transparent;

--- a/website/static/css/react-native.css
+++ b/website/static/css/react-native.css
@@ -44,7 +44,7 @@ body,
     max-width: 900px;
   }
   .docMainWrapper > *:last-child {
-    margin-right: 20px;
+    margin-right: 14px;
   }
 }
 


### PR DESCRIPTION
This PR updates the `RefreshControl` component page and introduces the following changes:
* platform and required labels
* example cleanup
* defined defaults
* section for `RefreshLayoutConsts.SIZE` with additional information
* minor formatting tweaks

Source for the changes: https://github.com/facebook/react-native/tree/master/Libraries/Components/RefreshControl

In addition to the page update the following PR sizes two minor display issues with the platform labels. One related to latest scroll fix and second related to the multiple platforms for one property.

### Preview
<img width="1094" alt="Annotation 2020-07-26 154432" src="https://user-images.githubusercontent.com/719641/88480576-facb8380-cf56-11ea-975a-8faef04d616a.png">

