### PR TITLE
Integration with existing apps updates

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -705,7 +705,7 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
         List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
         // Packages that cannot be autolinked yet can be added manually here, for example:
         // packages.add(new MyReactNativePackage());
-        // Remember to include them in `settings.gradle` too.
+        // Remember to include them in `settings.gradle` and `app/build.gradle` too.
 
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -86,10 +86,10 @@ Schedules an animation to happen on the next layout.
 
 #### Parameters:
 
-| Name              | Type     | Required | Description                                                |
-| ----------------- | -------- | -------- | ---------------------------------------------------------- |
-| config            | object   | Yes      | See config description below.                              |
-| onAnimationDidEnd | function | No       | Called when the animation finished.                        |
+| Name              | Type     | Required | Description                         |
+| ----------------- | -------- | -------- | ----------------------------------- |
+| config            | object   | Yes      | See config description below.       |
+| onAnimationDidEnd | function | No       | Called when the animation finished. |
 
 The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 

--- a/website/versioned_docs/version-0.5/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.5/integration-with-existing-apps.md
@@ -24,7 +24,7 @@ The specific steps are different depending on what platform you're targeting.
 
 <block class="objc swift android" />
 
-## Key Concepts test
+## Key Concepts
 
 <block class="objc swift" />
 

--- a/website/versioned_docs/version-0.5/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.5/integration-with-existing-apps.md
@@ -24,7 +24,7 @@ The specific steps are different depending on what platform you're targeting.
 
 <block class="objc swift android" />
 
-## Key Concepts
+## Key Concepts test
 
 <block class="objc swift" />
 

--- a/website/versioned_docs/version-0.62/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.62/integration-with-existing-apps.md
@@ -519,19 +519,20 @@ You can examine the code that added the React Native screen to our sample app on
 
 ### Configuring maven
 
-Add the React Native dependency to your app's `build.gradle` file:
+Add the React Native and JSC dependency to your app's `build.gradle` file:
 
 ```gradle
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation "com.android.support:appcompat-v7:27.1.1"
     ...
     implementation "com.facebook.react:react-native:+" // From node_modules
+    implementation "org.webkit:android-jsc:+"
 }
 ```
 
 > If you want to ensure that you are always using a specific React Native version in your native build, replace `+` with an actual React Native version you've downloaded from `npm`.
 
-Add an entry for the local React Native maven directory to `build.gradle`. Be sure to add it to the "allprojects" block, above other maven repositories:
+Add an entry for the local React Native and JSC maven directories to the top-level `build.gradle`. Be sure to add it to the “allprojects” block, above other maven repositories:
 
 ```gradle
 allprojects {
@@ -540,6 +541,10 @@ allprojects {
             // All of React Native (JS, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
         ...
     }
     ...
@@ -547,6 +552,20 @@ allprojects {
 ```
 
 > Make sure that the path is correct! You shouldn’t run into any “Failed to resolve: com.facebook.react:react-native:0.x.x" errors after running Gradle sync in Android Studio.
+
+### Enable native modules autolinking
+
+To use the power of [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md), we have to apply it a few places. First add the following entry to `settings.gradle`:
+
+```gradle
+apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+```
+
+Next add the following entry at the very bottom of the `app/build.gradle`:
+
+```gradle
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+```
 
 ### Configuring permissions
 
@@ -681,14 +700,20 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        SoLoader.init(this, false);
 
         mReactRootView = new ReactRootView(this);
+        List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // packages.add(new MyReactNativePackage());
+        // Remember to include them in `settings.gradle` too.
+
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())
                 .setCurrentActivity(this)
                 .setBundleAssetName("index.android.bundle")
                 .setJSMainModulePath("index")
-                .addPackage(new MainReactPackage())
+                .addPackages(packages)
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)
                 .build();
@@ -707,6 +732,8 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
 ```
 
 > If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
+
+Perform a “Sync Project files with Gradle” operation.
 
 If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `facebook` package.
 

--- a/website/versioned_docs/version-0.62/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.62/integration-with-existing-apps.md
@@ -706,7 +706,7 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
         List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
         // Packages that cannot be autolinked yet can be added manually here, for example:
         // packages.add(new MyReactNativePackage());
-        // Remember to include them in `settings.gradle` too.
+        // Remember to include them in `settings.gradle` and `app/build.gradle` too.
 
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())

--- a/website/versioned_docs/version-0.63/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.63/integration-with-existing-apps.md
@@ -706,7 +706,7 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
         List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
         // Packages that cannot be autolinked yet can be added manually here, for example:
         // packages.add(new MyReactNativePackage());
-        // Remember to include them in `settings.gradle` too.
+        // Remember to include them in `settings.gradle` and `app/build.gradle` too.
 
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())

--- a/website/versioned_docs/version-0.63/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.63/integration-with-existing-apps.md
@@ -532,7 +532,7 @@ dependencies {
 
 > If you want to ensure that you are always using a specific React Native version in your native build, replace `+` with an actual React Native version you've downloaded from `npm`.
 
-Add an entry for the local React Native and JSC maven directory to `build.gradle`. Be sure to add it to the "allprojects" block, above other maven repositories:
+Add an entry for the local React Native and JSC maven directories to the top-level `build.gradle`. Be sure to add it to the “allprojects” block, above other maven repositories:
 
 ```gradle
 allprojects {
@@ -561,7 +561,7 @@ To use the power of [autolinking](https://github.com/react-native-community/cli/
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 ```
 
-Open `app/build.gradle` and add the following entry at the very bottom:
+Next add the following entry at the very bottom of the `app/build.gradle`:
 
 ```gradle
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
@@ -700,19 +700,20 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        SoLoader.init(this, /* native exopackage */ false);
+        SoLoader.init(this, false);
 
         mReactRootView = new ReactRootView(this);
         List<ReactPackage> packages = new PackageList(getApplication()).getPackages();
         // Packages that cannot be autolinked yet can be added manually here, for example:
         // packages.add(new MyReactNativePackage());
+        // Remember to include them in `settings.gradle` too.
 
         mReactInstanceManager = ReactInstanceManager.builder()
                 .setApplication(getApplication())
                 .setCurrentActivity(this)
                 .setBundleAssetName("index.android.bundle")
                 .setJSMainModulePath("index")
-                .addPackage(packages)
+                .addPackages(packages)
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)
                 .build();
@@ -733,6 +734,8 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
 > If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
 
 If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `facebook` package.
+
+Perform a “Sync Project files with Gradle” operation.
 
 We need set the theme of `MyReactActivity` to `Theme.AppCompat.Light.NoActionBar` because some React Native UI components rely on this theme.
 

--- a/website/versioned_docs/version-0.63/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.63/integration-with-existing-apps.md
@@ -733,9 +733,9 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
 
 > If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
 
-If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `facebook` package.
-
 Perform a “Sync Project files with Gradle” operation.
+
+If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `facebook` package.
 
 We need set the theme of `MyReactActivity` to `Theme.AppCompat.Light.NoActionBar` because some React Native UI components rely on this theme.
 


### PR DESCRIPTION
I tried to follow the "[Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps)" Android guide, but did not succeed because the guide was outdated.
I have updated the guide with support for Autolinking.

My changes reflect what can be found in a [normal](https://github.com/facebook/react-native/tree/master/template/android) React Native Installation. 