### PR TITLE
fixes equality operator used in platform test

### DIFF
--- a/docs/keyboardavoidingview.md
+++ b/docs/keyboardavoidingview.md
@@ -14,7 +14,7 @@ import { View, KeyboardAvoidingView, TextInput, StyleSheet, Text, Platform, Touc
 const KeyboardAvoidingComponent = () => {
   return (
     <KeyboardAvoidingView
-      behavior={Platform.OS == "ios" ? "padding" : "height"}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
       style={styles.container}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss}>


### PR DESCRIPTION
changed the equality operator from equality to strict equality (from == to ===) when testing Platform.OS

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
