### PR TITLE
update references sections on several pages, improve few examples

### DIFF
--- a/docs/appregistry.md
+++ b/docs/appregistry.md
@@ -181,10 +181,10 @@ This is a way to run tasks in JavaScript while your app is in the background. It
 
 **Parameters:**
 
-| Name                                                                            | Type                                     | Description                                                                                                                                                                                                                         |
-| ------------------------------------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| taskKey<br/><div className="label basic required two-lines">Required</div>      | string                                   | The native id for this task instance that was used when startHeadlessTask was called.                                                                                                                                               |
-| taskProvider<br/><div className="label basic required two-lines">Required</div> | [TaskProvider](appregistry#taskprovider) | A promise returning function that takes some data passed from the native side as the only argument. When the promise is resolved or rejected the native side is notified of this event and it may decide to destroy the JS context. |
+| Name                                                                        | Type                                     | Description                                                                                                                                                                                                                         |
+| --------------------------------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| taskKey <div className="label basic required two-lines">Required</div>      | string                                   | The native id for this task instance that was used when startHeadlessTask was called.                                                                                                                                               |
+| taskProvider <div className="label basic required two-lines">Required</div> | [TaskProvider](appregistry#taskprovider) | A promise returning function that takes some data passed from the native side as the only argument. When the promise is resolved or rejected the native side is notified of this event and it may decide to destroy the JS context. |
 
 ---
 

--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -14,16 +14,27 @@ The `DevSettings` module exposes methods for customizing settings for developers
 ### `addMenuItem()`
 
 ```jsx
-static addMenuItem(title: string, handler: function)
+static addMenuItem(title, handler)
 ```
 
-Add a custom menu item to the developer menu:
+Add a custom menu item to the developer menu.
+
+**Parameters:**
+
+| Name                                                           | Type     |
+| -------------------------------------------------------------- | -------- |
+| title <div className="label basic required">Required</div>     | string   |
+| component <div className="label basic required">Required</div> | function |
+
+**Example:**
 
 ```jsx
 DevSettings.addMenuItem('Show Secret Dev Screen', () => {
   Alert.alert('Showing secret dev screen!');
 });
 ```
+
+---
 
 ### `reload()`
 

--- a/docs/interactionmanager.md
+++ b/docs/interactionmanager.md
@@ -226,7 +226,3 @@ static setDeadline(deadline)
 ```
 
 A positive number will use setTimeout to schedule any tasks after the eventLoopRunningTime hits the deadline value, otherwise all tasks will be executed in one setImmediate batch (default).
-
-## Properties
-
----

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -127,14 +127,14 @@ This function then returns the reference to the listener.
 
 **Parameters:**
 
-| Name      | Type     | Required | Description                                                                               |
-| --------- | -------- | -------- | ----------------------------------------------------------------------------------------- |
-| eventName | string   | Yes      | The `nativeEvent` is the string that identifies the event you're listening for. See below |
-| callback  | function | Yes      | The function to be called when the event fires                                            |
+| Name                                                                     | Type     | Description                                                                    |
+| ------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------ |
+| eventName <div className="label basic two-lines required">Required</div> | string   | The string that identifies the event you're listening for. See the list below. |
+| callback <div className="label basic two-lines required">Required</div>  | function | The function to be called when the event fires                                 |
 
-**nativeEvent**
+**`eventName`**
 
-This can be any of the following
+This can be any of the following:
 
 - `keyboardWillShow`
 - `keyboardDidShow`
@@ -143,7 +143,7 @@ This can be any of the following
 - `keyboardWillChangeFrame`
 - `keyboardDidChangeFrame`
 
-Note that if you set `android:windowSoftInputMode` to `adjustResize` or `adjustPan`, only `keyboardDidShow` and `keyboardDidHide` events will be available on Android. If you set `android:windowSoftInputMode` to `adjustNothing`, no events will be available on Android. `keyboardWillShow` as well as `keyboardWillHide` are generally not available on Android since there is no native corresponding event.
+> Note that if you set `android:windowSoftInputMode` to `adjustResize` or `adjustPan`, only `keyboardDidShow` and `keyboardDidHide` events will be available on Android. If you set `android:windowSoftInputMode` to `adjustNothing`, no events will be available on Android. `keyboardWillShow` as well as `keyboardWillHide` are generally not available on Android since there is no native corresponding event.
 
 ---
 

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -118,7 +118,7 @@ static create(duration, type, creationProp)
 
 Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
 
-Example usage:
+**Example:**
 
 <Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
@@ -336,7 +336,7 @@ Calls `configureNext()` with `Presets.linear`.
 
 Calls `configureNext()` with `Presets.spring`.
 
-Example usage:
+**Example:**
 
 <Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -102,11 +102,11 @@ There are two ways to handle URLs that open your app.
 
 #### 1. If the app is already open, the app is foregrounded and a Linking 'url' event is fired
 
-You can handle these events with `Linking.addEventListener('url', callback)` -- it calls `callback({ url })` with the linked URL
+You can handle these events with `Linking.addEventListener('url', callback)` - it calls `callback({ url })` with the linked URL
 
 #### 2. If the app is not already open, it is opened and the url is passed in as the initialURL
 
-You can handle these events with `Linking.getInitialURL()` -- it returns a Promise that resolves to the URL, if there is one.
+You can handle these events with `Linking.getInitialURL()` - it returns a Promise that resolves to the URL, if there is one.
 
 ---
 
@@ -283,14 +283,6 @@ export default App;
 
 ## Methods
 
-### `constructor()`
-
-```jsx
-constructor();
-```
-
----
-
 ### `addEventListener()`
 
 ```jsx
@@ -298,42 +290,6 @@ addEventListener(type, handler);
 ```
 
 Add a handler to Linking changes by listening to the `url` event type and providing the handler.
-
----
-
-### `removeEventListener()`
-
-```jsx
-removeEventListener(type, handler);
-```
-
-Remove a handler by passing the `url` event type and the handler.
-
----
-
-### `openURL()`
-
-```jsx
-openURL(url);
-```
-
-Try to open the given `url` with any of the installed apps.
-
-You can use other URLs, like a location (e.g. "geo:37.484847,-122.148386" on Android or "http://maps.apple.com/?ll=37.484847,-122.148386" on iOS), a contact, or any other URL that can be opened with the installed apps.
-
-The method returns a `Promise` object. If the user confirms the open dialog or the url automatically opens, the promise is resolved. If the user cancels the open dialog or there are no registered applications for the url, the promise is rejected.
-
-**Parameters:**
-
-| Name | Type   | Required | Description      |
-| ---- | ------ | -------- | ---------------- |
-| url  | string | Yes      | The URL to open. |
-
-> This method will fail if the system doesn't know how to open the specified URL. If you're passing in a non-http(s) URL, it's best to check {@code canOpenURL} first.
-
-> For web URLs, the protocol ("http://", "https://") must be set accordingly!
-
-> This method may behave differently in a simulator e.g. "tel:" links are not able to be handled in the iOS simulator as there's no access to the dialer app.
 
 ---
 
@@ -351,27 +307,17 @@ The `Promise` will reject on Android if it was impossible to check if the URL ca
 
 **Parameters:**
 
-| Name | Type   | Required | Description      |
-| ---- | ------ | -------- | ---------------- |
-| url  | string | Yes      | The URL to open. |
+| Name                                                     | Type   | Description      |
+| -------------------------------------------------------- | ------ | ---------------- |
+| url <div className="label basic required">Required</div> | string | The URL to open. |
 
-> For web URLs, the protocol ("http://", "https://") must be set accordingly!
-
-> As of iOS 9, your app needs to provide the `LSApplicationQueriesSchemes` key inside `Info.plist` or canOpenURL will always return false.
+> For web URLs, the protocol (`"http://"`, `"https://"`) must be set accordingly!
 
 > This method has limitations on iOS 9+. From [the official Apple documentation](https://developer.apple.com/documentation/uikit/uiapplication/1622952-canopenurl):
-
-> If your app is linked against an earlier version of iOS but is running in iOS 9.0 or later, you can call this method up to 50 times. After reaching that limit, subsequent calls always return false. If the user reinstalls or upgrades the app, iOS resets the limit.
-
----
-
-### `openSettings()`
-
-```jsx
-openSettings();
-```
-
-Open the Settings app and displays the app’s custom settings, if it has any.
+>
+> - If your app is linked against an earlier version of iOS but is running in iOS 9.0 or later, you can call this method up to 50 times. After reaching that limit, subsequent calls always return false. If the user reinstalls or upgrades the app, iOS resets the limit.
+>
+> As of iOS 9, your app also needs to provide the `LSApplicationQueriesSchemes` key inside `Info.plist` or `canOpenURL()` will always return `false`.
 
 ---
 
@@ -389,12 +335,63 @@ If the app launch was triggered by an app link, it will give the link url, other
 
 ---
 
-### `sendIntent()`
+### `openSettings()`
 
 ```jsx
-sendIntent(action: string, extras?: Array<{key: string, value: string | number | boolean}>)
+openSettings();
 ```
 
-> @platform android
+Open the Settings app and displays the app’s custom settings, if it has any.
 
-**Android-Only.** Launch an Android intent with extras (optional)
+---
+
+### `openURL()`
+
+```jsx
+openURL(url);
+```
+
+Try to open the given `url` with any of the installed apps.
+
+You can use other URLs, like a location (e.g. "geo:37.484847,-122.148386" on Android or "http://maps.apple.com/?ll=37.484847,-122.148386" on iOS), a contact, or any other URL that can be opened with the installed apps.
+
+The method returns a `Promise` object. If the user confirms the open dialog or the url automatically opens, the promise is resolved. If the user cancels the open dialog or there are no registered applications for the url, the promise is rejected.
+
+**Parameters:**
+
+| Name                                                     | Type   | Description      |
+| -------------------------------------------------------- | ------ | ---------------- |
+| url <div className="label basic required">Required</div> | string | The URL to open. |
+
+> This method will fail if the system doesn't know how to open the specified URL. If you're passing in a non-http(s) URL, it's best to check `canOpenURL()` first.
+
+> For web URLs, the protocol (`"http://"`, `"https://"`) must be set accordingly!
+
+> This method may behave differently in a simulator e.g. `"tel:"` links are not able to be handled in the iOS simulator as there's no access to the dialer app.
+
+---
+
+### `removeEventListener()`
+
+```jsx
+removeEventListener(type, handler);
+```
+
+Remove a handler by passing the `url` event type and the handler.
+
+---
+
+### `sendIntent()` <div class="label android">Android</div>
+
+```jsx
+sendIntent(action, extras);
+```
+
+Launch an Android intent with extras.
+
+**Parameters:**
+
+| Name                                                        | Type                                                     |
+| ----------------------------------------------------------- | -------------------------------------------------------- |
+| action <div className="label basic required">Required</div> | string                                                   |
+| extras                                                      | array of `{key: string, value: string, number, boolean}` |

--- a/docs/panresponder.md
+++ b/docs/panresponder.md
@@ -232,11 +232,11 @@ static create(config)
 
 **Parameters:**
 
-| Name   | Type   | Required | Description |
-| ------ | ------ | -------- | ----------- |
-| config | object | Yes      | Refer below |
+| Name                                                        | Type   | Description |
+| ----------------------------------------------------------- | ------ | ----------- |
+| config <div className="label basic required">Required</div> | object | Refer below |
 
-The config object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -64,6 +64,8 @@ static clearWatch(watchId: number)
 
 `watchId` is the number returned by `watchKeys()` when the subscription was originally configured.
 
+---
+
 ### `get()`
 
 ```jsx

--- a/docs/usecolorscheme.md
+++ b/docs/usecolorscheme.md
@@ -9,19 +9,38 @@ import { useColorScheme } from 'react-native';
 
 The `useColorScheme` React hook provides and subscribes to color scheme updates from the [`Appearance`](appearance) module. The return value indicates the current user preferred color scheme. The value may be updated later, either through direct user action (e.g. theme selection in device settings) or on a schedule (e.g. light and dark themes that follow the day/night cycle).
 
-Supported color schemes:
+### Supported color schemes
 
-- `light`: The user prefers a light color theme.
-- `dark`: The user prefers a dark color theme.
-- null: The user has not indicated a preferred color theme.
+- `"light"`: The user prefers a light color theme.
+- `"dark"`: The user prefers a dark color theme.
+- `null`: The user has not indicated a preferred color theme.
 
-```jsx
-import { Text, useColorScheme } from 'react-native';
+---
 
-const MyComponent = () => {
+## Example
+
+```SnackPlayer
+import React from 'react';
+import { Text, StyleSheet, useColorScheme, View } from 'react-native';
+
+const App = () => {
   const colorScheme = useColorScheme();
-  return <Text>useColorScheme(): {colorScheme}</Text>;
+  return (
+    <View style={styles.container}>
+      <Text>useColorScheme(): {colorScheme}</Text>
+    </View>
+  );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  },
+});
+
+export default App;
 ```
 
 You can find a complete example that demonstrates the use of this hook alongside a React context to add support for light and dark themes to your application in [`AppearanceExample.js`](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/Appearance/AppearanceExample.js).

--- a/docs/usewindowdimensions.md
+++ b/docs/usewindowdimensions.md
@@ -46,34 +46,40 @@ export default App;
 
 ### `fontScale`
 
-The scale of the font currently used. Some operating systems allow users to scale their font sizes larger or smaller for reading comfort. This property will let you know what is in effect.
-
 ```jsx
 useWindowDimensions().fontScale;
 ```
 
-### `height`
+The scale of the font currently used. Some operating systems allow users to scale their font sizes larger or smaller for reading comfort. This property will let you know what is in effect.
 
-The height in pixels of the window or screen your app occupies.
+---
+
+### `height`
 
 ```jsx
 useWindowDimensions().height;
 ```
 
-### `scale`
+The height in pixels of the window or screen your app occupies.
 
-The pixel ratio of the device your app is running on.
+---
+
+### `scale`
 
 ```jsx
 useWindowDimensions().scale;
 ```
 
+The pixel ratio of the device your app is running on.
+
 > A value of `1` indicates PPI/DPI of 96 (76 on some platforms). `2` indicates a Retina or high DPI display.
 
-### `width`
+---
 
-The width in pixels of the window or screen your app occupies.
+### `width`
 
 ```jsx
 useWindowDimensions().width;
 ```
+
+The width in pixels of the window or screen your app occupies.

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -203,10 +203,20 @@ export default App;
 
 ## Methods
 
+### `cancel()`
+
+```jsx
+Vibration.cancel();
+```
+
+Call this to stop vibrating after having invoked `vibrate()` with repetition enabled.
+
+---
+
 ### `vibrate()`
 
 ```jsx
-Vibration.vibrate(?pattern: number | Array<number>, ?repeat: boolean)
+Vibration.vibrate(pattern, repeat);
 ```
 
 Triggers a vibration with a fixed duration.
@@ -219,18 +229,7 @@ The `vibrate()` method can take a `pattern` argument with an array of numbers th
 
 **Parameters:**
 
-| Name    | Type             | Required | Description                                                | Platform     |
-| ------- | ---------------- | -------- | ---------------------------------------------------------- | ------------ |
-| pattern | number           | No       | Vibration duration in milliseconds. Defaults to 400 ms.    | Android      |
-| pattern | Array of numbers | No       | Vibration pattern as an array of numbers in milliseconds.  | Android, iOS |
-| repeat  | boolean          | No       | Repeat vibration pattern until cancel(), default to false. | Android, iOS |
-
----
-
-### `cancel()`
-
-```jsx
-Vibration.cancel();
-```
-
-Call this to stop vibrating after having invoked `vibrate()` with repetition enabled.
+| Name    | Type                                                                     | Default | Description                                                                                       |
+| ------- | ------------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------- |
+| pattern | number <div className="label android">Android</div><hr/>array of numbers | `400`   | Vibration duration in milliseconds.<hr/>Vibration pattern as an array of numbers in milliseconds. |
+| repeat  | boolean                                                                  | `false` | Repeat vibration pattern until `cancel()`.                                                        |

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -143,8 +143,8 @@ hr {
 
       code {
         display: inline-block;
-        line-height: 1.15em;
-        vertical-align: middle;
+        line-height: 1.1em;
+        vertical-align: top;
       }
     }
 


### PR DESCRIPTION
This PR focuses on updating the Reference section in various components and APIs, so they follow latest UX patterns (like pattern description, required markings, supported platforms, properties and methods order). 

I have also converted the `useColorScheme` hook example to Snack, because current version of Expo supports that hook (which were a problem short after the release).