### PR TITLE
distinguish forks vs out-of-tree platforms

### DIFF
--- a/website/versioned_docs/version-0.63/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.63/out-of-tree-platforms.md
@@ -15,7 +15,7 @@ React Native is not only for Android and iOS - there are community-supported pro
 
 Other major forks:
 
-- [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - adaptation of React Native for Apple tvOS
 - [ReNative](https://github.com/pavjacko/renative) - a fork that supports more platforms out of the box
 
 ## Creating your own React Native platform

--- a/website/versioned_docs/version-0.63/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.63/out-of-tree-platforms.md
@@ -10,9 +10,13 @@ React Native is not only for Android and iOS - there are community-supported pro
 - [React Native Turbolinks](https://github.com/lazaronixon/react-native-turbolinks) - React Native adapter for building hybrid apps with Turbolinks 5.
 - [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
 - [React Native macOS](https://github.com/ptmt/react-native-macos) - An experimental React Native fork targeting macOS and Cocoa
-- [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program(微信小程序).
 - [Proton Native](https://github.com/kusti8/proton-native) - A wrapper for React Native, using Qt to target Linux, MacOS, and Windows.
+
+Other major forks:
+
+- [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
+- [ReNative](https://github.com/pavjacko/renative) - a fork that supports more platforms out of the box
 
 ## Creating your own React Native platform
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Coming from #1279 I think that react-native-tvos should be listed as a fork and not an out-of-tree platform.

I am also listing [ReNative](https://github.com/pavjacko/renative) which seems to target some more platforms. @pavjacko please comment if you think we need a better one-liner for ReNative.