### PR TITLE
fix and update ImageBackground example

### DIFF
--- a/docs/imagebackground.md
+++ b/docs/imagebackground.md
@@ -40,7 +40,7 @@ const styles = StyleSheet.create({
     fontSize: 42,
     fontWeight: "bold",
     textAlign: "center",
-    background: "#000000a0"
+    backgroundColor: "#000000a0"
   }
 });
 

--- a/website/versioned_docs/version-0.63/imagebackground.md
+++ b/website/versioned_docs/version-0.63/imagebackground.md
@@ -36,9 +36,11 @@ const styles = StyleSheet.create({
     justifyContent: "center"
   },
   text: {
-    color: "grey",
-    fontSize: 30,
-    fontWeight: "bold"
+    color: "white",
+    fontSize: 42,
+    fontWeight: "bold",
+    textAlign: "center",
+    backgroundColor: "#000000a0"
   }
 });
 


### PR DESCRIPTION
Fixes #2303

This small PR updates `ImageBackground` page and fixes the error in the `next` example and ports the example changes back to `0.63` for the consistency.
