### PR TITLE
add percentage dimensions section to the Height and Width page

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -14,13 +14,19 @@ import React from 'react';
 import { View } from 'react-native';
 
 const FixedDimensionsBasics = () => {
-    return (
-      <View>
-        <View style={{width: 50, height: 50, backgroundColor: 'powderblue'}} />
-        <View style={{width: 100, height: 100, backgroundColor: 'skyblue'}} />
-        <View style={{width: 150, height: 150, backgroundColor: 'steelblue'}} />
-      </View>
-    );
+  return (
+    <View>
+      <View style={{
+        width: 50, height: 50, backgroundColor: 'powderblue'
+      }} />
+      <View style={{
+        width: 100, height: 100, backgroundColor: 'skyblue'
+      }} />
+      <View style={{
+        width: 150, height: 150, backgroundColor: 'steelblue'
+      }} />
+    </View>
+  );
 };
 
 export default FixedDimensionsBasics;
@@ -32,26 +38,55 @@ Setting dimensions this way is common for components that should always render a
 
 Use `flex` in a component's style to have the component expand and shrink dynamically based on available space. Normally you will use `flex: 1`, which tells a component to fill all available space, shared evenly amongst other components with the same parent. The larger the `flex` given, the higher the ratio of space a component will take compared to its siblings.
 
-> A component can only expand to fill available space if its parent has dimensions greater than 0. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of 0 and the `flex` children will not be visible.
+> A component can only expand to fill available space if its parent has dimensions greater than `0`. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of `0` and the `flex` children will not be visible.
 
 ```SnackPlayer name=Flex%20Dimensions
 import React from 'react';
 import { View } from 'react-native';
 
 const FlexDimensionsBasics = () => {
-    return (
-      // Try removing the `flex: 1` on the parent View.
-      // The parent will not have dimensions, so the children can't expand.
-      // What if you add `height: 300` instead of `flex: 1`?
-      <View style={{flex: 1}}>
-        <View style={{flex: 1, backgroundColor: 'powderblue'}} />
-        <View style={{flex: 2, backgroundColor: 'skyblue'}} />
-        <View style={{flex: 3, backgroundColor: 'steelblue'}} />
-      </View>
-    );
+  return (
+    // Try removing the `flex: 1` on the parent View.
+    // The parent will not have dimensions, so the children can't expand.
+    // What if you add `height: 300` instead of `flex: 1`?
+    <View style={{ flex: 1 }}>
+      <View style={{ flex: 1, backgroundColor: 'powderblue' }} />
+      <View style={{ flex: 2, backgroundColor: 'skyblue' }} />
+      <View style={{ flex: 3, backgroundColor: 'steelblue' }} />
+    </View>
+  );
 };
 
 export default FlexDimensionsBasics;
 ```
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](flexbox.md).
+
+## Percentage Dimensions
+
+If you want to fill the certain portion of the screen but you don't want to use the `flex` layout you can use the percentage values in the component's style. Similar to flex dimensions, percentage dimensions requires parent with a defined size.
+
+```SnackPlayer name=Percentage%20Dimensions
+import React from 'react';
+import { View } from 'react-native';
+
+const PercentageDimensionsBasics = () => {
+  // Try removing the `height: '100%'` on the parent View.
+  // The parent will not have dimensions, so the children can't expand.
+  return (
+    <View style={{ height: '100%' }}>
+      <View style={{
+        height: '15%', backgroundColor: 'powderblue'
+      }} />
+      <View style={{
+        width: '66%', height: '35%', backgroundColor: 'skyblue'
+      }} />
+      <View style={{
+        width: '33%', height: '50%', backgroundColor: 'steelblue'
+      }} />
+    </View>
+  );
+};
+
+export default PercentageDimensionsBasics;
+```

--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -64,7 +64,7 @@ After you can control a component's size, the next step is to [learn how to lay 
 
 ## Percentage Dimensions
 
-If you want to fill the certain portion of the screen but you don't want to use the `flex` layout you can use the percentage values in the component's style. Similar to flex dimensions, percentage dimensions requires parent with a defined size.
+If you want to fill a certain portion of the screen, but you _don't_ want to use the `flex` layout, you _can_ use **percentage values** in the component's style. Similar to flex dimensions, percentage dimensions require parent with a defined size.
 
 ```SnackPlayer name=Percentage%20Dimensions
 import React from 'react';


### PR DESCRIPTION
Fixes #2071

Refs #2079

---

This PR adds the Percentage Dimensions section with a Snack example and short description (which for certain can be updated and phrased better 😉) to the Height and Width page. 

I have also optimized a bit the readability of the other examples on that page.

## Preview
<img width="771" alt="Annotation 2020-07-26 204848" src="https://user-images.githubusercontent.com/719641/88486921-73473a00-cf81-11ea-890f-7921961b9e46.png">
