### PR TITLE
Added suggestion for `maintainVisibleContentPosition` support on android

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -340,7 +340,7 @@ Caveat 1: Reordering elements in the scrollview with this enabled will probably 
 
 Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute visibility. Occlusion, transforms, and other complexity won't be taken into account as to whether content is "visible" or not.
 
-Caveat 3: This is only available on iOS. For android, you can use the available alternative - [@stream-io/flat-list-mvcp](https://github.com/GetStream/flat-list-mvcp)
+Caveat 3: This is only available on iOS. For android, you can use the available alternative library instead - [@stream-io/flat-list-mvcp](https://github.com/GetStream/flat-list-mvcp)
 
 | Type                                                                     | Required | Platform |
 | ------------------------------------------------------------------------ | -------- | -------- |

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -340,6 +340,8 @@ Caveat 1: Reordering elements in the scrollview with this enabled will probably 
 
 Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute visibility. Occlusion, transforms, and other complexity won't be taken into account as to whether content is "visible" or not.
 
+Caveat 3: This is only available on iOS. For android, you can use the available alternative - [@stream-io/flat-list-mvcp](https://github.com/GetStream/flat-list-mvcp)
+
 | Type                                                                     | Required | Platform |
 | ------------------------------------------------------------------------ | -------- | -------- |
 | object: { minIndexForVisible: number, autoscrollToTopThreshold: number } | No       | iOS      |


### PR DESCRIPTION
ScrollView and FlatList supports a prop - `maintainVisibleContentPosition`, which is super useful in implementing bi-directional infinite scroll. Although it is only available for iOS right now. Until react-native team adds support for this prop on android, one could use alternative. - [@stream-io/flat-list-mvcp](https://github.com/GetStream/flat-list-mvcp). 

[#29055](https://github.com/facebook/react-native/issues/29055)
