### PR TITLE
docs: add another secure alternative to Async Storage in security page

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -62,6 +62,7 @@ The [Android Keystore](https://developer.android.com/training/articles/keystore)
 In order to use iOS Keychain services or Android Secure Shared Preferences, you can either write a bridge yourself or use a library which wraps them for you and provides a unified API at your own risk. Some libraries to consider:
 
 - [expo-secure-store](https://docs.expo.io/versions/latest/sdk/securestore/)
+- [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage) - uses Keychain on iOS and EncryptedSharedPreferences on Android.
 - [react-native-keychain](https://github.com/oblador/react-native-keychain)
 - [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [branch](https://github.com/mCodex/react-native-sensitive-info/tree/keystore) that uses Android Keystore.
   - [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info for Redux.

--- a/website/versioned_docs/version-0.63/security.md
+++ b/website/versioned_docs/version-0.63/security.md
@@ -63,6 +63,7 @@ In order to use iOS Keychain services or Android Secure Shared Preferences, you 
 
 - [expo-secure-store](https://docs.expo.io/versions/latest/sdk/securestore/)
 - [react-native-keychain](https://github.com/oblador/react-native-keychain)
+- [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage) - uses Keychain on iOS and EncryptedSharedPreferences on Android.
 - [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [branch](https://github.com/mCodex/react-native-sensitive-info/tree/keystore) that uses Android Keystore.
   - [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info for Redux.
 

--- a/website/versioned_docs/version-0.63/security.md
+++ b/website/versioned_docs/version-0.63/security.md
@@ -62,8 +62,8 @@ The [Android Keystore](https://developer.android.com/training/articles/keystore)
 In order to use iOS Keychain services or Android Secure Shared Preferences, you can either write a bridge yourself or use a library which wraps them for you and provides a unified API at your own risk. Some libraries to consider:
 
 - [expo-secure-store](https://docs.expo.io/versions/latest/sdk/securestore/)
-- [react-native-keychain](https://github.com/oblador/react-native-keychain)
 - [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage) - uses Keychain on iOS and EncryptedSharedPreferences on Android.
+- [react-native-keychain](https://github.com/oblador/react-native-keychain)
 - [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [branch](https://github.com/mCodex/react-native-sensitive-info/tree/keystore) that uses Android Keystore.
   - [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info for Redux.
 


### PR DESCRIPTION
Hello!

I am the author of [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage), secure alternative to Async Storage using Keychain and EncryptedSharedPreferences, and wanted to include it in the security docs, along with the existing options.