### PR TITLE
Fixed Linking.getInitialURL and addEventListener

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -106,13 +106,13 @@ If your app is using [Universal Links](https://developer.apple.com/library/prere
 
 There are two ways to handle URLs that open your app.
 
-#### 1. If the app is already open, the app is foregrounded and a Linking event is fired
+#### 1. If the app is already open, the app is foregrounded and a Linking 'url' event is fired
 
-You can handle these events with `Linking.addEventListener(url, callback)`.
+You can handle these events with `Linking.addEventListener('url', callback)` -- it calls `callback({ url })` with the linked URL
 
 #### 2. If the app is not already open, it is opened and the url is passed in as the initialURL
 
-You can handle these events with `Linking.getInitialURL(url)` -- it returns a Promise that resolves to the url, if there is one.
+You can handle these events with `Linking.getInitialURL()` -- it returns a Promise that resolves to the URL, if there is one.
 
 ---
 

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -391,6 +391,8 @@ If the app launch was triggered by an app link, it will give the link url, other
 
 > To support deep linking on Android, refer http://developer.android.com/training/app-indexing/deep-linking.html#handling-intents
 
+> getInitialURL may return `null` while debugging is enabled. Disable the debugger to ensure it gets passed.
+
 ---
 
 ### `sendIntent()`


### PR DESCRIPTION
getInitialURL does not need a parameter. It turns the URL. addEventListener needs a 'url' parameter, however it's simply the string 'url' which wasn't clear.

Also, it may return `null` when debugger is enabled.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
