### PR TITLE
Docs: Removing `onTextInput` prop from TextInput

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -563,16 +563,6 @@ Note that on iOS this method isn't called when using `keyboardType="phone-pad"`.
 
 ---
 
-### `onTextInput`
-
-Callback that is called on new text input with the argument `{ nativeEvent: { text, previousText, range: { start, end } } }`. This prop requires `multiline={true}` to be set.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
 ### `placeholder`
 
 The string that will be rendered before text input has been entered.

--- a/website/versioned_docs/version-0.62/textinput.md
+++ b/website/versioned_docs/version-0.62/textinput.md
@@ -518,16 +518,6 @@ Note that on iOS this method isn't called when using `keyboardType="phone-pad"`.
 
 ---
 
-### `onTextInput`
-
-Callback that is called on new text input with the argument `{ nativeEvent: { text, previousText, range: { start, end } } }`. This prop requires `multiline={true}` to be set.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
 ### `placeholder`
 
 The string that will be rendered before text input has been entered.

--- a/website/versioned_docs/version-0.63/textinput.md
+++ b/website/versioned_docs/version-0.63/textinput.md
@@ -522,16 +522,6 @@ Note that on iOS this method isn't called when using `keyboardType="phone-pad"`.
 
 ---
 
-### `onTextInput`
-
-Callback that is called on new text input with the argument `{ nativeEvent: { text, previousText, range: { start, end } } }`. This prop requires `multiline={true}` to be set.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
 ### `placeholder`
 
 The string that will be rendered before text input has been entered.


### PR DESCRIPTION
Release Note - https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#breaking-1
Commit - https://github.com/facebook/react-native/commit/3f7e0a2c9601fc186f25bfd794cd0008ac3983ab

According to the Release Notes, the `onTextInput` prop is removed from **TextInput**