### PR TITLE
cleanup after workspace introduction, fix remark-snackplayer tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 node_modules
 .DS_Store
 .idea
-lib/core/metadata.js
-lib/core/MetadataBlog.js
-website/build/
-website/yarn.lock
-website/node_modules
 .nvmrc
 .docusaurus
-website/scripts/sync-api-docs/generatedComponentApiDocs.js
-website/scripts/sync-api-docs/extracted.json
+
+website/build/
+
+sync-api-docs/generatedComponentApiDocs.js
+sync-api-docs/extracted.json

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -86,11 +86,11 @@ Schedules an animation to happen on the next layout.
 
 #### Parameters:
 
-| Name              | Type     | Required | Description                         |
-| ----------------- | -------- | -------- | ----------------------------------- |
-| config            | object   | Yes      | See config description below.       |
-| onAnimationDidEnd | function | No       | Called when the animation finished. |
-| onAnimationDidFail| function | No       | Called when the animation failed.   |
+| Name               | Type     | Required | Description                         |
+| ------------------ | -------- | -------- | ----------------------------------- |
+| config             | object   | Yes      | See config description below.       |
+| onAnimationDidEnd  | function | No       | Called when the animation finished. |
+| onAnimationDidFail | function | No       | Called when the animation failed.   |
 
 The `config` parameter is an object with the keys below. [`create`](layoutanimation.md#create) returns a valid object for `config`, and the [`Presets`](layoutanimation.md#presets) objects can also all be passed as the `config`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,22 @@
 {
   "private": true,
+  "workspaces": [
+    "website",
+    "plugins/*",
+    "sync-api-docs"
+  ],
   "scripts": {
+    "postinstall": "yarn update-lock",
     "update-lock": "npx yarn-deduplicate"
   },
-  "workspaces": ["website", "plugins/*", "sync-api-docs"]
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  },
+  "devDependencies": {
+    "husky": "^4.2.5",
+    "prettier": "1.16.4",
+    "pretty-quick": "^1.11.1"
+  }
 }

--- a/plugins/remark-snackplayer/README.md
+++ b/plugins/remark-snackplayer/README.md
@@ -1,20 +1,6 @@
-<h1 align="center"> Remark SnackPlayer </h1>
+<h1 align="center">Remark SnackPlayer</h1>
 
-<p align="center"> 
-Remark plugin to embed <a href="https://snack.expo.io/">Expo Snack's</a> using Code Blocks 
-</p>
-
-## Installation
-
-```shell
-yarn add remark-snackplayer
-```
-
-Add Snack Player embedded script to your website:
-
-```html
-<script async src="https://snack.expo.io/embed.js"></script>
-```
+<p align="center">Remark plugin to embed <a href="https://snack.expo.io/">Expo Snack's</a> using Code Blocks</p>
 
 ## Usage
 
@@ -28,20 +14,18 @@ import React from 'react';
 import { Text, View } from 'react-native';
 
 const YourApp = () => {
-    return (
+  return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-        <Text>
-        Try editing me! 🎉
-        </Text>
+      <Text>Try editing me! 🎉</Text>
     </View>
-    );
+  );
 }
 
 export default YourApp;
 ```
 ````
 
-The above code snippet would look like this on your page
+The above code snippet would look like this:
 
 <img width="783" alt="Screenshot 2020-10-03 at 1 11 19 AM" src="https://user-images.githubusercontent.com/11258286/94963203-67de3500-0515-11eb-974a-a2289c0bfdc8.png">
 
@@ -59,8 +43,3 @@ The above code snippet would look like this on your page
 ## Styling
 
 To style the Snack Player wrapper you can use `.snack-player` class.
-
-## To Do
-
-- Support Passing Configuration Parameters
-- Write Comprehensive tests

--- a/plugins/remark-snackplayer/package.json
+++ b/plugins/remark-snackplayer/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "remark-snackplayer",
+  "name": "@react-native-website/remark-snackplayer",
   "version": "0.0.5",
+  "private": true,
   "description": "Remark SnackPlayer Plugin",
   "main": "src/index.js",
-  "author": "Darsh <darshkpatel@gmail.com>",
   "keywords": [
     "remark",
     "react-native",
@@ -15,7 +15,8 @@
     "src"
   ],
   "scripts": {
-    "test": "node_modules/.bin/tape tests/index.js"
+    "prettier": "prettier --write \"{src/**/*.js,tests/**/*.js}\"",
+    "test": "yarn tape tests/index.js"
   },
   "dependencies": {
     "dedent": "^0.7.0",

--- a/plugins/remark-snackplayer/tests/index.js
+++ b/plugins/remark-snackplayer/tests/index.js
@@ -4,20 +4,27 @@ const test = require('tape');
 const remark = require('remark');
 const snackplayer = require('../');
 
-function read(name) {
-  return fs.readFileSync(path.join(__dirname, name), 'utf8');
-}
+const read = name => fs.readFileSync(path.join(__dirname, name), 'utf8');
+const normalizeLineEndings = str => str.replace(/\r\n/g, '\n');
 
 test('remark-snackplayer', async t => {
   const processor = remark().use(snackplayer);
 
   processor.process(read('markdown/test1.md'), (err, file) => {
     if (err) t.fail('Failed to process markdown/test1.md');
-    t.equal(String(file), read('output/output1.html'), 'With 1 Code Block');
+    t.equal(
+      normalizeLineEndings(String(file)),
+      normalizeLineEndings(read('output/output1.html')),
+      'With 1 Code Block'
+    );
   });
 
   processor.process(read('markdown/test2.md'), (err, file) => {
     if (err) t.fail('Failed to process markdown/test2.md');
-    t.equal(String(file), read('output/output2.html'), 'With 2 Code Blocks');
+    t.equal(
+      normalizeLineEndings(String(file)),
+      normalizeLineEndings(read('output/output2.html')),
+      'With 2 Code Blocks'
+    );
   });
 });

--- a/sync-api-docs/package.json
+++ b/sync-api-docs/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "prettier": "prettier --write \"**/*.js\"",
     "sync": "node sync-api-docs ../../react-native"
   },
   "devDependencies": {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -34,7 +34,7 @@ module.exports = {
             'https://github.com/facebook/react-native-website/blob/master/website/',
           path: '../docs',
           sidebarPath: require.resolve('./sidebars.json'),
-          remarkPlugins: [require('../plugins/remark-snackplayer')],
+          remarkPlugins: [require('@react-native-website/remark-snackplayer')],
         },
         blog: {
           path: 'blog',

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
+    "clean": "docusaurus clean",
     "publish-gh-pages": "yarn deploy",
     "ci-check": "yarn prettier:diff && node image-check.js",
     "format:source": "prettier --write \"{core/**/*.js,src/**/*.js,static/js/**/*.js}\"",
@@ -27,28 +28,19 @@
     "lint": "cd ../ && alex .",
     "lintv": "cd ../ && alex"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged"
-    }
-  },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.66",
     "@docusaurus/preset-classic": "2.0.0-alpha.66",
     "docusaurus-plugin-sass": "^0.1.11",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "react-github-btn": "^1.2.0",
-    "remark-snackplayer": "./plugins/remark-snackplayer"
+    "react-github-btn": "^1.2.0"
   },
   "devDependencies": {
     "alex": "^9.0.1",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",
-    "husky": "^4.2.5",
-    "path": "^0.12.7",
-    "prettier": "1.16.4",
-    "pretty-quick": "^1.11.1"
+    "path": "^0.12.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,109 +2,109 @@
 # yarn lockfile v1
 
 
-"@algolia/cache-browser-local-storage@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.6.0.tgz#79d825280f96ac5fc61df138a38aab3b658f3b65"
-  integrity sha512-3ObeNwZ5gfDvKPp9NXdtbBrCtz/yR1oyDu/AReG73Oanua3y30Y11p7VQzzpLe2R/gDCLOGdRgr17h11lGy1Hg==
+"@algolia/cache-browser-local-storage@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.7.0.tgz#e1770b6ce6a810e326bdf2c830feec7c6a6d3c14"
+  integrity sha512-qkGCcvyj/h/OCvKM/dZS7g8zwExxdx07r4Zb/vw18TAgTc4XHHiZIpEJt1u27iiYSxoXM0+prVGc/kMWjvoA6g==
   dependencies:
-    "@algolia/cache-common" "4.6.0"
+    "@algolia/cache-common" "4.7.0"
 
-"@algolia/cache-common@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.6.0.tgz#f67da65766a004368db0833caf4890fe450d8f0a"
-  integrity sha512-mEedrPb2O3WwtiIHggFoIhTbHVCMNikxMiiN9kqmwZkdDfClfxm435OUGZfAl67rBZfc0DNs/jmPM2mUoefM9A==
+"@algolia/cache-common@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.7.0.tgz#6622d59fa419be1c0a987f95165fd8ad28739411"
+  integrity sha512-b/4tmdDedD7r+ZRy0t4iKRMsyApz5mJUWAlxLjQ36sQz5R54H3yTs/zw3JwMAAZ2yaOsP+5gdaqPFf20m+O0Cg==
 
-"@algolia/cache-in-memory@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.6.0.tgz#f29bf505b52261d0fc29942a58b16c89527db16c"
-  integrity sha512-J7ayGokVWEFkuLxzgrIsPS4k1/ZndyGVpG/qPrG9RHVrs7ZogEhUSY1tbEyUlW3mGy7diIh+/52dtohDL/nbGQ==
+"@algolia/cache-in-memory@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.7.0.tgz#278483f80deef36f154673a639be7283c2d7af5b"
+  integrity sha512-cMGKB7xQhn7kRHp7MPuBgZXMMgIYLJRgPz8c0497hfe3PBp9ySIi3UI36zABuEDkWOiGC/LrHPpc5fkxkOny1Q==
   dependencies:
-    "@algolia/cache-common" "4.6.0"
+    "@algolia/cache-common" "4.7.0"
 
-"@algolia/client-account@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.6.0.tgz#bf68f8961b76b520d02bd46e08ddd0a949b73bb9"
-  integrity sha512-0t2yU6wNBNJgAmrARHrM1llhANyPT4Q/1wu6yEzv2WfPXlfsHwMhtKYNti4/k8eswwUt9wAri10WFV6TJI48rg==
+"@algolia/client-account@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.7.0.tgz#1925d3dc8fb7e2333ff9b8d0e7fc9ebc0370e744"
+  integrity sha512-exO+abGUBhz05YeFGxJep09coXWCzE/wxir6CyiiseQshAWSgWEjYatKIsBspMBFlE702eWVM+wlRddCuE57Ng==
   dependencies:
-    "@algolia/client-common" "4.6.0"
-    "@algolia/client-search" "4.6.0"
-    "@algolia/transporter" "4.6.0"
+    "@algolia/client-common" "4.7.0"
+    "@algolia/client-search" "4.7.0"
+    "@algolia/transporter" "4.7.0"
 
-"@algolia/client-analytics@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.6.0.tgz#ee180fe1793f4989cff7500e14a543cbfcb1b3a7"
-  integrity sha512-7yfn9pabA21Uw2iZjW1MNN4IJUT5y/YSg+ZJ+3HqBB6SgzOOqY0N3fATsPeGuN9EqSfVnqvnIrJMS8mI0b5FzQ==
+"@algolia/client-analytics@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.7.0.tgz#19d5381c59ec53152084a9c2fa338e4c7f663094"
+  integrity sha512-aVGnG6jsTKsX3n2Q22WqUBUpfkF20ttGNrdRzS8e9ng48da37PLFcAzsz+Nm2g5+2XaEEKm5KN5tBAIRGDuP5Q==
   dependencies:
-    "@algolia/client-common" "4.6.0"
-    "@algolia/client-search" "4.6.0"
-    "@algolia/requester-common" "4.6.0"
-    "@algolia/transporter" "4.6.0"
+    "@algolia/client-common" "4.7.0"
+    "@algolia/client-search" "4.7.0"
+    "@algolia/requester-common" "4.7.0"
+    "@algolia/transporter" "4.7.0"
 
-"@algolia/client-common@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.6.0.tgz#a2cd94cce0026335e89ac508087425dfce20dd07"
-  integrity sha512-60jK0LK5H+6q6HyyMyoBBD0fIs8zZzJt6BiyJGQG90o3gUV/SnjiNxO9Bx0RRlqdkE5s0OYFu1L7P9Y5TX7oAw==
+"@algolia/client-common@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.7.0.tgz#1e9235f54a7845f5dfc74cd753a5bc497478e4e7"
+  integrity sha512-0DR3Brl72gr/WpGdlDqX4qSmlmKADBmOEceH0bvmET6IHnCqkH+mL8nifesp+E4u1g6Jqv3rd5H9oqN7MixpDQ==
   dependencies:
-    "@algolia/requester-common" "4.6.0"
-    "@algolia/transporter" "4.6.0"
+    "@algolia/requester-common" "4.7.0"
+    "@algolia/transporter" "4.7.0"
 
-"@algolia/client-recommendation@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.6.0.tgz#22d0c9db79873f96ac41c1f66e3ab654b1a9b73d"
-  integrity sha512-j+Yb1z5QeIRDCCO+9hS9oZS3KNqRogPHDbJJsLTt6pkrs4CG2UVLVV67M977B1nzJ9OzaEki3VbpGQhRhPGNfQ==
+"@algolia/client-recommendation@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.7.0.tgz#67c0ddbe3039b9fbf2e1a71ab114ae345340a0d9"
+  integrity sha512-gmRX8ykToLZNdeDZG5tIiFKx9uk7fZZ1YC2OjFvapPPbljO7dsmNzbFHZ1AT8GsKZMcjTZh5Azlm5vCB9FzAYA==
   dependencies:
-    "@algolia/client-common" "4.6.0"
-    "@algolia/requester-common" "4.6.0"
-    "@algolia/transporter" "4.6.0"
+    "@algolia/client-common" "4.7.0"
+    "@algolia/requester-common" "4.7.0"
+    "@algolia/transporter" "4.7.0"
 
-"@algolia/client-search@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.6.0.tgz#5c73de6be352eeb35332cb5284b7c4b9e2f88ba7"
-  integrity sha512-+qA1NA88YnXvuCKifegfgts1RQs8IzcwccQqyurz8ins4hypZL1tXN2BkrOqqDIgvYIrUvFyhv+gLO6U9PpDUA==
+"@algolia/client-search@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.7.0.tgz#234e6c0ed66643d79f819152a29759b6557dbfb1"
+  integrity sha512-AzM9+x4zJN4pGi5Q55WF3y1UJi4iAAikxVUUG1ekQMFAIopaorlW66EetctHv4fSahPqbx5+42K2KTIXdrIACw==
   dependencies:
-    "@algolia/client-common" "4.6.0"
-    "@algolia/requester-common" "4.6.0"
-    "@algolia/transporter" "4.6.0"
+    "@algolia/client-common" "4.7.0"
+    "@algolia/requester-common" "4.7.0"
+    "@algolia/transporter" "4.7.0"
 
-"@algolia/logger-common@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.6.0.tgz#966591b903eae60201d12c4126fbf278303e2d2a"
-  integrity sha512-F+0HTGSQzJfWsX/cJq2l4eG2Y5JA6pqZ0YETyo5XJhZX4JaDrGszVKuOqp8kovZF/Ifebywxb8JdCiSUskmbig==
+"@algolia/logger-common@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.7.0.tgz#b3d1d9671296acf63f58b846918de26ba2c6875f"
+  integrity sha512-L49C/2OrMMZaiA0VDponA8Mz7lAciv5tNzQKXiRPgRDYf666FgSWb7uqy193FBleKvYfdgUkooJHn6hQC2fc7Q==
 
-"@algolia/logger-console@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.6.0.tgz#7e1811aa22e6aad22ef7946732f9a110b46c4eb0"
-  integrity sha512-ers7OhfU6qBQl6s7MOe5gNUkcpa7LGrhEzDWnD0cUwLSd5BvWt7zEN69O2CZVbvAUZYlZ5zJTzMMa49s0VXrKQ==
+"@algolia/logger-console@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.7.0.tgz#b2b31c778f1619d28b9a024704f9e5c2bb1be711"
+  integrity sha512-sBUKM83xIY5GZzu4xmrwn4whZT6N4eOvY19nlHucywIQhGZI0AC0Bb/sXsaMzp5H7EJfntVH1hvvS9tGs1drIw==
   dependencies:
-    "@algolia/logger-common" "4.6.0"
+    "@algolia/logger-common" "4.7.0"
 
-"@algolia/requester-browser-xhr@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.6.0.tgz#51870239c98467d5bf0a7071523111c120b560c1"
-  integrity sha512-ugrJT25VUkoKrl5vJVFclMdogbhTiDZ38Gss4xfTiSsP/SGE/0ei5VEOMEcj/bjkurJjPky1HfJZ3ykJhIsfCA==
+"@algolia/requester-browser-xhr@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.7.0.tgz#96d92583d2c294ac2dfb484856b155bf950dd247"
+  integrity sha512-sACLoGjYRIfgO/w916T2gWhaYQDEBWA6m6b/Wr0IHt1UBRCmKz3K2gbN8bvBdrbzWZp2qDXCyaIeZ7RK6mtJIg==
   dependencies:
-    "@algolia/requester-common" "4.6.0"
+    "@algolia/requester-common" "4.7.0"
 
-"@algolia/requester-common@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.6.0.tgz#0990f3b21414a3ec5a3a468f33f2b9bff4489222"
-  integrity sha512-DJ5iIGBGrRudimaaFnpBFM19pv8SsXiMYuukn9q1GgQh2mPPBCBBJiezKc7+OzE1UyCVrAFBpR/hrJnflZnRdQ==
+"@algolia/requester-common@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.7.0.tgz#179189bd40d60654f22dec8b607233b12c9a62be"
+  integrity sha512-vmbzqj+eU/t28H274NCrcExYcTiS870iq1oe71cTKEwvKzBuMY8quFcpGAxkgQVmOtcTzoXqsNBofODeJcAg1g==
 
-"@algolia/requester-node-http@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.6.0.tgz#a2e6c981507faf2f309f06fda2503f591e3a768d"
-  integrity sha512-MPZK3oZz0jSBsqrGiPxv7LOKMUNknlaRNyRDy0v/ASIYG+GvLhGTdEzG5Eyw5tgSvBr8CWrWM5tDC31EH40Ndw==
+"@algolia/requester-node-http@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.7.0.tgz#3bd0fd6c8ee4ba73c2a414545c57e0b69b5633d9"
+  integrity sha512-3SXjpNSo6grpSpmKsSOIhhTflWcrPa60+foExsXxt7eM5KD5WlWop6EkSt3lbfOH+71bpNciXeylFXakJzanRg==
   dependencies:
-    "@algolia/requester-common" "4.6.0"
+    "@algolia/requester-common" "4.7.0"
 
-"@algolia/transporter@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.6.0.tgz#741300a1cd7efd175fc660c37afee4d9903621e5"
-  integrity sha512-xp+HI8sB8gLCvP00scaOVPQEk5H7nboWUxrwLKyVUvtUO4o003bOfFPsH86NRyu5Dv7fzX9b8EH3rVxcLOhjqg==
+"@algolia/transporter@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.7.0.tgz#dc2ec996b9ca0a2cf960cea36c1921fd357c6915"
+  integrity sha512-gp65yvDBZcRdriUzLuMz8PUGg28CSYevrRc0i2FQx63OJ/ERmbp0aRZrZeDPxZ56E5J1txNeh02yyXpp0CW56A==
   dependencies:
-    "@algolia/cache-common" "4.6.0"
-    "@algolia/logger-common" "4.6.0"
-    "@algolia/requester-common" "4.6.0"
+    "@algolia/cache-common" "4.7.0"
+    "@algolia/logger-common" "4.7.0"
+    "@algolia/requester-common" "4.7.0"
 
 "@babel/code-frame@7.8.3":
   version "7.8.3"
@@ -2106,24 +2106,24 @@ algoliasearch-helper@^3.1.1:
     events "^1.1.1"
 
 algoliasearch@^4.0.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.6.0.tgz#ad96ecd6e4aa2f1187d5a6ade9f914b080001e28"
-  integrity sha512-f4QVfUYnWIGZwOupZh0RAqW8zEfpZAcZG6ZT0p6wDMztEyKBrjjbTXBk9p9uEaJqoIhFUm6TtApOxodTdHbqvw==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.7.0.tgz#5be53ad7588b4ec1ec6504fc61e9adacea9f2461"
+  integrity sha512-QxPtWy2EgU74S0OCO5GsSE2OlqEugJqsR8vo2fnBMl+W/VNGB/rRYxBjf3OsR+UYJ8mGYwByyCHafkknBX3cow==
   dependencies:
-    "@algolia/cache-browser-local-storage" "4.6.0"
-    "@algolia/cache-common" "4.6.0"
-    "@algolia/cache-in-memory" "4.6.0"
-    "@algolia/client-account" "4.6.0"
-    "@algolia/client-analytics" "4.6.0"
-    "@algolia/client-common" "4.6.0"
-    "@algolia/client-recommendation" "4.6.0"
-    "@algolia/client-search" "4.6.0"
-    "@algolia/logger-common" "4.6.0"
-    "@algolia/logger-console" "4.6.0"
-    "@algolia/requester-browser-xhr" "4.6.0"
-    "@algolia/requester-common" "4.6.0"
-    "@algolia/requester-node-http" "4.6.0"
-    "@algolia/transporter" "4.6.0"
+    "@algolia/cache-browser-local-storage" "4.7.0"
+    "@algolia/cache-common" "4.7.0"
+    "@algolia/cache-in-memory" "4.7.0"
+    "@algolia/client-account" "4.7.0"
+    "@algolia/client-analytics" "4.7.0"
+    "@algolia/client-common" "4.7.0"
+    "@algolia/client-recommendation" "4.7.0"
+    "@algolia/client-search" "4.7.0"
+    "@algolia/logger-common" "4.7.0"
+    "@algolia/logger-console" "4.7.0"
+    "@algolia/requester-browser-xhr" "4.7.0"
+    "@algolia/requester-common" "4.7.0"
+    "@algolia/requester-node-http" "4.7.0"
+    "@algolia/transporter" "4.7.0"
 
 alphanum-sort@^1.0.0:
   version "1.0.2"
@@ -9883,14 +9883,6 @@ remark-retext@^4.0.0:
   integrity sha512-cYCchalpf25bTtfXF24ribYvqytPKq0TiEhqQDBHvVEEsApebwruPWP1cTcvTFBidmpXyqzycm+y8ng7Kmvc8Q==
   dependencies:
     mdast-util-to-nlcst "^4.0.0"
-
-remark-snackplayer@./plugins/remark-snackplayer:
-  version "0.0.5"
-  dependencies:
-    dedent "^0.7.0"
-    object.fromentries "^2.0.2"
-    unist-builder "^2.0.3"
-    unist-util-visit-parents "^3.1.0"
 
 remark-squeeze-paragraphs@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR preforms cleanup after the workspace introduction and includes the following changes:
* `husky` and `prettier` has been moved to workspace dependencies, Prettier command has been added to the new workspaces and code has been formatted
* `remark-snackplayer` has been extracted to external package, than copied-in back during the migration process, so in theory we are using fork of [published in NPM package](https://www.npmjs.com/package/remark-snackplayer), to avoid confusion package has been set to private, name has been changed to `@react-native-website/remark-snackplayer` and installation section has been removed from readme file
* `@react-native-website/remark-snackplayer` tests fixed (and made cross-platform)
  <img width="447" alt="Screenshot 2020-11-17 011431" src="https://user-images.githubusercontent.com/719641/99323331-4e4d3e80-2872-11eb-902e-de8507ffd507.png">
* there is no need for `@react-native-website/remark-snackplayer` in the `website` dependencies
  * > Please note the fact that /workspace-a is aliased as /node_modules/workspace-a via a symlink. That’s the trick that allows you to require the package as if it was a normal one! 
* updated `.gitignore`
* updated website peer dependency `algoliasearch`