### PR TITLE
move SafeAreaView to iOS Components group

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -118,7 +118,6 @@
       "modal",
       "pressable",
       "refreshcontrol",
-      "safeareaview",
       "scrollview",
       "sectionlist",
       "statusbar",
@@ -138,7 +137,7 @@
       {
         "type": "subcategory",
         "label": "iOS Components",
-        "ids": ["inputaccessoryview", "maskedviewios"]
+        "ids": ["inputaccessoryview", "maskedviewios", "safeareaview"]
       }
     ],
     "Props": [

--- a/website/versioned_sidebars/version-0.62-sidebars.json
+++ b/website/versioned_sidebars/version-0.62-sidebars.json
@@ -83,7 +83,6 @@
       "version-0.62-keyboardavoidingview",
       "version-0.62-modal",
       "version-0.62-refreshcontrol",
-      "version-0.62-safeareaview",
       "version-0.62-scrollview",
       "version-0.62-sectionlist",
       "version-0.62-statusbar",
@@ -106,7 +105,7 @@
       {
         "type": "subcategory",
         "label": "iOS Components",
-        "ids": ["version-0.62-inputaccessoryview"]
+        "ids": ["version-0.62-inputaccessoryview", "version-0.62-safeareaview"]
       }
     ],
     "Props": [

--- a/website/versioned_sidebars/version-0.63-sidebars.json
+++ b/website/versioned_sidebars/version-0.63-sidebars.json
@@ -137,7 +137,6 @@
       "version-0.63-modal",
       "version-0.63-pressable",
       "version-0.63-refreshcontrol",
-      "version-0.63-safeareaview",
       "version-0.63-scrollview",
       "version-0.63-sectionlist",
       "version-0.63-statusbar",
@@ -160,7 +159,11 @@
       {
         "type": "subcategory",
         "label": "iOS Components",
-        "ids": ["version-0.63-inputaccessoryview", "version-0.63-maskedviewios"]
+        "ids": [
+          "version-0.63-inputaccessoryview",
+          "version-0.63-maskedviewios",
+          "version-0.63-safeareaview"
+        ]
       }
     ],
     "Props": [


### PR DESCRIPTION
When the platforms related sub groups have been created in the sidebar it look like I forget to put `SafeAreaView` into the iOS only components group. This PR fixes that issue for the current and all valid, versioned docs. 😉 

### Preview
<img width="1100" alt="Annotation 2020-08-21 135454" src="https://user-images.githubusercontent.com/719641/90888113-e9d72c00-e3b5-11ea-8411-dcc06fa4432a.png">
