### PR TITLE
[Core Components and APIs] fix android header, reorder sections, fix links

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -102,8 +102,9 @@ Many of the following components provide wrappers for commonly used Android clas
 <div className="component-grid component-grid-border">
   <div className="component">
     <a href="./backhandler">
-      </a><h3><a href="./backhandler">BackHandler</a></h3>
+      <h3>BackHandler</h3>
       <p>Detect hardware button presses for back navigation.</p>
+    </a>
   </div>
   <div className="component">
     <a href="./drawerlayoutandroid">
@@ -113,8 +114,9 @@ Many of the following components provide wrappers for commonly used Android clas
   </div>
   <div className="component">
     <a href="./permissionsandroid">
-      </a><h3><a href="./permissionsandroid">PermissionsAndroid</a></h3>
+      <h3>PermissionsAndroid</h3>
       <p>Provides access to the permissions model introduced in Android M.</p>
+    </a>
   </div>
   <div className="component">
     <a href="./toastandroid">

--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -8,8 +8,8 @@ React Native provides a number of built-in [Core Components](intro-react-native-
 - [Basic Components](components-and-apis#basic-components)
 - [User Interface](components-and-apis#user-interface)
 - [List Views](components-and-apis#list-views)
-- [iOS-specific](components-and-apis#ios-components-and-apis)
 - [Android-specific](components-and-apis#android-components-and-apis)
+- [iOS-specific](components-and-apis#ios-components-and-apis)
 - [Others](components-and-apis#others)
 
 You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, please refer to [this guide about finding libraries](libraries#finding-libraries).
@@ -95,18 +95,6 @@ Unlike the more generic [`ScrollView`](./scrollview), the following list view co
   </div>
 </div>
 
-## iOS Components and APIs
-
-Many of the following components provide wrappers for commonly used UIKit classes.
-
-<div className="component-grid component-grid-border">
-  <div className="component">
-    <a href="./actionsheetios">
-      <h3>ActionSheetIOS</h3>
-      <p>API to display an iOS action sheet or share sheet.</p>
-    </a>
-  </div>
-</div>
 ## Android Components and APIs
 
 Many of the following components provide wrappers for commonly used Android classes.
@@ -116,7 +104,6 @@ Many of the following components provide wrappers for commonly used Android clas
     <a href="./backhandler">
       </a><h3><a href="./backhandler">BackHandler</a></h3>
       <p>Detect hardware button presses for back navigation.</p>
-    
   </div>
   <div className="component">
     <a href="./drawerlayoutandroid">
@@ -128,12 +115,24 @@ Many of the following components provide wrappers for commonly used Android clas
     <a href="./permissionsandroid">
       </a><h3><a href="./permissionsandroid">PermissionsAndroid</a></h3>
       <p>Provides access to the permissions model introduced in Android M.</p>
-    
   </div>
   <div className="component">
     <a href="./toastandroid">
       <h3>ToastAndroid</h3>
       <p>Create an Android Toast alert.</p>
+    </a>
+  </div>
+</div>
+
+## iOS Components and APIs
+
+Many of the following components provide wrappers for commonly used UIKit classes.
+
+<div className="component-grid component-grid-border">
+  <div className="component">
+    <a href="./actionsheetios">
+      <h3>ActionSheetIOS</h3>
+      <p>API to display an iOS action sheet or share sheet.</p>
     </a>
   </div>
 </div>

--- a/website/versioned_docs/version-0.63/components-and-apis.md
+++ b/website/versioned_docs/version-0.63/components-and-apis.md
@@ -8,8 +8,8 @@ React Native provides a number of built-in [Core Components](intro-react-native-
 - [Basic Components](components-and-apis#basic-components)
 - [User Interface](components-and-apis#user-interface)
 - [List Views](components-and-apis#list-views)
-- [iOS-specific](components-and-apis#ios-components-and-apis)
 - [Android-specific](components-and-apis#android-components-and-apis)
+- [iOS-specific](components-and-apis#ios-components-and-apis)
 - [Others](components-and-apis#others)
 
 You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If you're looking for a library that does something specific, please refer to [this guide about finding libraries](libraries#finding-libraries).
@@ -95,19 +95,6 @@ Unlike the more generic [`ScrollView`](./scrollview), the following list view co
   </div>
 </div>
 
-## iOS Components and APIs
-
-Many of the following components provide wrappers for commonly used UIKit classes.
-
-<div class="component-grid component-grid-border">
-  <div class="component">
-    <a href="./actionsheetios">
-      <h3>ActionSheetIOS</h3>
-      <p>API to display an iOS action sheet or share sheet.</p>
-    </a>
-  </div>
-</div>
-
 ## Android Components and APIs
 
 Many of the following components provide wrappers for commonly used Android classes.
@@ -135,6 +122,19 @@ Many of the following components provide wrappers for commonly used Android clas
     <a href="./toastandroid">
       <h3>ToastAndroid</h3>
       <p>Create an Android Toast alert.</p>
+    </a>
+  </div>
+</div>
+
+## iOS Components and APIs
+
+Many of the following components provide wrappers for commonly used UIKit classes.
+
+<div class="component-grid component-grid-border">
+  <div class="component">
+    <a href="./actionsheetios">
+      <h3>ActionSheetIOS</h3>
+      <p>API to display an iOS action sheet or share sheet.</p>
     </a>
   </div>
 </div>


### PR DESCRIPTION
This PR update the Core Components and APIs page and introduces the following changes:
* moves Android section above iOS to match the docs sidebar order
* fixes the Android header in `next` docs
* fixes two malformed links in `next` docs

### Preview of the issues before the changes
<img width="635" alt="Screenshot 2020-11-03 133808" src="https://user-images.githubusercontent.com/719641/97986340-dc88e580-1dd9-11eb-817c-470db39f0089.png">
