### PR TITLE
TextInput: Add new `onPressIn` and `onPressOut` docs

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -481,6 +481,26 @@ Callback that is called when text input ends.
 
 ---
 
+### `onPressIn`
+
+Callback that is called when a touch is engaged.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
+### `onPressOut`
+
+Callback that is called when a touch is released.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
 ### `onFocus`
 
 Callback that is called when the text input is focused. This is called with `{ nativeEvent: { target } }`.


### PR DESCRIPTION
Original summary by @yungsters in [1b994f9](https://github.com/facebook/react-native/commit/b7b0e232028723794af4c79fc6366c483ae2350b):

> Introduces support for `onPressIn` and `onPressOut` on the `TextInput` component.
> This makes it possible to add visual feedback when users touch interact with `TextInput` components.
