### PR TITLE
add basic styling for figure and figcaption elements

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -105,6 +105,7 @@ hr {
     code {
       background-color: transparent;
       font-size: 90%;
+      padding: 0 6px;
     }
   }
 
@@ -125,7 +126,7 @@ hr {
     tr th {
       text-transform: uppercase;
       padding: 6px 10px;
-      font-size: 12px;
+      font-size: 0.7rem;
       text-align: left;
     }
 
@@ -142,6 +143,21 @@ hr {
 
     .wideColumn {
       width: 128px;
+    }
+  }
+
+  figure {
+    text-align: center;
+    padding: 8px;
+
+    figcaption {
+      padding: 8px;
+      font-size: 0.9rem;
+      color: var(--subtle);
+
+      code {
+        color: var(--subtle);
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds the basic styling for the `figure` and `figcaption` elements currently used, for example, on the Pressable page. The changeset also includes two small tweaks for other elements inside the `.markdown` scope.

### Preview
<img width="599" alt="Screenshot 2020-11-24 120528" src="https://user-images.githubusercontent.com/719641/100086535-d7a1d980-2e4d-11eb-8ef2-8f1ba9c9bc3b.png">
