### PR TITLE
Correct anchor height offset for Black Lives Matter banner

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -211,6 +211,16 @@ input#search_input_react:focus {
   height: 60px;
 }
 
+.anchor {
+  top: -160px;
+}
+
+@media only screen and (min-width: 735px) {
+  .anchor {
+    top: -180px;
+  }
+}
+
 .announcement {
   color: #fff;
   font-weight: bold;


### PR DESCRIPTION
|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/4138357/88712979-3776b680-d0e0-11ea-8259-d1fa026ef612.gif)|![after](https://user-images.githubusercontent.com/4138357/88712990-3b0a3d80-d0e0-11ea-9c18-7d9d556380e3.gif)|

The Black Lives Matter call to action banner added a fixed 100px to the pre-content banner height. Docusaurus seems to have a built-in anchor style to handle this itself, so this just updates that -80 to -180. Mobile was off a bit differently but 160px looked alright there.

EDIT: mobile before and after:

|Before|After|
|---|---|
|![before-mobile](https://user-images.githubusercontent.com/4138357/88713605-2ed2b000-d0e1-11ea-9329-108657a464b9.gif)|![after-mobile](https://user-images.githubusercontent.com/4138357/88713617-32fecd80-d0e1-11ea-97a8-664587b0b9b6.gif)|