### PR TITLE
Update documentation to point to new repo for Bob

### DIFF
--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -5,16 +5,16 @@ title: Native Modules NPM Package Setup
 
 Native modules are usually distributed as npm packages, except that on top of the usual JavaScript they will include some native code per platform. To understand more about npm packages you may find [this guide](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) useful.
 
-To get set up with the basic project structure for a native module we will use the community tool called [Bob](https://github.com/react-native-community/bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic `create` script:
+To get set up with the basic project structure for a native module we will use the community tool called [Bob](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic `create` script:
 
 ```shell
-npx @react-native-community/bob create react-native-awesome-module
+npx react-native-builder-bob create react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:
 
 ```shell
-yarn bootstrap
+yarn
 ```
 
 When the bootstrap is done, you will be able to start the example app by executing one of the following commands:


### PR DESCRIPTION
Bob now lives under https://github.com/callstack/react-native-builder-bob and published as `react-native-builder-bob`. This PR updates the references in the documentation.