### PR TITLE
Extend integration-with-existing-apps page with additional step for Pods setup

### DIFF
--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -238,6 +238,48 @@ end
 
 <block class="objc swift" />
 
+If your iOS project uses different build configuration names than the default ones (Debug and Release), you have to provide additional mapping for build configurations:
+
+<block class="objc" />
+
+```
+# The target name is most likely the name of your project.
+target 'NumberTileGame' do
+  # Use the project name which is most likely name of the target.
+  project 'NumberTileGame',
+    'YourCustomDebugBuildConfigurationName' => :debug,
+    'YourCustomReleaseBuildConfigurationName' => :release
+
+  # Your pods goes here
+  ...
+
+end
+```
+
+<block class="swift" />
+
+```
+source 'https://github.com/CocoaPods/Specs.git'
+
+# Required for Swift apps
+platform :ios, '8.0'
+use_frameworks!
+
+# The target name is most likely the name of your project.
+target 'swift-2048' do
+  # Use the project name which is most likely name of the target.
+  project 'swift-2048',
+    'YourCustomDebugBuildConfigurationName' => :debug,
+    'YourCustomReleaseBuildConfigurationName' => :release
+
+  # Your pods goes here
+  ...
+
+end
+```
+
+<block class="objc swift" />
+
 After you have created your `Podfile`, you are ready to install the React Native pod.
 
 ```sh


### PR DESCRIPTION
While working on adding React Native to the existing iOS app, I used the provided documentation. After following all the steps, I occurred the error described here:
https://github.com/facebook/react-native/issues/26987

There is a problem with the development pods if the user uses a custom build configuration names. It can happen pretty often while working on brownfield apps. 
I hope that this addition to the documentation will help other developers with similar use cases.