### PR TITLE
Describe new added feature userInterfaceStyle in ActionSheetIOS

### DIFF
--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -19,7 +19,8 @@ const App = () => {
       {
         options: ["Cancel", "Generate number", "Reset"],
         destructiveButtonIndex: 2,
-        cancelButtonIndex: 0
+        cancelButtonIndex: 0,
+        userInterfaceStyle: 'dark'
       },
       buttonIndex => {
         if (buttonIndex === 0) {
@@ -74,6 +75,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
 - `tintColor` (string) - the [color](colors) used for non-destructive button titles
 - `disabledButtonIndices` (array of numbers) - a list of button indices which should be disabled
+- `userInterfaceStyle` (string) - the interface style used for the action sheet, can be set to `light` or `dark`, otherwise the default system style will be used
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 

--- a/website/versioned_docs/version-0.63/actionsheetios.md
+++ b/website/versioned_docs/version-0.63/actionsheetios.md
@@ -19,7 +19,8 @@ const App = () => {
       {
         options: ["Cancel", "Generate number", "Reset"],
         destructiveButtonIndex: 2,
-        cancelButtonIndex: 0
+        cancelButtonIndex: 0,
+        userInterfaceStyle: 'dark'
       },
       buttonIndex => {
         if (buttonIndex === 0) {
@@ -73,6 +74,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
 - `tintColor` (string) - the [color](colors) used for non-destructive button titles
+- `userInterfaceStyle` (string) - the interface style used for the action sheet
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 

--- a/website/versioned_docs/version-0.63/actionsheetios.md
+++ b/website/versioned_docs/version-0.63/actionsheetios.md
@@ -74,7 +74,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)
 - `tintColor` (string) - the [color](colors) used for non-destructive button titles
-- `userInterfaceStyle` (string) - the interface style used for the action sheet
+- `userInterfaceStyle` (string) - the interface style used for the action sheet, can be set to `light` or `dark`, otherwise the default system style will be used
 
 The 'callback' function takes one parameter, the zero-based index of the selected item.
 


### PR DESCRIPTION
In RN codebase, we have added feature to indicate userInterfaceStyle for native action sheet, and the doc is deprecated.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
