### PR TITLE
Fix links in components-and-apis.md

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -5,12 +5,12 @@ title: Core Components and APIs
 
 React Native provides a number of built-in [Core Components](intro-react-native-components) ready for you to use in your app. You can find them all in the left sidebar (or menu above, if you are on a narrow screen). If you're not sure where to get started, take a look at the following categories:
 
-- [Basic Components](components-and-apis#basic-components)
-- [User Interface](components-and-apis#user-interface)
-- [List Views](components-and-apis#list-views)
-- [iOS-specific](components-and-apis#ios-components-and-apis)
-- [Android-specific](components-and-apis#android-components-and-apis)
-- [Others](components-and-apis#others)
+- [Basic Components](#basic-components)
+- [User Interface](#user-interface)
+- [List Views](#list-views)
+- [iOS-specific](#ios-components-and-apis)
+- [Android-specific](#android-components-and-apis)
+- [Others](#others)
 
 You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, please refer to [this guide about finding libraries](libraries#finding-libraries).
 
@@ -20,37 +20,37 @@ Most apps will end up using one of these basic components.
 
 <div className="component-grid component-grid-border">
   <div className="component">
-    <a href="./view">
+    <a href="/docs/view">
       <h3>View</h3>
       <p>The most fundamental component for building a UI.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./text">
+    <a href="/docs/text">
       <h3>Text</h3>
       <p>A component for displaying text.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./image">
+    <a href="/docs/image">
       <h3>Image</h3>
       <p>A component for displaying images.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./textinput">
+    <a href="/docs/textinput">
       <h3>TextInput</h3>
       <p>A component for inputting text into the app via a keyboard.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./scrollview">
+    <a href="/docs/scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./stylesheet">
+    <a href="/docs/stylesheet">
       <h3>StyleSheet</h3>
       <p>Provides an abstraction layer similar to CSS stylesheets.</p>
     </a>
@@ -63,13 +63,13 @@ These common user interface controls will render on any platform.
 
 <div className="component-grid component-grid-border">
   <div className="component">
-    <a href="./button">
+    <a href="/docs/button">
       <h3>Button</h3>
       <p>A basic button component for handling touches that should render nicely on any platform.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./switch">
+    <a href="/docs/switch">
       <h3>Switch</h3>
       <p>Renders a boolean input.</p>
     </a>
@@ -78,17 +78,17 @@ These common user interface controls will render on any platform.
 
 ## List Views
 
-Unlike the more generic [`ScrollView`](./scrollview), the following list view components only render elements that are currently showing on the screen. This makes them a performant choice for displaying long lists of data.
+Unlike the more generic [`ScrollView`](/docs/scrollview), the following list view components only render elements that are currently showing on the screen. This makes them a performant choice for displaying long lists of data.
 
 <div className="component-grid component-grid-border">
   <div className="component">
-    <a href="./flatlist">
+    <a href="/docs/flatlist">
       <h3>FlatList</h3>
       <p>A component for rendering performant scrollable lists.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./sectionlist">
+    <a href="/docs/sectionlist">
       <h3>SectionList</h3>
       <p>Like <code>FlatList</code>, but for sectioned lists.</p>
     </a>
@@ -101,7 +101,7 @@ Many of the following components provide wrappers for commonly used UIKit classe
 
 <div className="component-grid component-grid-border">
   <div className="component">
-    <a href="./actionsheetios">
+    <a href="/docs/actionsheetios">
       <h3>ActionSheetIOS</h3>
       <p>API to display an iOS action sheet or share sheet.</p>
     </a>
@@ -113,25 +113,25 @@ Many of the following components provide wrappers for commonly used Android clas
 
 <div className="component-grid component-grid-border">
   <div className="component">
-    <a href="./backhandler">
-      </a><h3><a href="./backhandler">BackHandler</a></h3>
+    <a href="/docs/backhandler">
+      </a><h3><a href="/docs/backhandler">BackHandler</a></h3>
       <p>Detect hardware button presses for back navigation.</p>
     
   </div>
   <div className="component">
-    <a href="./drawerlayoutandroid">
+    <a href="/docs/drawerlayoutandroid">
       <h3>DrawerLayoutAndroid</h3>
       <p>Renders a <code>DrawerLayout</code> on Android.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./permissionsandroid">
-      </a><h3><a href="./permissionsandroid">PermissionsAndroid</a></h3>
+    <a href="/docs/permissionsandroid">
+      </a><h3><a href="/docs/permissionsandroid">PermissionsAndroid</a></h3>
       <p>Provides access to the permissions model introduced in Android M.</p>
     
   </div>
   <div className="component">
-    <a href="./toastandroid">
+    <a href="/docs/toastandroid">
       <h3>ToastAndroid</h3>
       <p>Create an Android Toast alert.</p>
     </a>
@@ -144,63 +144,64 @@ These components may be useful for certain applications. For an exhaustive list 
 
 <div className="component-grid">
   <div className="component">
-    <a href="./activityindicator">
+    <a href="/docs/activityindicator">
       <h3>ActivityIndicator</h3>
       <p>Displays a circular loading indicator.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./alert">
+    <a href="/docs/alert">
       <h3>Alert</h3>
       <p>Launches an alert dialog with the specified title and message.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./animated">
+    <a href="/docs/animated">
       <h3>Animated</h3>
       <p>A library for creating fluid, powerful animations that are easy to build and maintain.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./dimensions">
+    <a href="/docs/dimensions">
       <h3>Dimensions</h3>
       <p>Provides an interface for getting device dimensions.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./keyboardavoidingview">
+    <a href="/docs/keyboardavoidingview">
       <h3>KeyboardAvoidingView</h3>
       <p>Provides a view that moves out of the way of the virtual keyboard automatically.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./linking">
+    <a href="/docs/linking">
       <h3>Linking</h3>
       <p>Provides a general interface to interact with both incoming and outgoing app links.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./modal">
+    <a href="/docs/modal">
       <h3>Modal</h3>
       <p>Provides a simple way to present content above an enclosing view.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./pixelratio">
+    <a href="/docs/pixelratio">
       <h3>PixelRatio</h3>
       <p>Provides access to the device pixel density.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./refreshcontrol">
+    <a href="/docs/refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>
     </a>
   </div>
   <div className="component">
-    <a href="./statusbar">
+    <a href="/docs/statusbar">
       <h3>StatusBar</h3>
       <p>Component to control the app status bar.</p>
     </a>
   </div>
 </div>
+

--- a/website/versioned_docs/version-0.63/components-and-apis.md
+++ b/website/versioned_docs/version-0.63/components-and-apis.md
@@ -5,12 +5,12 @@ title: Core Components and APIs
 
 React Native provides a number of built-in [Core Components](intro-react-native-components) ready for you to use in your app. You can find them all in the left sidebar (or menu above, if you are on a narrow screen). If you're not sure where to get started, take a look at the following categories:
 
-- [Basic Components](components-and-apis#basic-components)
-- [User Interface](components-and-apis#user-interface)
-- [List Views](components-and-apis#list-views)
-- [iOS-specific](components-and-apis#ios-components-and-apis)
-- [Android-specific](components-and-apis#android-components-and-apis)
-- [Others](components-and-apis#others)
+- [Basic Components](#basic-components)
+- [User Interface](#user-interface)
+- [List Views](#list-views)
+- [iOS-specific](#ios-components-and-apis)
+- [Android-specific](#android-components-and-apis)
+- [Others](#others)
 
 You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, please refer to [this guide about finding libraries](libraries#finding-libraries).
 
@@ -20,37 +20,37 @@ Most apps will end up using one of these basic components.
 
 <div class="component-grid component-grid-border">
   <div class="component">
-    <a href="./view">
+    <a href="/docs/view">
       <h3>View</h3>
       <p>The most fundamental component for building a UI.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./text">
+    <a href="/docs/text">
       <h3>Text</h3>
       <p>A component for displaying text.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./image">
+    <a href="/docs/image">
       <h3>Image</h3>
       <p>A component for displaying images.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./textinput">
+    <a href="/docs/textinput">
       <h3>TextInput</h3>
       <p>A component for inputting text into the app via a keyboard.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./scrollview">
+    <a href="/docs/scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./stylesheet">
+    <a href="/docs/stylesheet">
       <h3>StyleSheet</h3>
       <p>Provides an abstraction layer similar to CSS stylesheets.</p>
     </a>
@@ -63,13 +63,13 @@ These common user interface controls will render on any platform.
 
 <div class="component-grid component-grid-border">
   <div class="component">
-    <a href="./button">
+    <a href="/docs/button">
       <h3>Button</h3>
       <p>A basic button component for handling touches that should render nicely on any platform.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./switch">
+    <a href="/docs/switch">
       <h3>Switch</h3>
       <p>Renders a boolean input.</p>
     </a>
@@ -78,17 +78,17 @@ These common user interface controls will render on any platform.
 
 ## List Views
 
-Unlike the more generic [`ScrollView`](./scrollview), the following list view components only render elements that are currently showing on the screen. This makes them a performant choice for displaying long lists of data.
+Unlike the more generic [`ScrollView`](/docs/scrollview), the following list view components only render elements that are currently showing on the screen. This makes them a performant choice for displaying long lists of data.
 
 <div class="component-grid component-grid-border">
   <div class="component">
-    <a href="./flatlist">
+    <a href="/docs/flatlist">
       <h3>FlatList</h3>
       <p>A component for rendering performant scrollable lists.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./sectionlist">
+    <a href="/docs/sectionlist">
       <h3>SectionList</h3>
       <p>Like <code>FlatList</code>, but for sectioned lists.</p>
     </a>
@@ -101,7 +101,7 @@ Many of the following components provide wrappers for commonly used UIKit classe
 
 <div class="component-grid component-grid-border">
   <div class="component">
-    <a href="./actionsheetios">
+    <a href="/docs/actionsheetios">
       <h3>ActionSheetIOS</h3>
       <p>API to display an iOS action sheet or share sheet.</p>
     </a>
@@ -114,25 +114,25 @@ Many of the following components provide wrappers for commonly used Android clas
 
 <div class="component-grid component-grid-border">
   <div class="component">
-    <a href="./backhandler">
+    <a href="/docs/backhandler">
       <h3>BackHandler</h3>
       <p>Detect hardware button presses for back navigation.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./drawerlayoutandroid">
+    <a href="/docs/drawerlayoutandroid">
       <h3>DrawerLayoutAndroid</h3>
       <p>Renders a <code>DrawerLayout</code> on Android.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./permissionsandroid">
+    <a href="/docs/permissionsandroid">
       <h3>PermissionsAndroid</h3>
       <p>Provides access to the permissions model introduced in Android M.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./toastandroid">
+    <a href="/docs/toastandroid">
       <h3>ToastAndroid</h3>
       <p>Create an Android Toast alert.</p>
     </a>
@@ -145,61 +145,61 @@ These components may be useful for certain applications. For an exhaustive list 
 
 <div class="component-grid">
   <div class="component">
-    <a href="./activityindicator">
+    <a href="/docs/activityindicator">
       <h3>ActivityIndicator</h3>
       <p>Displays a circular loading indicator.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./alert">
+    <a href="/docs/alert">
       <h3>Alert</h3>
       <p>Launches an alert dialog with the specified title and message.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./animated">
+    <a href="/docs/animated">
       <h3>Animated</h3>
       <p>A library for creating fluid, powerful animations that are easy to build and maintain.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./dimensions">
+    <a href="/docs/dimensions">
       <h3>Dimensions</h3>
       <p>Provides an interface for getting device dimensions.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./keyboardavoidingview">
+    <a href="/docske/yboardavoidingview">
       <h3>KeyboardAvoidingView</h3>
       <p>Provides a view that moves out of the way of the virtual keyboard automatically.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./linking">
+    <a href="/docs/linking">
       <h3>Linking</h3>
       <p>Provides a general interface to interact with both incoming and outgoing app links.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./modal">
+    <a href="/docs/modal">
       <h3>Modal</h3>
       <p>Provides a simple way to present content above an enclosing view.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./pixelratio">
+    <a href="/docs/pixelratio">
       <h3>PixelRatio</h3>
       <p>Provides access to the device pixel density.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./refreshcontrol">
+    <a href="/docs/refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>
     </a>
   </div>
   <div class="component">
-    <a href="./statusbar">
+    <a href="/docs/statusbar">
       <h3>StatusBar</h3>
       <p>Component to control the app status bar.</p>
     </a>


### PR DESCRIPTION
Links in  https://reactnative.dev/docs/components-and-apis using incorrect relative urls.
Using absolute urls with pattern like `/docs/xxx` instead of `./xxx`.
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
