### PR TITLE
Documentation Update for RN PR #30737 - Remove Android specifier for progressViewOffset prop.

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -455,7 +455,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 ---
 
-### `progressViewOffset` <div class="label android">Android</div>
+### `progressViewOffset`
 
 Set this when offset is needed for the loading indicator to show correctly.
 

--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -119,7 +119,7 @@ The background color of the refresh indicator.
 
 ---
 
-### `progressViewOffset` <div class="label android">Android</div>
+### `progressViewOffset`
 
 Progress view top offset.
 

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -417,7 +417,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 ---
 
-### `progressViewOffset` <div class="label android">Android</div>
+### `progressViewOffset`
 
 Set this when offset is needed for the loading indicator to show correctly.
 


### PR DESCRIPTION
React Native PR [30737](https://github.com/facebook/react-native/pull/30737) introduces iOS support for the `progressViewOffset` prop in `RefreshControl`, `FlatList`, and `VirtualizedList`.

This PR updates the documentation for those components to remove the `Android` specifier.