### PR TITLE
Add Osmi CLI reference as a third-party CLI

### DIFF
--- a/website/versioned_docs/version-0.63/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-linux-android.md
@@ -87,7 +87,7 @@ React Native has a built-in command line interface, which you can use to generat
 npx react-native init AwesomeProject
 ```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite) or [Osmi CLI](https://github.com/OsmiCSX/osmi).
 
 <h3>[Optional] Using a specific version or template</h3>
 

--- a/website/versioned_docs/version-0.63/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-macos-android.md
@@ -99,7 +99,7 @@ React Native has a built-in command line interface, which you can use to generat
 npx react-native init AwesomeProject
 ```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite) or [Osmi CLI](https://github.com/OsmiCSX/osmi).
 
 <h3>[Optional] Using a specific version or template</h3>
 

--- a/website/versioned_docs/version-0.63/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.63/_getting-started-macos-ios.md
@@ -59,7 +59,7 @@ You can use React Native's built-in command line interface to generate a new pro
 npx react-native init AwesomeProject
 ```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite) or [Osmi CLI](https://github.com/OsmiCSX/osmi).
 
 ### [Optional] Using a specific version or template
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -116,7 +116,7 @@ React Native has a built-in command line interface, which you can use to generat
 npx react-native init AwesomeProject
 ```
 
-This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
+This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Platform Specific Code](platform-specific-code.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite) or [Osmi CLI](https://github.com/OsmiCSX/osmi).
 
 <h3>[Optional] Using a specific version or template</h3>
 


### PR DESCRIPTION
Add Osmi CLI reference as a third-party CLI. Osmi CLI is an alternative for Ignite CLI