### PR TITLE
remove unnecessary argument of render()

### DIFF
--- a/docs/intro-react.md
+++ b/docs/intro-react.md
@@ -444,7 +444,7 @@ import { Button, Text, View } from "react-native";
 class Cat extends Component {
   state = { isHungry: true };
 
-  render(props) {
+  render() {
     return (
       <View>
         <Text>


### PR DESCRIPTION
Appreciate to the good document.
I think 'props' in render() is unnecessary. This will cause confusion to the biginner like me.


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
