### PR TITLE
fix homepage community section links

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -430,24 +430,28 @@ function Community() {
               </p>
               <p>
                 In 2018, React Native had the{' '}
-                <a href="https://octoverse.github.com/2018/projects.html#repositories">
+                <a href="https://octoverse.github.com/2018/projects#repositories">
                   2nd highest
                 </a>{' '}
                 number of contributors for any repository in GitHub. Today,
                 React Native is supported by contributions from individuals and
                 companies around the world including{' '}
-                <a href="https://callstack.com/">Callstack</a>,{' '}
-                <a href="https://expo.io/">Expo</a>,{' '}
+                <span>
+                  <a href="https://callstack.com/">Callstack</a>
+                </span>
+                , <a href="https://expo.io/">Expo</a>,{' '}
                 <a href="https://infinite.red/">Infinite Red</a>,{' '}
-                <a href="https://www.microsoft.com/en-gb/">Microsoft</a> and{' '}
+                <a href="https://www.microsoft.com/">Microsoft</a> and{' '}
                 <a href="https://swmansion.com/">Software Mansion</a>.
               </p>
               <p>
                 Our community is always shipping exciting new projects and
                 exploring platforms beyond Android and iOS with repos like{' '}
-                <a href="https://github.com/microsoft/react-native-windows#readme">
-                  React Native Windows
-                </a>
+                <span>
+                  <a href="https://github.com/microsoft/react-native-windows#readme">
+                    React Native Windows
+                  </a>
+                </span>
                 ,{' '}
                 <a href="https://github.com/microsoft/react-native-macos#readme">
                   React Native macOS

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -439,10 +439,23 @@ function Community() {
                 <span>
                   <a href="https://callstack.com/">Callstack</a>
                 </span>
-                , <a href="https://expo.io/">Expo</a>,{' '}
-                <a href="https://infinite.red/">Infinite Red</a>,{' '}
-                <a href="https://www.microsoft.com/">Microsoft</a> and{' '}
-                <a href="https://swmansion.com/">Software Mansion</a>.
+                ,{' '}
+                <span>
+                  <a href="https://expo.io/">Expo</a>
+                </span>
+                ,{' '}
+                <span>
+                  <a href="https://infinite.red/">Infinite Red</a>
+                </span>
+                ,{' '}
+                <span>
+                  <a href="https://www.microsoft.com/">Microsoft</a>
+                </span>{' '}
+                and{' '}
+                <span>
+                  <a href="https://swmansion.com/">Software Mansion</a>
+                </span>
+                .
               </p>
               <p>
                 Our community is always shipping exciting new projects and
@@ -453,13 +466,17 @@ function Community() {
                   </a>
                 </span>
                 ,{' '}
-                <a href="https://github.com/microsoft/react-native-macos#readme">
-                  React Native macOS
-                </a>{' '}
+                <span>
+                  <a href="https://github.com/microsoft/react-native-macos#readme">
+                    React Native macOS
+                  </a>
+                </span>{' '}
                 and{' '}
-                <a href="https://github.com/necolas/react-native-web#readme">
-                  React Native Web
-                </a>
+                <span>
+                  <a href="https://github.com/necolas/react-native-web#readme">
+                    React Native Web
+                  </a>
+                </span>
                 .
               </p>
             </>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -439,23 +439,13 @@ function Community() {
                 <span>
                   <a href="https://callstack.com/">Callstack</a>
                 </span>
-                ,{' '}
+                ,
                 <span>
                   <a href="https://expo.io/">Expo</a>
                 </span>
-                ,{' '}
-                <span>
-                  <a href="https://infinite.red/">Infinite Red</a>
-                </span>
-                ,{' '}
-                <span>
-                  <a href="https://www.microsoft.com/">Microsoft</a>
-                </span>{' '}
-                and{' '}
-                <span>
-                  <a href="https://swmansion.com/">Software Mansion</a>
-                </span>
-                .
+                , <a href="https://infinite.red/">Infinite Red</a>,{' '}
+                <a href="https://www.microsoft.com/">Microsoft</a> and{' '}
+                <a href="https://swmansion.com/">Software Mansion</a>.
               </p>
               <p>
                 Our community is always shipping exciting new projects and
@@ -466,17 +456,13 @@ function Community() {
                   </a>
                 </span>
                 ,{' '}
-                <span>
-                  <a href="https://github.com/microsoft/react-native-macos#readme">
-                    React Native macOS
-                  </a>
-                </span>{' '}
+                <a href="https://github.com/microsoft/react-native-macos#readme">
+                  React Native macOS
+                </a>{' '}
                 and{' '}
-                <span>
-                  <a href="https://github.com/necolas/react-native-web#readme">
-                    React Native Web
-                  </a>
-                </span>
+                <a href="https://github.com/necolas/react-native-web#readme">
+                  React Native Web
+                </a>
                 .
               </p>
             </>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -439,7 +439,7 @@ function Community() {
                 <span>
                   <a href="https://callstack.com/">Callstack</a>
                 </span>
-                ,
+                ,{' '}
                 <span>
                   <a href="https://expo.io/">Expo</a>
                 </span>


### PR DESCRIPTION
Fixes #2285

This PR adds a "fix" for the reported issue by wrapping two links with `<span>` tags. 

I have also updated the two links used in in that section.