### PR TITLE
Fix the description for the *Component props for vritualized lists

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -253,21 +253,21 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, function, element |
+| component, element           |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, function, element |
+| component, element           |
 
 ---
 
@@ -283,11 +283,11 @@ Styling for internal View for `ListFooterComponent`.
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, function, element |
+| component, element           |
 
 ---
 

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -266,7 +266,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type                         |
 | ---------------------------- |
-| component, element, function |
+| component, element           |
 
 ---
 
@@ -282,31 +282,31 @@ Used to extract a unique key for a given item at the specified index. Key is use
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, element, function |
+| component, element           |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the very end of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, element, function |
+| component, element           |
 
 ---
 
 ### `ListHeaderComponent`
 
-Rendered at the very beginning of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, element, function |
+| component, element           |
 
 ---
 
@@ -398,7 +398,7 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 | Type                         |
 | ---------------------------- |
-| component, element, function |
+| component, element           |
 
 ---
 
@@ -473,5 +473,5 @@ An object that identifies the data to be rendered for a given section.
 | data <div class="label basic required">Required</div> | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#data).                                                  |
 | key                                                   | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
 | renderItem                                            | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| ItemSeparatorComponent                                | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
 | keyExtractor                                          | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -166,11 +166,11 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, function, element |
+| component, element           |
 
 ---
 
@@ -186,11 +186,11 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, function, element |
+| component, element           |
 
 ---
 
@@ -206,11 +206,11 @@ Styling for internal View for `ListFooterComponent`.
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         |
 | ---------------------------- |
-| component, function, element |
+| component, element           |
 
 ---
 

--- a/website/versioned_docs/version-0.60/flatlist.md
+++ b/website/versioned_docs/version-0.60/flatlist.md
@@ -256,21 +256,21 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -286,11 +286,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.60/sectionlist.md
+++ b/website/versioned_docs/version-0.60/sectionlist.md
@@ -215,7 +215,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
@@ -241,31 +241,31 @@ The legacy implementation is no longer supported.
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the very end of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListHeaderComponent`
 
-Rendered at the very beginning of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -451,5 +451,5 @@ An object that identifies the data to be rendered for a given section.
 | data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
 | [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [ItemSeparatorComponent] | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
 | [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.60/virtualizedlist.md
+++ b/website/versioned_docs/version-0.60/virtualizedlist.md
@@ -151,11 +151,11 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -171,11 +171,11 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -191,11 +191,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.61/flatlist.md
+++ b/website/versioned_docs/version-0.61/flatlist.md
@@ -256,21 +256,21 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -286,11 +286,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.61/sectionlist.md
+++ b/website/versioned_docs/version-0.61/sectionlist.md
@@ -215,7 +215,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
@@ -241,31 +241,31 @@ The legacy implementation is no longer supported.
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the very end of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListHeaderComponent`
 
-Rendered at the very beginning of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -451,5 +451,5 @@ An object that identifies the data to be rendered for a given section.
 | data                       | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | `[key]`                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
 | `[renderItem]`             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| `[ItemSeparatorComponent]` | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| `[ItemSeparatorComponent]` | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
 | `[keyExtractor]`           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.61/virtualizedlist.md
+++ b/website/versioned_docs/version-0.61/virtualizedlist.md
@@ -151,11 +151,11 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -171,11 +171,11 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -191,11 +191,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.62/flatlist.md
+++ b/website/versioned_docs/version-0.62/flatlist.md
@@ -257,21 +257,21 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -287,11 +287,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.62/sectionlist.md
+++ b/website/versioned_docs/version-0.62/sectionlist.md
@@ -262,7 +262,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
@@ -278,31 +278,31 @@ Used to extract a unique key for a given item at the specified index. Key is use
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the very end of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListHeaderComponent`
 
-Rendered at the very beginning of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -488,5 +488,5 @@ An object that identifies the data to be rendered for a given section.
 | data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
 | [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [ItemSeparatorComponent] | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
 | [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.62/virtualizedlist.md
+++ b/website/versioned_docs/version-0.62/virtualizedlist.md
@@ -227,11 +227,11 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -247,11 +247,11 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -267,11 +267,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.63/flatlist.md
+++ b/website/versioned_docs/version-0.63/flatlist.md
@@ -249,21 +249,21 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -279,11 +279,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.63/sectionlist.md
+++ b/website/versioned_docs/version-0.63/sectionlist.md
@@ -262,7 +262,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
@@ -278,31 +278,31 @@ Used to extract a unique key for a given item at the specified index. Key is use
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListFooterComponent`
 
-Rendered at the very end of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                           | Required |
 | ------------------------------ | -------- |
-| [component, function, element] | No       |
+| [component, element]           | No       |
 
 ---
 
 ### `ListHeaderComponent`
 
-Rendered at the very beginning of the list. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -488,5 +488,5 @@ An object that identifies the data to be rendered for a given section.
 | data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
 | [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
 | [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, function, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [ItemSeparatorComponent] | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
 | [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.63/virtualizedlist.md
+++ b/website/versioned_docs/version-0.63/virtualizedlist.md
@@ -227,11 +227,11 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 ### `ListEmptyComponent`
 
-Rendered when the list is empty. Can be a React Component Class, a render function, or a rendered element.
+Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -247,11 +247,11 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 ### `ListFooterComponent`
 
-Rendered at the bottom of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 
@@ -267,11 +267,11 @@ Styling for internal View for ListFooterComponent
 
 ### `ListHeaderComponent`
 
-Rendered at the top of all the items. Can be a React Component Class, a render function, or a rendered element.
+Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
 | Type                         | Required |
 | ---------------------------- | -------- |
-| component, function, element | No       |
+| component, element           | No       |
 
 ---
 


### PR DESCRIPTION
The docs for components such as `ListHeaderComponent`, `ListFooterComponent` etc. in the virtualized list components (`FlatList`, `VirtualizedList` etc.) say that it can accept a React Component Class, a render function, or a rendered element. However, they don't really accept a render function.

You can see from the source code that the code never calls the passed prop as a function, only as a component or element: https://github.com/facebook/react-native/blob/6079256fcc222fb2581c804c340905ed9d8ac1ca/Libraries/Lists/VirtualizedList.js#L878. The type annotations for this prop also annotate it as a component or element.

While passing a render function (`ListHeaderComponent={() => <SomeThing />}`) appears to work, it's only because this is also the same signature as a function component. But it can actually cause issues. Since using it this way means every re-render will result in a new component, which means it will get unmounted and remounted causing perf issues as well as losing any local state. I've seen people put text input there which causes issues (https://github.com/facebook/react-native/issues/13365)

So I think it's better to remove the incorrect description from the docs.