### PR TITLE
Docs: Remove deprecated method `didReceiveLocalNotification` from Push Notification iOS

### DIFF
--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -69,11 +69,6 @@ And then in your AppDelegate implementation add the following:
  {
   [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
  }
- // Required for the localNotification event.
- - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
- {
-  [RCTPushNotificationManager didReceiveLocalNotification:notification];
- }
 ```
 
 To show notifications while being in the foreground (available starting from iOS 10) add the following lines:


### PR DESCRIPTION
## Description

This is related with the following issue: https://github.com/facebook/react-native/issues/26199

According to [iOS docs](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622930-application?language=objc), `didReceiveLocalNotification` is deprecated and should be replaced by 

> ![Screenshot 2020-09-17 at 17 09 57](https://user-images.githubusercontent.com/7629661/93490347-a74b3580-f908-11ea-84a6-3bae7b2f4166.png)

This PR removes the following method from the PushNotificationIOS documentation
