### PR TITLE
Remove documentation of setOpacityTo instance method

### DIFF
--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -225,13 +225,3 @@ TV next focus up (see documentation for the View component).
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
 | number | No       | Android  |
-
-## Methods
-
-### `setOpacityTo()`
-
-```jsx
-setOpacityTo((value: number), (duration: number));
-```
-
-Animate the touchable to a new opacity.

--- a/website/versioned_docs/version-0.62/touchableopacity.md
+++ b/website/versioned_docs/version-0.62/touchableopacity.md
@@ -215,13 +215,3 @@ TV next focus up (see documentation for the View component).
 | Type | Required | Platform |
 | ---- | -------- | -------- |
 | bool | No       | Android  |
-
-## Methods
-
-### `setOpacityTo()`
-
-```jsx
-setOpacityTo((value: number), (duration: number));
-```
-
-Animate the touchable to a new opacity.

--- a/website/versioned_docs/version-0.63/touchableopacity.md
+++ b/website/versioned_docs/version-0.63/touchableopacity.md
@@ -221,13 +221,3 @@ TV next focus up (see documentation for the View component).
 | Type | Required | Platform |
 | ---- | -------- | -------- |
 | bool | No       | Android  |
-
-## Methods
-
-### `setOpacityTo()`
-
-```jsx
-setOpacityTo((value: number), (duration: number));
-```
-
-Animate the touchable to a new opacity.


### PR DESCRIPTION
Per the discussion here https://github.com/facebook/react-native/issues/29272, setOpacityTo is now a deprecated and completely-removed API. This PR updates the TouchableOpacity documentation to remove it from there as well.