### PR TITLE
fix example in PlatformColor

### DIFF
--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
           PlatformColor('systemTealColor'),
       },
       android: {
-        color: PlatformColor('?attr/textColor'),
+        color: PlatformColor('?android:attr/textColor'),
         backgroundColor:
           PlatformColor('@android:color/holo_blue_bright'),
       },

--- a/website/versioned_docs/version-0.63/platformcolor.md
+++ b/website/versioned_docs/version-0.63/platformcolor.md
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
           PlatformColor('systemTealColor'),
       },
       android: {
-        color: PlatformColor('?attr/textColor'),
+        color: PlatformColor('?android:attr/textColor'),
         backgroundColor:
           PlatformColor('@android:color/holo_blue_bright'),
       },


### PR DESCRIPTION
this PR update android example in `PlatformColor` when you run in android device app crash, i fix that according this closed PR https://github.com/facebook/react-native/pull/27908, reference this issue #2454 