### PR TITLE
Document FlatList's 'keyboardShouldPersistTaps'

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -379,6 +379,22 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 
 ---
 
+### `keyboardShouldPersistTaps`
+
+Determines when the keyboard should stay visible after a tap.
+
+- `'never'` (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
+- `'always'`, the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
+- `'handled'`, the keyboard will not dismiss automatically when the tap was handled by children of the scroll view (or captured by an ancestor).
+- `false`, **_deprecated_**, use 'never' instead
+- `true`, **_deprecated_**, use 'always' instead
+
+| Type                                            | Required |
+| ----------------------------------------------- | -------- |
+| enum('always', 'never', 'handled', false, true) | No       |
+
+---
+
 ### `keyExtractor`
 
 ```jsx


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Documentation doesn't mention that `keyboardShouldPersistTaps` property exists not only in the `ScrollView` but also in the `FlatList` which is very confusing as this property can be very useful.

Not sure if there are also other components that have it if so, let me know :)
