### PR TITLE
Chaged from 'background' to 'backgroundColor'

### DIFF
--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -55,7 +55,7 @@ const App = () => {
 
 const style = StyleSheet.create({
   tile: {
-    background: "lightGrey",
+    backgroundColor: "lightgrey",
     borderWidth: 0.5,
     borderColor: "#d6d7da"
   },

--- a/website/versioned_docs/version-0.63/layoutanimation.md
+++ b/website/versioned_docs/version-0.63/layoutanimation.md
@@ -55,7 +55,7 @@ const App = () => {
 
 const style = StyleSheet.create({
   tile: {
-    background: "lightGrey",
+    backgroundColor: "lightgrey",
     borderWidth: 0.5,
     borderColor: "#d6d7da"
   },


### PR DESCRIPTION
Changes:
```diff
- background: "lightGrey"
+ backgroundColor: "lightgrey"
```

In example of LayoutAnimation stylesheet for 'title' contains 'background' property.
It throws error as it should be 'backgroundColor'.
also value of the same is 'lightGrey' which is not supported. It should be 'lightgrey'.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
