### PR TITLE
chore: simplify parseParams in Snacks plugin, comment out few logs

### DIFF
--- a/website/plugins/remark-snackplayer/package.json
+++ b/website/plugins/remark-snackplayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-snackplayer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Remark SnackPlayer Plugin",
   "main": "src/index.js",
   "author": "Darsh <darshkpatel@gmail.com>",

--- a/website/plugins/remark-snackplayer/src/index.js
+++ b/website/plugins/remark-snackplayer/src/index.js
@@ -3,78 +3,70 @@ const visit = require('unist-util-visit-parents');
 const u = require('unist-builder');
 const dedent = require('dedent');
 
-function parseParams(paramString) {
-  var params = {};
-
-  if (paramString) {
-    var pairs = paramString.split('&');
-    for (var i = 0; i < pairs.length; i++) {
-      var pair = pairs[i].split('=');
-      params[pair[0]] = pair[1];
-    }
-  }
+const parseParams = (paramString = '') => {
+  const params = Object.fromEntries(new URLSearchParams(paramString));
 
   if (!params.platform) {
     params.platform = 'web';
   }
 
   return params;
-}
+};
 
-function SnackPlayer() {
+const processNode = (node, parent) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      let params = parseParams(node.meta);
+
+      // Gather necessary Params
+      const name = params.name ? decodeURIComponent(params.name) : 'Example';
+      const description = params.description
+        ? decodeURIComponent(params.description)
+        : 'Example usage';
+      const sampleCode = node.value;
+      const encodedSampleCode = encodeURIComponent(sampleCode);
+      const platform = params.platform ? params.platform : 'web';
+      const supportedPlatforms = params.supportedPlatforms
+        ? params.supportedPlatforms
+        : 'ios,android,web';
+      const theme = params.theme ? params.theme : 'light';
+      const preview = params.preview ? params.preview : 'true';
+
+      // Generate Node for SnackPlayer
+      const snackPlayerDiv = u('html', {
+        value: dedent`
+          <div
+            class="snack-player"
+            data-snack-name="${name}"
+            data-snack-description="${description}"
+            data-snack-code="${encodedSampleCode}"
+            data-snack-platform="${platform}"
+            data-snack-supported-platforms="${supportedPlatforms}"
+            data-snack-theme="${theme}"
+            data-snack-preview="${preview}"
+          ></div>
+          `,
+      });
+
+      // Replace code block with SnackPlayer Node
+      const index = parent[0].children.indexOf(node);
+      parent[0].children.splice(index, 1, snackPlayerDiv);
+    } catch (e) {
+      return reject(e);
+    }
+    resolve();
+  });
+};
+
+const SnackPlayer = () => {
   return tree =>
     new Promise(async (resolve, reject) => {
       const nodesToProcess = [];
       // Parse all CodeBlocks
       visit(tree, 'code', (node, parent) => {
-        //Add SnackPlayer CodeBlocks to processing queue
+        // Add SnackPlayer CodeBlocks to processing queue
         if (node.lang == 'SnackPlayer') {
-          nodesToProcess.push(
-            new Promise(async (resolve, reject) => {
-              try {
-                let params = parseParams(node.meta);
-
-                // Gather necessary Params
-                const name = params.name
-                  ? decodeURIComponent(params.name)
-                  : 'Example';
-                const description = params.description
-                  ? decodeURIComponent(params.description)
-                  : 'Example usage';
-                const sampleCode = node.value;
-                const encodedSampleCode = encodeURIComponent(sampleCode);
-                const platform = params.platform ? params.platform : 'web';
-                const supportedPlatforms = params.supportedPlatforms
-                  ? params.supportedPlatforms
-                  : 'ios,android,web';
-                const theme = params.theme ? params.theme : 'light';
-                const preview = params.preview ? params.preview : 'true';
-
-                // Generate Node for SnackPlayer
-                const snackPlayerDiv = u('html', {
-                  value: dedent`
-                <div
-                  class="snack-player"
-                  data-snack-name="${name}"
-                  data-snack-description="${description}"
-                  data-snack-code="${encodedSampleCode}"
-                  data-snack-platform="${platform}"
-                  data-snack-supported-platforms="${supportedPlatforms}"
-                  data-snack-theme="${theme}"
-                  data-snack-preview="${preview}"
-                ></div>
-                `,
-                });
-
-                // Replace code block with SnackPlayer Node
-                const index = parent[0].children.indexOf(node);
-                parent[0].children.splice(index, 1, snackPlayerDiv);
-              } catch (e) {
-                return reject(e);
-              }
-              resolve();
-            })
-          );
+          nodesToProcess.push(processNode(node, parent));
         }
       });
 
@@ -83,6 +75,6 @@ function SnackPlayer() {
         .then(resolve())
         .catch(reject());
     });
-}
+};
 
 module.exports = SnackPlayer;

--- a/website/sitePlugin.js
+++ b/website/sitePlugin.js
@@ -15,20 +15,15 @@ async function generateSimpleHtmlFiles(outDir) {
   console.log('generateSimpleHtmlFiles', outDir);
 
   const pattern = path.join(outDir, '/**/index.html');
-  // console.log('pattern', pattern);
-
   const filePaths = (await glob(pattern)).filter(filePath => {
     return filePath !== path.join(outDir, '/index.html');
   });
-
-  // console.log('filePaths', filePaths);
 
   await Promise.all(
     filePaths.map(async filePath => {
       if ((await fs.stat(filePath)).isDirectory()) {
         return;
       }
-      // console.log(file);
       const filePathCopy = `${path.dirname(filePath)}.html`;
       if (await fs.pathExists(filePathCopy)) {
         // console.log(`Skipping ${filePathCopy}`);
@@ -40,8 +35,7 @@ async function generateSimpleHtmlFiles(outDir) {
   );
 }
 
-module.exports = function() {
-  console.log('site plugin');
+module.exports = () => {
   return {
     plugin: 'site-plugin',
     async postBuild(props) {

--- a/website/snackPlayerInitializer.js
+++ b/website/snackPlayerInitializer.js
@@ -20,7 +20,7 @@ export default (() => {
   };
 
   const initSnackPlayers = () => {
-    console.log('initSnackPlayers');
+    // console.log('initSnackPlayers');
     updateSnacksTheme();
     window.ExpoSnack && window.ExpoSnack.initialize();
   };
@@ -51,7 +51,7 @@ export default (() => {
   // Reset snack iframes on theme changes to sync theme
   // Hacky, but no better solution for now
   // see https://github.com/expo/snack-web/blob/master/src/client/components/EmbedCode.tsx#L60
-  function setupThemeSynchronization() {
+  const setupThemeSynchronization = () => {
     new MutationObserver((mutations, observer) => {
       if ('ExpoSnack' in window) {
         document.querySelectorAll('.snack-player').forEach(container => {
@@ -66,7 +66,7 @@ export default (() => {
       childList: false,
       subtree: false,
     });
-  }
+  };
 
   // Need to set the theme before the snack script (deferred) initialize
   updateSnacksTheme();
@@ -74,7 +74,7 @@ export default (() => {
 
   return {
     onRouteUpdate({location}) {
-      console.log('onRouteUpdate', {location});
+      // console.log('onRouteUpdate', {location});
 
       // TODO temporary, because onRouteUpdate fires before the new route renders...
       // see https://github.com/facebook/docusaurus/issues/3399#issuecomment-704401189

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9770,7 +9770,7 @@ remark-retext@^4.0.0:
     mdast-util-to-nlcst "^4.0.0"
 
 remark-snackplayer@./plugins/remark-snackplayer:
-  version "0.0.4"
+  version "0.0.5"
   dependencies:
     dedent "^0.7.0"
     unist-builder "^2.0.3"


### PR DESCRIPTION
This PR simplifies the `parseParams` method used in `remark-snackplayer` plugin, extracts node processing to separate function and comments out few console logs left from debugging here and there.