### PR TITLE
add few package managers tabs, update few code blocks

### DIFF
--- a/docs/_integration-with-exisiting-apps-objc.md
+++ b/docs/_integration-with-exisiting-apps-objc.md
@@ -1,3 +1,5 @@
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 ## Key Concepts
 
 The keys to integrating React Native components into your iOS application are to:
@@ -37,9 +39,22 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
+
 ```shell
-$ yarn add react-native
+npm install react-native
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn add react-native
+```
+
+</TabItem>
+</Tabs>
 
 This will print a message similar to the following (scroll up in the yarn output to see it):
 
@@ -47,11 +62,24 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
+
 ```shell
-$ yarn add react@version_printed_above
+npm install react@version_printed_above
 ```
 
-Yarn has created a new `/node_modules` folder. This folder stores all the JavaScript dependencies required to build your project.
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn add react@version_printed_above
+```
+
+</TabItem>
+</Tabs>
+
+Installation process has created a new `/node_modules` folder. This folder stores all the JavaScript dependencies required to build your project.
 
 Add `node_modules/` to your `.gitignore` file.
 
@@ -62,7 +90,7 @@ Add `node_modules/` to your `.gitignore` file.
 We recommend installing CocoaPods using [Homebrew](http://brew.sh/).
 
 ```shell
-$ brew install cocoapods
+brew install cocoapods
 ```
 
 > It is technically possible not to use CocoaPods, but that would require manual library and linker additions that would overly complicate this process.
@@ -88,7 +116,7 @@ The list of supported `subspec`s is available in [`/node_modules/react-native/Re
 You can specify which `subspec`s your app will depend on in a `Podfile` file. The easiest way to create a `Podfile` is by running the CocoaPods `init` command in the `/ios` subfolder of your project:
 
 ```shell
-$ pod init
+pod init
 ```
 
 The `Podfile` will contain a boilerplate setup that you will tweak for your integration purposes.
@@ -325,9 +353,22 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
+
 ```shell
-$ npm start
+npm start
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn start
+```
+
+</TabItem>
+</Tabs>
 
 ##### 3. Run the app
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -3,6 +3,8 @@ id: debugging
 title: Debugging
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 ## Accessing the In-App Developer Menu
 
 You can access the developer menu by shaking your device or by selecting "Shake Gesture" inside the Hardware menu in the iOS Simulator. You can also use the `⌘D` keyboard shortcut when your app is running in the iOS Simulator, or `⌘M` when running in an Android emulator on Mac OS and `Ctrl+M` on Windows and Linux. Alternatively for Android, you can run the command `adb shell input keyevent 82` to open the dev menu (82 being the Menu key code).
@@ -87,13 +89,26 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-```
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
+
+```shell
 npm install -g react-devtools
 ```
 
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn global add react-devtools
+```
+
+</TabItem>
+</Tabs>
+
 Now run `react-devtools` from the terminal to launch the standalone DevTools app:
 
-```
+```shell
 react-devtools
 ```
 
@@ -153,8 +168,8 @@ You can view installation instructions [in the README](https://github.com/infini
 You can display the console logs for an iOS or Android app by using the following commands in a terminal while the app is running:
 
 ```shell
-$ npx react-native log-ios
-$ npx react-native log-android
+npx react-native log-ios
+npx react-native log-android
 ```
 
 You may also access these through `Debug → Open System Log...` in the iOS Simulator or by running `adb logcat *:S ReactNative:V ReactNativeJS:V` in a terminal while an Android app is running on a device or emulator.

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -6,6 +6,8 @@ authorURL: 'https://twitter.com/notbrent'
 description: This guide introduces React Native developers to finding, installing, and using third-party libraries in their apps.
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 React Native provides a set of built-in [Core Components and APIs](./components-and-apis) ready to use in your app. You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If the Core Components and APIs don't have what you are looking for, you may be able to find and install a library from the community to add the functionality to your app.
 
 ## Selecting a Package Manager
@@ -18,11 +20,24 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 ## Installing a Library
 
-To install a library in your project, navigate to your project directory in your terminal and run `npm install <name-of-the-library>`. Let's try this with `react-native-webview`:
+To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-```bash
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
+
+```shell
 npm install react-native-webview
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn add react-native-webview
+```
+
+</TabItem>
+</Tabs>
 
 The library that we installed includes native code, and we need to link to our app before we use it.
 

--- a/docs/linking-libraries-ios.md
+++ b/docs/linking-libraries-ios.md
@@ -19,8 +19,8 @@ _All the libraries we ship with React Native live on the `Libraries` folder in t
 
 Install a library with native dependencies:
 
-```bash
-$ npm install <library-with-native-dependencies> --save
+```shell
+npm install <library-with-native-dependencies> --save
 ```
 
 > **_Note:_** `--save` or `--save-dev` flag is very important for this step. React Native will link your libs based on `dependencies` and `devDependencies` in your `package.json` file.
@@ -29,8 +29,8 @@ $ npm install <library-with-native-dependencies> --save
 
 Link your native dependencies:
 
-```bash
-$ npx react-native link
+```shell
+npx react-native link
 ```
 
 Done! All libraries with native dependencies should be successfully linked to your iOS/Android project.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,13 +14,13 @@ The [Metro bundler][metro] runs on port 8081. If another process is already usin
 Run the following command to find the id for the process that is listening on port 8081:
 
 ```shell
-$ sudo lsof -i :8081
+sudo lsof -i :8081
 ```
 
 Then run the following to terminate the process:
 
 ```shell
-$ kill -9 <PID>
+kill -9 <PID>
 ```
 
 On Windows you can find the process using port 8081 using [Resource Monitor](https://stackoverflow.com/questions/48198/how-can-you-find-out-which-process-is-listening-on-a-port-on-windows) and stop it using Task Manager.
@@ -30,7 +30,7 @@ On Windows you can find the process using port 8081 using [Resource Monitor](htt
 You can configure the bundler to use a port other than 8081 by using the `port` parameter:
 
 ```shell
-$ npx react-native start --port=8088
+npx react-native start --port=8088
 ```
 
 You will also need to update your applications to load the JavaScript bundle from the new port. If running on device from Xcode, you can do this by updating occurrences of `8081` to your chosen port in the `node_modules/react-native/React/React.xcodeproj/project.pbxproj` file.
@@ -39,7 +39,7 @@ You will also need to update your applications to load the JavaScript bundle fro
 
 If you encounter an error such as `npm WARN locking Error: EACCES` while using the React Native CLI, try running the following:
 
-```
+```shell
 sudo chown -R $USER ~/.npm
 sudo chown -R $USER /usr/local/lib/node_modules
 ```
@@ -95,7 +95,7 @@ Try [downgrading your Gradle version to 1.2.3](https://github.com/facebook/react
 
 If you run into issues where running `npx react-native init` hangs in your system, try running it again in verbose mode and referring to [#2797](https://github.com/facebook/react-native/issues/2797) for common causes:
 
-```
+```shell
 npx react-native init --verbose
 ```
 
@@ -105,7 +105,7 @@ npx react-native init --verbose
 
 Issue caused by the number of directories [inotify](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers) (used by watchman on Linux) can monitor. To solve it, run this command in your terminal window
 
-```
+```shell
 echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 


### PR DESCRIPTION
This PR adds few missing NPM/Yarn tabs instead of static code blocks (related only to one package manager). The changeset also includes the small tweaks to other code blocks (correct syntax highlight - when no language is specified, default is `jsx`).

### Preview
<img width="824" alt="Screenshot 2020-11-12 105653" src="https://user-images.githubusercontent.com/719641/98925056-d67bbe80-24d5-11eb-8728-d230dada8bcd.png">
