### PR TITLE
add simple React Native logo animation

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -348,6 +348,11 @@ html[data-theme="dark"] .avatar__name a {
   .navbar__logo {
     width: 38px;
     height: 34px;
+    transition: transform 0.5s;
+  }
+
+  .navbar__brand:hover .navbar__logo {
+    transform: rotate(180deg) scale(0.9);
   }
 
   .react-toggle {


### PR DESCRIPTION
This PR adds simple React Native logo animation which is triggered on hover over the logo wrapper (so it's mainly relevant for the desktop users). The animation addition is not targeted to change the website visitor experience or amaze anyone, rather than it's a little step to make interacting with website a bit more unique, than the usual, generic docs site.

### Preview (might not show the effect correctly, it's GIF after all)
![ani](https://user-images.githubusercontent.com/719641/99455112-ac882900-2927-11eb-93bf-6f929b73adb4.gif)
