### PR TITLE
Update introduction.md

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -52,7 +52,7 @@ The above is a Snack Player. It’s a handy tool created by Expo to embed and ru
 
 With React, you can make components using either classes or functions. Originally, class components were the only components that could have state. But since the introduction of React's Hooks API, you can add state and more to function components.
 
-[Hooks were introduced in React Native 0.58.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
+[Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
 <div class="toggler">
   <ul role="tablist" class="toggle-syntax">


### PR DESCRIPTION
Hooks were introduced in React Native 0.59, not 0.58.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
