### PR TITLE
Update share.md

### DIFF
--- a/docs/share.md
+++ b/docs/share.md
@@ -116,7 +116,7 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 #### iOS
 
-- `url` - an URL to share
+- `url` - a URL to share
 
 At least one of URL and message is required.
 


### PR DESCRIPTION
Fix grammar.

# Why
"a" should be used instead of "an" before the word "URL" because the U here is a consonant sound. (e.g. a Uniform)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
