### PR TITLE
[PlatformColor] updated supported colors section, updated example converted to snack

### DIFF
--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -19,6 +19,17 @@ PlatformColor('bogusName', 'linkColor');
 
 Since native colors can be sensitive to themes and/or high contrast, this platform specific logic also translates inside your components.
 
+### Supported colors
+
+For a full list of the types of system colors supported, see:
+
+- Android:
+  - [R.attr](https://developer.android.com/reference/android/R.attr) - `?attr` prefix
+  - [R.color](https://developer.android.com/reference/android/R.color) - `@android:color` prefix
+- iOS (Objective-C and Swift notations):
+  - [UIColor Standard Colors](https://developer.apple.com/documentation/uikit/uicolor/standard_colors)
+  - [UIColor UI Element Colors](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors)
+
 #### Developer notes
 
 <Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
@@ -30,16 +41,9 @@ Since native colors can be sensitive to themes and/or high contrast, this platfo
 </TabItem>
 </Tabs>
 
-For a full list of the types of system colors supported, see:
-
-- Android:
-  - [R.attr](https://developer.android.com/reference/android/R.attr) - `?attr` prefix
-  - [R.color](https://developer.android.com/reference/android/R.color) - `@android:color` prefix
-- [iOS UIColor](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors)
-
 ## Example
 
-```jsx
+```SnackPlayer name=PlatformColor%20Example&supportedPlatforms=android,ios
 import React from 'react';
 import {
   Platform,
@@ -49,27 +53,39 @@ import {
   View
 } from 'react-native';
 
-export default (App = () => (
-  <View>
-    <Text style={styles.labelCell}>
+const App = () => (
+  <View style={styles.container}>
+    <Text style={styles.label}>
       I am a special label color!
     </Text>
   </View>
-));
+);
 
 const styles = StyleSheet.create({
-  labelCell: {
-    flex: 1,
-    alignItems: 'stretch',
+  label: {
+    padding: 16,
     ...Platform.select({
-      ios: { color: PlatformColor('label') },
+      ios: {
+        color: PlatformColor('label'),
+        backgroundColor:
+          PlatformColor('systemTealColor'),
+      },
       android: {
-        color: PlatformColor('?attr/colorControlNormal')
+        color: PlatformColor('?attr/textColor'),
+        backgroundColor:
+          PlatformColor('@android:color/holo_blue_bright'),
       },
       default: { color: 'black' }
     })
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   }
 });
+
+export default App;
 ```
 
 The string value provided to the `PlatformColor` function must match the string as it exists on the native platform where the app is running. In order to avoid runtime errors, the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.Select()`, as shown on the example above.

--- a/website/versioned_docs/version-0.63/platformcolor.md
+++ b/website/versioned_docs/version-0.63/platformcolor.md
@@ -19,6 +19,17 @@ PlatformColor('bogusName', 'linkColor');
 
 Since native colors can be sensitive to themes and/or high contrast, this platform specific logic also translates inside your components.
 
+### Supported colors
+
+For a full list of the types of system colors supported, see:
+
+- Android:
+  - [R.attr](https://developer.android.com/reference/android/R.attr) - `?attr` prefix
+  - [R.color](https://developer.android.com/reference/android/R.color) - `@android:color` prefix
+- iOS (Objective-C and Swift notations):
+  - [UIColor Standard Colors](https://developer.apple.com/documentation/uikit/uicolor/standard_colors)
+  - [UIColor UI Element Colors](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors)
+
 #### Developer notes
 
 <Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
@@ -30,16 +41,9 @@ Since native colors can be sensitive to themes and/or high contrast, this platfo
 </TabItem>
 </Tabs>
 
-For a full list of the types of system colors supported, see:
-
-- Android:
-  - [R.attr](https://developer.android.com/reference/android/R.attr) - `?attr` prefix
-  - [R.color](https://developer.android.com/reference/android/R.color) - `@android:color` prefix
-- [iOS UIColor](https://developer.apple.com/documentation/uikit/uicolor/ui_element_colors)
-
 ## Example
 
-```jsx
+```SnackPlayer name=PlatformColor%20Example&supportedPlatforms=android,ios
 import React from 'react';
 import {
   Platform,
@@ -49,29 +53,41 @@ import {
   View
 } from 'react-native';
 
-export default (App = () => (
-  <View>
-    <Text style={styles.labelCell}>
+const App = () => (
+  <View style={styles.container}>
+    <Text style={styles.label}>
       I am a special label color!
     </Text>
   </View>
-));
+);
 
 const styles = StyleSheet.create({
-  labelCell: {
-    flex: 1,
-    alignItems: 'stretch',
+  label: {
+    padding: 16,
     ...Platform.select({
-      ios: { color: PlatformColor('label') },
+      ios: {
+        color: PlatformColor('label'),
+        backgroundColor:
+          PlatformColor('systemTealColor'),
+      },
       android: {
-        color: PlatformColor('?attr/colorControlNormal')
+        color: PlatformColor('?attr/textColor'),
+        backgroundColor:
+          PlatformColor('@android:color/holo_blue_bright'),
       },
       default: { color: 'black' }
     })
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   }
 });
+
+export default App;
 ```
 
-The string value provided to the `PlatformColor` function must match and agree with the same string as it exists on the native platform the app is being run on. This means to avoid runtime errors the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.Select()`.
+The string value provided to the `PlatformColor` function must match the string as it exists on the native platform where the app is running. In order to avoid runtime errors, the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.Select()`, as shown on the example above.
 
 > **Note:** You can find a complete example that demonstrates proper, intended use of `PlatformColor` in [PlatformColorExample.js](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js).


### PR DESCRIPTION
This PR updates the `PlatformColor` API page and introduce the following changes:
* header for supported colors list
* colors list moved above Developer Notes
* mention about supporting both notations (Objective-C and Swift) on iOS
* additional link to supported [UIColor Standard Colors](https://developer.apple.com/documentation/uikit/uicolor/standard_colors) on iOS
* example converted to Snack
* example content updated in a way which shows colors usage from each supported list for both platforms

The changes has been also backported to `0.63` docs. 

Earlier due to lack of support of `PlatformColor` in Expo SDK guide had to use plain code blocks, but in a meanwhile the SDK 39 has been released which includes this API.

### Preview

<img width="1078" alt="Screenshot 2020-11-02 215621" src="https://user-images.githubusercontent.com/719641/97918342-46f84200-1d56-11eb-9d12-7151494cda23.png">

