### PR TITLE
fix "Javascript" capitalization typo across all docs

### DIFF
--- a/docs/building-for-tv.md
+++ b/docs/building-for-tv.md
@@ -181,7 +181,7 @@ class Game2048 extends React.Component {
 
 - _Back navigation with the TV remote menu button_: The `BackHandler` component, originally written to support the Android back button, now also supports back navigation on the Apple TV using the menu button on the TV remote.
 
-- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from Javascript on initial render, and is controlled after that by the user through native code.
+- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from JavaScript on initial render, and is controlled after that by the user through native code.
 
 - _Known issues_:
 

--- a/docs/native-components-ios.md
+++ b/docs/native-components-ios.md
@@ -65,7 +65,7 @@ render() {
 }
 ```
 
-Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in Javascript.
+Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in JavaScript.
 
 **Note:** When rendering, don't forget to stretch the view, otherwise you'll be staring at a blank screen.
 

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -52,11 +52,11 @@ public class CalendarModule extends ReactContextBaseJavaModule {
 }
 ```
 
-As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaModule` class. For Android, Java native modules are written as classes that extend `ReactContextBaseJavaModule` and implement the functionality required by Javascript.
+As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaModule` class. For Android, Java native modules are written as classes that extend `ReactContextBaseJavaModule` and implement the functionality required by JavaScript.
 
 > It is worth noting that technically Java classes only need to extend the `BaseJavaModule` class or implement the `NativeModule` interface to be considered a Native Module by React Native.
 
-> However we recommend that you use `ReactContextBaseJavaModule`, as shown above. `ReactContextBaseJavaModule` gives access to the `ReactApplicationContext` (RAC), which is useful for Native Modules that need to hook into activity lifecycle methods. Using `ReactContextBaseJavaModule` will also make it easier to make your native module type-safe in the future. For native module type-safety, which is coming in future releases, React Native looks at each native module's Javascript spec and generates an abstract base class that extends `ReactContextBaseJavaModule`.
+> However we recommend that you use `ReactContextBaseJavaModule`, as shown above. `ReactContextBaseJavaModule` gives access to the `ReactApplicationContext` (RAC), which is useful for Native Modules that need to hook into activity lifecycle methods. Using `ReactContextBaseJavaModule` will also make it easier to make your native module type-safe in the future. For native module type-safety, which is coming in future releases, React Native looks at each native module's JavaScript spec and generates an abstract base class that extends `ReactContextBaseJavaModule`.
 
 ### Module Name
 
@@ -78,7 +78,7 @@ const { CalendarModule } = ReactNative.NativeModules;
 
 ### Export a Native Method to JavaScript
 
-Next you will need to add a method to your native module that will create calendar events and can be invoked in Javascript. All native module methods meant to be invoked from JavaScript must be annotated with `@ReactMethod`.
+Next you will need to add a method to your native module that will create calendar events and can be invoked in JavaScript. All native module methods meant to be invoked from JavaScript must be annotated with `@ReactMethod`.
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
@@ -116,7 +116,7 @@ At the moment, we do not recommend this, since calling methods synchronously can
 
 Once a native module is written, it needs to be registered with React Native. In order to do so, you need to add your native module to a `ReactPackage` and register the `ReactPackage` with React Native. During initialization, React Native will loop over all packages, and for each `ReactPackage`, register each native module within.
 
-React Native invokes the method `createNativeModules()` on a `ReactPackage` in order to get the list of native modules to register. For Android, if a module is not instantiated and returned in createNativeModules it will not be available from Javascript.
+React Native invokes the method `createNativeModules()` on a `ReactPackage` in order to get the list of native modules to register. For Android, if a module is not instantiated and returned in createNativeModules it will not be available from JavaScript.
 
 To add your Native Module to `ReactPackage`, first create a new Java Class named `MyAppPackage.java` that implements `ReactPackage` inside the `android/app/src/main/java/com/your-app-name/` folder:
 
@@ -201,7 +201,7 @@ const NewModuleButton = () => {
 export default NewModuleButton;
 ```
 
-In order to access your native module from Javascript you need to first import `NativeModules` from React Native:
+In order to access your native module from JavaScript you need to first import `NativeModules` from React Native:
 
 ```jsx
 import { NativeModules } from 'react-native';
@@ -229,7 +229,7 @@ npx react-native run-android
 
 ### Building as You Iterate
 
-As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from Javascript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in Javascript and rebuild on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-android` command.
+As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from JavaScript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in JavaScript and rebuild on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-android` command.
 
 ### Recap✨
 
@@ -240,7 +240,7 @@ You should now be able to invoke your `createCalendarEvent()` method on your nat
   <figcaption>Image of ADB logs in Android Studio</figcaption>
 </figure>
 
-At this point you have created an Android native module and invoked it’s native method from Javascript in your React Native application. You can read on to learn more about things like argument types available to a native module method and how to setup callbacks and promises.
+At this point you have created an Android native module and invoked it’s native method from JavaScript in your React Native application. You can read on to learn more about things like argument types available to a native module method and how to setup callbacks and promises.
 
 ## Beyond a Calendar Native Module
 
@@ -248,7 +248,7 @@ At this point you have created an Android native module and invoked it’s nativ
 
 Importing your native module by pulling it off of `NativeModules` like above is a bit clunky.
 
-To save consumers of your native module from needing to do that each time they want to access your native module, you can create a Javascript wrapper for the module. Create a new Javascript file named `CalendarModule.js` with the following content:
+To save consumers of your native module from needing to do that each time they want to access your native module, you can create a JavaScript wrapper for the module. Create a new JavaScript file named `CalendarModule.js` with the following content:
 
 ```jsx
 /**
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This Javascript file also becomes a good location for you to add any Javascript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**
@@ -281,7 +281,7 @@ interface CalendarInterface {
 export default CalendarModule as CalendarInterface;
 ```
 
-In your other Javascript files you can access the native module and invoke its method like this:
+In your other JavaScript files you can access the native module and invoke its method like this:
 
 ```jsx
 import CalendarModule from './CalendarModule';
@@ -292,9 +292,9 @@ CalendarModule.createCalendarEvent('foo', 'bar');
 
 ### Argument Types
 
-When a native module method is invoked in Javascript, React Native converts the arguments from JS objects to their Java object analogues. So for example, if your Java Native Module method accepts a double, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the Javascript equivalents they map to.
+When a native module method is invoked in JavaScript, React Native converts the arguments from JS objects to their Java object analogues. So for example, if your Java Native Module method accepts a double, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the JavaScript equivalents they map to.
 
-| Java          | Javascript |
+| Java          | JavaScript |
 | ------------- | ---------- |
 | Boolean       | ?boolean   |
 | boolean       | boolean    |
@@ -326,7 +326,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 ### Exporting Constants
 
-A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in Javascript:
+A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
 ```java
 @Override
@@ -362,7 +362,7 @@ public void createCalendarEvent(String name, String location, Callback callBack)
 }
 ```
 
-You can invoke the callback in your Java method, providing whatever data you want to pass to Javascript. Please note that you can only pass serializable data from native code to Javascript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
+You can invoke the callback in your Java method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
 ```java
   @ReactMethod
@@ -372,7 +372,7 @@ You can invoke the callback in your Java method, providing whatever data you wan
    }
 ```
 
-This method could then be accessed in Javascript using:
+This method could then be accessed in JavaScript using:
 
 ```jsx
 const onPress = () => {
@@ -398,7 +398,7 @@ public void createCalendarEvent(String name, String location, Callback myFailure
 }
 ```
 
-In Javascript, you can then check the first argument to see if an error was passed through:
+In JavaScript, you can then check the first argument to see if an error was passed through:
 
 ```jsx
 const onPress = () => {
@@ -423,7 +423,7 @@ public void createCalendarEvent(String name, String location, Callback myFailure
 }
 ```
 
-Then in Javascript you can add a seperate callback for error and success responses:
+Then in JavaScript you can add a seperate callback for error and success responses:
 
 ```jsx
 const onPress = () => {
@@ -484,7 +484,7 @@ The reject method takes different combinations of the following arguments:
 String code, String message, WritableMap userInfo, Throwable throwable
 ```
 
-For more detail, you can find the `Promise.java` interface [here](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.java#L1). If `userInfo` is not provided, ReactNative will set it to null. For the rest of the parameters React Native will use a default value. The `message` argument provides the error `message` shown at the top of an error call stack. Below is an example of the error message shown in Javascript from the following reject call in Java.
+For more detail, you can find the `Promise.java` interface [here](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.java#L1). If `userInfo` is not provided, ReactNative will set it to null. For the rest of the parameters React Native will use a default value. The `message` argument provides the error `message` shown at the top of an error call stack. Below is an example of the error message shown in JavaScript from the following reject call in Java.
 
 Java reject call:
 
@@ -499,9 +499,9 @@ Error message in React Native App when promise is rejected:
   <figcaption>Image of error message</figcaption>
 </figure>
 
-### Sending Events to Javascript
+### Sending Events to JavaScript
 
-Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to Javascript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
+Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
 ```java
 ...

--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -7,7 +7,7 @@ Welcome to Native Modules for iOS. Please start by reading the [Native Modules I
 
 ## Create a Calendar Native Module
 
-In the following guide you will create a native module, `CalendarModule`, that will allow you to access Apple's calendar APIs from Javascript. By the end you will be able to call `CalendarModule.createCalendarEvent('Dinner Party', 'My House');` from JavaScript, invoking a native method that creates a calendar event.
+In the following guide you will create a native module, `CalendarModule`, that will allow you to access Apple's calendar APIs from JavaScript. By the end you will be able to call `CalendarModule.createCalendarEvent('Dinner Party', 'My House');` from JavaScript, invoking a native method that creates a calendar event.
 
 > The React Native team is currently working on a re-architecture of the Native Module system. This new system is called TurboModules, and it will help facilitate more efficient type-safe communication between JavaScript and native, without relying on the React Native bridge. It will also enable new extensions that weren't possible with the legacy Native Module system. You can read more about it [here](https://github.com/react-native-community/discussions-and-proposals/issues/40). Throughout these docs we have added notes around parts of Native Modules that will change in the TurboModules release and how you can best prepare for a smooth upgrade to TurboModules.
 
@@ -92,7 +92,7 @@ The native module can then be accessed in JS like this:
 const { CalendarModule } = ReactNative.NativeModules;
 ```
 
-### Export a Native Method to Javascript
+### Export a Native Method to JavaScript
 
 React Native will not expose any methods in a native module to JavaScript unless explicitly told to. This can be done using the `RCT_EXPORT_METHOD` macro. Methods written in the `RCT_EXPORT_METHOD` macro are asynchronous and the return type is therefore always void. In order to pass a result from a `RCT_EXPORT_METHOD` method to JavaScript you can use callbacks or emit events (covered below). Let’s go ahead and set up a native method for our `CalendarModule` native module using the `RCT_EXPORT_METHOD` macro. Call it `createCalendarEvent()` and for now have it take in name and location arguments as strings. Argument type options will be covered shortly.
 
@@ -104,7 +104,7 @@ RCT_EXPORT_METHOD(createCalendarEvent:(NSString *)name location:(NSString *)loca
 
 > Please note that the `RCT_EXPORT_METHOD` macro will not be necessary with TurboModules unless your method relies on RCT argument conversion (see argument types below). Ultimately, React Native will remove `RCT_EXPORT_MACRO,` so we discourage people from using `RCTConvert`. Instead, you can do the argument conversion within the method body.
 
-Before you build out the `createCalendarEvent()` method’s functionality, add a console log in the method so you can confirm it has been invoked from Javascript in your React Native application. Use the `RCTLog` APIs from React. Let’s import that header at the top of your file and then add the log call.
+Before you build out the `createCalendarEvent()` method’s functionality, add a console log in the method so you can confirm it has been invoked from JavaScript in your React Native application. Use the `RCTLog` APIs from React. Let’s import that header at the top of your file and then add the log call.
 
 ```objectivec
 #import <React/RCTLog.h>
@@ -156,7 +156,7 @@ const NewModuleButton = () => {
 export default NewModuleButton;
 ```
 
-In order to access your native module from Javascript you need to first import `NativeNodules` from React Native:
+In order to access your native module from JavaScript you need to first import `NativeNodules` from React Native:
 
 ```jsx
 import { NativeModules } from 'react-native';
@@ -184,18 +184,18 @@ npx react-native run-ios
 
 ### Building as You Iterate
 
-As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from Javascript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in Javascript and rebuild JS bundle on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-ios` command.
+As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from JavaScript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in JavaScript and rebuild JS bundle on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-ios` command.
 
 ### Recap✨
 
-You should now be able to invoke your `createCalendarEvent()` method on your native module in Javascript. Since you are using `RCTLog` in the function, you can confirm your native method is being invoked by [enabling debug mode in your app](https://reactnative.dev/docs/debugging#chrome-developer-tools) and looking at the JS console in Chrome or the mobile app debugger Flipper. You should see your `RCTLogInfo(@"Pretending to create an event %@ at %@", name, location);` message each time you invoke the native module method.
+You should now be able to invoke your `createCalendarEvent()` method on your native module in JavaScript. Since you are using `RCTLog` in the function, you can confirm your native method is being invoked by [enabling debug mode in your app](https://reactnative.dev/docs/debugging#chrome-developer-tools) and looking at the JS console in Chrome or the mobile app debugger Flipper. You should see your `RCTLogInfo(@"Pretending to create an event %@ at %@", name, location);` message each time you invoke the native module method.
 
 <figure>
   <img src="/docs/assets/native-modules-ios-logs.png" width="1000" alt="Image of logs." />
   <figcaption>Image of iOS logs in Flipper</figcaption>
 </figure>
 
-At this point you have created an iOS native module and invoked a method on it from Javascript in your React Native application. You can read on to learn more about things like what argument types your native module method takes and how to setup callbacks and promises within your native module.
+At this point you have created an iOS native module and invoked a method on it from JavaScript in your React Native application. You can read on to learn more about things like what argument types your native module method takes and how to setup callbacks and promises within your native module.
 
 ## Beyond a Calendar Native Module
 
@@ -203,7 +203,7 @@ At this point you have created an iOS native module and invoked a method on it f
 
 Importing your native module by pulling it off of `NativeModules` like above is a bit clunky.
 
-To save consumers of your native module from needing to do that each time they want to access your native module, you can create a Javascript wrapper for the module. Create a new Javascript file named NativeCalendarModule.js with the following content:
+To save consumers of your native module from needing to do that each time they want to access your native module, you can create a JavaScript wrapper for the module. Create a new JavaScript file named NativeCalendarModule.js with the following content:
 
 ```jsx
 /**
@@ -218,7 +218,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This Javascript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, with these type annotations, all your JS code will be type safe. These annotations will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the Calendar Module:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, with these type annotations, all your JS code will be type safe. These annotations will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the Calendar Module:
 
 ```jsx
 /**
@@ -236,7 +236,7 @@ interface CalendarInterface {
 export default CalendarModule as CalendarInterface;
 ```
 
-In your other Javascript files you can access the native module and invoke its method like this:
+In your other JavaScript files you can access the native module and invoke its method like this:
 
 ```jsx
 import NativeCalendarModule from './NativeCalendarModule';
@@ -247,9 +247,9 @@ NativeCalendarModule.createCalendarEvent('foo', 'bar');
 
 ### Argument Types
 
-When a native module method is invoked in Javascript, React Native converts the arguments from JS objects to their Objective-C/Swift object analogues. So for example, if your Objective-C Native Module method accepts a NSNumber, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the JavaScript equivalents they map to.
+When a native module method is invoked in JavaScript, React Native converts the arguments from JS objects to their Objective-C/Swift object analogues. So for example, if your Objective-C Native Module method accepts a NSNumber, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the JavaScript equivalents they map to.
 
-| Objective-C | Javascript |
+| Objective-C | JavaScript |
 | --- | --- |
 | NSString | string |
 | NSString | ?string |
@@ -276,7 +276,7 @@ For iOS, you can also write native module methods with any argument type that is
 
 ### Exporting Constants
 
-A native module can export constants by overriding the native method `constantsToExport()`. Below `constantsToExport()` is overriden, and returns a Dictionary that contains a default event name property you can access in Javascript like so:
+A native module can export constants by overriding the native method `constantsToExport()`. Below `constantsToExport()` is overriden, and returns a Dictionary that contains a default event name property you can access in JavaScript like so:
 
 ```objectivec
 - (NSDictionary *)constantsToExport
@@ -296,11 +296,11 @@ Technically, it is possible to access constants exported in `constantsToExport()
 
 > Note that the constants are exported only at initialization time, so if you change `constantsToExport()` values at runtime it won't affect the JavaScript environment.
 
-For iOS, if you override `constantsToExport()` then you should also implement `+ requiresMainQueueSetup` to let React Native know if your module needs to be initialized on the main thread, before any Javascript code executes. Otherwise you will see a warning that in the future your module may be initialized on a background thread unless you explicitly opt out with `+ requiresMainQueueSetup:`. If your module does not require access to UIKit, then you should respond to `+ requiresMainQueueSetup` with NO.
+For iOS, if you override `constantsToExport()` then you should also implement `+ requiresMainQueueSetup` to let React Native know if your module needs to be initialized on the main thread, before any JavaScript code executes. Otherwise you will see a warning that in the future your module may be initialized on a background thread unless you explicitly opt out with `+ requiresMainQueueSetup:`. If your module does not require access to UIKit, then you should respond to `+ requiresMainQueueSetup` with NO.
 
 ### Callbacks
 
-Native modules also support a unique kind of argument - a callback. Callbacks are used to pass data from Objective-C to Javascript for asynchronous methods. They can also be used to asynchronously execute JS from the native side.
+Native modules also support a unique kind of argument - a callback. Callbacks are used to pass data from Objective-C to JavaScript for asynchronous methods. They can also be used to asynchronously execute JS from the native side.
 
 For iOS, callbacks are implemented using the type `RCTResponseSenderBlock`. Below the callback parameter `myCallBack` is added to the `createCalendarEventMethod()`:
 
@@ -311,7 +311,7 @@ RCT_EXPORT_METHOD(createCalendarEvent:(NSString *)title
 
 ```
 
-You can then invoke the callback in your native function, providing whatever result you want to pass to Javascript in an array. Note that `RCTResponseSenderBlock` accepts only one argument - an array of parameters to pass to the JavaScript callback. Below you will pass back the ID of an event created in an earlier call.
+You can then invoke the callback in your native function, providing whatever result you want to pass to JavaScript in an array. Note that `RCTResponseSenderBlock` accepts only one argument - an array of parameters to pass to the JavaScript callback. Below you will pass back the ID of an event created in an earlier call.
 
 > It is important to highlight that the callback is not invoked immediately after the native function completes—remember the communication is asynchronous.
 
@@ -326,7 +326,7 @@ RCT_EXPORT_METHOD(createCalendarEvent:(NSString *)title location:(NSString *)loc
 
 ```
 
-This method could then be accessed in Javascript using the following:
+This method could then be accessed in JavaScript using the following:
 
 ```jsx
 const onSubmit = () => {
@@ -352,7 +352,7 @@ RCT_EXPORT_METHOD(createCalendarEventCallback:(NSString *)title location:(NSStri
 }
 ```
 
-In Javascript, you can then check the first argument to see if an error was passed through:
+In JavaScript, you can then check the first argument to see if an error was passed through:
 
 ```jsx
 const onPress = () => {
@@ -388,7 +388,7 @@ RCT_EXPORT_METHOD(createCalendarEventCallback:(NSString *)title
 }
 ```
 
-Then in Javascript you can add a seperate callback for error and success responses:
+Then in JavaScript you can add a seperate callback for error and success responses:
 
 ```jsx
 const onPress = () => {
@@ -445,9 +445,9 @@ const onSubmit = async () => {
 };
 ```
 
-### Sending Events to Javascript
+### Sending Events to JavaScript
 
-Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to Javascript a reminder that a calendar event from the native iOS calendar app will occur soon. The preferred way to do this is to subclass `RCTEventEmitter`, implement `supportedEvents` and call self `sendEventWithName`:
+Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native iOS calendar app will occur soon. The preferred way to do this is to subclass `RCTEventEmitter`, implement `supportedEvents` and call self `sendEventWithName`:
 
 Update your header class to import `RCTEventEmitter` and subclass `RCTEventEmitter`:
 

--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -3,7 +3,7 @@ id: native-modules-setup
 title: Native Modules NPM Package Setup
 ---
 
-Native modules are usually distributed as npm packages, except that on top of the usual Javascript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
+Native modules are usually distributed as npm packages, except that on top of the usual JavaScript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
 To get set up with the basic project structure for a native module we will use the community tool called [Bob](https://github.com/react-native-community/bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic `create` script:
 

--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -105,7 +105,7 @@ shouldComponentUpdate() {
 
 ### Use cached optimized images
 
-You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your Javascript thread will be free again.
+You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
 
 ### Use getItemLayout
 

--- a/website/versioned_docs/version-0.60/building-for-tv.md
+++ b/website/versioned_docs/version-0.60/building-for-tv.md
@@ -177,7 +177,7 @@ class Game2048 extends React.Component {
 
 - _Back navigation with the TV remote menu button_: The `BackHandler` component, originally written to support the Android back button, now also supports back navigation on the Apple TV using the menu button on the TV remote.
 
-- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from Javascript on initial render, and is controlled after that by the user through native code.
+- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from JavaScript on initial render, and is controlled after that by the user through native code.
 
 - _Known issues_:
 

--- a/website/versioned_docs/version-0.60/native-components-ios.md
+++ b/website/versioned_docs/version-0.60/native-components-ios.md
@@ -65,7 +65,7 @@ render() {
 }
 ```
 
-Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in Javascript.
+Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in JavaScript.
 
 **Note:** When rendering, don't forget to stretch the view, otherwise you'll be staring at a blank screen.
 

--- a/website/versioned_docs/version-0.60/native-modules-setup.md
+++ b/website/versioned_docs/version-0.60/native-modules-setup.md
@@ -3,7 +3,7 @@ id: native-modules-setup
 title: Native Modules Setup
 ---
 
-Native modules are usually distributed as npm packages, except that on top of the usual Javascript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
+Native modules are usually distributed as npm packages, except that on top of the usual JavaScript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
 
 To get set up with the basic project structure for a native module we will use a third party tool [create-react-native-module](https://github.com/brodybits/create-react-native-module). You can go ahead further and dive deep into how that library works, for our needs we will only need:
 

--- a/website/versioned_docs/version-0.60/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.60/optimizing-flatlist-configuration.md
@@ -117,7 +117,7 @@ shouldComponentUpdate() {
 
 ### Use cached optimized images
 
-You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your Javascript thread will be free again.
+You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
 
 ### Use getItemLayout
 

--- a/website/versioned_docs/version-0.61/building-for-tv.md
+++ b/website/versioned_docs/version-0.61/building-for-tv.md
@@ -177,7 +177,7 @@ class Game2048 extends React.Component {
 
 - _Back navigation with the TV remote menu button_: The `BackHandler` component, originally written to support the Android back button, now also supports back navigation on the Apple TV using the menu button on the TV remote.
 
-- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from Javascript on initial render, and is controlled after that by the user through native code.
+- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from JavaScript on initial render, and is controlled after that by the user through native code.
 
 - _Known issues_:
 

--- a/website/versioned_docs/version-0.61/native-components-ios.md
+++ b/website/versioned_docs/version-0.61/native-components-ios.md
@@ -65,7 +65,7 @@ render() {
 }
 ```
 
-Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in Javascript.
+Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in JavaScript.
 
 **Note:** When rendering, don't forget to stretch the view, otherwise you'll be staring at a blank screen.
 

--- a/website/versioned_docs/version-0.61/native-modules-setup.md
+++ b/website/versioned_docs/version-0.61/native-modules-setup.md
@@ -3,7 +3,7 @@ id: native-modules-setup
 title: Native Modules Setup
 ---
 
-Native modules are usually distributed as npm packages, except that on top of the usual Javascript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
+Native modules are usually distributed as npm packages, except that on top of the usual JavaScript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
 
 To get set up with the basic project structure for a native module we will use a third party tool [create-react-native-module](https://github.com/brodybits/create-react-native-module). You can go ahead further and dive deep into how that library works, for our needs we will only need:
 

--- a/website/versioned_docs/version-0.61/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.61/optimizing-flatlist-configuration.md
@@ -117,7 +117,7 @@ shouldComponentUpdate() {
 
 ### Use cached optimized images
 
-You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your Javascript thread will be free again.
+You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
 
 ### Use getItemLayout
 

--- a/website/versioned_docs/version-0.62/building-for-tv.md
+++ b/website/versioned_docs/version-0.62/building-for-tv.md
@@ -181,7 +181,7 @@ class Game2048 extends React.Component {
 
 - _Back navigation with the TV remote menu button_: The `BackHandler` component, originally written to support the Android back button, now also supports back navigation on the Apple TV using the menu button on the TV remote.
 
-- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from Javascript on initial render, and is controlled after that by the user through native code.
+- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from JavaScript on initial render, and is controlled after that by the user through native code.
 
 - _Known issues_:
 

--- a/website/versioned_docs/version-0.62/native-components-ios.md
+++ b/website/versioned_docs/version-0.62/native-components-ios.md
@@ -65,7 +65,7 @@ render() {
 }
 ```
 
-Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in Javascript.
+Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in JavaScript.
 
 **Note:** When rendering, don't forget to stretch the view, otherwise you'll be staring at a blank screen.
 

--- a/website/versioned_docs/version-0.62/native-modules-setup.md
+++ b/website/versioned_docs/version-0.62/native-modules-setup.md
@@ -3,7 +3,7 @@ id: native-modules-setup
 title: Native Modules Setup
 ---
 
-Native modules are usually distributed as npm packages, except that on top of the usual Javascript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
+Native modules are usually distributed as npm packages, except that on top of the usual JavaScript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/getting-started/publishing-npm-packages) useful.
 
 To get set up with the basic project structure for a native module we will use a third party tool [create-react-native-module](https://github.com/brodybits/create-react-native-module). You can go ahead further and dive deep into how that library works, for our needs we will only need:
 

--- a/website/versioned_docs/version-0.62/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.62/optimizing-flatlist-configuration.md
@@ -117,7 +117,7 @@ shouldComponentUpdate() {
 
 ### Use cached optimized images
 
-You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your Javascript thread will be free again.
+You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
 
 ### Use getItemLayout
 

--- a/website/versioned_docs/version-0.63/building-for-tv.md
+++ b/website/versioned_docs/version-0.63/building-for-tv.md
@@ -177,7 +177,7 @@ class Game2048 extends React.Component {
 
 - _Back navigation with the TV remote menu button_: The `BackHandler` component, originally written to support the Android back button, now also supports back navigation on the Apple TV using the menu button on the TV remote.
 
-- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from Javascript on initial render, and is controlled after that by the user through native code.
+- _TabBarIOS behavior_: The `TabBarIOS` component wraps the native `UITabBar` API, which works differently on Apple TV. To avoid jittery re-rendering of the tab bar in tvOS (see [this issue](https://github.com/facebook/react-native/issues/15081)), the selected tab bar item can only be set from JavaScript on initial render, and is controlled after that by the user through native code.
 
 - _Known issues_:
 

--- a/website/versioned_docs/version-0.63/native-components-ios.md
+++ b/website/versioned_docs/version-0.63/native-components-ios.md
@@ -65,7 +65,7 @@ render() {
 }
 ```
 
-Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in Javascript.
+Make sure to use `RNTMap` here. We want to require the manager here, which will expose the view of our manager for use in JavaScript.
 
 **Note:** When rendering, don't forget to stretch the view, otherwise you'll be staring at a blank screen.
 

--- a/website/versioned_docs/version-0.63/native-modules-android.md
+++ b/website/versioned_docs/version-0.63/native-modules-android.md
@@ -52,11 +52,11 @@ public class CalendarModule extends ReactContextBaseJavaModule {
 }
 ```
 
-As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaModule` class. For Android, Java native modules are written as classes that extend `ReactContextBaseJavaModule` and implement the functionality required by Javascript.
+As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaModule` class. For Android, Java native modules are written as classes that extend `ReactContextBaseJavaModule` and implement the functionality required by JavaScript.
 
 > It is worth noting that technically Java classes only need to extend the `BaseJavaModule` class or implement the `NativeModule` interface to be considered a Native Module by React Native.
 
-> However we recommend that you use `ReactContextBaseJavaModule`, as shown above. `ReactContextBaseJavaModule` gives access to the `ReactApplicationContext` (RAC), which is useful for Native Modules that need to hook into activity lifecycle methods. Using `ReactContextBaseJavaModule` will also make it easier to make your native module type-safe in the future. For native module type-safety, which is coming in future releases, React Native looks at each native module's Javascript spec and generates an abstract base class that extends `ReactContextBaseJavaModule`.
+> However we recommend that you use `ReactContextBaseJavaModule`, as shown above. `ReactContextBaseJavaModule` gives access to the `ReactApplicationContext` (RAC), which is useful for Native Modules that need to hook into activity lifecycle methods. Using `ReactContextBaseJavaModule` will also make it easier to make your native module type-safe in the future. For native module type-safety, which is coming in future releases, React Native looks at each native module's JavaScript spec and generates an abstract base class that extends `ReactContextBaseJavaModule`.
 
 ### Module Name
 
@@ -77,7 +77,7 @@ const { CalendarModule } = ReactNative.NativeModules;
 
 ### Export a Native Method to JavaScript
 
-Next you will need to add a method to your native module that will create calendar events and can be invoked in Javascript. All native module methods meant to be invoked from JavaScript must be annotated with `@ReactMethod`.
+Next you will need to add a method to your native module that will create calendar events and can be invoked in JavaScript. All native module methods meant to be invoked from JavaScript must be annotated with `@ReactMethod`.
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
@@ -116,7 +116,7 @@ At the moment, we do not recommend this, since calling methods synchronously can
 
 Once a native module is written, it needs to be registered with React Native. In order to do so, you need to add your native module to a `ReactPackage` and register the `ReactPackage` with React Native. During initialization, React Native will loop over all packages, and for each `ReactPackage`, register each native module within.
 
-React Native invokes the method `createNativeModules()` on a `ReactPackage` in order to get the list of native modules to register. For Android, if a module is not instantiated and returned in createNativeModules it will not be available from Javascript.
+React Native invokes the method `createNativeModules()` on a `ReactPackage` in order to get the list of native modules to register. For Android, if a module is not instantiated and returned in createNativeModules it will not be available from JavaScript.
 
 To add your Native Module to `ReactPackage`, first create a new Java Class named `MyAppPackage.java` that implements `ReactPackage` inside the `android/app/src/main/java/com/your-app-name/` folder:
 
@@ -201,7 +201,7 @@ const NewModuleButton = () => {
 export default NewModuleButton;
 ```
 
-In order to access your native module from Javascript you need to first import `NativeModules` from React Native:
+In order to access your native module from JavaScript you need to first import `NativeModules` from React Native:
 
 ```jsx
 import { NativeModules } from 'react-native';
@@ -229,7 +229,7 @@ npx react-native run-android
 
 ### Building as You Iterate
 
-As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from Javascript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in Javascript and rebuild on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-android` command.
+As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from JavaScript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in JavaScript and rebuild on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-android` command.
 
 ### Recap✨
 
@@ -240,7 +240,7 @@ You should now be able to invoke your `createCalendarEvent()` method on your nat
   <figcaption>Image of ADB logs in Android Studio</figcaption>
 </figure>
 
-At this point you have created an Android native module and invoked it’s native method from Javascript in your React Native application. You can read on to learn more about things like argument types available to a native module method and how to setup callbacks and promises.
+At this point you have created an Android native module and invoked it’s native method from JavaScript in your React Native application. You can read on to learn more about things like argument types available to a native module method and how to setup callbacks and promises.
 
 ## Beyond a Calendar Native Module
 
@@ -248,7 +248,7 @@ At this point you have created an Android native module and invoked it’s nativ
 
 Importing your native module by pulling it off of `NativeModules` like above is a bit clunky.
 
-To save consumers of your native module from needing to do that each time they want to access your native module, you can create a Javascript wrapper for the module. Create a new Javascript file named `CalendarModule.js` with the following content:
+To save consumers of your native module from needing to do that each time they want to access your native module, you can create a JavaScript wrapper for the module. Create a new JavaScript file named `CalendarModule.js` with the following content:
 
 ```jsx
 /**
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This Javascript file also becomes a good location for you to add any Javascript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**
@@ -281,7 +281,7 @@ interface CalendarInterface {
 export default CalendarModule as CalendarInterface;
 ```
 
-In your other Javascript files you can access the native module and invoke its method like this:
+In your other JavaScript files you can access the native module and invoke its method like this:
 
 ```jsx
 import CalendarModule from './CalendarModule';
@@ -292,9 +292,9 @@ CalendarModule.createCalendarEvent('foo', 'bar');
 
 ### Argument Types
 
-When a native module method is invoked in Javascript, React Native converts the arguments from JS objects to their Java object analogues. So for example, if your Java Native Module method accepts a double, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the Javascript equivalents they map to.
+When a native module method is invoked in JavaScript, React Native converts the arguments from JS objects to their Java object analogues. So for example, if your Java Native Module method accepts a double, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the JavaScript equivalents they map to.
 
-| Java          | Javascript |
+| Java          | JavaScript |
 | ------------- | ---------- |
 | Boolean       | ?boolean   |
 | boolean       | boolean    |
@@ -326,7 +326,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 ### Exporting Constants
 
-A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in Javascript:
+A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
 ```java
 @Override
@@ -362,7 +362,7 @@ public void createCalendarEvent(String name, String location, Callback callBack)
 }
 ```
 
-You can invoke the callback in your Java method, providing whatever data you want to pass to Javascript. Please note that you can only pass serializable data from native code to Javascript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
+You can invoke the callback in your Java method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
 ```java
   @ReactMethod
@@ -372,7 +372,7 @@ You can invoke the callback in your Java method, providing whatever data you wan
    }
 ```
 
-This method could then be accessed in Javascript using:
+This method could then be accessed in JavaScript using:
 
 ```jsx
 const onPress = () => {
@@ -398,7 +398,7 @@ public void createCalendarEvent(String name, String location, Callback myFailure
 }
 ```
 
-In Javascript, you can then check the first argument to see if an error was passed through:
+In JavaScript, you can then check the first argument to see if an error was passed through:
 
 ```jsx
 const onPress = () => {
@@ -423,7 +423,7 @@ public void createCalendarEvent(String name, String location, Callback myFailure
 }
 ```
 
-Then in Javascript you can add a seperate callback for error and success responses:
+Then in JavaScript you can add a seperate callback for error and success responses:
 
 ```jsx
 const onPress = () => {
@@ -484,7 +484,7 @@ The reject method takes different combinations of the following arguments:
 String code, String message, WritableMap userInfo, Throwable throwable
 ```
 
-For more detail, you can find the `Promise.java` interface [here](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.java#L1). If `userInfo` is not provided, ReactNative will set it to null. For the rest of the parameters React Native will use a default value. The `message` argument provides the error `message` shown at the top of an error call stack. Below is an example of the error message shown in Javascript from the following reject call in Java.
+For more detail, you can find the `Promise.java` interface [here](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.java#L1). If `userInfo` is not provided, ReactNative will set it to null. For the rest of the parameters React Native will use a default value. The `message` argument provides the error `message` shown at the top of an error call stack. Below is an example of the error message shown in JavaScript from the following reject call in Java.
 
 Java reject call:
 
@@ -499,9 +499,9 @@ Error message in React Native App when promise is rejected:
   <figcaption>Image of error message</figcaption>
 </figure>
 
-### Sending Events to Javascript
+### Sending Events to JavaScript
 
-Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to Javascript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
+Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
 ```java
 ...

--- a/website/versioned_docs/version-0.63/native-modules-intro.md
+++ b/website/versioned_docs/version-0.63/native-modules-intro.md
@@ -3,7 +3,7 @@ id: native-modules-intro
 title: Native Modules Intro
 ---
 
-Sometimes a React Native app needs to access a native platform API that is not available by default in Javascript, for example the native APIs to access Apple or Android pay. Maybe you want to reuse some existing Objective-C, Swift, Java or C++ libraries without having to reimplement it in JavaScript, or write some high performance, multi-threaded code for things like image processing.
+Sometimes a React Native app needs to access a native platform API that is not available by default in JavaScript, for example the native APIs to access Apple or Android pay. Maybe you want to reuse some existing Objective-C, Swift, Java or C++ libraries without having to reimplement it in JavaScript, or write some high performance, multi-threaded code for things like image processing.
 
 The NativeModule system exposes instances of Java/Objective-C/C++ (native) classes to JavaScript (JS) as JS objects, thereby allowing you to execute arbitrary native code from within JS. While we don't expect this feature to be part of the usual development process, it is essential that it exists. If React Native doesn't export a native API that your JS app needs you should be able to export it yourself!
 
@@ -20,6 +20,6 @@ This guide will first walk you through implementing a native module directly wit
 
 In the following sections we will walk you through guides on how to build a native module directly within a React Native application. As a prerequisite, you will need a React Native application to work within. You can follow the steps [here](getting-started) to setup a React Native application if you do not already have one.
 
-Imagine that you want to access the iOS/Android native calendar APIs from Javascript within a React Native application in order to create calendar events. React Native does not expose a Javascript API to communicate with the native calendar libraries. However, through native modules, you can write native code that communicates with native calendar APIs. Then you can invoke that native code through Javascript in your React Native application.
+Imagine that you want to access the iOS/Android native calendar APIs from JavaScript within a React Native application in order to create calendar events. React Native does not expose a JavaScript API to communicate with the native calendar libraries. However, through native modules, you can write native code that communicates with native calendar APIs. Then you can invoke that native code through JavaScript in your React Native application.
 
 In the following sections you will create such a Calendar native module for both [Android](native-modules-android) and [iOS](native-modules-ios).

--- a/website/versioned_docs/version-0.63/native-modules-ios.md
+++ b/website/versioned_docs/version-0.63/native-modules-ios.md
@@ -7,7 +7,7 @@ Welcome to Native Modules for iOS. Please start by reading the [Native Modules I
 
 ## Create a Calendar Native Module
 
-In the following guide you will create a native module, `CalendarModule`, that will allow you to access Apple's calendar APIs from Javascript. By the end you will be able to call `CalendarModule.createCalendarEvent('Dinner Party', 'My House');` from JavaScript, invoking a native method that creates a calendar event.
+In the following guide you will create a native module, `CalendarModule`, that will allow you to access Apple's calendar APIs from JavaScript. By the end you will be able to call `CalendarModule.createCalendarEvent('Dinner Party', 'My House');` from JavaScript, invoking a native method that creates a calendar event.
 
 > The React Native team is currently working on a re-architecture of the Native Module system. This new system is called TurboModules, and it will help facilitate more efficient type-safe communication between JavaScript and native, without relying on the React Native bridge. It will also enable new extensions that weren't possible with the legacy Native Module system. You can read more about it [here](https://github.com/react-native-community/discussions-and-proposals/issues/40). Throughout these docs we have added notes around parts of Native Modules that will change in the TurboModules release and how you can best prepare for a smooth upgrade to TurboModules.
 
@@ -92,7 +92,7 @@ The native module can then be accessed in JS like this:
 const { CalendarModule } = ReactNative.NativeModules;
 ```
 
-### Export a Native Method to Javascript
+### Export a Native Method to JavaScript
 
 React Native will not expose any methods in a native module to JavaScript unless explicitly told to. This can be done using the `RCT_EXPORT_METHOD` macro. Methods written in the `RCT_EXPORT_METHOD` macro are asynchronous and the return type is therefore always void. In order to pass a result from a `RCT_EXPORT_METHOD` method to JavaScript you can use callbacks or emit events (covered below). Let’s go ahead and set up a native method for our `CalendarModule` native module using the `RCT_EXPORT_METHOD` macro. Call it `createCalendarEvent()` and for now have it take in name and location arguments as strings. Argument type options will be covered shortly.
 
@@ -104,7 +104,7 @@ RCT_EXPORT_METHOD(createCalendarEvent:(NSString *)name location:(NSString *)loca
 
 > Please note that the `RCT_EXPORT_METHOD` macro will not be necessary with TurboModules unless your method relies on RCT argument conversion (see argument types below). Ultimately, React Native will remove `RCT_EXPORT_MACRO,` so we discourage people from using `RCTConvert`. Instead, you can do the argument conversion within the method body.
 
-Before you build out the `createCalendarEvent()` method’s functionality, add a console log in the method so you can confirm it has been invoked from Javascript in your React Native application. Use the `RCTLog` APIs from React. Let’s import that header at the top of your file and then add the log call.
+Before you build out the `createCalendarEvent()` method’s functionality, add a console log in the method so you can confirm it has been invoked from JavaScript in your React Native application. Use the `RCTLog` APIs from React. Let’s import that header at the top of your file and then add the log call.
 
 ```objectivec
 #import <React/RCTLog.h>
@@ -156,7 +156,7 @@ const NewModuleButton = () => {
 export default NewModuleButton;
 ```
 
-In order to access your native module from Javascript you need to first import `NativeNodules` from React Native:
+In order to access your native module from JavaScript you need to first import `NativeNodules` from React Native:
 
 ```jsx
 import { NativeModules } from 'react-native';
@@ -184,18 +184,18 @@ npx react-native run-ios
 
 ### Building as You Iterate
 
-As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from Javascript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in Javascript and rebuild JS bundle on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-ios` command.
+As you work through these guides and iterate on your native module, you will need to do a native rebuild of your application to access your most recent changes from JavaScript. This is because the code that you are writing sits within the native part of your application. While React Native’s metro bundler can watch for changes in JavaScript and rebuild JS bundle on the fly for you, it will not do so for native code. So if you want to test your latest native changes you need to rebuild by using the `npx react-native run-ios` command.
 
 ### Recap✨
 
-You should now be able to invoke your `createCalendarEvent()` method on your native module in Javascript. Since you are using `RCTLog` in the function, you can confirm your native method is being invoked by [enabling debug mode in your app](https://reactnative.dev/docs/debugging#chrome-developer-tools) and looking at the JS console in Chrome or the mobile app debugger Flipper. You should see your `RCTLogInfo(@"Pretending to create an event %@ at %@", name, location);` message each time you invoke the native module method.
+You should now be able to invoke your `createCalendarEvent()` method on your native module in JavaScript. Since you are using `RCTLog` in the function, you can confirm your native method is being invoked by [enabling debug mode in your app](https://reactnative.dev/docs/debugging#chrome-developer-tools) and looking at the JS console in Chrome or the mobile app debugger Flipper. You should see your `RCTLogInfo(@"Pretending to create an event %@ at %@", name, location);` message each time you invoke the native module method.
 
 <figure>
   <img src="/docs/assets/native-modules-ios-logs.png" width="1000" alt="Image of logs." />
   <figcaption>Image of iOS logs in Flipper</figcaption>
 </figure>
 
-At this point you have created an iOS native module and invoked a method on it from Javascript in your React Native application. You can read on to learn more about things like what argument types your native module method takes and how to setup callbacks and promises within your native module.
+At this point you have created an iOS native module and invoked a method on it from JavaScript in your React Native application. You can read on to learn more about things like what argument types your native module method takes and how to setup callbacks and promises within your native module.
 
 ## Beyond a Calendar Native Module
 
@@ -203,7 +203,7 @@ At this point you have created an iOS native module and invoked a method on it f
 
 Importing your native module by pulling it off of `NativeModules` like above is a bit clunky.
 
-To save consumers of your native module from needing to do that each time they want to access your native module, you can create a Javascript wrapper for the module. Create a new Javascript file named NativeCalendarModule.js with the following content:
+To save consumers of your native module from needing to do that each time they want to access your native module, you can create a JavaScript wrapper for the module. Create a new JavaScript file named NativeCalendarModule.js with the following content:
 
 ```jsx
 /**
@@ -218,7 +218,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This Javascript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, with these type annotations, all your JS code will be type safe. These annotations will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the Calendar Module:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, with these type annotations, all your JS code will be type safe. These annotations will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the Calendar Module:
 
 ```jsx
 /**
@@ -236,7 +236,7 @@ interface CalendarInterface {
 export default CalendarModule as CalendarInterface;
 ```
 
-In your other Javascript files you can access the native module and invoke its method like this:
+In your other JavaScript files you can access the native module and invoke its method like this:
 
 ```jsx
 import NativeCalendarModule from './NativeCalendarModule';
@@ -247,9 +247,9 @@ NativeCalendarModule.createCalendarEvent('foo', 'bar');
 
 ### Argument Types
 
-When a native module method is invoked in Javascript, React Native converts the arguments from JS objects to their Objective-C/Swift object analogues. So for example, if your Objective-C Native Module method accepts a NSNumber, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the JavaScript equivalents they map to.
+When a native module method is invoked in JavaScript, React Native converts the arguments from JS objects to their Objective-C/Swift object analogues. So for example, if your Objective-C Native Module method accepts a NSNumber, in JS you need to call the method with a number. React Native will handle the conversion for you. Below is a list of the argument types supported for native module methods and the JavaScript equivalents they map to.
 
-| Objective-C                                   | Javascript         |
+| Objective-C                                   | JavaScript         |
 | --------------------------------------------- | ------------------ |
 | NSString                                      | string             |
 | NSString                                      | ?string            |
@@ -276,7 +276,7 @@ For iOS, you can also write native module methods with any argument type that is
 
 ### Exporting Constants
 
-A native module can export constants by overriding the native method `constantsToExport()`. Below `constantsToExport()` is overriden, and returns a Dictionary that contains a default event name property you can access in Javascript like so:
+A native module can export constants by overriding the native method `constantsToExport()`. Below `constantsToExport()` is overriden, and returns a Dictionary that contains a default event name property you can access in JavaScript like so:
 
 ```objectivec
 - (NSDictionary *)constantsToExport
@@ -296,11 +296,11 @@ Technically, it is possible to access constants exported in `constantsToExport()
 
 > Note that the constants are exported only at initialization time, so if you change `constantsToExport()` values at runtime it won't affect the JavaScript environment.
 
-For iOS, if you override `constantsToExport()` then you should also implement `+ requiresMainQueueSetup` to let React Native know if your module needs to be initialized on the main thread, before any Javascript code executes. Otherwise you will see a warning that in the future your module may be initialized on a background thread unless you explicitly opt out with `+ requiresMainQueueSetup:`. If your module does not require access to UIKit, then you should respond to `+ requiresMainQueueSetup` with NO.
+For iOS, if you override `constantsToExport()` then you should also implement `+ requiresMainQueueSetup` to let React Native know if your module needs to be initialized on the main thread, before any JavaScript code executes. Otherwise you will see a warning that in the future your module may be initialized on a background thread unless you explicitly opt out with `+ requiresMainQueueSetup:`. If your module does not require access to UIKit, then you should respond to `+ requiresMainQueueSetup` with NO.
 
 ### Callbacks
 
-Native modules also support a unique kind of argument - a callback. Callbacks are used to pass data from Objective-C to Javascript for asynchronous methods. They can also be used to asynchronously execute JS from the native side.
+Native modules also support a unique kind of argument - a callback. Callbacks are used to pass data from Objective-C to JavaScript for asynchronous methods. They can also be used to asynchronously execute JS from the native side.
 
 For iOS, callbacks are implemented using the type `RCTResponseSenderBlock`. Below the callback parameter `myCallBack` is added to the `createCalendarEventMethod()`:
 
@@ -311,7 +311,7 @@ RCT_EXPORT_METHOD(createCalendarEvent:(NSString *)title
 
 ```
 
-You can then invoke the callback in your native function, providing whatever result you want to pass to Javascript in an array. Note that `RCTResponseSenderBlock` accepts only one argument - an array of parameters to pass to the JavaScript callback. Below you will pass back the ID of an event created in an earlier call.
+You can then invoke the callback in your native function, providing whatever result you want to pass to JavaScript in an array. Note that `RCTResponseSenderBlock` accepts only one argument - an array of parameters to pass to the JavaScript callback. Below you will pass back the ID of an event created in an earlier call.
 
 > It is important to highlight that the callback is not invoked immediately after the native function completes—remember the communication is asynchronous.
 
@@ -326,7 +326,7 @@ RCT_EXPORT_METHOD(createCalendarEvent:(NSString *)title location:(NSString *)loc
 
 ```
 
-This method could then be accessed in Javascript using the following:
+This method could then be accessed in JavaScript using the following:
 
 ```jsx
 const onSubmit = () => {
@@ -352,7 +352,7 @@ RCT_EXPORT_METHOD(createCalendarEventCallback:(NSString *)title location:(NSStri
 }
 ```
 
-In Javascript, you can then check the first argument to see if an error was passed through:
+In JavaScript, you can then check the first argument to see if an error was passed through:
 
 ```jsx
 const onPress = () => {
@@ -388,7 +388,7 @@ RCT_EXPORT_METHOD(createCalendarEventCallback:(NSString *)title
 }
 ```
 
-Then in Javascript you can add a seperate callback for error and success responses:
+Then in JavaScript you can add a seperate callback for error and success responses:
 
 ```jsx
 const onPress = () => {
@@ -445,9 +445,9 @@ const onSubmit = async () => {
 };
 ```
 
-### Sending Events to Javascript
+### Sending Events to JavaScript
 
-Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to Javascript a reminder that a calendar event from the native iOS calendar app will occur soon. The preferred way to do this is to subclass `RCTEventEmitter`, implement `supportedEvents` and call self `sendEventWithName`:
+Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native iOS calendar app will occur soon. The preferred way to do this is to subclass `RCTEventEmitter`, implement `supportedEvents` and call self `sendEventWithName`:
 
 Update your header class to import `RCTEventEmitter` and subclass `RCTEventEmitter`:
 

--- a/website/versioned_docs/version-0.63/native-modules-setup.md
+++ b/website/versioned_docs/version-0.63/native-modules-setup.md
@@ -3,7 +3,7 @@ id: native-modules-setup
 title: Native Modules NPM Package Setup
 ---
 
-Native modules are usually distributed as npm packages, except that on top of the usual Javascript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
+Native modules are usually distributed as npm packages, except that on top of the usual JavaScript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
 To get set up with the basic project structure for a native module we will use the community tool called [Bob](https://github.com/react-native-community/bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic `create` script:
 

--- a/website/versioned_docs/version-0.63/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.63/optimizing-flatlist-configuration.md
@@ -105,7 +105,7 @@ shouldComponentUpdate() {
 
 ### Use cached optimized images
 
-You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your Javascript thread will be free again.
+You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
 
 ### Use getItemLayout
 


### PR DESCRIPTION
Refs #2364

This PR fixes the "Javascript" -> "JavaScript" capitalization typo across all docs and versioned docs files.
