### PR TITLE
Add correct prop types for Android props in TouchableOpacity

### DIFF
--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -184,9 +184,9 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 TV next focus down (see documentation for the View component).
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
 
 ---
 
@@ -194,9 +194,9 @@ TV next focus down (see documentation for the View component).
 
 TV next focus forward (see documentation for the View component).
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
 
 ---
 
@@ -204,9 +204,9 @@ TV next focus forward (see documentation for the View component).
 
 TV next focus left (see documentation for the View component).
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
 
 ---
 
@@ -214,9 +214,9 @@ TV next focus left (see documentation for the View component).
 
 TV next focus right (see documentation for the View component).
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
 
 ---
 
@@ -224,9 +224,9 @@ TV next focus right (see documentation for the View component).
 
 TV next focus up (see documentation for the View component).
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   | Required | Platform |
+| ------ | -------- | -------- |
+| number | No       | Android  |
 
 ## Methods
 


### PR DESCRIPTION
Fixes #2141 

## Summary
Fix prop types of android props in TouchableOpacity component by replacing the `bool` type to `number` type in the markdown.

![Screenshot from 2020-08-19 17-32-40](https://user-images.githubusercontent.com/33171576/90632598-4dd8e380-e242-11ea-9bfa-9ca45b2eef88.png)
