### PR TITLE
update AccessibilityInfo page, small fixes on other pages

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -177,56 +177,6 @@ export default AccessibilityStatusExample;
 
 ## Methods
 
-### `isBoldTextEnabled()`
-
-```jsx
-static isBoldTextEnabled()
-```
-
-**iOS-Only.** Query whether a bold text is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when bold text is enabled and `false` otherwise.
-
-### `isGrayscaleEnabled()`
-
-```jsx
-static isGrayscaleEnabled()
-```
-
-**iOS-Only.** Query whether grayscale is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when grayscale is enabled and `false` otherwise.
-
-### `isInvertColorsEnabled()`
-
-```jsx
-static isInvertColorsEnabled()
-```
-
-**iOS-Only.** Query whether invert colors is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when invert colors is enabled and `false` otherwise.
-
-### `isReduceMotionEnabled()`
-
-```jsx
-static isReduceMotionEnabled()
-```
-
-Query whether reduce motion is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when reduce motion is enabled and `false` otherwise.
-
-### `isReduceTransparencyEnabled()`
-
-```jsx
-static isReduceTransparencyEnabled()
-```
-
-**iOS-Only.** Query whether reduce transparency is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when a reduce transparency is enabled and `false` otherwise.
-
-### `isScreenReaderEnabled()`
-
-```jsx
-static isScreenReaderEnabled()
-```
-
-Query whether a screen reader is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when a screen reader is enabled and `false` otherwise.
-
----
-
 ### `addEventListener()`
 
 ```jsx
@@ -235,27 +185,15 @@ static addEventListener(eventName, handler)
 
 Add an event handler. Supported events:
 
-- `boldTextChanged`: iOS-only event. Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.
-- `grayscaleChanged`: iOS-only event. Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.
-- `invertColorsChanged`: iOS-only event. Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.
-- `reduceMotionChanged`: Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.
-- `screenReaderChanged`: Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.
-- `reduceTransparencyChanged`: iOS-only event. Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.
-- `announcementFinished`: iOS-only event. Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:
-  - `announcement`: The string announced by the screen reader.
-  - `success`: A boolean indicating whether the announcement was successfully made.
-
----
-
-### `setAccessibilityFocus()`
-
-```jsx
-static setAccessibilityFocus(reactTag)
-```
-
-Set accessibility focus to a React component. On Android, this calls `UIManager.sendAccessibilityEvent(reactTag, UIManager.AccessibilityEventTypes.typeViewFocused);`.
-
-> **Note**: Make sure that any `View` you want to receive the accessibility focus has `accessible={true}`.
+| Event name                                                                 | Description                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>      | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>          | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>       | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                      | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div> | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                      | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -269,6 +207,66 @@ Post a string to be announced by the screen reader.
 
 ---
 
+### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+
+```jsx
+static isBoldTextEnabled()
+```
+
+Query whether a bold text is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when bold text is enabled and `false` otherwise.
+
+---
+
+### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+
+```jsx
+static isGrayscaleEnabled()
+```
+
+Query whether grayscale is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when grayscale is enabled and `false` otherwise.
+
+---
+
+### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+
+```jsx
+static isInvertColorsEnabled()
+```
+
+Query whether invert colors is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when invert colors is enabled and `false` otherwise.
+
+---
+
+### `isReduceMotionEnabled()`
+
+```jsx
+static isReduceMotionEnabled()
+```
+
+Query whether reduce motion is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when reduce motion is enabled and `false` otherwise.
+
+---
+
+### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+
+```jsx
+static isReduceTransparencyEnabled()
+```
+
+Query whether reduce transparency is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when a reduce transparency is enabled and `false` otherwise.
+
+---
+
+### `isScreenReaderEnabled()`
+
+```jsx
+static isScreenReaderEnabled()
+```
+
+Query whether a screen reader is currently enabled. Returns a promise which resolves to a boolean. The result is `true` when a screen reader is enabled and `false` otherwise.
+
+---
+
 ### `removeEventListener()`
 
 ```jsx
@@ -276,3 +274,17 @@ static removeEventListener(eventName, handler)
 ```
 
 Remove an event handler.
+
+---
+
+### `setAccessibilityFocus()`
+
+```jsx
+static setAccessibilityFocus(reactTag)
+```
+
+Set accessibility focus to a React component.
+
+On Android, this calls `UIManager.sendAccessibilityEvent` method with passed `reactTag` and `UIManager.AccessibilityEventTypes.typeViewFocused` arguments.
+
+> **Note**: Make sure that any `View` you want to receive the accessibility focus has `accessible={true}`.

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -45,6 +45,8 @@ if (colorScheme === 'dark') {
 
 Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
+---
+
 # Reference
 
 ## Methods
@@ -67,6 +69,8 @@ See also: `useColorScheme` hook.
 
 > Note: `getColorScheme()` will always return `light` when debugging with Chrome.
 
+---
+
 ### `addChangeListener()`
 
 ```jsx
@@ -74,6 +78,8 @@ static addChangeListener(listener)
 ```
 
 Add an event handler that is fired when appearance preferences change.
+
+---
 
 ### `removeChangeListener()`
 

--- a/docs/devsettings.md
+++ b/docs/devsettings.md
@@ -42,7 +42,9 @@ DevSettings.addMenuItem('Show Secret Dev Screen', () => {
 static reload()
 ```
 
-Reload the application. Can be invoked directly or on user interaction:
+Reload the application. Can be invoked directly or on user interaction.
+
+**Example:**
 
 ```jsx
 <Button title="Reload" onPress={() => DevSettings.reload()} />

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -320,19 +320,19 @@ A set of predefined animation configs to pass into [`configureNext`](layoutanima
 
 ---
 
-### `easeInEaseOut()`
+### `easeInEaseOut`
 
 Calls `configureNext()` with `Presets.easeInEaseOut`.
 
 ---
 
-### `linear()`
+### `linear`
 
 Calls `configureNext()` with `Presets.linear`.
 
 ---
 
-### `spring()`
+### `spring`
 
 Calls `configureNext()` with `Presets.spring`.
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -146,6 +146,11 @@ hr {
         line-height: 1.1em;
         vertical-align: top;
       }
+
+      ul {
+        margin: 8px 0 0 0;
+        padding: 4px 0 4px 20px;
+      }
     }
 
     hr {
@@ -1092,7 +1097,13 @@ td .label {
 
   &.two-lines {
     margin-left: 0;
-    margin-top: 4px;
+    margin-top: 5px;
+
+    &.ios,
+    &.android,
+    &.tv {
+      margin-left: 8px;
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the `AccessibilityInfo` page to the latest UX pattern, adds platform labels, sorts the methods and properties in alphabetical order and adds minor formatting tweaks.

The change set includes also minor changes to few pages, but the changes are only related to the formatting.

### Preview
<img width="1080" alt="Screenshot 2020-12-12 162528" src="https://user-images.githubusercontent.com/719641/101987824-b6871880-3c96-11eb-9be1-c70b3185a87f.png">

