### PR TITLE
Bump Node minimum required version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -152,7 +152,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 
@@ -188,7 +188,7 @@ Open an Administrator Command Prompt (right click Command Prompt and select "Run
 choco install -y nodejs.install openjdk8
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 

--- a/website/versioned_docs/version-0.63/getting-started.md
+++ b/website/versioned_docs/version-0.63/getting-started.md
@@ -153,7 +153,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 
@@ -189,7 +189,7 @@ Open an Administrator Command Prompt (right click Command Prompt and select "Run
 choco install -y nodejs.install python2 openjdk8
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 


### PR DESCRIPTION
To be merged once https://github.com/facebook/react-native/pull/30237 lands, as it will affect the next OSS release to be cut.
Node 14 becomes the new Active LTS on October 27, 2020, which means we can bump the minimum to Node 12 then.