### PR TITLE
adjust BLM banner height and text style

### DIFF
--- a/website/static/css/header.css
+++ b/website/static/css/header.css
@@ -204,7 +204,7 @@ input#search_input_react:focus {
 }
 
 .headerWrapper.wrapper {
-  padding-top: 100px;
+  padding-top: 60px;
 }
 
 .navigationSlider .slidingNav {
@@ -225,9 +225,9 @@ input#search_input_react:focus {
   color: #fff;
   font-weight: bold;
   font-size: 24px;
-  padding: 30px;
+  padding: 8px 30px;
   text-align: center;
-  height: 100px;
+  height: 60px;
   position: absolute;
   width: 100%;
 }
@@ -235,6 +235,7 @@ input#search_input_react:focus {
 .announcement-inner {
   margin: 0 auto;
   max-width: 768px;
+  line-height: 44px;
 }
 
 .announcement-inner a {
@@ -275,37 +276,41 @@ body {
   }
   .announcement {
     padding: 10px;
-  }
-}
-
-@media only screen and (max-width: 500px) {
-  .announcement {
     font-size: 18px;
   }
 }
 
 @media only screen and (min-width: 1024px) {
   .navPusher {
-    padding-top: 160px;
+    padding-top: 120px;
   }
   .docsNavContainer {
-    top: 136px;
+    top: 96px;
   }
   .onPageNav {
-    top: 172px;
-    max-height: calc(100vh - 172px);
+    top: 136px;
+    max-height: calc(100vh - 136px);
   }
 }
 
 @media only screen and (max-width: 1023px) {
   ul.nav-site.nav-site-internal {
-    margin-top: 160px;
+    margin-top: 120px;
   }
   .navPusher {
-    padding-top: 210px;
+    padding-top: 170px;
   }
   .navSearchWrapper {
-    top: 114px;
+    top: 74px;
+  }
+}
+
+@media (max-width: 500px) {
+  .announcement {
+    font-size: 15px;
+  }
+  .announcement-inner {
+    line-height: 22px;
   }
 }
 /* End announcement banner override */

--- a/website/static/js/announcement.js
+++ b/website/static/js/announcement.js
@@ -23,9 +23,9 @@ window.onscroll = () => {
       document.body.scrollTop > scrollStartBoundary ||
       document.documentElement.scrollTop > scrollStartBoundary
     ) {
-      fixedHeaderContainer.style.top = '-100px';
-      navPusher.style.top = '-100px';
-      navPusher.style.marginBottom = '-100px';
+      fixedHeaderContainer.style.top = '-60px';
+      navPusher.style.top = '-60px';
+      navPusher.style.marginBottom = '-60px';
     } else {
       fixedHeaderContainer.style.top = '0';
       navPusher.style.top = '0';


### PR DESCRIPTION
Fixes #2134

This PR changes the height of BLM banner from `100px` to `60px` and updates the banner text style to ensure that in the most cases text will fit in two lines (previously on some mobile devices text could break to three lines) and additional space can be reduced.

### Preview
**Desktop (Win + 4k)**
<img width="1094" src="https://user-images.githubusercontent.com/719641/89938904-77c55100-dc17-11ea-8407-35d63fdb0b1e.png">

**Desktop (MacBook Pro 15)**
<img width="1471" alt="Screenshot 2020-08-11 at 21 17 29" src="https://user-images.githubusercontent.com/719641/89939383-308b9000-dc18-11ea-8524-53db01cdb86e.png">

**Mobile (iPhone SE)**
<img width="400" src="https://user-images.githubusercontent.com/719641/89939068-b78c3880-dc17-11ea-8397-9e79404b7f34.png">