### PR TITLE
[docs]: minor grammar change

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -7,7 +7,7 @@ Headless JS is a way to run tasks in JavaScript while your app is in the backgro
 
 ## The JS API
 
-A task is a async function that you register on `AppRegistry`, similar to registering React applications:
+A task is an async function that you register on `AppRegistry`, similar to registering React applications:
 
 ```jsx
 import { AppRegistry } from 'react-native';

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -116,7 +116,7 @@ const HomeScreen = ({ navigation }) => {
   );
 };
 const ProfileScreen = ({ navigation, route }) => {
-  return <Text>This is { route.params.name }'s profile</Text>;
+  return <Text>This is {route.params.name}'s profile</Text>;
 };
 ```
 

--- a/website/versioned_docs/version-0.63/headless-js-android.md
+++ b/website/versioned_docs/version-0.63/headless-js-android.md
@@ -7,7 +7,7 @@ Headless JS is a way to run tasks in JavaScript while your app is in the backgro
 
 ## The JS API
 
-A task is a async function that you register on `AppRegistry`, similar to registering React applications:
+A task is an async function that you register on `AppRegistry`, similar to registering React applications:
 
 ```jsx
 import { AppRegistry } from 'react-native';

--- a/website/versioned_docs/version-0.63/navigation.md
+++ b/website/versioned_docs/version-0.63/navigation.md
@@ -116,7 +116,7 @@ const HomeScreen = ({ navigation }) => {
   );
 };
 const ProfileScreen = ({ navigation, route }) => {
-  return <Text>This is { route.params.name }'s profile</Text>;
+  return <Text>This is {route.params.name}'s profile</Text>;
 };
 ```
 


### PR DESCRIPTION
Changed **"A task is a async function"**  to **"A task is an async function"** on both the `docs` folder located in /docs and the docs for version 0.63.