### PR TITLE
Add link to Wix blog post

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -136,8 +136,8 @@
     "icon": "wix.png",
     "linkAppStore": "https://itunes.apple.com/us/app/wix-com/id1099748482?mt=8",
     "linkPlayStore": "https://play.google.com/store/apps/details?id=com.wix.android",
-    "infoLink": "https://www.wix.com/wix-lp/wix-app",
-    "infoTitle": "Get the New Wix App!",
+    "infoLink": "https://medium.com/wix-engineering/react-native-at-wix-the-architecture-db6361764da6",
+    "infoTitle": "React Native at Wix — The Architecture",
     "pinned": true
   },
   {


### PR DESCRIPTION
Update blog link for Wix in the customer showcase to be: https://medium.com/wix-engineering/react-native-at-wix-the-architecture-db6361764da6

Built locally:
<img width="1197" alt="Screen Shot 2020-11-10 at 10 47 56 AM" src="https://user-images.githubusercontent.com/8042156/98717709-4a855d80-2342-11eb-903e-6532c9244ea6.png">
