### PR TITLE
Adding notes regarding the issue when Android timers are not in sync with the debugger

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,7 +57,7 @@ To debug the JavaScript code in Chrome, select "Debug JS Remotely" from the Deve
 
 Select `Tools → Developer Tools` from the Chrome Menu to open the [Developer Tools](https://developer.chrome.com/devtools). You may also access the DevTools using keyboard shortcuts (`⌘⌥I` on macOS, `Ctrl` `Shift` `I` on Windows). You may also want to enable [Pause On Caught Exceptions](http://stackoverflow.com/questions/2233339/javascript-is-there-a-way-to-get-chrome-to-break-on-all-errors/17324511#17324511) for a better debugging experience.
 
-> Note: on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine. Root access is required for the use in real device.
+> Note: on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S%3N`" `` on your debugger machine. Root access is required for the use in real device.
 
 > Note: the React Developer Tools Chrome extension does not work with React Native, but you can use its standalone version instead. Read [this section](debugging.md#react-developer-tools) to learn how.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,7 +57,7 @@ To debug the JavaScript code in Chrome, select "Debug JS Remotely" from the Deve
 
 Select `Tools → Developer Tools` from the Chrome Menu to open the [Developer Tools](https://developer.chrome.com/devtools). You may also access the DevTools using keyboard shortcuts (`⌘⌥I` on macOS, `Ctrl` `Shift` `I` on Windows). You may also want to enable [Pause On Caught Exceptions](http://stackoverflow.com/questions/2233339/javascript-is-there-a-way-to-get-chrome-to-break-on-all-errors/17324511#17324511) for a better debugging experience.
 
-> Note: on Android, if the times between the debugger and device have drifted by more than 60s things might not work or results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine.
+> Note: on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine. Root access is required for the use in real device.
 
 > Note: the React Developer Tools Chrome extension does not work with React Native, but you can use its standalone version instead. Read [this section](debugging.md#react-developer-tools) to learn how.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,6 +57,8 @@ To debug the JavaScript code in Chrome, select "Debug JS Remotely" from the Deve
 
 Select `Tools → Developer Tools` from the Chrome Menu to open the [Developer Tools](https://developer.chrome.com/devtools). You may also access the DevTools using keyboard shortcuts (`⌘⌥I` on macOS, `Ctrl` `Shift` `I` on Windows). You may also want to enable [Pause On Caught Exceptions](http://stackoverflow.com/questions/2233339/javascript-is-there-a-way-to-get-chrome-to-break-on-all-errors/17324511#17324511) for a better debugging experience.
 
+> Note: on Android, if the times between the debugger and device have drifted by more than 60s things might not work or results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine.
+
 > Note: the React Developer Tools Chrome extension does not work with React Native, but you can use its standalone version instead. Read [this section](debugging.md#react-developer-tools) to learn how.
 
 ### Debugging using a custom JavaScript debugger

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -5,6 +5,8 @@ title: Timers
 
 Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Timers).
 
+> Note: when debugging on Android, if the times between the debugger and device have drifted by more than 60s things might not work or results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine.
+
 ## Timers
 
 - setTimeout, clearTimeout

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -5,7 +5,7 @@ title: Timers
 
 Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Timers).
 
-> Note: when debugging on Android, if the times between the debugger and device have drifted by more than 60s things might not work or results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine.
+> Note: when debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine. Root access is required for the use in real device.
 
 ## Timers
 

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -5,7 +5,7 @@ title: Timers
 
 Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Timers).
 
-> Note: when debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S`" `` on your debugger machine. Root access is required for the use in real device.
+> Note: when debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S%3N`" `` on your debugger machine. Root access is required for the use in real device.
 
 ## Timers
 

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -5,8 +5,6 @@ title: Timers
 
 Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Timers).
 
-> Note: when debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S%3N`" `` on your debugger machine. Root access is required for the use in real device.
-
 ## Timers
 
 - setTimeout, clearTimeout
@@ -19,6 +17,8 @@ Timers are an important part of an application and React Native implements the [
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 
 The `Promise` implementation uses `setImmediate` as its asynchronicity implementation.
+
+> Note: when debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S%3N`" `` on your debugger machine. Root access is required for the use in real device.
 
 ## InteractionManager
 


### PR DESCRIPTION
This PR adds notes regarding the issue when Android timers are not in sync with the debugger. 

See here for the discussion https://github.com/facebook/react-native/issues/29591.