### PR TITLE
[Typescript] port back changes from `next`

### DIFF
--- a/website/versioned_docs/version-0.63/typescript.md
+++ b/website/versioned_docs/version-0.63/typescript.md
@@ -3,43 +3,88 @@ id: typescript
 title: Using TypeScript
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 [TypeScript][ts] is a language which extends JavaScript by adding type definitions, much like [Flow][flow]. While React Native is built in Flow, it supports both TypeScript _and_ Flow by default.
 
 ## Getting Started with TypeScript
 
-If you're starting a new project, there are a few different ways to get started. You can use the [TypeScript template][ts-template]:
+If you're starting a new project, there are a few different ways to get started.
+
+You can use the [TypeScript template][ts-template]:
 
 ```shell
 npx react-native init MyApp --template react-native-template-typescript
 ```
 
-> **Note** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your pc. Try uninstalling the cli and run the cli using `npx`.
+> **Note:** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your system. To fix the issue try uninstalling the CLI:
+>
+> - `npm uninstall -g react-native-cli` or `yarn global remove react-native-cli`
+>
+> and then run the `npx` command again.
 
 You can use [Expo][expo] which has two TypeScript templates:
+
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
 
 ```shell
 npm install -g expo-cli
 expo init MyTSProject
 ```
 
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn global add expo-cli
+expo init MyTSProject
+```
+
+</TabItem>
+</Tabs>
+
 Or you could use [Ignite][ignite], which also has a TypeScript template:
+
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
 
 ```shell
 npm install -g ignite-cli
 ignite new MyTSProject
 ```
 
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn global add ignite-cli
+ignite new MyTSProject
+```
+
+</TabItem>
+</Tabs>
+
 ## Adding TypeScript to an Existing Project
 
-1. Add TypeScript and the types for React Native and Jest to your project via `yarn` or `npm`.
+1. Add TypeScript and the types for React Native and Jest to your project.
+
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
 
 ```shell
-yarn add --dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
 ```
 
+</TabItem>
+<TabItem value="yarn">
+
 ```shell
-npm install --save-dev typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+yarn add -d typescript @types/jest @types/react @types/react-native @types/react-test-renderer
 ```
+
+</TabItem>
+</Tabs>
 
 2. Add a TypeScript config file. Create a `tsconfig.json` in the root of your project:
 
@@ -87,10 +132,9 @@ Out of the box, transforming your files to JavaScript works via the same [Babel 
 
 ## What does React Native + TypeScript look like
 
-You can provide an interface for a React Component's [Props]](props) and [State]](state) via `React.Component<Props, State>` which will provide type-checking and editor auto-completing when working with that component in JSX.
+You can provide an interface for a React Component's [Props](props) and [State](state) via `React.Component<Props, State>` which will provide type-checking and editor auto-completing when working with that component in JSX.
 
-```tsx
-// components/Hello.tsx
+```tsx title="components/Hello.tsx"
 import React from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
@@ -117,7 +161,6 @@ const Hello: React.FC<Props> = (props) => {
         Hello{' '}
         {props.name + getExclamationMarks(enthusiasmLevel || 0)}
       </Text>
-
       <View style={styles.buttons}>
         <View style={styles.button}>
           <Button
@@ -127,7 +170,6 @@ const Hello: React.FC<Props> = (props) => {
             color="red"
           />
         </View>
-
         <View style={styles.button}>
           <Button
             title="+"
@@ -141,7 +183,6 @@ const Hello: React.FC<Props> = (props) => {
   );
 };
 
-// styles
 const styles = StyleSheet.create({
   root: {
     alignItems: 'center',
@@ -181,7 +222,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 1. Edit your `tsconfig.json` to have your [custom path mappings][path-map]. Set anything in the root of `src` to be available with no preceding path reference, and allow any test file to be accessed by using `tests/File.tsx`:
 
-```diff
+```diff {2-7}
     "target": "esnext",
 +     "baseUrl": ".",
 +     "paths": {
@@ -192,17 +233,28 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
     }
 ```
 
-2. Configure the Babel side done by adding a new dependency, [`babel-plugin-module-resolver`][bpmr]:
+2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
+
+<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
 
 ```shell
-yarn add --dev babel-plugin-module-resolver
-# or
 npm install --save-dev babel-plugin-module-resolver
 ```
 
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn add --dev babel-plugin-module-resolver
+```
+
+</TabItem>
+</Tabs>
+
 3. Finally, configure your `babel.config.js` (note that the syntax for your `babel.config.js` is different from your `tsconfig.json`):
 
-```diff
+```diff {3-13}
 {
   plugins: [
 +    [
@@ -227,9 +279,9 @@ npm install --save-dev babel-plugin-module-resolver
 [babel]: /docs/javascript-environment#javascript-syntax-transformers
 [babel-7-caveats]: https://babeljs.io/docs/en/next/babel-plugin-transform-typescript
 [cheat]: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#reacttypescript-cheatsheets
-[ts-handbook]: http://www.typescriptlang.org/docs/home.html
+[ts-handbook]: https://www.typescriptlang.org/docs/handbook/intro.html
 [path-map]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping
 [bpmr]: https://github.com/tleunen/babel-plugin-module-resolver
 [expo]: https://expo.io
-[ignite]: https://infinite.red/ignite
+[ignite]: https://github.com/infinitered/ignite
 [tsplay]: https://www.typescriptlang.org/play/?strictNullChecks=false&esModuleInterop=true&jsx=3#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4BYAKFEljgG8AhAVxhggDsAaOAZRgCeAGyS8AFkiQweAFSQAPaXABqwJAHcAvnGy4CRdDAC0HFDGAA3JGSpUFteMA4wkUTOiRwACjjABnBio4YLhTECQALjg-GCgnAHMKShC4JGcxZj9gFD8QABkkKyEAfiiOZhAAI1ckzVtKNE4YuAAJJCEhCCjkQwA6ADEAYQAeHwh-AD44AF44AAowXz8AShmp+iCQxo5mgG00mAysnPzC9p4-KQBRdMzs3IKigF0ZxGIYXszRGDMkBaXegcjvdTkVlklNsFts1OABJDhoIjhZyvOaraZTS4wG6HO4nR7tOZzIF4h5nIRwAA+lLgAAZVgBqOAARnBkLg0PgnAAIkhEUhkfBZmi1tFrrdjmSikSSZLQe0qTT6XAjCy2ZR2Zy4PFrvI0EIUCAzMBOABZFBQADWAWF5RAgzEFr8ZQq1Sg6KmAEEoFAUAI5naHU64EzWb0AFYQJxzfAAQnw6pSRBgzCgHHm7JSw1UGmighE03oMWESD8vRwEBgmgmmZCwzkijzJcLxZEZfiRCkCWrtZSwTaHQg9HwBDqyT7E-oi3GZbCniZOuxeoNRvMZot1uJEpBBIp1LpyzHE+CwwA9A2YDWNeOJ9m1OomwWi-nS71Kqx2Dsezfjyecw-WyQFsXzLd82E4b9fyzFhwI4XsoPMGACwAIiMZD4N-TgfFLPxCx5PkkQOI8oIndA0Bw4BKmAIRgEEPIUGqIRpmQgATAiBQOdCfxIqEIE6KBmKIFiuJ4uBTyvUSz3-K8MLrf9HyA58S1Aj8IIknjhhgz9ZInRCUIZETRJCLCiD8XD6DhBFCOcYijLgMiKKomi6IY9pmKcflBUMuzGn45jKiEZgkG8qDxJ0uApPvdTb1PaT4MijRorgRMQjHMcqFPU8FL8KgtUAm0+BfcRJA+flfjmDYfwrGAokq38UBo+IOFhFwQGdAhyOcVx8C4eCGuAJreHaTAonwTqXCgHr2U0XqfzAz92rqidMBEeRuWAIgMBNDhRpwdQpu4kIQCcNoBrEGq4AAdlpWb6sa5rWva-AYmTNAxAOu6Bo4IahBGjqDm627j0qaA2KgAB1YAWMOKIAFYgeCGb2XmzhavglaFCiZkEb7MAUBYliEmUVxzDQBqohu6acY7EqEjRw7eP40aAGIAE52Y+49ME4GBwaQM6LvwEGhBYznEdmzRwSAA


### PR DESCRIPTION
Refs #2319

This PR ports back changes to the Typescript page from `next` branch to to the `0.63`. The changes mainly includes migration to Tabs component and corrected links.
