### PR TITLE
fix CameraRoll edit button

### DIFF
--- a/website/versioned_docs/version-0.58/cameraroll.md
+++ b/website/versioned_docs/version-0.58/cameraroll.md
@@ -2,6 +2,7 @@
 id: version-0.58-cameraroll
 title: 🚧 CameraRoll
 original_id: cameraroll
+custom_edit_url: https://github.com/facebook/react-native-website/edit/master/website/versioned_docs/version-0.58/cameraroll.md
 ---
 
 > **Deprecated.** Use [@react-native-community/cameraroll](https://github.com/react-native-community/react-native-cameraroll) instead.


### PR DESCRIPTION
Refs #2001 

This small PR fixes the `Edit` button on the latest versioned docs page for CameraRoll. The autogenerated by Docusaurus link is broken because the CameraRoll page has been removed from the current docs.