### PR TITLE
Update flatlist.md and virtualizedlist.md

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -389,7 +389,7 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key` and `item.id`, then falls back to using the index, like React does.
 
 | Type     |
 | -------- |

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -389,7 +389,7 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key` and `item.id`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     |
 | -------- |

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -325,7 +325,7 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key` and `item.id`, then falls back to using the index, like React does.
 
 | Type     |
 | -------- |

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -325,7 +325,7 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key` and `item.id`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     |
 | -------- |

--- a/website/versioned_docs/version-0.60/flatlist.md
+++ b/website/versioned_docs/version-0.60/flatlist.md
@@ -392,7 +392,7 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.60/virtualizedlist.md
+++ b/website/versioned_docs/version-0.60/virtualizedlist.md
@@ -356,7 +356,7 @@ How many items to render in the initial batch. This should be enough to fill the
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.61/flatlist.md
+++ b/website/versioned_docs/version-0.61/flatlist.md
@@ -392,7 +392,7 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.61/virtualizedlist.md
+++ b/website/versioned_docs/version-0.61/virtualizedlist.md
@@ -356,7 +356,7 @@ How many items to render in the initial batch. This should be enough to fill the
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.62/flatlist.md
+++ b/website/versioned_docs/version-0.62/flatlist.md
@@ -393,7 +393,7 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.62/virtualizedlist.md
+++ b/website/versioned_docs/version-0.62/virtualizedlist.md
@@ -424,7 +424,7 @@ How many items to render in the initial batch. This should be enough to fill the
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.63/flatlist.md
+++ b/website/versioned_docs/version-0.63/flatlist.md
@@ -385,7 +385,7 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |

--- a/website/versioned_docs/version-0.63/virtualizedlist.md
+++ b/website/versioned_docs/version-0.63/virtualizedlist.md
@@ -424,7 +424,7 @@ How many items to render in the initial batch. This should be enough to fill the
 (item: object, index: number) => string;
 ```
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the react key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
FlatList and VirtualizedList's default keyExtractor now checks item.id and item.key as of v60.0