### PR TITLE
temporary fix .html ending links on the client side

### DIFF
--- a/website/src/theme/Layout.js
+++ b/website/src/theme/Layout.js
@@ -6,18 +6,21 @@ import {Redirect, useLocation} from '@docusaurus/router';
 // See https://github.com/facebook/react-native-website/issues/2291
 // Inspired by https://jasonwatmore.com/post/2020/03/23/react-router-remove-trailing-slash-from-urls
 const RemoveTrailingSlashRedirect = () => {
-  const location = useLocation();
-  if (location.pathname.endsWith('/')) {
-    return <Redirect to={location.pathname.slice(0, -1)} />;
+  const {pathname} = useLocation();
+  if (pathname.endsWith('/')) {
+    return <Redirect to={pathname.slice(0, -1)} />;
+  }
+  if (pathname.endsWith('.html')) {
+    return <Redirect to={pathname.slice(0, -5)} />;
   }
   return null;
 };
 
-export default function Layout(props) {
-  return (
-    <>
-      <RemoveTrailingSlashRedirect />
-      <OriginalLayout {...props} />
-    </>
-  );
-}
+const Layout = props => (
+  <>
+    <RemoveTrailingSlashRedirect />
+    <OriginalLayout {...props} />
+  </>
+);
+
+export default Layout;


### PR DESCRIPTION
Currently old links like https://reactnative.dev/docs/switch.html are leading to 404 pages. 

<img width="1095" alt="Screenshot 2020-11-02 154949" src="https://user-images.githubusercontent.com/719641/97881757-16e37b80-1d23-11eb-92c9-efee602c102e.png">

This PR adds a temporary redirect (in same fashion as trailing slash fix) for links ending with `.html`. 

The result isn't ideal (the redirect is visible), but this should be enough until the problem will be fixed on the built server package.