### PR TITLE
#2453 - Add missing methods section to Platform API reference

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -166,7 +166,7 @@ Returns the most fitting value for the platform you are currently running on.
 | ------ | ------ | -------- | ----------------------------- |
 | config | object | Yes      | See config description below. |
 
-[`select`](platform.md#select) method, given an object where keys can be one of `'android' | 'ios' | 'native' | 'default'`, returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `android` and `ios` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
+Select method returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `android` and `ios` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
 
 The `config` parameter is an object with the following keys:
 
@@ -175,7 +175,7 @@ The `config` parameter is an object with the following keys:
 - `native` (any)
 - `default` (any)
 
-Example usage:
+**Example usage:**
 
 ```jsx
 import { Platform, StyleSheet } from 'react-native';

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -62,23 +62,23 @@ Returns an object which contains all available common and specific constants rel
 
 **Properties:**
 
-| <div className="widerColumn">Name</div>                   | Type    | Optional | Description                                                                                                                                                                                      |
-| --------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| isTesting                                                 | boolean | No       |                                                                                                                                                                                                  |
-| reactNativeVersion                                        | object  | No       | Information about React Native version. Keys are `major`, `minor`, `patch` with optional `prerelease` and values are `number`s.                                                                  |
-| Version <div className="label android">Android</div>      | number  | No       | OS version constant specific to Android.                                                                                                                                                         |
-| Release <div className="label android">Android</div>      | string  | No       |                                                                                                                                                                                                  |
-| Serial <div className="label android">Android</div>       | string  | No       | Hardware serial number of an Android device.                                                                                                                                                     |
-| Fingerprint <div className="label android">Android</div>  | string  | No       | A string that uniquely identifies the build.                                                                                                                                                     |
-| Model <div className="label android">Android</div>        | string  | No       | The end-user-visible name for the Android device.                                                                                                                                                |
-| Brand <div className="label android">Android</div>        | string  | No       | The consumer-visible brand with which the product/hardware will be associated.                                                                                                                   |
-| Manufacturer <div className="label android">Android</div> | string  | No       | The manufacturer of the Android device.                                                                                                                                                          |
-| ServerHost <div className="label android">Android</div>   | string  | Yes      |                                                                                                                                                                                                  |
+| <div className="widerColumn">Name</div>                   | Type    | Optional | Description                                                                                                                                                                                       |
+| --------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| isTesting                                                 | boolean | No       |                                                                                                                                                                                                   |
+| reactNativeVersion                                        | object  | No       | Information about React Native version. Keys are `major`, `minor`, `patch` with optional `prerelease` and values are `number`s.                                                                   |
+| Version <div className="label android">Android</div>      | number  | No       | OS version constant specific to Android.                                                                                                                                                          |
+| Release <div className="label android">Android</div>      | string  | No       |                                                                                                                                                                                                   |
+| Serial <div className="label android">Android</div>       | string  | No       | Hardware serial number of an Android device.                                                                                                                                                      |
+| Fingerprint <div className="label android">Android</div>  | string  | No       | A string that uniquely identifies the build.                                                                                                                                                      |
+| Model <div className="label android">Android</div>        | string  | No       | The end-user-visible name for the Android device.                                                                                                                                                 |
+| Brand <div className="label android">Android</div>        | string  | No       | The consumer-visible brand with which the product/hardware will be associated.                                                                                                                    |
+| Manufacturer <div className="label android">Android</div> | string  | No       | The manufacturer of the Android device.                                                                                                                                                           |
+| ServerHost <div className="label android">Android</div>   | string  | Yes      |                                                                                                                                                                                                   |
 | uiMode <div className="label android">Android</div>       | string  | No       | Possible values are: `'car'`, `'desk'`, `'normal'`,`'tv'`, `'watch'` and `'unknown'`. Read more about [Android ModeType](https://developer.android.com/reference/android/app/UiModeManager.html). |
-| forceTouchAvailable <div className="label ios">iOS</div>  | boolean | No       | Indicate the availability of 3D Touch on a device.                                                                                                                                               |
-| interfaceIdiom <div className="label ios">iOS</div>       | string  | No       | The interface type for the device. Read more about [UIUserInterfaceIdiom](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom).                                                 |
-| osVersion <div className="label ios">iOS</div>            | string  | No       | OS version constant specific to iOS.                                                                                                                                                             |
-| systemName <div className="label ios">iOS</div>           | string  | No       | OS name constant specific to iOS.                                                                                                                                                                |
+| forceTouchAvailable <div className="label ios">iOS</div>  | boolean | No       | Indicate the availability of 3D Touch on a device.                                                                                                                                                |
+| interfaceIdiom <div className="label ios">iOS</div>       | string  | No       | The interface type for the device. Read more about [UIUserInterfaceIdiom](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom).                                                  |
+| osVersion <div className="label ios">iOS</div>            | string  | No       | OS version constant specific to iOS.                                                                                                                                                              |
+| systemName <div className="label ios">iOS</div>           | string  | No       | OS name constant specific to iOS.                                                                                                                                                                 |
 
 ---
 
@@ -149,3 +149,74 @@ Returns the version of the OS.
 | Type                                                                                                 |
 | ---------------------------------------------------------------------------------------------------- |
 | number <div className="label android">Android</div><hr />string <div className="label ios">iOS</div> |
+
+## Methods
+
+### `select()`
+
+```jsx
+static select(config: object): any
+```
+
+Returns the most fitting value for the platform you are currently running on.
+
+#### Parameters:
+
+| Name   | Type   | Required | Description                   |
+| ------ | ------ | -------- | ----------------------------- |
+| config | object | Yes      | See config description below. |
+
+[`select`](platform.md#select) method, given an object where keys can be one of `'android' | 'ios' | 'native' | 'default'`, returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `android` and `ios` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
+
+The `config` parameter is an object with the following keys:
+
+- `android` (any)
+- `ios` (any)
+- `native` (any)
+- `default` (any)
+
+Example usage:
+
+```jsx
+import { Platform, StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    ...Platform.select({
+      android: {
+        backgroundColor: 'green'
+      },
+      ios: {
+        backgroundColor: 'red'
+      },
+      default: {
+        // other platforms, web for example
+        backgroundColor: 'blue'
+      }
+    })
+  }
+});
+```
+
+This will result in a container having `flex: 1` on all platforms, a green background color on Android, a red background color on iOS, and a blue background color on other platforms.
+
+Since the value of the corresponding platform key can be of type `any`, [`select`](platform.md#select) method can also be used to return platform-specific components, like below:
+
+```jsx
+const Component = Platform.select({
+  ios: () => require('ComponentIOS'),
+  android: () => require('ComponentAndroid')
+})();
+
+<Component />;
+```
+
+```jsx
+const Component = Platform.select({
+  native: () => require('ComponentForNative'),
+  default: () => require('ComponentForWeb')
+})();
+
+<Component />;
+```

--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -88,6 +88,6 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-The string value provided to the `PlatformColor` function must match the string as it exists on the native platform where the app is running. In order to avoid runtime errors, the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.Select()`, as shown on the example above.
+The string value provided to the `PlatformColor` function must match the string as it exists on the native platform where the app is running. In order to avoid runtime errors, the function should be wrapped in a platform check, either through a `Platform.OS === 'platform'` or a `Platform.select()`, as shown on the example above.
 
 > **Note:** You can find a complete example that demonstrates proper, intended use of `PlatformColor` in [PlatformColorExample.js](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js).

--- a/website/versioned_docs/version-0.63/platform.md
+++ b/website/versioned_docs/version-0.63/platform.md
@@ -166,7 +166,7 @@ Returns the most fitting value for the platform you are currently running on.
 | ------ | ------ | -------- | ----------------------------- |
 | config | object | Yes      | See config description below. |
 
-[`select`](platform.md#select) method, given an object where keys can be one of `'android' | 'ios' | 'native' | 'default'`, returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `android` and `ios` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
+Select method returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `android` and `ios` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
 
 The `config` parameter is an object with the following keys:
 
@@ -175,7 +175,7 @@ The `config` parameter is an object with the following keys:
 - `native` (any)
 - `default` (any)
 
-Example usage:
+**Example usage:**
 
 ```jsx
 import { Platform, StyleSheet } from 'react-native';

--- a/website/versioned_docs/version-0.63/platform.md
+++ b/website/versioned_docs/version-0.63/platform.md
@@ -62,23 +62,23 @@ Returns an object which contains all available common and specific constants rel
 
 **Properties:**
 
-| <div className="widerColumn">Name</div>                   | Type    | Optional | Description                                                                                                                                                                                      |
-| --------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| isTesting                                                 | boolean | No       |                                                                                                                                                                                                  |
-| reactNativeVersion                                        | object  | No       | Information about React Native version. Keys are `major`, `minor`, `patch` with optional `prerelease` and values are `number`s.                                                                  |
-| Version <div className="label android">Android</div>      | number  | No       | OS version constant specific to Android.                                                                                                                                                         |
-| Release <div className="label android">Android</div>      | string  | No       |                                                                                                                                                                                                  |
-| Serial <div className="label android">Android</div>       | string  | No       | Hardware serial number of an Android device.                                                                                                                                                     |
-| Fingerprint <div className="label android">Android</div>  | string  | No       | A string that uniquely identifies the build.                                                                                                                                                     |
-| Model <div className="label android">Android</div>        | string  | No       | The end-user-visible name for the Android device.                                                                                                                                                |
-| Brand <div className="label android">Android</div>        | string  | No       | The consumer-visible brand with which the product/hardware will be associated.                                                                                                                   |
-| Manufacturer <div className="label android">Android</div> | string  | No       | The manufacturer of the Android device.                                                                                                                                                          |
-| ServerHost <div className="label android">Android</div>   | string  | Yes      |                                                                                                                                                                                                  |
+| <div className="widerColumn">Name</div>                   | Type    | Optional | Description                                                                                                                                                                                       |
+| --------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| isTesting                                                 | boolean | No       |                                                                                                                                                                                                   |
+| reactNativeVersion                                        | object  | No       | Information about React Native version. Keys are `major`, `minor`, `patch` with optional `prerelease` and values are `number`s.                                                                   |
+| Version <div className="label android">Android</div>      | number  | No       | OS version constant specific to Android.                                                                                                                                                          |
+| Release <div className="label android">Android</div>      | string  | No       |                                                                                                                                                                                                   |
+| Serial <div className="label android">Android</div>       | string  | No       | Hardware serial number of an Android device.                                                                                                                                                      |
+| Fingerprint <div className="label android">Android</div>  | string  | No       | A string that uniquely identifies the build.                                                                                                                                                      |
+| Model <div className="label android">Android</div>        | string  | No       | The end-user-visible name for the Android device.                                                                                                                                                 |
+| Brand <div className="label android">Android</div>        | string  | No       | The consumer-visible brand with which the product/hardware will be associated.                                                                                                                    |
+| Manufacturer <div className="label android">Android</div> | string  | No       | The manufacturer of the Android device.                                                                                                                                                           |
+| ServerHost <div className="label android">Android</div>   | string  | Yes      |                                                                                                                                                                                                   |
 | uiMode <div className="label android">Android</div>       | string  | No       | Possible values are: `'car'`, `'desk'`, `'normal'`,`'tv'`, `'watch'` and `'unknown'`. Read more about [Android ModeType](https://developer.android.com/reference/android/app/UiModeManager.html). |
-| forceTouchAvailable <div className="label ios">iOS</div>  | boolean | No       | Indicate the availability of 3D Touch on a device.                                                                                                                                               |
-| interfaceIdiom <div className="label ios">iOS</div>       | string  | No       | The interface type for the device. Read more about [UIUserInterfaceIdiom](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom).                                                 |
-| osVersion <div className="label ios">iOS</div>            | string  | No       | OS version constant specific to iOS.                                                                                                                                                             |
-| systemName <div className="label ios">iOS</div>           | string  | No       | OS name constant specific to iOS.                                                                                                                                                                |
+| forceTouchAvailable <div className="label ios">iOS</div>  | boolean | No       | Indicate the availability of 3D Touch on a device.                                                                                                                                                |
+| interfaceIdiom <div className="label ios">iOS</div>       | string  | No       | The interface type for the device. Read more about [UIUserInterfaceIdiom](https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom).                                                  |
+| osVersion <div className="label ios">iOS</div>            | string  | No       | OS version constant specific to iOS.                                                                                                                                                              |
+| systemName <div className="label ios">iOS</div>           | string  | No       | OS name constant specific to iOS.                                                                                                                                                                 |
 
 ---
 
@@ -149,3 +149,74 @@ Returns the version of the OS.
 | Type                                                                                                 |
 | ---------------------------------------------------------------------------------------------------- |
 | number <div className="label android">Android</div><hr />string <div className="label ios">iOS</div> |
+
+## Methods
+
+### `select()`
+
+```jsx
+static select(config: object): any
+```
+
+Returns the most fitting value for the platform you are currently running on.
+
+#### Parameters:
+
+| Name   | Type   | Required | Description                   |
+| ------ | ------ | -------- | ----------------------------- |
+| config | object | Yes      | See config description below. |
+
+[`select`](platform.md#select) method, given an object where keys can be one of `'android' | 'ios' | 'native' | 'default'`, returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `android` and `ios` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
+
+The `config` parameter is an object with the following keys:
+
+- `android` (any)
+- `ios` (any)
+- `native` (any)
+- `default` (any)
+
+Example usage:
+
+```jsx
+import { Platform, StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    ...Platform.select({
+      android: {
+        backgroundColor: 'green'
+      },
+      ios: {
+        backgroundColor: 'red'
+      },
+      default: {
+        // other platforms, web for example
+        backgroundColor: 'blue'
+      }
+    })
+  }
+});
+```
+
+This will result in a container having `flex: 1` on all platforms, a green background color on Android, a red background color on iOS, and a blue background color on other platforms.
+
+Since the value of the corresponding platform key can be of type `any`, [`select`](platform.md#select) method can also be used to return platform-specific components, like below:
+
+```jsx
+const Component = Platform.select({
+  ios: () => require('ComponentIOS'),
+  android: () => require('ComponentAndroid')
+})();
+
+<Component />;
+```
+
+```jsx
+const Component = Platform.select({
+  native: () => require('ComponentForNative'),
+  default: () => require('ComponentForWeb')
+})();
+
+<Component />;
+```


### PR DESCRIPTION
#### Summary

- Added missing "methods" section with a `select()` method to [Platform API](https://reactnative.dev/docs/platform) reference as detailed in the [Platform Specific Code](https://reactnative.dev/docs/next/platform-specific-code#platform-module) section.

#### Linked Issue

Fixes [#2453](https://github.com/facebook/react-native-website/issues/2453)
