### PR TITLE
docs: update deprecated usage of findNodeHandle in measureLayout

### DIFF
--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -181,53 +181,65 @@ Determines the location of the given view in the window and returns the values v
 
 ### measureLayout(relativeToNativeComponentRef, onSuccess, onFail)
 
-Like `measure()`, but measures the view relative to an ancestor, specified as `relativeToNativeComponentRef`. This means that the returned x, y are relative to the origin x, y of the ancestor view. _Can also be called with a relativeNativeNodeHandle but is deprecated._
+Like `measure()`, but measures the view relative to an ancestor, specified with `relativeToNativeComponentRef` refrence. This means that the returned coordinates are relative to the origin `x`, `y` of the ancestor view.
 
-```SnackPlayer name=measureLayout%20example
-import React, { useRef, useEffect } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+> Note: This method can also be called with a `relativeToNativeNode` handler (instead of reference), but this variant is deprecated.
 
-export default function App() {
+```SnackPlayer name=measureLayout%20example&supportedPlatforms=android,ios
+import React, { useEffect, useRef, useState } from "react";
+import { Text, View, StyleSheet } from "react-native";
+
+const App = () => {
   const textContainerRef = useRef(null);
   const textRef = useRef(null);
+  const [measure, setMeasure] = useState(null);
 
   useEffect(() => {
     if (textRef.current && textContainerRef.current) {
       textRef.current.measureLayout(
         textContainerRef.current,
         (left, top, width, height) => {
-          console.log('measureLayout', { left, top, width, height });
+          setMeasure({ left, top, width, height });
         }
       );
     }
-  }, []);
+  }, [measure]);
 
   return (
     <View style={styles.container}>
-      <View ref={textContainerRef} style={styles.textContainer}>
-        <Text ref={textRef} style={styles.paragraph}>
-          Where am I?
+      <View
+        ref={textContainerRef}
+        style={styles.textContainer}
+      >
+        <Text ref={textRef}>
+          Where am I? (relative to the text container)
         </Text>
       </View>
+      <Text style={styles.measure}>
+        {JSON.stringify(measure)}
+      </Text>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: "center",
   },
   textContainer: {
-    backgroundColor: 'green',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 8,
+    backgroundColor: "#61dafb",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 12,
   },
-  paragraph: {
-    backgroundColor: 'white',
+  measure: {
+    textAlign: "center",
+    padding: 12,
   },
 });
+
+export default App;
 ```
 
 ### focus()

--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -179,14 +179,55 @@ Determines the location of the given view in the window and returns the values v
 - width
 - height
 
-### measureLayout(relativeToNativeNode, onSuccess, onFail)
+### measureLayout(relativeToNativeComponentRef, onSuccess, onFail)
 
-Like `measure()`, but measures the view relative to an ancestor, specified as `relativeToNativeNode`. This means that the returned x, y are relative to the origin x, y of the ancestor view.
+Like `measure()`, but measures the view relative to an ancestor, specified as `relativeToNativeComponentRef`. This means that the returned x, y are relative to the origin x, y of the ancestor view. _Can also be called with a relativeNativeNodeHandle but is deprecated._
 
-As always, to obtain a native node handle for a component, you can use `findNodeHandle(component)`.
+```SnackPlayer name=measureLayout%20example
+import React, { useRef, useEffect } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
 
-```jsx
-import { findNodeHandle } from 'react-native';
+export default function App() {
+  const textContainerRef = useRef(null);
+  const textRef = useRef(null);
+
+  useEffect(() => {
+    if (textRef.current && textContainerRef.current) {
+      textRef.current.measureLayout(
+        textContainerRef.current,
+        (left, top, width, height) => {
+          console.log('measureLayout', { left, top, width, height });
+        }
+      );
+    }
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <View ref={textContainerRef} style={styles.textContainer}>
+        <Text ref={textRef} style={styles.paragraph}>
+          Where am I?
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  textContainer: {
+    backgroundColor: 'green',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 8,
+  },
+  paragraph: {
+    backgroundColor: 'white',
+  },
+});
 ```
 
 ### focus()


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
