### PR TITLE
update Share, Shadow and View Props pages to match latest patterns

### DIFF
--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -99,46 +99,44 @@ export default App;
 
 # Reference
 
-These properties are iOS only - for similar functionality on Android, use the [`elevation` property](view-style-props#elevation).
-
 ## Props
 
 ### `shadowColor`
 
-Sets the drop shadow color
+Sets the drop shadow color.
 
-> This will not work on Android (API < 28)
+This property will only work on Android API 28 and above. For similar functionality on lower Android APIs, use the [`elevation` property](view-style-props#elevation).
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
-
----
-
-### `shadowOffset`
-
-Sets the drop shadow offset
-
-| Type                                   | Required | Platform |
-| -------------------------------------- | -------- | -------- |
-| object: {width: number,height: number} | No       | iOS      |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
-### `shadowOpacity`
+### `shadowOffset` <div class="label ios">iOS</div>
 
-Sets the drop shadow opacity (multiplied by the color's alpha component)
+Sets the drop shadow offset.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type                                   |
+| -------------------------------------- |
+| object: {width: number,height: number} |
 
 ---
 
-### `shadowRadius`
+### `shadowOpacity` <div class="label ios">iOS</div>
 
-Sets the drop shadow blur radius
+Sets the drop shadow opacity (multiplied by the color's alpha component).
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `shadowRadius` <div class="label ios">iOS</div>
+
+Sets the drop shadow blur radius.
+
+| Type   |
+| ------ |
+| number |

--- a/docs/share.md
+++ b/docs/share.md
@@ -104,33 +104,16 @@ In iOS, returns a Promise which will be invoked with an object containing `actio
 
 In Android, returns a Promise which will always be resolved with action being `Share.sharedAction`.
 
-### Content
+**Properties:**
 
-- `message` - a message to share
-
-#### iOS
-
-- `url` - a URL to share
-
-At least one of URL and message is required.
-
-#### Android
-
-- `title` - title of the message
-
-### Options
-
-#### iOS
-
-- `subject` - a subject to share via email
-- `excludedActivityTypes`
-- `tintColor`
-
-#### Android
-
-- `dialogTitle`
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                        |
+| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div> |
 
 ---
+
+## Properties
 
 ### `sharedAction`
 
@@ -142,10 +125,10 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction`
+### `dismissedAction` <div class="label ios">iOS</div>
 
 ```jsx
 static dismissedAction
 ```
 
-_iOS Only_. The dialog has been dismissed.
+The dialog has been dismissed.

--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -55,99 +55,99 @@ export default ViewStyleProps;
 
 ## Props
 
-### `borderRightColor`
+### `backfaceVisibility`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type                          |
+| ----------------------------- |
+| enum(`'visible'`, `'hidden'`) |
 
 ---
 
-### `backfaceVisibility`
+### `backgroundColor`
 
-| Type                      | Required |
-| ------------------------- | -------- |
-| enum('visible', 'hidden') | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderBottomColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderBottomEndRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderBottomLeftRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderBottomRightRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderBottomStartRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderBottomWidth`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderEndColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderLeftColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderLeftWidth`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
@@ -155,112 +155,112 @@ export default ViewStyleProps;
 
 If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
-### `backgroundColor`
+### `borderRightColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderRightWidth`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderStartColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderStyle`
 
-| Type                              | Required |
-| --------------------------------- | -------- |
-| enum('solid', 'dotted', 'dashed') | No       |
+| Type                                    |
+| --------------------------------------- |
+| enum(`'solid'`, `'dotted'`, `'dashed'`) |
 
 ---
 
 ### `borderTopColor`
 
-| Type               | Required |
-| ------------------ | -------- |
-| [color](colors.md) | No       |
+| Type               |
+| ------------------ |
+| [color](colors.md) |
 
 ---
 
 ### `borderTopEndRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderTopLeftRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderTopRightRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderTopStartRadius`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderTopWidth`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `borderWidth`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `elevation` <div class="label android">Android</div>
+
+Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
+
+| Type   |
+| ------ |
+| number |
 
 ---
 
 ### `opacity`
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `elevation`
-
-(Android-only) Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | Android  |
+| Type   |
+| ------ |
+| number |

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -136,6 +136,12 @@ hr {
       line-height: 1.3em;
       padding: 10px;
       text-align: left;
+
+      code {
+        display: inline-block;
+        line-height: 1.15em;
+        vertical-align: middle;
+      }
     }
 
     hr {


### PR DESCRIPTION
This PR updates the Share, Shadow Props and View Props page to match latest patterns for doc pages. The changes includes platform labels, alphabetic order, fixed grouping and more.

Also the style of `<code>` blocks inside the table has be adjust a bit for better appearance when used inside the text line.
