### PR TITLE
expose inherited props link in the right sidebar

### DIFF
--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -88,6 +88,8 @@ export default App;
 
 ## Props
 
+### [View Props](view#props)
+
 Inherits [View Props](view#props).
 
 ---

--- a/docs/drawerlayoutandroid.md
+++ b/docs/drawerlayoutandroid.md
@@ -75,7 +75,11 @@ export default App;
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
+
+---
 
 ### `drawerBackgroundColor`
 

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -170,7 +170,11 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
+### [ScrollView Props](scrollview.md#props)
+
 Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
+
+---
 
 ### `renderItem`
 

--- a/docs/imagebackground.md
+++ b/docs/imagebackground.md
@@ -51,7 +51,11 @@ export default App;
 
 ## Props
 
+### [Image Props](image.md#props)
+
 Inherits [Image Props](image.md#props).
+
+---
 
 ### `style`
 

--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -64,7 +64,11 @@ export default KeyboardAvoidingComponent;
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
+
+---
 
 ### `behavior`
 

--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -63,6 +63,8 @@ export default App;
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
 
 ---

--- a/docs/safeareaview.md
+++ b/docs/safeareaview.md
@@ -38,9 +38,13 @@ export default App;
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
 
-As padding is used to implement the behavior of the component, padding rules in styles applied to a `SafeAreaView` will be ignored and can cause different results depending on the platform. See [#22211](https://github.com/facebook/react-native/issues/22211) for details.
+> As padding is used to implement the behavior of the component, padding rules in styles applied to a `SafeAreaView` will be ignored and can cause different results depending on the platform. See [#22211](https://github.com/facebook/react-native/issues/22211) for details.
+
+---
 
 ### `emulateUnlessSupported`
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -67,7 +67,11 @@ export default App;
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
+
+---
 
 ### `alwaysBounceHorizontal`
 

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -198,7 +198,11 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
+### [ScrollView Props](scrollview.md#props)
+
 Inherits [ScrollView Props](scrollview.md#props).
+
+---
 
 ### `renderItem`
 

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -47,7 +47,11 @@ export default App;
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
+
+---
 
 ### `disabled`
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -79,7 +79,11 @@ Note that on Android performing text selection in input can change app's activit
 
 ## Props
 
+### [View Props](view.md#props)
+
 Inherits [View Props](view.md#props).
+
+---
 
 ### `allowFontScaling`
 

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -157,7 +157,11 @@ export default App;
 
 ## Props
 
+### [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props)
+
 Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
+
+---
 
 ### `activeOpacity`
 

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -64,7 +64,11 @@ export default App;
 
 ## Props
 
+### [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props)
+
 Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
+
+---
 
 ### `background`
 

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -131,7 +131,11 @@ export default App;
 
 ## Props
 
+### [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props)
+
 Inherits [TouchableWithoutFeedback Props](touchablewithoutfeedback.md#props).
+
+---
 
 ### `style`
 

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -86,7 +86,11 @@ Some caveats:
 
 ## Props
 
+### [ScrollView Props](scrollview.md#props)
+
 Inherits [ScrollView Props](scrollview.md#props).
+
+---
 
 ### `renderItem`
 


### PR DESCRIPTION
Refs #2160

This PR adds links to the inherited by the component props to the right sidebar (TOC). Clicking this link in TOC won't scroll the page, but the user will be moved to the parent component page. This should improve the UX when browsing props and make it more clear which component props, are inherited.

### Preview
<img width="1101" alt="Annotation 2020-08-21 141826" src="https://user-images.githubusercontent.com/719641/90889886-34a67300-e3b9-11ea-8892-a4b9470988b6.png">