### PR TITLE
avoid confusing clipboard copy behavior

### DIFF
--- a/website/versioned_docs/version-0.63/typescript.md
+++ b/website/versioned_docs/version-0.63/typescript.md
@@ -31,11 +31,13 @@ ignite new MyTSProject
 
 ## Adding TypeScript to an Existing Project
 
-1. Add TypeScript and the types for React Native and Jest to your project.
+1. Add TypeScript and the types for React Native and Jest to your project via `yarn` or `npm`.
 
 ```shell
 yarn add --dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
-# or for npm
+```
+
+```shell
 npm install --save-dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
 ```
 


### PR DESCRIPTION
On the React Native documentation website, code snippets have a `Copy` button in the top right corner.  So if the commands for `yarn` and `npm` are in the same code block, the user might click `Copy` and then paste both commands into their shell.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
