### PR TITLE
Update platform-specific-code.md

### DIFF
--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 
 This will result in a container having `flex: 1` on all platforms, a red background color on iOS, a green background color on Android, and a blue background color on other platforms.
 
-Since it accepts `any` value, you can also use it to return platform specific component, like below:
+Since it accepts `any` value, you can also use it to return platform-specific components, like below:
 
 ```jsx
 const Component = Platform.select({

--- a/website/versioned_docs/version-0.63/platform-specific-code.md
+++ b/website/versioned_docs/version-0.63/platform-specific-code.md
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 
 This will result in a container having `flex: 1` on all platforms, a red background color on iOS, a green background color on Android, and a blue background color on other platforms.
 
-Since it accepts `any` value, you can also use it to return platform specific component, like below:
+Since it accepts `any` value, you can also use it to return platform-specific components, like below:
 
 ```jsx
 const Component = Platform.select({


### PR DESCRIPTION
- Improve grammar by changing "you can also use it to return platform specific component" to "you can also use it to return _platform-specific components_".

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
