### PR TITLE
Fix Typescript hyperlink in testing-overview docs

### DIFF
--- a/website/versioned_docs/version-0.63/testing-overview.md
+++ b/website/versioned_docs/version-0.63/testing-overview.md
@@ -29,7 +29,7 @@ The first step to improve your code quality is to start using static analysis to
 - **Linters** analyze code to catch common errors such as unused code and to help avoid pitfalls, to flag style guide no-nos like using tabs instead of spaces (or vice versa, depending on your configuration).
 - **Type checking** ensures that the construct you’re passing to a function matches what the function was designed to accept, preventing passing a string to a counting function that expects a number, for instance.
 
-React Native comes with two such tools configured out of the box: [ESLint](https://eslint.org/) for linting and [Flow](https://flow.org/en/docs/) for type checking. You can also use [TypeScript](https://www.typescriptlang.org/), which is a typed language that compiles to plain JavaScript.
+React Native comes with two such tools configured out of the box: [ESLint](https://eslint.org/) for linting and [Flow](https://flow.org/en/docs/) for type checking. You can also use [TypeScript](https://reactnative.dev/docs/typescript/), which is a typed language that compiles to plain JavaScript.
 
 ## Writing Testable Code
 

--- a/website/versioned_docs/version-0.63/testing-overview.md
+++ b/website/versioned_docs/version-0.63/testing-overview.md
@@ -29,7 +29,7 @@ The first step to improve your code quality is to start using static analysis to
 - **Linters** analyze code to catch common errors such as unused code and to help avoid pitfalls, to flag style guide no-nos like using tabs instead of spaces (or vice versa, depending on your configuration).
 - **Type checking** ensures that the construct you’re passing to a function matches what the function was designed to accept, preventing passing a string to a counting function that expects a number, for instance.
 
-React Native comes with two such tools configured out of the box: [ESLint](https://eslint.org/) for linting and [Flow](https://flow.org/en/docs/) for type checking. You can also use [TypeScript](typescript), which is a typed language that compiles to plain JavaScript.
+React Native comes with two such tools configured out of the box: [ESLint](https://eslint.org/) for linting and [Flow](https://flow.org/en/docs/) for type checking. You can also use [TypeScript](https://www.typescriptlang.org/), which is a typed language that compiles to plain JavaScript.
 
 ## Writing Testable Code
 


### PR DESCRIPTION
https://reactnative.dev/docs/testing-overview/#static-analysis

Clicking on the `Typescript` hyperlink will navigate to `https://reactnative.dev/docs/testing-overview/typescript` which does not exist.

This update fixes the link in the docs to `https://www.typescriptlang.org/`
