### PR TITLE
docs: fix url of transferred repositories

### DIFF
--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -3,7 +3,7 @@ id: clipboard
 title: 🚧 Clipboard
 ---
 
-> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-community/clipboard) instead.
+> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-clipboard/clipboard) instead.
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS
 

--- a/docs/pickerios.md
+++ b/docs/pickerios.md
@@ -3,7 +3,7 @@ id: pickerios
 title: 🚧 PickerIOS
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-picker/react-native-picker) instead.
 
 ---
 

--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -3,7 +3,7 @@ id: progressbarandroid
 title: 🚧 ProgressBarAndroid
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-community/progress-bar-android) instead.
+> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-progress-view/progress-bar-android) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/website/versioned_docs/version-0.61/clipboard.md
+++ b/website/versioned_docs/version-0.61/clipboard.md
@@ -4,7 +4,7 @@ title: 🚧 Clipboard
 original_id: clipboard
 ---
 
-> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-community/clipboard) instead.
+> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-clipboard/clipboard) instead.
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS
 

--- a/website/versioned_docs/version-0.61/pickerios.md
+++ b/website/versioned_docs/version-0.61/pickerios.md
@@ -4,7 +4,7 @@ title: 🚧 PickerIOS
 original_id: pickerios
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-picker/react-native-picker) instead.
 
 ---
 

--- a/website/versioned_docs/version-0.61/progressbarandroid.md
+++ b/website/versioned_docs/version-0.61/progressbarandroid.md
@@ -4,7 +4,7 @@ title: 🚧 ProgressBarAndroid
 original_id: progressbarandroid
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-community/progress-bar-android) instead.
+> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-progress-view/progress-bar-android) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/website/versioned_docs/version-0.61/progressviewios.md
+++ b/website/versioned_docs/version-0.61/progressviewios.md
@@ -4,7 +4,7 @@ title: 🚧 ProgressViewIOS
 original_id: progressviewios
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-community/progress-view) instead.
+> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-progress-view/progress-view) instead.
 
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 

--- a/website/versioned_docs/version-0.62/clipboard.md
+++ b/website/versioned_docs/version-0.62/clipboard.md
@@ -4,7 +4,7 @@ title: 🚧 Clipboard
 original_id: clipboard
 ---
 
-> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-community/clipboard) instead.
+> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-clipboard/clipboard) instead.
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS
 

--- a/website/versioned_docs/version-0.62/picker.md
+++ b/website/versioned_docs/version-0.62/picker.md
@@ -4,7 +4,7 @@ title: 🚧 Picker
 original_id: picker
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-picker/react-native-picker) instead.
 
 Renders the native picker component on Android and iOS.
 

--- a/website/versioned_docs/version-0.62/progressbarandroid.md
+++ b/website/versioned_docs/version-0.62/progressbarandroid.md
@@ -4,7 +4,7 @@ title: 🚧 ProgressBarAndroid
 original_id: progressbarandroid
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-community/progress-bar-android) instead.
+> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-progress-view/progress-bar-android) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/website/versioned_docs/version-0.62/progressviewios.md
+++ b/website/versioned_docs/version-0.62/progressviewios.md
@@ -4,7 +4,7 @@ title: 🚧 ProgressViewIOS
 original_id: progressviewios
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-community/progress-view) instead.
+> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-progress-view/progress-view) instead.
 
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 

--- a/website/versioned_docs/version-0.63/picker.md
+++ b/website/versioned_docs/version-0.63/picker.md
@@ -4,7 +4,7 @@ title: 🚧 Picker
 original_id: picker
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-picker/react-native-picker) instead.
 
 Renders the native picker component on Android and iOS.
 

--- a/website/versioned_docs/version-0.63/progressbarandroid.md
+++ b/website/versioned_docs/version-0.63/progressbarandroid.md
@@ -4,7 +4,7 @@ title: 🚧 ProgressBarAndroid
 original_id: progressbarandroid
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-community/progress-bar-android) instead.
+> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-progress-view/progress-bar-android) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/website/versioned_docs/version-0.63/progressviewios.md
+++ b/website/versioned_docs/version-0.63/progressviewios.md
@@ -4,7 +4,7 @@ title: 🚧 ProgressViewIOS
 original_id: progressviewios
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-community/progress-view) instead.
+> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-progress-view/progress-view) instead.
 
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Some of the deprecated modules has been moved out of the react-native-community org to its own orgs. (ref: https://github.com/react-native-community/discussions-and-proposals/blob/master/partners/0002-apply-organization-repository-policy.md)

This PR fixes the URL of some of the transferred repositories to the new url.

- Picker
- ProgressView
- ProgressBarAndroid
- Clipboard
