### PR TITLE
[docs]: Add 0.64 required updates to the documentation - Part 1/x

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -345,7 +345,7 @@ Invoked when a partial load of the image is complete. The definition of what con
 
 ---
 
-### `onProgress` <div class="label android">Android</div><div class="label ios">iOS</div>
+### `onProgress`
 
 Invoked on download progress.
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -345,7 +345,7 @@ Invoked when a partial load of the image is complete. The definition of what con
 
 ---
 
-### `onProgress` <div class="label ios">iOS</div>
+### `onProgress` <div class="label android">Android</div><div class="label ios">iOS</div>
 
 Invoked on download progress.
 

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -133,6 +133,14 @@ Either children or a function that receives a boolean reflecting whether the com
 | ------------------------ | -------- |
 | [React Node](react-node) | No       |
 
+### `unstable_pressDelay`
+
+Duration (in milliseconds) to wait after press down before calling `onPressIn`.
+
+| Type   | Required |
+| ------ | -------- |
+| number | No       |
+
 ### `delayLongPress`
 
 Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -186,7 +186,7 @@ This property specifies how the safe area insets are used to modify the content 
 
 ---
 
-### `contentOffset` <div class="label android">Android</div><div class="label ios">iOS</div>
+### `contentOffset`
 
 Used to manually set the starting scroll offset. The default value is `{x: 0, y: 0}`.
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -605,16 +605,6 @@ When true, the scroll view scrolls to top when the status bar is tapped. The def
 
 ---
 
-### `DEPRECATED_sendUpdatedChildFrames`
-
-When true, ScrollView will emit updateChildFrames data in scroll events, otherwise will not compute or emit child frame data. This only exists to support legacy issues, `onLayout` should be used instead to retrieve frame data. The default value is false.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
-
----
-
 ### `showsHorizontalScrollIndicator`
 
 When true, shows a horizontal scroll indicator. The default value is true.

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -186,13 +186,13 @@ This property specifies how the safe area insets are used to modify the content 
 
 ---
 
-### `contentOffset`
+### `contentOffset` <div class="label android">Android</div><div class="label ios">iOS</div>
 
 Used to manually set the starting scroll offset. The default value is `{x: 0, y: 0}`.
 
-| Type          | Required | Platform |
-| ------------- | -------- | -------- |
-| PointPropType | No       | iOS      |
+| Type          | Required |
+| ------------- | -------- |
+| PointPropType | No       |
 
 ---
 

--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -103,13 +103,13 @@ These properties are iOS only - for similar functionality on Android, use the [`
 
 ## Props
 
-### `shadowColor`
+### `shadowColor` <div class="label android">Android >= 28</div><div class="label ios">iOS</div>
 
 Sets the drop shadow color
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](colors.md) | No       | iOS      |
+| Type               | Required |
+| ------------------ | -------- |
+| [color](colors.md) | No       |
 
 ---
 

--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -103,9 +103,11 @@ These properties are iOS only - for similar functionality on Android, use the [`
 
 ## Props
 
-### `shadowColor` <div class="label android">Android >= 28</div><div class="label ios">iOS</div>
+### `shadowColor`
 
 Sets the drop shadow color
+
+> This will not work on Android (API < 28)
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -693,7 +693,7 @@ If `true`, all text will automatically be selected on focus.
 
 ---
 
-### `showSoftInputOnFocus` <div class="label android">Android</div><div class="label ios">iOS</div>
+### `showSoftInputOnFocus`
 
 When `false`, it will prevent the soft keyboard from showing when the field is focused. The default value is `true`.
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -693,13 +693,13 @@ If `true`, all text will automatically be selected on focus.
 
 ---
 
-### `showSoftInputOnFocus`
+### `showSoftInputOnFocus` <div class="label android">Android</div><div class="label ios">iOS</div>
 
 When `false`, it will prevent the soft keyboard from showing when the field is focused. The default value is `true`.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
 
 ---
 


### PR DESCRIPTION
## Original Summary

- Add support for `shadowColor` on API level >= 28 ([cfa4260598](https://github.com/facebook/react-native/commit/cfa42605989eee5a9de42bdb1259fb7f4d9451fb) by [@IjzerenHein](https://github.com/IjzerenHein))
- Adds support for the `onProgress` event on `Image` ([fa0e6f8051](https://github.com/facebook/react-native/commit/fa0e6f8051d2208af467b789a2a9306ec7ddad76) by [@yungsters](https://github.com/yungsters))
- ScrollView now supports `contentOffset` ([ed29ba13f9](https://github.com/facebook/react-native/commit/ed29ba13f97f240c91fdf6c0ef3fb601046697b9) by [@JoshuaGross](https://github.com/JoshuaGross))
- Add `showSoftInputOnFocus` to TextInput on `iOS` ([d54113d8c4](https://github.com/facebook/react-native/commit/d54113d8c4bcd0e0c7a09acca60819724eb69926) by [@gurs1kh](https://github.com/gurs1kh))
- Removed `DEPRECATED_sendUpdatedChildFrames` prop from `ScrollView` component ([345d0c1abb](https://github.com/facebook/react-native/commit/345d0c1abb1afe937a06982c4328caee57820832) by [@ZHUANGPP](https://github.com/ZHUANGPP))
- Add `unstable_pressDelay` prop to `Pressable`. ([a6395d5406](https://github.com/facebook/react-native/commit/a6395d5406a297d06619e0f60afdfb3e6651a1af) by [@yungsters](https://github.com/yungsters))