### PR TITLE
Fix swift bug in native-modules-ios.md

### DIFF
--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -558,7 +558,7 @@ Swift doesn't have support for macros, so exposing native modules and their meth
 class CalendarManager: NSObject {
 
  @objc(addEvent:location:date:)
- func addEvent(name: String, location: String, date: NSNumber) -> Void {
+ func addEvent(_ name: String, location: String, date: NSNumber) -> Void {
    // Date is ready to use!
  }
 

--- a/website/versioned_docs/version-0.63/native-modules-ios.md
+++ b/website/versioned_docs/version-0.63/native-modules-ios.md
@@ -558,7 +558,7 @@ Swift doesn't have support for macros, so exposing native modules and their meth
 class CalendarManager: NSObject {
 
  @objc(addEvent:location:date:)
- func addEvent(name: String, location: String, date: NSNumber) -> Void {
+ func addEvent(_ name: String, location: String, date: NSNumber) -> Void {
    // Date is ready to use!
  }
 


### PR DESCRIPTION
I tried the following code example and got an error. Read [this stackoverflow question](https://stackoverflow.com/questions/39692230/got-is-not-a-recognized-objective-c-method-when-bridging-swift-to-react-native) for the details. Since this affects swift 3+ I propose correcting this code example, and optionally mentioning this quirk in a short sentence.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
