### PR TITLE
Add missing Platform API docs

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node, JDK</h3>
 
-We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows. 
+We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 
 If you want to be able to switch between different Node versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -1,0 +1,151 @@
+---
+id: platform
+title: Platform
+---
+
+## Example
+
+```SnackPlayer name=Platform%20API%20Example&supportedPlatforms=ios,android
+import React from 'react';
+import { Platform, StyleSheet, Text, ScrollView } from 'react-native';
+
+const App = () => {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text>OS</Text>
+      <Text style={styles.value}>{Platform.OS}</Text>
+      <Text>OS Version</Text>
+      <Text style={styles.value}>{Platform.Version}</Text>
+      <Text>isTV</Text>
+      <Text style={styles.value}>{Platform.isTV.toString()}</Text>
+      {Platform.OS === 'ios' && <>
+        <Text>isPad</Text>
+        <Text style={styles.value}>{Platform.isPad.toString()}</Text>
+      </>}
+      <Text>Constants</Text>
+      <Text style={styles.value}>
+        {JSON.stringify(Platform.constants, null, 2)}
+      </Text>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  value: {
+    fontWeight: '600',
+    padding: 4,
+    marginBottom: 8
+  }
+});
+
+export default App;
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `constants`
+
+```jsx
+Platform.constants;
+```
+
+Returns an object which contains all avaiable common and specific constants related to the platform.
+
+**Properties:**
+
+| <div className="widerColumn">Name</div>                   | Type    | Optional | Description                                                                                                                                                                                      |
+| --------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| isTesting                                                 | boolean | No       |                                                                                                                                                                                                  |
+| reactNativeVersion                                        | object  | No       | Information about React Native version. Keys are `major`, `minor`, `patch` with optional `prerelease` and values are `number`s.                                                                  |
+| Version <div className="label android">Android</div>      | number  | No       | OS version constant specific to Android.                                                                                                                                                         |
+| Release <div className="label android">Android</div>      | string  | No       |                                                                                                                                                                                                  |
+| Serial <div className="label android">Android</div>       | string  | No       | Hardware serial number of an Android device.                                                                                                                                                     |
+| Fingerprint <div className="label android">Android</div>  | string  | No       | A string that uniquely identifies the build.                                                                                                                                                     |
+| Model <div className="label android">Android</div>        | string  | No       | The end-user-visible name for the Android device.                                                                                                                                                |
+| Brand <div className="label android">Android</div>        | string  | No       | The consumer-visible brand with which the product/hardware will be associated.                                                                                                                   |
+| Manufacturer <div className="label android">Android</div> | string  | No       | The manufacturer of the Android device.                                                                                                                                                          |
+| ServerHost <div className="label android">Android</div>   | string  | Yes      |                                                                                                                                                                                                  |
+| uiMode <div className="label android">Android</div>       | string  | No       | Possible values are: `'car'`, `'desk'`, `'normal'`,`'tv'`, `'watch'` and `'unknow'`. Read more about [Android ModeType](https://developer.android.com/reference/android/app/UiModeManager.html). |
+| forceTouchAvailable <div className="label ios">iOS</div>  | boolean | No       | Indicate the availability of 3D Touch on a device.                                                                                                                                               |
+| interfaceIdiom <div className="label ios">iOS</div>       | string  | No       | The interface type for the device. Read more about [UIUserInterfaceIdiom](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom).                                                 |
+| osVersion <div className="label ios">iOS</div>            | string  | No       | OS version constant specific to iOS.                                                                                                                                                             |
+| systemName <div className="label ios">iOS</div>           | string  | No       | OS name constant specific to iOS.                                                                                                                                                                |
+
+---
+
+### `isPad` <div class="label ios">iOS</div>
+
+```jsx
+Platform.isPad;
+```
+
+Returns a boolean which defines if device is an iPad.
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `isTV`
+
+```jsx
+Platform.isTV;
+```
+
+Returns a boolean which defines if device is a TV.
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `isTesting`
+
+```jsx
+Platform.isTesting;
+```
+
+Returns a boolean which defines if application is running in Developer Mode with testing flag set.
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `OS`
+
+```jsx
+static Platform.OS
+```
+
+Returns string value representing the current OS.
+
+| Type                       |
+| -------------------------- |
+| enum(`'android'`, `'ios'`) |
+
+---
+
+### `Version`
+
+```jsx
+Platform.Version;
+```
+
+Returns the version of the OS.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| number <div className="label android">Android</div><hr />string <div className="label ios">iOS</div> |

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -56,10 +56,7 @@
       "native-components-ios",
       "direct-manipulation"
     ],
-    "Guides (Android)": [
-      "headless-js-android",
-      "signed-apk-android"
-    ],
+    "Guides (Android)": ["headless-js-android", "signed-apk-android"],
     "Guides (iOS)": [
       "linking-libraries-ios",
       "running-on-simulator-ios",
@@ -87,6 +84,7 @@
       "linking",
       "panresponder",
       "pixelratio",
+      "platform",
       "platformcolor",
       "share",
       "stylesheet",

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -155,6 +155,10 @@ hr {
     .wideColumn {
       width: 128px;
     }
+
+    .widerColumn {
+      width: 180px;
+    }
   }
 
   figure {

--- a/website/versioned_docs/version-0.63/platform.md
+++ b/website/versioned_docs/version-0.63/platform.md
@@ -1,0 +1,151 @@
+---
+id: platform
+title: Platform
+---
+
+## Example
+
+```SnackPlayer name=Platform%20API%20Example&supportedPlatforms=ios,android
+import React from 'react';
+import { Platform, StyleSheet, Text, ScrollView } from 'react-native';
+
+const App = () => {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text>OS</Text>
+      <Text style={styles.value}>{Platform.OS}</Text>
+      <Text>OS Version</Text>
+      <Text style={styles.value}>{Platform.Version}</Text>
+      <Text>isTV</Text>
+      <Text style={styles.value}>{Platform.isTV.toString()}</Text>
+      {Platform.OS === 'ios' && <>
+        <Text>isPad</Text>
+        <Text style={styles.value}>{Platform.isPad.toString()}</Text>
+      </>}
+      <Text>Constants</Text>
+      <Text style={styles.value}>
+        {JSON.stringify(Platform.constants, null, 2)}
+      </Text>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  value: {
+    fontWeight: '600',
+    padding: 4,
+    marginBottom: 8
+  }
+});
+
+export default App;
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `constants`
+
+```jsx
+Platform.constants;
+```
+
+Returns an object which contains all avaiable common and specific constants related to the platform.
+
+**Properties:**
+
+| <div className="widerColumn">Name</div>                   | Type    | Optional | Description                                                                                                                                                                                      |
+| --------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| isTesting                                                 | boolean | No       |                                                                                                                                                                                                  |
+| reactNativeVersion                                        | object  | No       | Information about React Native version. Keys are `major`, `minor`, `patch` with optional `prerelease` and values are `number`s.                                                                  |
+| Version <div className="label android">Android</div>      | number  | No       | OS version constant specific to Android.                                                                                                                                                         |
+| Release <div className="label android">Android</div>      | string  | No       |                                                                                                                                                                                                  |
+| Serial <div className="label android">Android</div>       | string  | No       | Hardware serial number of an Android device.                                                                                                                                                     |
+| Fingerprint <div className="label android">Android</div>  | string  | No       | A string that uniquely identifies the build.                                                                                                                                                     |
+| Model <div className="label android">Android</div>        | string  | No       | The end-user-visible name for the Android device.                                                                                                                                                |
+| Brand <div className="label android">Android</div>        | string  | No       | The consumer-visible brand with which the product/hardware will be associated.                                                                                                                   |
+| Manufacturer <div className="label android">Android</div> | string  | No       | The manufacturer of the Android device.                                                                                                                                                          |
+| ServerHost <div className="label android">Android</div>   | string  | Yes      |                                                                                                                                                                                                  |
+| uiMode <div className="label android">Android</div>       | string  | No       | Possible values are: `'car'`, `'desk'`, `'normal'`,`'tv'`, `'watch'` and `'unknow'`. Read more about [Android ModeType](https://developer.android.com/reference/android/app/UiModeManager.html). |
+| forceTouchAvailable <div className="label ios">iOS</div>  | boolean | No       | Indicate the availability of 3D Touch on a device.                                                                                                                                               |
+| interfaceIdiom <div className="label ios">iOS</div>       | string  | No       | The interface type for the device. Read more about [UIUserInterfaceIdiom](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom).                                                 |
+| osVersion <div className="label ios">iOS</div>            | string  | No       | OS version constant specific to iOS.                                                                                                                                                             |
+| systemName <div className="label ios">iOS</div>           | string  | No       | OS name constant specific to iOS.                                                                                                                                                                |
+
+---
+
+### `isPad` <div class="label ios">iOS</div>
+
+```jsx
+Platform.isPad;
+```
+
+Returns a boolean which defines if device is an iPad.
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `isTV`
+
+```jsx
+Platform.isTV;
+```
+
+Returns a boolean which defines if device is a TV.
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `isTesting`
+
+```jsx
+Platform.isTesting;
+```
+
+Returns a boolean which defines if application is running in Developer Mode with testing flag set.
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
+### `OS`
+
+```jsx
+static Platform.OS
+```
+
+Returns string value representing the current OS.
+
+| Type                       |
+| -------------------------- |
+| enum(`'android'`, `'ios'`) |
+
+---
+
+### `Version`
+
+```jsx
+Platform.Version;
+```
+
+Returns the version of the OS.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| number <div className="label android">Android</div><hr />string <div className="label ios">iOS</div> |

--- a/website/versioned_sidebars/version-0.63-sidebars.json
+++ b/website/versioned_sidebars/version-0.63-sidebars.json
@@ -366,6 +366,10 @@
         },
         {
           "type": "doc",
+          "id": "version-0.63/platform"
+        },
+        {
+          "type": "doc",
           "id": "version-0.63/platformcolor"
         },
         {


### PR DESCRIPTION
Fixes: #1509

This PR adds the initial version of `Platform` API page to the documentation. The page is present in main docs and has also been ported to latest versioned docs - `0.63`.

The page currently will include basic example and simple definitions of available properties.

Probably the descriptions can bee improved a lot and more content could be added in. The main goal for me was to add a missing part of documentation, hope someone will improve this in time.

### Preview
<img width="1093" alt="Screenshot 2020-12-12 140707" src="https://user-images.githubusercontent.com/719641/101984705-6eaac600-3c83-11eb-9e81-be345fc18f60.png">
<img width="967" alt="Screenshot 2020-12-12 140859" src="https://user-images.githubusercontent.com/719641/101984731-9bf77400-3c83-11eb-9df0-6c5527bbb039.png">
