### PR TITLE
[image-component] add docu for method parameters and return value

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -505,16 +505,17 @@ Does not work for static image resources.
 ### `prefetch()`
 
 ```jsx
-Image.prefetch(url);
+await Image.prefetch(url);
 ```
 
-Prefetches a remote image for later use by downloading it to the disk cache
+Prefetches a remote image for later use by downloading it to the disk cache. Returns a promise which resolves to a boolean.
 
 **Parameters:**
 
-| Name | Type   | Required | Description                       |
-| ---- | ------ | -------- | --------------------------------- |
-| url  | string | Yes      | The remote location of the image. |
+| Name       | Type     | Required | Description                                                         |
+| ---------- | -------- | -------- | ------------------------------------------------------------------- |
+| url        | string   | Yes      | The remote location of the image.                                   |
+| callback   | function | No       | [Android only] The function that will be called with the requestId. |
 
 ---
 
@@ -537,10 +538,10 @@ Abort prefetch request. Android-only.
 ### `queryCache()`
 
 ```jsx
-Image.queryCache(urls);
+await Image.queryCache(urls);
 ```
 
-Perform cache interrogation. Returns a mapping from URL to cache status, such as "disk" or "memory". If a requested URL is not in the mapping, it means it's not in the cache.
+Perform cache interrogation. Returns a promise which resolves to a mapping from URL to cache status, such as "disk" or "memory". If a requested URL is not in the mapping, it means it's not in the cache.
 
 **Parameters:**
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -512,10 +512,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name       | Type     | Required | Description                                                         |
-| ---------- | -------- | -------- | ------------------------------------------------------------------- |
-| url        | string   | Yes      | The remote location of the image.                                   |
-| callback   | function | No       | [Android only] The function that will be called with the requestId. |
+| Name       | Type                                 | Required | Description                                                         |
+| ---------- | ------------------------------------ | -------- | ------------------------------------------------------------------- |
+| url        | string                               | Yes      | The remote location of the image.                                   |
+| callback   | function <div class="label android"> | No       | The function that will be called with the requestId.                |
 
 ---
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -515,7 +515,7 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 | Name       | Type                                 | Required | Description                                                         |
 | ---------- | ------------------------------------ | -------- | ------------------------------------------------------------------- |
 | url        | string                               | Yes      | The remote location of the image.                                   |
-| callback   | function <div class="label android"> | No       | The function that will be called with the requestId.                |
+| callback   | function <div class="label android">Android</div> | No       | The function that will be called with the requestId.                |
 
 ---
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -541,7 +541,7 @@ Abort prefetch request. Android-only.
 await Image.queryCache(urls);
 ```
 
-Perform cache interrogation. Returns a promise which resolves to a mapping from URL to cache status, such as "disk" or "memory". If a requested URL is not in the mapping, it means it's not in the cache.
+Perform cache interrogation. Returns a promise which resolves to a mapping from URL to cache status, such as "disk", "memory" or "disk/memory". If a requested URL is not in the mapping, it means it's not in the cache.
 
 **Parameters:**
 


### PR DESCRIPTION
The Image component methods "prefetch" and "queryCache" are async functions.
I added this to the docs and added the android only callback of the prefetch method. 
(RN-source: https://github.com/facebook/react-native/blob/master/Libraries/Image/Image.android.js#L197)

The prefetch method returns a Promise<boolean> (that is always true but added it anyway).
Elements of the "queryCache" result can also be "disk/memory", 
(RN-source: https://github.com/facebook/react-native/blob/master/Libraries/Image/Image.android.js#L214)

I could add some example code to the queryCache method.
Not sure if that would be helpful.

