### PR TITLE
KeyboardAvoidingView: Describe `keyboardVerticalOffset` more precisely.

### DIFF
--- a/website/versioned_docs/version-0.63/keyboardavoidingview.md
+++ b/website/versioned_docs/version-0.63/keyboardavoidingview.md
@@ -100,7 +100,7 @@ Enabled or disabled KeyboardAvoidingView. The default is `true`.
 
 ### `keyboardVerticalOffset`
 
-This is the distance between the top of the user screen and the react native view, may be non-zero in some use cases. Defaults to 0.
+The distance between the top of the screen and the top of the KeyboardAvoidingView. Defaults to 0.
 
 | Type   | Required |
 | ------ | -------- |


### PR DESCRIPTION
A common use case is to pass the height of a header, if the
`KeyboardAvoidingView` is just below the header without including
it. So, help make it easier to decide whether or not to use this
prop by clarifying what it does. When I read "the react native view"
and "some use cases", I had a vague idea that it probably wouldn't
help in my case, and that it was something I'd reach for if I was
using React Native for parts of my app and not others.

But it turned out to be quite useful for my use case!

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
