### PR TITLE
Update Reactiflux invite link

### DIFF
--- a/website/src/pages/help.md
+++ b/website/src/pages/help.md
@@ -38,7 +38,7 @@ There are a lot of [React Native Meetups](http://www.meetup.com/topics/react-nat
 
 ### Reactiflux Chat
 
-If you need an answer right away, check out the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bZjGY5n) community. There are usually a number of React Native experts there who can help out or point you to somewhere you might want to look.
+If you need an answer right away, check out the [Reactiflux Discord](https://discord.gg/JuTwWB8rsy) community. There are usually a number of React Native experts there who can help out or point you to somewhere you might want to look.
 
 ### Forum-like groups
 


### PR DESCRIPTION
We have replaced the #react-native channel with #help-react-native, which this now links to directly

Related to #2405

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
