### PR TITLE
Remove HAXM requirement

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -38,7 +38,6 @@ Setting up your development environment can be somewhat tedious if you're new to
 - `Android SDK`
 - `Android SDK Platform`
 - `Android Virtual Device`
-- If you are not already using Hyper-V: `Performance (Intel ® HAXM)` ([See here for AMD or Hyper-V](https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html))
 
 Then, click "Next" to install all of these components.
 
@@ -132,8 +131,6 @@ If you use Android Studio to open `./AwesomeProject/android`, you can see the li
 ![Android Studio AVD Manager](/docs/assets/GettingStartedAndroidStudioAVD.png)
 
 If you have recently installed Android Studio, you will likely need to [create a new AVD](https://developer.android.com/studio/run/managing-avds.html). Select "Create Virtual Device...", then pick any Phone from the list and click "Next", then select the **Q** API Level 29 image.
-
-> If you don't have HAXM installed, follow [these instructions](https://github.com/intel/haxm/wiki/Installation-Instructions-on-macOS) to set it up, then go back to the AVD Manager.
 
 Click "Next" then "Finish" to create your AVD. At this point you should be able to click on the green triangle button next to your AVD to launch it, then proceed to the next step.
 


### PR DESCRIPTION
Remove HAXM requirement because hard it's:
1. not needed
2. virtually impossible to install on newer macOS:

## Not needed

 Not used on OS X v10.10 Yosemite and higher:

"For OS X v10.10 Yosemite and higher, the Android Emulator uses the built-in Hypervisor.Framework by default, and falls back to using the Intel Hardware Accelerated Execution Manager (HAXM) if Hypervisor.Framework fails to initialize (such as when running on OS X v10.9 or earlier)."
https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html

Not supported on OS X v10.9 or earlier:

"Supported Operating Systems:
...
macOS* 10.12, 10.13, 10.14"
https://github.com/intel/haxm/releases/tag/v7.6.5"
(https://github.com/intel/haxm/releases/download/v7.6.5/haxm-macosx_v7_6_5.zip -> Release Notes.txt)

So by my deduction, it's not needed on any OS X / macOS then?

# Virtually impossible to install on newer macOS

"Since macOS Catalina 10.15 Beta 4, HAXM cannot be upgraded from Android SDK Tools directly because the authorization services upgrade in macOS. A workaround method is to download the release package from the official release page and run 'sudo ./silent_install.sh' manually after extraction."
https://android-developers.googleblog.com/2018/07/android-emulator-amd-processor-hyper-v.html

"Note: For users of macOS 10.13 High Sierra and higher: macOS 10.13 disables installation of kernel extensions by default. Because Intel HAXM is a kernel extension, you might need to manually enable its installation. For more details, see Known Issues."
https://developer.android.com/studio/run/emulator-acceleration#vm-mac

From above you can see because of new Apple security it's virtually impossible to install HAXM on newer macOS's  - particularly for new users who this guide is aimed at. I'm experienced and failed after hours trying to install manually on macOS 10.15, and I know what ```chmod +x``` means (which a lot of new React Native devs probably won't know.)

If we want to encourage more adoption of React Native over, say Flutter, I think getting started needs to be easy for new devs, so I think we should dropping the HAXM requirement in the documentation would be a good step.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
