### PR TITLE
Modernize code examples in the direct manipulation section

### DIFF
--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -39,12 +39,8 @@ Let's imagine that `setNativeProps` was not available. One way that we might imp
 const [buttonOpacity, setButtonOpacity] = useState(1);
 return (
   <TouchableOpacity
-    onPressIn={() => {
-      setButtonOpacity(0.5);
-    }}
-    onPressOut={() => {
-      setButtonOpacity(1);
-    }}>
+    onPressIn={() => setButtonOpacity(0.5)}
+    onPressOut={() => setButtonOpacity(1)}>
     <View style={{ opacity: buttonOpacity }}>
       <Text>Press me!</Text>
     </View>
@@ -61,24 +57,20 @@ If you look at the implementation of `setNativeProps` in [NativeMethodsMixin](ht
 Composite components are not backed by a native view, so you cannot call `setNativeProps` on them. Consider this example:
 
 ```SnackPlayer name=setNativeProps%20with%20Composite%20Components
-import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import React from "react";
+import { Text, TouchableOpacity, View } from "react-native";
 
-const MyButton = (props) => {
-  return (
-    <View style={{marginTop: 50}}>
-      <Text>{props.label}</Text>
-    </View>
-  )
-};
+const MyButton = (props) => (
+  <View style={{ marginTop: 50 }}>
+    <Text>{props.label}</Text>
+  </View>
+);
 
-export default App = () => {
-  return (
-    <TouchableOpacity>
-      <MyButton label="Press me!" />
-    </TouchableOpacity>
-  )
-};
+export default App = () => (
+  <TouchableOpacity>
+    <MyButton label="Press me!" />
+  </TouchableOpacity>
+);
 ```
 
 If you run this you will immediately see this error: `Touchable child must either be native or forward setNativeProps to a native component`. This occurs because `MyButton` isn't directly backed by a native view whose opacity should be set. You can think about it like this: if you define a component with `createReactClass` you would not expect to be able to set a style prop on it and have that work - you would need to pass the style prop down to a child, unless you are wrapping a native component. Similarly, we are going to forward `setNativeProps` to a native-backed child component.
@@ -88,27 +80,20 @@ If you run this you will immediately see this error: `Touchable child must eithe
 Since the `setNativeProps` method exists on any ref to a `View` component, it is enough to forward a ref on your custom component to one of the `<View />` components that it renders. This means that a call to `setNativeProps` on the custom component will have the same effect as if you called `setNativeProps` on the wrapped `View` component itself.
 
 ```SnackPlayer name=Forwarding%20setNativeProps
-import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import React from "react";
+import { Text, TouchableOpacity, View } from "react-native";
 
-const MyButton = React.forwardRef((props, ref) => {
-  return (
-    <View
-      {...props}
-      ref={ref}
-      style={{marginTop: 50}}>
-      <Text>{props.label}</Text>
-    </View>
-  );
-});
+const MyButton = React.forwardRef((props, ref) => (
+  <View {...props} ref={ref} style={{ marginTop: 50 }}>
+    <Text>{props.label}</Text>
+  </View>
+));
 
-export default App = () => {
-  return (
-    <TouchableOpacity>
-      <MyButton label="Press me!" />
-    </TouchableOpacity>
-  )
-}
+export default App = () => (
+  <TouchableOpacity>
+    <MyButton label="Press me!" />
+  </TouchableOpacity>
+);
 ```
 
 You can now use `MyButton` inside of `TouchableOpacity`!
@@ -120,28 +105,42 @@ You may have noticed that we passed all of the props down to the child view usin
 Another very common use case of `setNativeProps` is to clear the value of a TextInput. The `controlled` prop of TextInput can sometimes drop characters when the `bufferDelay` is low and the user types very quickly. Some developers prefer to skip this prop entirely and instead use `setNativeProps` to directly manipulate the TextInput value when necessary. For example, the following code demonstrates clearing the input when you tap a button:
 
 ```SnackPlayer name=Clear%20text
-import React from 'react';
-import { useCallback } from 'react';
-import { TextInput, Text, TouchableOpacity, View } from 'react-native';
+import React from "react";
+import { useCallback, useRef } from "react";
+import { StyleSheet, TextInput, Text, TouchableOpacity, View } from "react-native";
 
-export default App = () => {
+const App = () => {
   const inputRef = useRef();
   const clearText = useCallback(() => {
-    inputRef.current.setNativeProps({text: ''});
+    inputRef.current.setNativeProps({ text: "" });
   }, []);
 
   return (
-    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
-      <TextInput
-        ref={inputRef}
-        style={{height: 50, width: 200, marginHorizontal: 20, borderWidth: 1, borderColor: '#ccc'}}
-      />
+    <View style={styles.container}>
+      <TextInput ref={inputRef} style={styles.input} />
       <TouchableOpacity onPress={clearText}>
         <Text>Clear text</Text>
       </TouchableOpacity>
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  input: {
+    height: 50,
+    width: 200,
+    marginHorizontal: 20,
+    borderWidth: 1,
+    borderColor: "#ccc",
+  },
+});
+
+export default App;
 ```
 
 ## Avoiding conflicts with the render function


### PR DESCRIPTION
The examples in the Direct Manipulation section look to have fallen victim to a rogue codemod; they are currently a mix of functional and class syntax that doesn't actually work.

In this PR I do too many things (sorry):

* fix indentation (2 spaces everywhere)
* remove styles that don't aid in the understanding of the concept of direct manipulation
* convert everything from class to functional/hooks syntax
* repair the opacity example by dimming the button `onPressIn` instead of `onPress`
* use conventional ref forwarding to achieve the desired effect in the example where we show how to forward the effect of `setNativeProps` from a wrapper component to a child component

T74535407