### PR TITLE
Fix template not found error

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -10,7 +10,7 @@ title: Using TypeScript
 If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
 
 ```sh
-npx react-native init MyApp --template react-native-template-typescript
+npx react-native init MyApp --template typescript
 ```
 
 > **Note:** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your system. To fix the issue try uninstalling the CLI:


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

I get this error consistently

![image](https://user-images.githubusercontent.com/13140065/92027132-fee97e80-ed16-11ea-996a-3009cb7f4430.png)

when running `npx react-native init MyApp --template react-native-template-typescript`