### PR TITLE
update Readme to match the workspace changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ If you are looking for the source code of the [React Native Archive website](htt
 ### Installation
 
 1.  `cd react-native-website` to go into the project root.
+1.  `yarn` to install the website's workspace dependencies.
 1.  `cd website` to go into the website portion of the project.
-1.  `yarn` or `npm install` to install the website's npm dependencies.
 
 ### Running locally
 
-1.  `yarn start` or `npm start` to start the development server _(powered by [Docusaurus](https://v2.docusaurus.io))_.
+1.  `yarn start` to start the development server _(powered by [Docusaurus](https://v2.docusaurus.io))_.
 1.  `open http://localhost:3000/` to open the site in your favorite browser.
 
 ## 📖 Overview
@@ -99,7 +99,7 @@ Docusaurus keeps track of the list of versions for the site in the `website/vers
 
 1.  `cd react-native-website` to go into the project root.
 1.  `cd website` to go into the website portion of the project.
-1.  Run `yarn run version <newVersion>` or `npm run version <newVersion>` where `<newVersion>` is the new version being released.
+1.  Run `yarn run version <newVersion>` where `<newVersion>` is the new version being released.
 
 ## 🔧 Website configuration
 
@@ -142,7 +142,7 @@ If possible, test any visual changes in all latest versions of the following bro
 
 ### Push it
 
-1.  Run `yarn prettier` or `npm run prettier` to ensure your changes are consistent with other files in the repo.
+1.  Run `yarn prettier` to ensure your changes are consistent with other files in the repo.
 1.  `git add -A && git commit -m "My message"` to stage and commit your changes.
     > replace `My message` with a commit message, such as `Fixed header logo on Android`
 1.  `git push my-fork-name the-name-of-my-branch`


### PR DESCRIPTION
This PR updates Readme to match the workspace changes. Unfortunately Yarn workspaces are not compatible with the npm, but Yarn already is already listed in prerequisites. So to prevent the compatibility issues the npm alternative command has been removed.

Lately NPM released v7 of their CLI page which supports workspaces, but the implementation is different than Yarn and the both workspaces setups are not compatible with each other - https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/

Maybe in time the compatibility package emerges which allow user of both tools to work with both workspace setups.
