### PR TITLE
Update animations.md

### DIFF
--- a/website/versioned_docs/version-0.63/animations.md
+++ b/website/versioned_docs/version-0.63/animations.md
@@ -24,7 +24,7 @@ import { Animated, Text, View } from 'react-native';
 const FadeInView = (props) => {
   const fadeAnim = useRef(new Animated.Value(0)).current  // Initial value for opacity: 0
 
-  React.useEffect(() => {
+  useEffect(() => {
     Animated.timing(
       fadeAnim,
       {


### PR DESCRIPTION
- Replace unnecessary `React.useEffect` with simply `useEffect` (as the named export `useEffect` has already been imported)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
