### PR TITLE
tweak footer design to fit better four columns

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -677,6 +677,8 @@ div[class^="tableOfContents"] {
 
   .footer__item {
     font-size: 15px;
+    padding: 8px 0 0;
+    min-height: 30px;
   }
 
   .footer__title {
@@ -688,7 +690,13 @@ div[class^="tableOfContents"] {
   }
 
   .footer__col {
-    margin: 4px 0 12px 4%;
+    margin: 4px 0 12px 2%;
+    padding-left: 0 !important;
+  }
+
+  .footer__link-item {
+    line-height: 1.44;
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
This small PR tweaks a bit the footer design to fit better the four columns introduced in #2329. Changes includes better spacing and improved line height (because there are now multi line links).

### Preview
<img width="707" alt="Screenshot 2020-11-17 124320" src="https://user-images.githubusercontent.com/719641/99386278-7ff5f200-28d2-11eb-97b6-085aa4df9acd.png">
