### PR TITLE
Inserting omitted code

### DIFF
--- a/website/versioned_docs/version-0.63/modal.md
+++ b/website/versioned_docs/version-0.63/modal.md
@@ -33,6 +33,7 @@ const App = () => {
         visible={modalVisible}
         onRequestClose={() => {
           Alert.alert("Modal has been closed.");
+          setModalVisible(false);
         }}
       >
         <View style={styles.centeredView}>


### PR DESCRIPTION
With Android back button, there was an announcement that the modal window closed, but the code failed to make it invisible.
Inserted line corrects this.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
