### PR TITLE
add temporary fix for navbar overflow issue

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -496,9 +496,15 @@ html[data-theme="dark"] .navbar-sidebar {
   background: var(--ifm-background-color);
 }
 
-@media (max-width: 750px) {
+@media (max-width: 1080px) {
   .navbar .DocSearch-Button {
     padding: 0 12px;
+  }
+
+  .DocSearch-Button-Key,
+  .DocSearch-Button-KeySeparator,
+  .DocSearch-Button-Placeholder {
+    display: none;
   }
 }
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -497,14 +497,16 @@ html[data-theme="dark"] .navbar-sidebar {
 }
 
 @media (max-width: 1080px) {
-  .navbar .DocSearch-Button {
-    padding: 0 12px;
-  }
+  .navbar {
+    .DocSearch-Button {
+      padding: 0 12px;
+    }
 
-  .DocSearch-Button-Key,
-  .DocSearch-Button-KeySeparator,
-  .DocSearch-Button-Placeholder {
-    display: none;
+    .DocSearch-Button-Key,
+    .DocSearch-Button-KeySeparator,
+    .DocSearch-Button-Placeholder {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Refs https://github.com/facebook/docusaurus/issues/3820

This small PR add a temporary fix/workaround to the Navbar overflow issues reported in the Docusuaurs repository.

The fix causes the Algolia search button to shrink to small version earlier and the width breakpoint have been selected in a way which should prevent an overflow to happen.

This should not hurt UX in any significant way, since the search field is only a button, which pops out the search form in modal.

### Preview
<img width="738" alt="Screenshot 2020-11-30 125527" src="https://user-images.githubusercontent.com/719641/100607937-f69be200-330b-11eb-9e2e-556024d9dda2.png">
