### PR TITLE
Recommend Node be installed via nvm-windows

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -6,7 +6,9 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node, JDK</h3>
 
-We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
+We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows. 
+
+If you want to be able to switch between different Node versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 
 React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using Chocolatey as well.
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -6,7 +6,9 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node, JDK</h3>
 
-We recommend installing Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows. This will make it easier to switch between different Node versions as your various projects require.
+We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows. 
+
+If you want to be able to switch between different Node versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 
 React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using [Chocolatey](https://chocolatey.org/), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -6,11 +6,11 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node, JDK</h3>
 
-We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows. 
+We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 
 If you want to be able to switch between different Node versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 
-React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using [Chocolatey](https://chocolatey.org/), a popular package manager for Windows.
+React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using Chocolatey as well.
 
 Open an Administrator Command Prompt (right click Command Prompt and select "Run as Administrator"), then run the following command:
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -6,9 +6,9 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node, JDK</h3>
 
-We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
+We recommend installing Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows. This will make it easy to switch between different Node versions as your various projects require.
 
-React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using Chocolatey as well.
+React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using [Chocolatey](https://chocolatey.org/), a popular package manager for Windows.
 
 Open an Administrator Command Prompt (right click Command Prompt and select "Run as Administrator"), then run the following command:
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node, JDK</h3>
 
-We recommend installing Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows. This will make it easy to switch between different Node versions as your various projects require.
+We recommend installing Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows. This will make it easier to switch between different Node versions as your various projects require.
 
 React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using [Chocolatey](https://chocolatey.org/), a popular package manager for Windows.
 


### PR DESCRIPTION
By installing Node via nvm-windows instead of directly, users will be able to easily switch between the multiple different versions of Node that their various projects may require. If users first install Node directly and then realize they need the version-switching functionality that nvm-windows provides, they will need to uninstall Node before installing nvm-windows and re-installing Node through there - a likely and avoidable hassle.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
