### PR TITLE
update deprecation notes to point to the RN Directory instead of single package

### DIFF
--- a/docs/asyncstorage.md
+++ b/docs/asyncstorage.md
@@ -3,7 +3,7 @@ id: asyncstorage
 title: '🚧 AsyncStorage'
 ---
 
-> **Deprecated.** Use [@react-native-async-storage/async-storage](https://github.com/react-native-async-storage/async-storage) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.
 
 `AsyncStorage` is an unencrypted, asynchronous, persistent, key-value storage system that is global to the app. It should be used instead of LocalStorage.
 

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -3,7 +3,7 @@ id: checkbox
 title: '🚧 CheckBox'
 ---
 
-> **Deprecated.** Use [@react-native-community/checkbox](https://github.com/react-native-community/react-native-checkbox) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.
 
 Renders a boolean input (Android only).
 

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -3,7 +3,7 @@ id: clipboard
 title: '🚧 Clipboard'
 ---
 
-> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-clipboard/clipboard) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS
 

--- a/docs/datepickerandroid.md
+++ b/docs/datepickerandroid.md
@@ -3,7 +3,7 @@ id: datepickerandroid
 title: '🚧 DatePickerAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.
 
 Opens the standard Android date picker dialog.
 

--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -5,7 +5,7 @@ title: '🚧 DatePickerIOS'
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.
 
 Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a controlled component, so you must hook in to the `onDateChange` callback and update the `date` prop in order for the component to update, otherwise the user's change will be reverted immediately to reflect `props.date` as the source of truth.
 

--- a/docs/imageeditor.md
+++ b/docs/imageeditor.md
@@ -3,7 +3,7 @@ id: imageeditor
 title: '🚧 ImageEditor'
 ---
 
-> **Deprecated.** Use [@react-native-community/image-editor](https://github.com/react-native-community/react-native-image-editor) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=imageeditor) instead.
 
 ---
 

--- a/docs/imagepickerios.md
+++ b/docs/imagepickerios.md
@@ -3,7 +3,7 @@ id: imagepickerios
 title: '🚧 ImagePickerIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/image-picker-ios](https://github.com/react-native-community/react-native-image-picker-ios) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.
 
 ---
 

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -3,7 +3,7 @@ id: picker
 title: '🚧 Picker'
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=picker) instead.
 
 Renders the native picker component on Android and iOS.
 

--- a/docs/pickerios.md
+++ b/docs/pickerios.md
@@ -3,7 +3,7 @@ id: pickerios
 title: '🚧 PickerIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-picker/react-native-picker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=picker) instead.
 
 ---
 

--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -3,7 +3,7 @@ id: progressbarandroid
 title: '🚧 ProgressBarAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-progress-view/progress-bar-android) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/docs/progressviewios.md
+++ b/docs/progressviewios.md
@@ -3,7 +3,7 @@ id: progressviewios
 title: '🚧 ProgressViewIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-community/progress-view) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressview) instead.
 
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -3,7 +3,7 @@ id: pushnotificationios
 title: '🚧 PushNotificationIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/push-notification-ios](https://github.com/react-native-community/react-native-push-notification-ios) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=push+notification) instead.
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>

--- a/docs/segmentedcontrolios.md
+++ b/docs/segmentedcontrolios.md
@@ -3,9 +3,9 @@ id: segmentedcontrolios
 title: '🚧 SegmentedControlIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/segmented-control](https://github.com/react-native-segmented-control/segmented-control) instead.
-
-Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.
+>
+> Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 
 #### Programmatically changing selected index
 

--- a/docs/segmentedcontrolios.md
+++ b/docs/segmentedcontrolios.md
@@ -4,8 +4,8 @@ title: '🚧 SegmentedControlIOS'
 ---
 
 > **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.
->
-> Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
+
+Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 
 #### Programmatically changing selected index
 

--- a/docs/slider.md
+++ b/docs/slider.md
@@ -3,7 +3,7 @@ id: slider
 title: '🚧 Slider'
 ---
 
-> **Deprecated.** Use [@react-native-community/slider](https://github.com/react-native-community/react-native-slider) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=slider) instead.
 
 A component used to select a single value from a range of values.
 

--- a/docs/timepickerandroid.md
+++ b/docs/timepickerandroid.md
@@ -3,7 +3,7 @@ id: timepickerandroid
 title: '🚧 TimePickerAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.
 
 Opens the standard Android time picker dialog.
 

--- a/docs/viewpagerandroid.md
+++ b/docs/viewpagerandroid.md
@@ -3,7 +3,7 @@ id: viewpagerandroid
 title: '🚧 ViewPagerAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/viewpager](https://github.com/react-native-community/react-native-viewpager) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=viewpager) instead.
 
 Container that allows to flip left and right between child views. Each child view of the `ViewPagerAndroid` will be treated as a separate page and will be stretched to fill the `ViewPagerAndroid`.
 

--- a/website/versioned_docs/version-0.63/asyncstorage.md
+++ b/website/versioned_docs/version-0.63/asyncstorage.md
@@ -3,7 +3,7 @@ id: asyncstorage
 title: '🚧 AsyncStorage'
 ---
 
-> **Deprecated.** Use [@react-native-async-storage/async-storage](https://github.com/react-native-async-storage/async-storage) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.
 
 `AsyncStorage` is an unencrypted, asynchronous, persistent, key-value storage system that is global to the app. It should be used instead of LocalStorage.
 

--- a/website/versioned_docs/version-0.63/cameraroll.md
+++ b/website/versioned_docs/version-0.63/cameraroll.md
@@ -1,11 +1,9 @@
 ---
 id: cameraroll
 title: '🚧 CameraRoll'
-
-custom_edit_url: 'https://github.com/facebook/react-native-website/edit/master/website/versioned_docs/version-0.58/cameraroll.md'
 ---
 
-> **Deprecated.** Use [@react-native-community/cameraroll](https://github.com/react-native-community/react-native-cameraroll) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=cameraroll) instead.
 
 `CameraRoll` provides access to the local camera roll or photo library.
 

--- a/website/versioned_docs/version-0.63/checkbox.md
+++ b/website/versioned_docs/version-0.63/checkbox.md
@@ -3,7 +3,7 @@ id: checkbox
 title: '🚧 CheckBox'
 ---
 
-> **Deprecated.** Use [@react-native-community/checkbox](https://github.com/react-native-community/react-native-checkbox) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.
 
 Renders a boolean input (Android only).
 

--- a/website/versioned_docs/version-0.63/clipboard.md
+++ b/website/versioned_docs/version-0.63/clipboard.md
@@ -3,7 +3,7 @@ id: clipboard
 title: '🚧 Clipboard'
 ---
 
-> **Deprecated.** Use [@react-native-community/clipboard](https://github.com/react-native-community/clipboard) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.
 
 `Clipboard` gives you an interface for setting and getting content from Clipboard on both Android and iOS
 

--- a/website/versioned_docs/version-0.63/datepickerandroid.md
+++ b/website/versioned_docs/version-0.63/datepickerandroid.md
@@ -3,7 +3,7 @@ id: datepickerandroid
 title: '🚧 DatePickerAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.
 
 Opens the standard Android date picker dialog.
 

--- a/website/versioned_docs/version-0.63/datepickerios.md
+++ b/website/versioned_docs/version-0.63/datepickerios.md
@@ -5,7 +5,7 @@ title: '🚧 DatePickerIOS'
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.
 
 Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a controlled component, so you must hook in to the `onDateChange` callback and update the `date` prop in order for the component to update, otherwise the user's change will be reverted immediately to reflect `props.date` as the source of truth.
 

--- a/website/versioned_docs/version-0.63/geolocation.md
+++ b/website/versioned_docs/version-0.63/geolocation.md
@@ -3,7 +3,7 @@ id: geolocation
 title: '🚧 Geolocation'
 ---
 
-> **Deprecated.** Use [@react-native-community/geolocation](https://github.com/react-native-community/react-native-geolocation) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=geolocation) instead.
 
 The Geolocation API extends the [Geolocation web spec](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation).
 

--- a/website/versioned_docs/version-0.63/imageeditor.md
+++ b/website/versioned_docs/version-0.63/imageeditor.md
@@ -3,7 +3,7 @@ id: imageeditor
 title: '🚧 ImageEditor'
 ---
 
-> **Deprecated.** Use [@react-native-community/image-editor](https://github.com/react-native-community/react-native-image-editor) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=imageeditor) instead.
 
 ---
 

--- a/website/versioned_docs/version-0.63/imagepickerios.md
+++ b/website/versioned_docs/version-0.63/imagepickerios.md
@@ -3,7 +3,7 @@ id: imagepickerios
 title: '🚧 ImagePickerIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/image-picker-ios](https://github.com/react-native-community/react-native-image-picker-ios) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.
 
 ---
 

--- a/website/versioned_docs/version-0.63/imagestore.md
+++ b/website/versioned_docs/version-0.63/imagestore.md
@@ -3,7 +3,7 @@ id: imagestore
 title: ImageStore
 ---
 
-> **Deprecated.** Use [expo-file-system](https://github.com/expo/expo/tree/master/packages/expo-file-system) or [react-native-fs](https://github.com/itinance/react-native-fs) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=file) instead.
 
 ### Methods
 

--- a/website/versioned_docs/version-0.63/maskedviewios.md
+++ b/website/versioned_docs/version-0.63/maskedviewios.md
@@ -3,7 +3,7 @@ id: maskedviewios
 title: '🚧 MaskedViewIOS'
 ---
 
-> **Deprecated.** Use [@react-native-masked-view/masked-view](https://github.com/react-native-masked-view/masked-view) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=masked) instead.
 
 Renders the child view with a mask specified in the `maskElement` prop.
 

--- a/website/versioned_docs/version-0.63/netinfo.md
+++ b/website/versioned_docs/version-0.63/netinfo.md
@@ -3,7 +3,7 @@ id: netinfo
 title: NetInfo
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-netinfo](https://github.com/react-native-community/react-native-netinfo) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=network) instead.
 
 NetInfo exposes info about online/offline status
 

--- a/website/versioned_docs/version-0.63/picker.md
+++ b/website/versioned_docs/version-0.63/picker.md
@@ -3,7 +3,7 @@ id: picker
 title: '🚧 Picker'
 ---
 
-> **Deprecated.** Use [@react-native-picker/picker](https://github.com/react-native-picker/react-native-picker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=picker) instead.
 
 Renders the native picker component on Android and iOS.
 

--- a/website/versioned_docs/version-0.63/pickerios.md
+++ b/website/versioned_docs/version-0.63/pickerios.md
@@ -3,7 +3,7 @@ id: pickerios
 title: '🚧 PickerIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/picker](https://github.com/react-native-community/react-native-picker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=picker) instead.
 
 ---
 

--- a/website/versioned_docs/version-0.63/progressbarandroid.md
+++ b/website/versioned_docs/version-0.63/progressbarandroid.md
@@ -3,7 +3,7 @@ id: progressbarandroid
 title: '🚧 ProgressBarAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-bar-android](https://github.com/react-native-progress-view/progress-bar-android) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.
 
 Android-only React component used to indicate that the app is loading or there is some activity in the app.
 

--- a/website/versioned_docs/version-0.63/progressviewios.md
+++ b/website/versioned_docs/version-0.63/progressviewios.md
@@ -3,7 +3,7 @@ id: progressviewios
 title: '🚧 ProgressViewIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/progress-view](https://github.com/react-native-progress-view/progress-view) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressview) instead.
 
 Uses `ProgressViewIOS` to render a UIProgressView on iOS.
 

--- a/website/versioned_docs/version-0.63/pushnotificationios.md
+++ b/website/versioned_docs/version-0.63/pushnotificationios.md
@@ -3,7 +3,7 @@ id: pushnotificationios
 title: '🚧 PushNotificationIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/push-notification-ios](https://github.com/react-native-community/react-native-push-notification-ios) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=push+notification) instead.
 
 <div class="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>

--- a/website/versioned_docs/version-0.63/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.63/segmentedcontrolios.md
@@ -3,7 +3,7 @@ id: segmentedcontrolios
 title: '🚧 SegmentedControlIOS'
 ---
 
-> **Deprecated.** Use [@react-native-community/segmented-control](https://github.com/react-native-segmented-control/segmented-control) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 

--- a/website/versioned_docs/version-0.63/slider.md
+++ b/website/versioned_docs/version-0.63/slider.md
@@ -3,7 +3,7 @@ id: slider
 title: '🚧 Slider'
 ---
 
-> **Deprecated.** Use [@react-native-community/slider](https://github.com/react-native-community/react-native-slider) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=slider) instead.
 
 A component used to select a single value from a range of values.
 

--- a/website/versioned_docs/version-0.63/timepickerandroid.md
+++ b/website/versioned_docs/version-0.63/timepickerandroid.md
@@ -3,7 +3,7 @@ id: timepickerandroid
 title: '🚧 TimePickerAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/datetimepicker](https://github.com/react-native-community/react-native-datetimepicker) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.
 
 Opens the standard Android time picker dialog.
 

--- a/website/versioned_docs/version-0.63/viewpagerandroid.md
+++ b/website/versioned_docs/version-0.63/viewpagerandroid.md
@@ -3,7 +3,7 @@ id: viewpagerandroid
 title: '🚧 ViewPagerAndroid'
 ---
 
-> **Deprecated.** Use [@react-native-community/viewpager](https://github.com/react-native-community/react-native-viewpager) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=viewpager) instead.
 
 Container that allows to flip left and right between child views. Each child view of the `ViewPagerAndroid` will be treated as a separate page and will be stretched to fill the `ViewPagerAndroid`.
 

--- a/website/versioned_docs/version-0.63/webview.md
+++ b/website/versioned_docs/version-0.63/webview.md
@@ -3,7 +3,7 @@ id: webview
 title: '🚧 WebView'
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-webview](https://github.com/react-native-community/react-native-webview) instead.
+> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=webview) instead.
 
 `WebView` renders web content in a native view.
 


### PR DESCRIPTION
This PR updates the deprecation notes for several components and APIs, replacing link to the single package with link to the React Native Directory with a predefined search term. 

The goal is to avoid selection process and prevent favorizing one package over others, especially after latest changes to the React Native Community org structure and rules.

This change also reduce the further maintenance on those notes, so changing the package name or moving it to other organization won't require updating the website. 

The all links have been tested and search terms were chosen in the way to provide as many valuable packages as possible, also I make sure that every list includes the package earlier listed directly in the note.

Refs: #2469
