### PR TITLE
fix typo

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -194,7 +194,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
     }
 ```
 
-2. Configuring the Babel side done by adding a new dependency, [`babel-plugin-module-resolver`][bpmr]:
+2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
 ```sh
 yarn add --dev babel-plugin-module-resolver

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -194,7 +194,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
     }
 ```
 
-2. Configure the Babel side done by adding a new dependency, [`babel-plugin-module-resolver`][bpmr]:
+2. Configuring the Babel side done by adding a new dependency, [`babel-plugin-module-resolver`][bpmr]:
 
 ```sh
 yarn add --dev babel-plugin-module-resolver


### PR DESCRIPTION
fixes typo in "Using Custom Path Aliases with TypeScript" section (configure -> configuring)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
