### PR TITLE
Fix Linking docs

### DIFF
--- a/website/versioned_docs/version-0.62/linking.md
+++ b/website/versioned_docs/version-0.62/linking.md
@@ -102,11 +102,11 @@ There are two ways to handle URLs that open your app.
 
 #### 1. If the app is already open, the app is foregrounded and a Linking event is fired
 
-You can handle these events with `Linking.addEventListener(url, callback)`.
+You can handle these events with `Linking.addEventListener('url', callback)`.
 
 #### 2. If the app is not already open, it is opened and the url is passed in as the initialURL
 
-You can handle these events with `Linking.getInitialURL(url)` -- it returns a Promise that resolves to the url, if there is one.
+You can handle these events with `Linking.getInitialURL()` -- it returns a Promise that resolves to the url, if there is one.
 
 ---
 

--- a/website/versioned_docs/version-0.63/linking.md
+++ b/website/versioned_docs/version-0.63/linking.md
@@ -102,11 +102,11 @@ There are two ways to handle URLs that open your app.
 
 #### 1. If the app is already open, the app is foregrounded and a Linking event is fired
 
-You can handle these events with `Linking.addEventListener(url, callback)`.
+You can handle these events with `Linking.addEventListener('url', callback)`.
 
 #### 2. If the app is not already open, it is opened and the url is passed in as the initialURL
 
-You can handle these events with `Linking.getInitialURL(url)` -- it returns a Promise that resolves to the url, if there is one.
+You can handle these events with `Linking.getInitialURL()` -- it returns a Promise that resolves to the url, if there is one.
 
 ---
 


### PR DESCRIPTION
- `Linking.addEventListener(url, callback)` tempts the reader to pass in a URL, when it should be the hardcoded string `"url"` instead
- `Linking.getInitialURL` doesn't take an argument

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
