### PR TITLE
wrong prop usage fixed

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -155,7 +155,7 @@ const App = () => {
       <Text>You clicked {count} times</Text>
       <Button
         onPress={() => setCount(count + 1)}
-        titles="Click me!"
+        title="Click me!"
       />
     </View>
   );

--- a/website/versioned_docs/version-0.63/tutorial.md
+++ b/website/versioned_docs/version-0.63/tutorial.md
@@ -155,7 +155,7 @@ const App = () => {
       <Text>You clicked {count} times</Text>
       <Button
         onPress={() => setCount(count + 1)}
-        titles="Click me!"
+        title="Click me!"
       />
     </View>
   );


### PR DESCRIPTION
Titles prop is given in button component in tutorial, it is fixed as title
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
