### PR TITLE
Bump minimum Node version to 12

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node</h3>
 
-Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 10 or newer.
+Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 12 or newer.
 
 <h3>Java Development Kit</h3>
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -16,7 +16,7 @@ Open an Administrator Command Prompt (right click Command Prompt and select "Run
 choco install -y nodejs.install openjdk8
 ```
 
-If you have already installed Node on your system, make sure it is Node 10 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
+If you have already installed Node on your system, make sure it is Node 12 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 


### PR DESCRIPTION
Node 14 is the new active LTS as of October 27, 2020, so we have dropped support for Node 10 and declared Node 12 LTS as the minimum supported version going forward. This should only affect releases 0.64 and onward.


