### PR TITLE
add blog posts feeds

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,6 +40,10 @@ module.exports = {
           path: 'blog',
           blogSidebarCount: 'ALL',
           blogSidebarTitle: 'All Blog Posts',
+          feedOptions: {
+            type: 'all',
+            copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+          },
         },
         theme: {
           customCss: [


### PR DESCRIPTION
Fixes #2295

This PR adds [blog plugin configuration option](https://v2.docusaurus.io/docs/blog/#feed) which enables the RSS feeds for the blog posts on the website.
