### PR TITLE
Update text.md adjustsFontSizeToFit platform

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -310,7 +310,7 @@ See the [Accessibility guide](accessibility#accessible-ios-android) for more inf
 
 ---
 
-### `adjustsFontSizeToFit` <div class="label ios">iOS</div>
+### `adjustsFontSizeToFit`
 
 Specifies whether fonts should be scaled down automatically to fit given style constraints.
 

--- a/website/versioned_docs/version-0.62/text.md
+++ b/website/versioned_docs/version-0.62/text.md
@@ -325,9 +325,9 @@ See the [Accessibility guide](accessibility.md#accessible-ios-android) for more 
 
 Specifies whether fonts should be scaled down automatically to fit given style constraints.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.63/text.md
+++ b/website/versioned_docs/version-0.63/text.md
@@ -327,9 +327,9 @@ See the [Accessibility guide](accessibility.md#accessible-ios-android) for more 
 
 Specifies whether fonts should be scaled down automatically to fit given style constraints.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Required |
+| ---- | -------- |
+| bool | No       |
 
 ---
 


### PR DESCRIPTION
Remove platform section from `adjustsFontSizeToFit` attribute in v0.62.0 and v0.63.0 documentation.

Text components `adjustsFontSizeToFit` platform support is currently marked as `iOS` even though this PR has added the feature to Android as well: https://github.com/facebook/react-native/pull/26389 and is mentioned in the release notes of v0.62.0 here: https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0620
