### PR TITLE
remove expo-constants from examples in favor of build-in solutions, prettier doc files

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -255,9 +255,9 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -265,9 +265,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -285,9 +285,9 @@ Styling for internal View for `ListFooterComponent`.
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -11,8 +11,7 @@ The following example shows how different properties can affect or shape a React
 
 ```SnackPlayer name=LayoutProps%20Example
 import React, { useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
-import Constants from 'expo-constants';
+import { Button, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
 
 const App = () => {
   const flexDirections = ['row', 'row-reverse', 'column', 'column-reverse'];
@@ -54,19 +53,10 @@ const App = () => {
     }
     setterFunction(value + 1);
   };
-
-  const Square = () => {
-    const sqStyle = {
-      width: 50,
-      height: 50,
-      backgroundColor: randomHexColor(),
-    };
-    return <View style={sqStyle} />;
-  };
-  const [squares, setSquares] = useState([Square(), Square(), Square()]);
+  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
   return (
     <>
-      <View style={{ paddingTop: Constants.statusBarHeight }} />
+      <View style={{ paddingTop: StatusBar.currentHeight }} />
       <View style={[styles.container, styles.playingSpace, hookedStyles]}>
         {squares.map(elem => elem)}
       </View>
@@ -120,7 +110,7 @@ const App = () => {
           <View style={styles.buttonView}>
             <Button
               title="Add Square"
-              onPress={() => setSquares([...squares, Square()])}
+              onPress={() => setSquares([...squares, <Square/>])}
             />
           </View>
           <View style={styles.buttonView}>
@@ -157,6 +147,14 @@ const styles = StyleSheet.create({
   },
   text: { textAlign: 'center' },
 });
+
+const Square = () => (
+  <View style={{
+    width: 50,
+    height: 50,
+    backgroundColor: randomHexColor(),
+  }} />
+);
 
 const randomHexColor = () => {
   return '#000000'.replace(/0/g, () => {

--- a/docs/native-components-ios.md
+++ b/docs/native-components-ios.md
@@ -402,7 +402,11 @@ When the user interacts with the component, like clicking the button, the `backg
 <View>
   <MyNativeView ref={this.myNativeReference} />
   <MyNativeView ref={this.myNativeReference2} />
-  <Button onPress={() => { this.myNativeReference.callNativeMethod() }}/>
+  <Button
+    onPress={() => {
+      this.myNativeReference.callNativeMethod();
+    }}
+  />
 </View>
 ```
 

--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -25,8 +25,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android
 import React from "react";
-import { StyleSheet, Text, View, SafeAreaView, PermissionsAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { Button, PermissionsAndroid, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
 
 const requestCameraPermission = async () => {
   try {
@@ -63,7 +62,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },
@@ -83,8 +82,7 @@ export default App;
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android
 import React, { Component } from "react";
-import { StyleSheet, Text, View, SafeAreaView, PermissionsAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { Button, PermissionsAndroid, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
 
 const requestCameraPermission = async () => {
   try {
@@ -125,7 +123,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -23,8 +23,7 @@ This is where `FlatList` comes into play. `FlatList` renders items lazily, when 
 
 ```SnackPlayer name=ScrollView
 import React from 'react';
-import { StyleSheet, Text, SafeAreaView, ScrollView } from 'react-native';
-import Constants from 'expo-constants';
+import { StyleSheet, Text, SafeAreaView, ScrollView, StatusBar } from 'react-native';
 
 const App = () => {
   return (
@@ -47,7 +46,7 @@ const App = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
   },
   scrollView: {
     backgroundColor: 'pink',

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -27,14 +27,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ```SnackPlayer name=SectionList%20Example
 import React from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  SectionList
-} from "react-native";
-import Constants from "expo-constants";
+import { StyleSheet, Text, View, SafeAreaView, SectionList, StatusBar } from "react-native";
 
 const DATA = [
   {
@@ -77,7 +70,7 @@ const App = () => (
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     marginHorizontal: 16
   },
   item: {
@@ -102,14 +95,7 @@ export default App;
 
 ```SnackPlayer name=SectionList%20Example
 import React, { Component } from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  SectionList
-} from "react-native";
-import Constants from "expo-constants";
+import { StyleSheet, Text, View, SafeAreaView, SectionList, StatusBar } from "react-native";
 
 const DATA = [
   {
@@ -156,7 +142,7 @@ class App extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     marginHorizontal: 16
   },
   item: {
@@ -264,9 +250,9 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Section]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -284,9 +270,9 @@ Used to extract a unique key for a given item at the specified index. Key is use
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -294,9 +280,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -304,9 +290,9 @@ Rendered at the very end of the list. Can be a React Component (e.g. `SomeCompon
 
 Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -396,9 +382,9 @@ Rendered at the top of each section. These stick to the top of the `ScrollView` 
 
 Rendered at the top and bottom of each section (note this is different from `ItemSeparatorComponent` which is only rendered between items). These are intended to separate sections from the headers above and below and typically have the same highlight response as `ItemSeparatorComponent`. Also receives `highlighted`, `[leading/trailing][Item/Section]`, and any custom props from `separators.updateProps`.
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -468,10 +454,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type                         | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#data).                                                  |
-| key                                                   | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                  | Type               | Description                                                                                                                                                         |
+| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#data).                                                  |
+| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -5,11 +5,9 @@ title: Text Style Props
 
 ### Example
 
-```SnackPlayer name=TextStyleProps&dependencies=expo-constants,@react-native-community/slider
+```SnackPlayer name=TextStyleProps
 import React, { useState } from "react";
 import { FlatList, Platform, ScrollView, StyleSheet, Switch, Text, TouchableWithoutFeedback, View } from "react-native";
-import Slider from '@react-native-community/slider';
-import Constants from "expo-constants";
 
 const fontStyles = ["normal", "italic"];
 const fontVariants = [
@@ -302,7 +300,7 @@ const CustomPicker = ({ label, data, currentIndex, onSelected }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },

--- a/docs/toastandroid.md
+++ b/docs/toastandroid.md
@@ -14,8 +14,7 @@ The 'showWithGravityAndOffset(message, duration, gravity, xOffset, yOffset)' met
 
 ```SnackPlayer name=Toast%20Android%20API%20Example&supportedPlatforms=android
 import React from "react";
-import { View, StyleSheet, ToastAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { View, StyleSheet, ToastAndroid, Button, StatusBar } from "react-native";
 
 const App = () => {
   const showToast = () => {
@@ -59,7 +58,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#888888",
     padding: 8
   }
@@ -74,8 +73,7 @@ The ToastAndroid API is imperative, but there is a way to expose a declarative c
 
 ```SnackPlayer name=Advanced%20Toast%20Android%20API%20Example&supportedPlatforms=android
 import React, { useState, useEffect } from "react";
-import { View, StyleSheet, ToastAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { View, StyleSheet, ToastAndroid, Button, StatusBar } from "react-native";
 
 const Toast = ({ visible, message }) => {
   if (visible) {
@@ -112,7 +110,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#888888",
     padding: 8
   }

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -15,14 +15,8 @@ Background drawable of native feedback touchable can be customized with `backgro
 
 ```SnackPlayer name=TouchableNativeFeedback%20Android%20Component%20Example&supportedPlatforms=android
 import React, { useState } from "react";
-import { Text, View, StyleSheet, TouchableNativeFeedback } from "react-native";
-import Constants from "expo-constants";
+import { Text, View, StyleSheet, TouchableNativeFeedback, StatusBar } from "react-native";
 
-const randomHexColor = () => {
-  return "#000000".replace(/0/g, function() {
-    return (~~(Math.random() * 16)).toString(16);
-  });
-};
 const App = () => {
   const [rippleColor, setRippleColor] = useState(randomHexColor());
   const [rippleOverflow, setRippleOverflow] = useState(false);
@@ -43,11 +37,17 @@ const App = () => {
   );
 };
 
+const randomHexColor = () => {
+  return "#000000".replace(/0/g, function() {
+    return (~~(Math.random() * 16)).toString(16);
+  });
+};
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -11,31 +11,24 @@ Virtualization massively improves memory consumption and performance of large li
 
 ```SnackPlayer name=VirtualizedListExample
 import React from 'react';
-import { SafeAreaView, View, VirtualizedList, StyleSheet, Text } from 'react-native';
-import Constants from 'expo-constants';
+import { SafeAreaView, View, VirtualizedList, StyleSheet, Text, StatusBar } from 'react-native';
 
 const DATA = [];
 
-const getItem = (data, index) => {
-  return {
-    id: Math.random().toString(12).substring(0),
-    title: `Item ${index+1}`
-  }
-}
+const getItem = (data, index) => ({
+  id: Math.random().toString(12).substring(0),
+  title: `Item ${index+1}`
+});
 
-const getItemCount = (data) => {
-  return 50;
-}
+const getItemCount = (data) => 50;
 
-const Item = ({ title })=> {
-  return (
-    <View style={styles.item}>
-      <Text style={styles.title}>{title}</Text>
-    </View>
-  );
-}
+const Item = ({ title }) => (
+  <View style={styles.item}>
+    <Text style={styles.title}>{title}</Text>
+  </View>
+);
 
-const VirtualizedListExample = () => {
+const App = () => {
   return (
     <SafeAreaView style={styles.container}>
       <VirtualizedList
@@ -53,7 +46,7 @@ const VirtualizedListExample = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    marginTop: StatusBar.currentHeight,
   },
   item: {
     backgroundColor: '#f9c2ff',
@@ -68,7 +61,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default VirtualizedListExample;
+export default App;
 ```
 
 ---
@@ -168,9 +161,9 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -188,9 +181,9 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
@@ -208,9 +201,9 @@ Styling for internal View for `ListFooterComponent`.
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         |
-| ---------------------------- |
-| component, element           |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 

--- a/website/versioned_docs/version-0.60/flatlist.md
+++ b/website/versioned_docs/version-0.60/flatlist.md
@@ -258,9 +258,9 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -268,9 +268,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -288,9 +288,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.60/native-components-ios.md
+++ b/website/versioned_docs/version-0.60/native-components-ios.md
@@ -402,7 +402,11 @@ When the user interacts with the component, like clicking the button, the `backg
 <View>
   <MyNativeView ref={this.myNativeReference} />
   <MyNativeView ref={this.myNativeReference2} />
-  <Button onPress={() => { this.myNativeReference.callNativeMethod() }}/>
+  <Button
+    onPress={() => {
+      this.myNativeReference.callNativeMethod();
+    }}
+  />
 </View>
 ```
 

--- a/website/versioned_docs/version-0.60/sectionlist.md
+++ b/website/versioned_docs/version-0.60/sectionlist.md
@@ -213,9 +213,9 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Section]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -243,9 +243,9 @@ The legacy implementation is no longer supported.
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -253,9 +253,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -263,9 +263,9 @@ Rendered at the very end of the list. Can be a React Component (e.g. `SomeCompon
 
 Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -446,10 +446,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                     | Type                         | Description                                                                                                                                                            |
-| ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
-| [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |
+| Name                     | Type               | Description                                                                                                                                                            |
+| ------------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data                     | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
+| [key]                    | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
+| [renderItem]             | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.60/virtualizedlist.md
+++ b/website/versioned_docs/version-0.60/virtualizedlist.md
@@ -153,9 +153,9 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -173,9 +173,9 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -193,9 +193,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.61/flatlist.md
+++ b/website/versioned_docs/version-0.61/flatlist.md
@@ -258,9 +258,9 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -268,9 +268,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -288,9 +288,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.61/native-components-ios.md
+++ b/website/versioned_docs/version-0.61/native-components-ios.md
@@ -402,7 +402,11 @@ When the user interacts with the component, like clicking the button, the `backg
 <View>
   <MyNativeView ref={this.myNativeReference} />
   <MyNativeView ref={this.myNativeReference2} />
-  <Button onPress={() => { this.myNativeReference.callNativeMethod() }}/>
+  <Button
+    onPress={() => {
+      this.myNativeReference.callNativeMethod();
+    }}
+  />
 </View>
 ```
 

--- a/website/versioned_docs/version-0.61/sectionlist.md
+++ b/website/versioned_docs/version-0.61/sectionlist.md
@@ -213,9 +213,9 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Section]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -243,9 +243,9 @@ The legacy implementation is no longer supported.
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -253,9 +253,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -263,9 +263,9 @@ Rendered at the very end of the list. Can be a React Component (e.g. `SomeCompon
 
 Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -446,10 +446,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                       | Type                         | Description                                                                                                                                                            |
-| -------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                       | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
-| `[key]`                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
-| `[renderItem]`             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| `[ItemSeparatorComponent]` | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
-| `[keyExtractor]`           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |
+| Name                       | Type               | Description                                                                                                                                                            |
+| -------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data                       | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
+| `[key]`                    | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
+| `[renderItem]`             | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| `[ItemSeparatorComponent]` | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| `[keyExtractor]`           | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.61/virtualizedlist.md
+++ b/website/versioned_docs/version-0.61/virtualizedlist.md
@@ -153,9 +153,9 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -173,9 +173,9 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -193,9 +193,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.62/flatlist.md
+++ b/website/versioned_docs/version-0.62/flatlist.md
@@ -259,9 +259,9 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -269,9 +269,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -289,9 +289,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.62/native-components-ios.md
+++ b/website/versioned_docs/version-0.62/native-components-ios.md
@@ -402,7 +402,11 @@ When the user interacts with the component, like clicking the button, the `backg
 <View>
   <MyNativeView ref={this.myNativeReference} />
   <MyNativeView ref={this.myNativeReference2} />
-  <Button onPress={() => { this.myNativeReference.callNativeMethod() }}/>
+  <Button
+    onPress={() => {
+      this.myNativeReference.callNativeMethod();
+    }}
+  />
 </View>
 ```
 

--- a/website/versioned_docs/version-0.62/sectionlist.md
+++ b/website/versioned_docs/version-0.62/sectionlist.md
@@ -260,9 +260,9 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Section]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -280,9 +280,9 @@ Used to extract a unique key for a given item at the specified index. Key is use
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -290,9 +290,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -300,9 +300,9 @@ Rendered at the very end of the list. Can be a React Component (e.g. `SomeCompon
 
 Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -483,10 +483,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                     | Type                         | Description                                                                                                                                                            |
-| ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
-| [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |
+| Name                     | Type               | Description                                                                                                                                                            |
+| ------------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data                     | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
+| [key]                    | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
+| [renderItem]             | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.62/virtualizedlist.md
+++ b/website/versioned_docs/version-0.62/virtualizedlist.md
@@ -229,9 +229,9 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -249,9 +249,9 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -269,9 +269,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.63/flatlist.md
+++ b/website/versioned_docs/version-0.63/flatlist.md
@@ -251,9 +251,9 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -261,9 +261,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -281,9 +281,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.63/layout-props.md
+++ b/website/versioned_docs/version-0.63/layout-props.md
@@ -11,8 +11,7 @@ The following example shows how different properties can affect or shape a React
 
 ```SnackPlayer name=LayoutProps%20Example
 import React, { useState } from 'react';
-import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
-import Constants from 'expo-constants';
+import { Button, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native';
 
 const App = () => {
   const flexDirections = ['row', 'row-reverse', 'column', 'column-reverse'];
@@ -54,19 +53,10 @@ const App = () => {
     }
     setterFunction(value + 1);
   };
-
-  const Square = () => {
-    const sqStyle = {
-      width: 50,
-      height: 50,
-      backgroundColor: randomHexColor(),
-    };
-    return <View style={sqStyle} />;
-  };
-  const [squares, setSquares] = useState([Square(), Square(), Square()]);
+  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
   return (
     <>
-      <View style={{ paddingTop: Constants.statusBarHeight }} />
+      <View style={{ paddingTop: StatusBar.currentHeight }} />
       <View style={[styles.container, styles.playingSpace, hookedStyles]}>
         {squares.map(elem => elem)}
       </View>
@@ -120,7 +110,7 @@ const App = () => {
           <View style={styles.buttonView}>
             <Button
               title="Add Square"
-              onPress={() => setSquares([...squares, Square()])}
+              onPress={() => setSquares([...squares, <Square/>])}
             />
           </View>
           <View style={styles.buttonView}>
@@ -157,6 +147,14 @@ const styles = StyleSheet.create({
   },
   text: { textAlign: 'center' },
 });
+
+const Square = () => (
+  <View style={{
+    width: 50,
+    height: 50,
+    backgroundColor: randomHexColor(),
+  }} />
+);
 
 const randomHexColor = () => {
   return '#000000'.replace(/0/g, () => {

--- a/website/versioned_docs/version-0.63/native-components-ios.md
+++ b/website/versioned_docs/version-0.63/native-components-ios.md
@@ -402,7 +402,11 @@ When the user interacts with the component, like clicking the button, the `backg
 <View>
   <MyNativeView ref={this.myNativeReference} />
   <MyNativeView ref={this.myNativeReference2} />
-  <Button onPress={() => { this.myNativeReference.callNativeMethod() }}/>
+  <Button
+    onPress={() => {
+      this.myNativeReference.callNativeMethod();
+    }}
+  />
 </View>
 ```
 

--- a/website/versioned_docs/version-0.63/permissionsandroid.md
+++ b/website/versioned_docs/version-0.63/permissionsandroid.md
@@ -25,8 +25,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android
 import React from "react";
-import { StyleSheet, Text, View, SafeAreaView, PermissionsAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { Button, PermissionsAndroid, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
 
 const requestCameraPermission = async () => {
   try {
@@ -63,7 +62,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },
@@ -83,8 +82,7 @@ export default App;
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android
 import React, { Component } from "react";
-import { StyleSheet, Text, View, SafeAreaView, PermissionsAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { Button, PermissionsAndroid, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
 
 const requestCameraPermission = async () => {
   try {
@@ -125,7 +123,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },

--- a/website/versioned_docs/version-0.63/refreshcontrol.md
+++ b/website/versioned_docs/version-0.63/refreshcontrol.md
@@ -9,19 +9,10 @@ This component is used inside a ScrollView or ListView to add pull to refresh fu
 
 ```SnackPlayer name=RefreshControl&supportedPlatforms=ios,android
 import React from 'react';
-import {
-  ScrollView,
-  RefreshControl,
-  StyleSheet,
-  Text,
-  SafeAreaView,
-} from 'react-native';
-import Constants from 'expo-constants';
+import { RefreshControl, SafeAreaView, ScrollView, StyleSheet, Text } from 'react-native';
 
 const wait = (timeout) => {
-  return new Promise(resolve => {
-    setTimeout(resolve, timeout);
-  });
+  return new Promise(resolve => setTimeout(resolve, timeout));
 }
 
 const App = () => {
@@ -29,7 +20,6 @@ const App = () => {
 
   const onRefresh = React.useCallback(() => {
     setRefreshing(true);
-
     wait(2000).then(() => setRefreshing(false));
   }, []);
 
@@ -38,7 +28,10 @@ const App = () => {
       <ScrollView
         contentContainerStyle={styles.scrollView}
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+          />
         }
       >
         <Text>Pull down to see RefreshControl indicator</Text>
@@ -50,7 +43,6 @@ const App = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
   },
   scrollView: {
     flex: 1,

--- a/website/versioned_docs/version-0.63/scrollview.md
+++ b/website/versioned_docs/version-0.63/scrollview.md
@@ -23,8 +23,7 @@ This is where `FlatList` comes into play. `FlatList` renders items lazily, when 
 
 ```SnackPlayer name=ScrollView
 import React from 'react';
-import { StyleSheet, Text, SafeAreaView, ScrollView } from 'react-native';
-import Constants from 'expo-constants';
+import { StyleSheet, Text, SafeAreaView, ScrollView, StatusBar } from 'react-native';
 
 const App = () => {
   return (
@@ -47,7 +46,7 @@ const App = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
   },
   scrollView: {
     backgroundColor: 'pink',

--- a/website/versioned_docs/version-0.63/sectionlist.md
+++ b/website/versioned_docs/version-0.63/sectionlist.md
@@ -27,14 +27,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ```SnackPlayer name=SectionList%20Example
 import React from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  SectionList
-} from "react-native";
-import Constants from "expo-constants";
+import { StyleSheet, Text, View, SafeAreaView, SectionList, StatusBar } from "react-native";
 
 const DATA = [
   {
@@ -77,7 +70,7 @@ const App = () => (
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     marginHorizontal: 16
   },
   item: {
@@ -102,14 +95,7 @@ export default App;
 
 ```SnackPlayer name=SectionList%20Example
 import React, { Component } from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  SectionList
-} from "react-native";
-import Constants from "expo-constants";
+import { StyleSheet, Text, View, SafeAreaView, SectionList, StatusBar } from "react-native";
 
 const DATA = [
   {
@@ -156,7 +142,7 @@ class App extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     marginHorizontal: 16
   },
   item: {
@@ -260,9 +246,9 @@ Reverses the direction of scroll. Uses scale transforms of -1.
 
 Rendered in between each item, but not at the top or bottom. By default, `highlighted`, `section`, and `[leading/trailing][Item/Section]` props are provided. `renderItem` provides `separators.highlight`/`unhighlight` which will update the `highlighted` prop, but you can also add custom props with `separators.updateProps`.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -280,9 +266,9 @@ Used to extract a unique key for a given item at the specified index. Key is use
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -290,9 +276,9 @@ Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`)
 
 Rendered at the very end of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [component, element]           | No       |
+| Type                 | Required |
+| -------------------- | -------- |
+| [component, element] | No       |
 
 ---
 
@@ -300,9 +286,9 @@ Rendered at the very end of the list. Can be a React Component (e.g. `SomeCompon
 
 Rendered at the very beginning of the list. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -483,10 +469,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                     | Type                         | Description                                                                                                                                                            |
-| ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data                     | array                        | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
-| [key]                    | string                       | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
-| [renderItem]             | function                     | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
-| [ItemSeparatorComponent] | component, element           | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
-| [keyExtractor]           | function                     | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |
+| Name                     | Type               | Description                                                                                                                                                            |
+| ------------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data                     | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist.md#data).                                                  |
+| [key]                    | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                                 |
+| [renderItem]             | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist.md#renderitem) for the list.                          |
+| [ItemSeparatorComponent] | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist.md#itemseparatorcomponent) for the list. |
+| [keyExtractor]           | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist.md#keyextractor).                                   |

--- a/website/versioned_docs/version-0.63/statusbar.md
+++ b/website/versioned_docs/version-0.63/statusbar.md
@@ -9,47 +9,74 @@ Component to control the app status bar.
 
 It is possible to have multiple `StatusBar` components mounted at the same time. The props will be merged in the order the `StatusBar` components were mounted.
 
-```SnackPlayer name=StatusBar%20Android%20and%20iOS%20Component%20Example&supportedPlatforms=android,ios
-import React, { useState } from "react";
-import { Button, Text, StyleSheet, StatusBar, View } from "react-native";
+```SnackPlayer name=StatusBar%20Component%20Example&supportedPlatforms=android,ios
+import React, { useState } from 'react';
+import { Button, Platform, SafeAreaView, StatusBar, StyleSheet, Text, View } from 'react-native';
 
-import Constants from "expo-constants";
+const STYLES = ['default', 'dark-content', 'light-content'];
+const TRANSITIONS = ['fade', 'slide', 'none'];
 
 const App = () => {
-  const styleTypes = ['default','dark-content', 'light-content'];
-  const [visibleStatusBar, setVisibleStatusBar] = useState(false);
-  const [styleStatusBar, setStyleStatusBar] = useState(styleTypes[0]);
+  const [hidden, setHidden] = useState(false);
+  const [statusBarStyle, setStatusBarStyle] = useState(STYLES[0]);
+  const [statusBarTransition, setStatusBarTransition] = useState(TRANSITIONS[0]);
 
-  const changeVisibilityStatusBar = () => {
-    setVisibleStatusBar(!visibleStatusBar);
+  const changeStatusBarVisibility = () => setHidden(!hidden);
+
+  const changeStatusBarStyle = () => {
+    const styleId = STYLES.indexOf(statusBarStyle) + 1;
+    if (styleId === STYLES.length) {
+      setStatusBarStyle(STYLES[0]);
+    } else {
+      setStatusBarStyle(STYLES[styleId]);
+    }
   };
 
-  const changeStyleStatusBar = () => {
-    const styleId = styleTypes.indexOf(styleStatusBar) + 1;
-
-    if(styleId === styleTypes.length){
-      return setStyleStatusBar(styleTypes[0]);
+  const changeStatusBarTransition = () => {
+    const transition = TRANSITIONS.indexOf(statusBarTransition) + 1;
+    if (transition === TRANSITIONS.length) {
+      setStatusBarTransition(TRANSITIONS[0]);
+    } else {
+      setStatusBarTransition(TRANSITIONS[transition]);
     }
-    return setStyleStatusBar(styleTypes[styleId]);
   };
 
   return (
-    <View style={styles.container}>
-      <View>
-        <Text style={styles.textStyle}>StatusBar Style: {styleStatusBar}</Text>
-        <Text style={styles.textStyle}>StatusBar Visibility: {!visibleStatusBar ? 'Visible': 'Hidden'}</Text>
+    <SafeAreaView style={styles.container}>
+      <StatusBar
+        animated={true}
+        backgroundColor="#61dafb"
+        barStyle={statusBarStyle}
+        showHideTransition={statusBarTransition}
+        hidden={hidden} />
+      <Text style={styles.textStyle}>
+        StatusBar Visibility:{'\n'}
+        {hidden ? 'Hidden' : 'Visible'}
+      </Text>
+      <Text style={styles.textStyle}>
+        StatusBar Style:{'\n'}
+        {statusBarStyle}
+      </Text>
+      {Platform.OS === 'ios' ? (
+        <Text style={styles.textStyle}>
+          StatusBar Transition:{'\n'}
+          {statusBarTransition}
+        </Text>
+      ) : null}
+      <View style={styles.buttonsContainer}>
+        <Button
+          title="Toggle StatusBar"
+          onPress={changeStatusBarVisibility} />
+        <Button
+          title="Change StatusBar Style"
+          onPress={changeStatusBarStyle} />
+        {Platform.OS === 'ios' ? (
+          <Button
+            title="Change StatusBar Transition"
+            onPress={changeStatusBarTransition} />
+        ) : null}
       </View>
-      <StatusBar backgroundColor="blue" barStyle={styleStatusBar} />
-      <View>
-        <StatusBar hidden={visibleStatusBar} />
-      </View>
-      <View style={styles.buttonContainer}>
-        <Button title="Toggle StatusBar" onPress={() => changeVisibilityStatusBar()} />
-      </View>
-      <View style={styles.buttonContainer}>
-        <Button title="Change StatusBar Style" onPress={() => changeStyleStatusBar()} />
-      </View>
-    </View>
+    </SafeAreaView>
   );
 };
 
@@ -57,15 +84,14 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    paddingTop: Constants.statusBarHeight,
-    backgroundColor: '#ECF0F1',
-    padding: 8
+    backgroundColor: '#ECF0F1'
   },
-  buttonContainer:{
+  buttonsContainer: {
     padding: 10
   },
-  textStyle:{
-    textAlign: 'center'
+  textStyle: {
+    textAlign: 'center',
+    marginBottom: 8
   }
 });
 

--- a/website/versioned_docs/version-0.63/text-style-props.md
+++ b/website/versioned_docs/version-0.63/text-style-props.md
@@ -7,8 +7,7 @@ title: Text Style Props
 
 ```SnackPlayer name=TextStyleProps&supportedPlatforms=android,ios
 import React, { useState } from "react";
-import { FlatList, Platform, ScrollView, Slider, StyleSheet, Switch, Text, TouchableWithoutFeedback, View } from "react-native";
-import Constants from "expo-constants";
+import { FlatList, Platform, ScrollView, Slider, StyleSheet, Switch, Text, TouchableWithoutFeedback, View, StatusBar } from "react-native";
 
 const fontStyles = ["normal", "italic"];
 const fontVariants = [
@@ -301,7 +300,7 @@ const CustomPicker = ({ label, data, currentIndex, onSelected }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },

--- a/website/versioned_docs/version-0.63/toastandroid.md
+++ b/website/versioned_docs/version-0.63/toastandroid.md
@@ -14,8 +14,7 @@ The 'showWithGravityAndOffset(message, duration, gravity, xOffset, yOffset)' met
 
 ```SnackPlayer name=Toast%20Android%20API%20Example&supportedPlatforms=android
 import React from "react";
-import { View, StyleSheet, ToastAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { View, StyleSheet, ToastAndroid, Button, StatusBar } from "react-native";
 
 const App = () => {
   const showToast = () => {
@@ -59,7 +58,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#888888",
     padding: 8
   }
@@ -74,8 +73,7 @@ The ToastAndroid API is imperative, but there is a way to expose a declarative c
 
 ```SnackPlayer name=Advanced%20Toast%20Android%20API%20Example&supportedPlatforms=android
 import React, { useState, useEffect } from "react";
-import { View, StyleSheet, ToastAndroid, Button } from "react-native";
-import Constants from "expo-constants";
+import { View, StyleSheet, ToastAndroid, Button, StatusBar } from "react-native";
 
 const Toast = ({ visible, message }) => {
   if (visible) {
@@ -112,7 +110,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#888888",
     padding: 8
   }

--- a/website/versioned_docs/version-0.63/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.63/touchablenativefeedback.md
@@ -15,14 +15,8 @@ Background drawable of native feedback touchable can be customized with `backgro
 
 ```SnackPlayer name=TouchableNativeFeedback%20Android%20Component%20Example&supportedPlatforms=android
 import React, { useState } from "react";
-import { Text, View, StyleSheet, TouchableNativeFeedback } from "react-native";
-import Constants from "expo-constants";
+import { Text, View, StyleSheet, TouchableNativeFeedback, StatusBar } from "react-native";
 
-const randomHexColor = () => {
-  return "#000000".replace(/0/g, function() {
-    return (~~(Math.random() * 16)).toString(16);
-  });
-};
 const App = () => {
   const [rippleColor, setRippleColor] = useState(randomHexColor());
   const [rippleOverflow, setRippleOverflow] = useState(false);
@@ -43,11 +37,17 @@ const App = () => {
   );
 };
 
+const randomHexColor = () => {
+  return "#000000".replace(/0/g, function() {
+    return (~~(Math.random() * 16)).toString(16);
+  });
+};
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    paddingTop: Constants.statusBarHeight,
+    paddingTop: StatusBar.currentHeight,
     backgroundColor: "#ecf0f1",
     padding: 8
   },

--- a/website/versioned_docs/version-0.63/virtualizedlist.md
+++ b/website/versioned_docs/version-0.63/virtualizedlist.md
@@ -11,31 +11,24 @@ Virtualization massively improves memory consumption and performance of large li
 
 ```SnackPlayer name=VirtualizedListExample
 import React from 'react';
-import { SafeAreaView, View, VirtualizedList, StyleSheet, Text } from 'react-native';
-import Constants from 'expo-constants';
+import { SafeAreaView, View, VirtualizedList, StyleSheet, Text, StatusBar } from 'react-native';
 
 const DATA = [];
 
-const getItem = (data, index) => {
-  return {
-    id: Math.random().toString(12).substring(0),
-    title: `Item ${index+1}`
-  }
-}
+const getItem = (data, index) => ({
+  id: Math.random().toString(12).substring(0),
+  title: `Item ${index+1}`
+});
 
-const getItemCount = (data) => {
-  return 50;
-}
+const getItemCount = (data) => 50;
 
-const Item = ({ title })=> {
-  return (
-    <View style={styles.item}>
-      <Text style={styles.title}>{title}</Text>
-    </View>
-  );
-}
+const Item = ({ title }) => (
+  <View style={styles.item}>
+    <Text style={styles.title}>{title}</Text>
+  </View>
+);
 
-const VirtualizedListExample = () => {
+const App = () => {
   return (
     <SafeAreaView style={styles.container}>
       <VirtualizedList
@@ -53,7 +46,7 @@ const VirtualizedListExample = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginTop: Constants.statusBarHeight,
+    marginTop: StatusBar.currentHeight,
   },
   item: {
     backgroundColor: '#f9c2ff',
@@ -68,7 +61,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default VirtualizedListExample;
+export default App;
 ```
 
 ---
@@ -229,9 +222,9 @@ A unique identifier for this list. If there are multiple VirtualizedLists at the
 
 Rendered when the list is empty. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -249,9 +242,9 @@ Each data item is rendered using this element. Can be a React Component Class, o
 
 Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 
@@ -269,9 +262,9 @@ Styling for internal View for ListFooterComponent
 
 Rendered at the top of all the items. Can be a React Component (e.g. `SomeComponent`), or a React element (e.g. `<SomeComponent />`).
 
-| Type                         | Required |
-| ---------------------------- | -------- |
-| component, element           | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
 
 ---
 


### PR DESCRIPTION
This PR removes the `expo-constants` package usage from examples in base docs and latest versioned docs (`0.63`). 

The only use case of `expo-constants` in all examples was `Constants.statusBarHeight`. The build-in React Native solutions have be used instead, depending on the case, it was `StatusBar.currentHeight` or example restyling, in a way, which do not require the Status Bar correction. 

Additionally I have run the Prettier on the docs files, to reformat files affected by the changes from this PR and few other PR sent lately.

Refs: #2475