### PR TITLE
move SafeAreaView to iOS components, fix sidebar in next docs

### DIFF
--- a/docs/safeareaview.md
+++ b/docs/safeareaview.md
@@ -11,7 +11,7 @@ The purpose of `SafeAreaView` is to render content within the safe area boundari
 
 To use, wrap your top level view with a `SafeAreaView` with a `flex: 1` style applied to it. You may also want to use a background color that matches your application's design.
 
-```SnackPlayer name=SafeAreaView
+```SnackPlayer name=SafeAreaView&supportedPlatforms=ios
 import React from 'react';
 import { StyleSheet, Text, SafeAreaView } from 'react-native';
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -144,7 +144,7 @@
         "type": "category",
         "label": "iOS Components",
         "collapsed": false,
-        "items": ["inputaccessoryview"]
+        "items": ["inputaccessoryview", "safeareaview"]
       }
     ],
     "Props": [

--- a/website/versioned_docs/version-0.63/safeareaview.md
+++ b/website/versioned_docs/version-0.63/safeareaview.md
@@ -11,7 +11,7 @@ The purpose of `SafeAreaView` is to render content within the safe area boundari
 
 To use, wrap your top level view with a `SafeAreaView` with a `flex: 1` style applied to it. You may also want to use a background color that matches your application's design.
 
-```SnackPlayer name=SafeAreaView
+```SnackPlayer name=SafeAreaView&supportedPlatforms=ios
 import React from 'react';
 import { StyleSheet, Text, SafeAreaView } from 'react-native';
 

--- a/website/versioned_sidebars/version-0.63-sidebars.json
+++ b/website/versioned_sidebars/version-0.63-sidebars.json
@@ -481,10 +481,6 @@
         },
         {
           "type": "doc",
-          "id": "version-0.63/safeareaview"
-        },
-        {
-          "type": "doc",
           "id": "version-0.63/scrollview"
         },
         {
@@ -554,6 +550,10 @@
             {
               "type": "doc",
               "id": "version-0.63/maskedviewios"
+            },
+            {
+              "type": "doc",
+              "id": "version-0.63/safeareaview"
             }
           ]
         }


### PR DESCRIPTION
This PR moves the [`SafeAreaView`](https://reactnative.dev/docs/safeareaview) component to the iOS Components group, because it only have an effect on the some iOS devices. On Android it is treater as a regular `View` component. 

The component implementation was working like that from the beginning, but the page was probably missed during the sidebar groups refactor. We were able to spot this earlier and patch it in the V1 (Archive) `next` branch, but it looks like that after the V2 merge the entry in `next` sidebar was missing.

The change is applied to `next` and `0.63` docs and includes `supportedPlatforms` parameter for the Snack examples.