### PR TITLE
update ScrollView page, add platform labels, add missing prop and defaults

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -275,9 +275,9 @@ Rendered at the bottom of all the items. Can be a React Component (e.g. `SomeCom
 
 Styling for internal View for `ListFooterComponent`.
 
-| Type                                 |
-| ------------------------------------ |
-| [View Style Props](view-style-props) |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ---
 
@@ -295,9 +295,9 @@ Rendered at the top of all the items. Can be a React Component (e.g. `SomeCompon
 
 Styling for internal View for `ListHeaderComponent`.
 
-| Type                                 |
-| ------------------------------------ |
-| [View Style Props](view-style-props) |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ---
 
@@ -305,9 +305,9 @@ Styling for internal View for `ListHeaderComponent`.
 
 Optional custom style for multi-item rows generated when `numColumns > 1`.
 
-| Type                                 |
-| ------------------------------------ |
-| [View Style Props](view-style-props) |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ---
 

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -209,9 +209,9 @@ Additional distance outside of this view in which a touch is considered a press 
 
 Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.
 
-| Type                              | Required |
-| --------------------------------- | -------- |
-| [ViewStyleProp](view-style-props) | No       |
+| Type                           | Required |
+| ------------------------------ | -------- |
+| [View Style](view-style-props) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -68,77 +68,87 @@ export default App;
 
 ### [View Props](view.md#props)
 
-Inherits [View Props](view.md#props).
+Inherits [View Props](view#props).
 
 ---
 
-### `alwaysBounceHorizontal`
+### `StickyHeaderComponent`
 
-When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself. The default value is true when `horizontal={true}` and false otherwise.
+A React Component that will be used to render sticky headers, should be used together with `stickyHeaderIndices`. You may need to set this component if your sticky header uses custom transforms, for example, when you want your list to have an animated and hidable header.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type               |
+| ------------------ |
+| component, element |
 
 ---
 
-### `alwaysBounceVertical`
+### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+
+When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
+
+| Type | Default                                               |
+| ---- | ----------------------------------------------------- |
+| bool | `true` when `horizontal={true}`<hr/>`false` otherwise |
+
+---
+
+### `alwaysBounceVertical` <div class="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself. The default value is false when `vertical={true}` and true otherwise.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default                                             |
+| ---- | --------------------------------------------------- |
+| bool | `false` when `vertical={true}`<hr/>`true` otherwise |
 
 ---
 
-### `automaticallyAdjustContentInsets`
+### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
 
-Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/ toolbar. The default value is true.
+Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
-
----
-
-### `bounces`
-
-When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When false, it disables all bouncing even if the `alwaysBounce*` props are true. The default value is true.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
-### `bouncesZoom`
+### `bounces` <div class="label ios">iOS</div>
 
-When true, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
+When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
-
----
-
-### `canCancelContentTouches`
-
-When false, once tracking starts, won't try to drag if the touch moves. The default value is true.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
-### `centerContent`
+### `bouncesZoom` <div class="label ios">iOS</div>
 
-When true, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect. The default value is false.
+When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
+### `canCancelContentTouches` <div class="label ios">iOS</div>
+
+When `false`, once tracking starts, won't try to drag if the touch moves.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
+### `centerContent` <div class="label ios">iOS</div>
+
+When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
@@ -159,39 +169,39 @@ const styles = StyleSheet.create({
 });
 ```
 
-| Type                                 | Required |
-| ------------------------------------ | -------- |
-| StyleSheetPropType(View Style props) | No       |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ---
 
-### `contentInset`
+### `contentInset` <div class="label ios">iOS</div>
 
-The amount by which the scroll view content is inset from the edges of the scroll view. Defaults to `{top: 0, left: 0, bottom: 0, right: 0}`.
+The amount by which the scroll view content is inset from the edges of the scroll view.
 
-| Type                                                               | Required | Platform |
-| ------------------------------------------------------------------ | -------- | -------- |
-| object: {top: number, left: number, bottom: number, right: number} | No       | iOS      |
+| Type                                                               | Default                                  |
+| ------------------------------------------------------------------ | ---------------------------------------- |
+| object: {top: number, left: number, bottom: number, right: number} | `{top: 0, left: 0, bottom: 0, right: 0}` |
 
 ---
 
-### `contentInsetAdjustmentBehavior`
+### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
 
-This property specifies how the safe area insets are used to modify the content area of the scroll view. The default value of this property is "never". Available on iOS 11 and later.
+This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
-| Type                                                   | Required | Platform |
-| ------------------------------------------------------ | -------- | -------- |
-| enum('automatic', 'scrollableAxes', 'never', 'always') | No       | iOS      |
+| Type                                                           | Default   |
+| -------------------------------------------------------------- | --------- |
+| enum(`'automatic'`, `'scrollableAxes'`, `'never'`, `'always'`) | `'never'` |
 
 ---
 
 ### `contentOffset`
 
-Used to manually set the starting scroll offset. The default value is `{x: 0, y: 0}`.
+Used to manually set the starting scroll offset.
 
-| Type          | Required |
-| ------------- | -------- |
-| PointPropType | No       |
+| Type  | Default        |
+| ----- | -------------- |
+| Point | `{x: 0, y: 0}` |
 
 ---
 
@@ -199,88 +209,88 @@ Used to manually set the starting scroll offset. The default value is `{x: 0, y:
 
 A floating-point number that determines how quickly the scroll view decelerates after the user lifts their finger. You may also use string shortcuts `"normal"` and `"fast"` which match the underlying iOS settings for `UIScrollViewDecelerationRateNormal` and `UIScrollViewDecelerationRateFast` respectively.
 
-- `'normal'` (the default), 0.998 on iOS, 0.985 on Android.
+- `'normal'` 0.998 on iOS, 0.985 on Android.
 - `'fast'`, 0.99 on iOS, 0.9 on Android.
 
-| Type                            | Required |
-| ------------------------------- | -------- |
-| enum('fast', 'normal'), ,number | No       |
+| Type                               | Default    |
+| ---------------------------------- | ---------- |
+| enum(`'fast'`, `'normal'`), number | `'normal'` |
 
 ---
 
-### `directionalLockEnabled`
+### `directionalLockEnabled` <div class="label ios">iOS</div>
 
-When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging. The default value is false.
+When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
 ### `disableIntervalMomentum`
 
-When true, the scroll view stops on the next index (in relation to scroll position at release) regardless of how fast the gesture is. This can be used for pagination when the page is less than the width of the horizontal ScrollView or the height of the vertical ScrollView. The default value is false.
+When true, the scroll view stops on the next index (in relation to scroll position at release) regardless of how fast the gesture is. This can be used for pagination when the page is less than the width of the horizontal ScrollView or the height of the vertical ScrollView.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
 ### `disableScrollViewPanResponder`
 
-When true, the default JS pan responder on the ScrollView is disabled, and full control over touches inside the ScrollView is left to its child components. This is particularly useful if `snapToInterval` is enabled, since it does not follow typical touch patterns. Do not use this on regular ScrollView use cases without `snapToInterval` as it may cause unexpected touches to occur while scrolling. The default value is false.
+When true, the default JS pan responder on the ScrollView is disabled, and full control over touches inside the ScrollView is left to its child components. This is particularly useful if `snapToInterval` is enabled, since it does not follow typical touch patterns. Do not use this on regular ScrollView use cases without `snapToInterval` as it may cause unexpected touches to occur while scrolling.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
-### `endFillColor`
+### `endFillColor` <div class="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](colors.md) | No       | Android  |
+| Type            |
+| --------------- |
+| [color](colors) |
 
 ---
 
-### `fadingEdgeLength`
+### `fadingEdgeLength` <div class="label android">Android</div>
 
 Fades out the edges of the the scroll content.
 
-If the value is greater than 0, the fading edges will be set accordingly to the current scroll direction and position, indicating if there is more content to show.
+If the value is greater than `0`, the fading edges will be set accordingly to the current scroll direction and position, indicating if there is more content to show.
 
-| Type   | Required | Default | Platform |
-| ------ | -------- | ------- | -------- |
-| number | No       | 0       | Android  |
+| Type   | Default |
+| ------ | ------- |
+| number | `0`     |
 
 ---
 
 ### `horizontal`
 
-When true, the scroll view's children are arranged horizontally in a row instead of vertically in a column. The default value is false.
+When `true`, the scroll view's children are arranged horizontally in a row instead of vertically in a column.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
-### `indicatorStyle`
+### `indicatorStyle` <div class="label ios">iOS</div>
 
 The style of the scroll indicators.
 
-- `'default'` (the default), same as `black`.
+- `'default'` same as `black`.
 - `'black'`, scroll indicator is `black`. This style is good against a light background.
 - `'white'`, scroll indicator is `white`. This style is good against a dark background.
 
-| Type                              | Required | Platform |
-| --------------------------------- | -------- | -------- |
-| enum('default', 'black', 'white') | No       | iOS      |
+| Type                                    | Default     |
+| --------------------------------------- | ----------- |
+| enum(`'default'`, `'black'`, `'white'`) | `'default'` |
 
 ---
 
@@ -288,9 +298,9 @@ The style of the scroll indicators.
 
 If sticky headers should stick at the bottom instead of the top of the ScrollView. This is usually used with inverted ScrollViews.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
@@ -298,18 +308,16 @@ If sticky headers should stick at the bottom instead of the top of the ScrollVie
 
 Determines whether the keyboard gets dismissed in response to a drag.
 
-_Cross platform_
-
-- `'none'` (the default), drags do not dismiss the keyboard.
+- `'none'`, drags do not dismiss the keyboard.
 - `'on-drag'`, the keyboard is dismissed when a drag begins.
 
-_iOS Only_
+**iOS Only**
 
-- `'interactive'`, the keyboard is dismissed interactively with the drag and moves in synchrony with the touch; dragging upwards cancels the dismissal. On android this is not supported and it will have the same behavior as 'none'.
+- `'interactive'`, the keyboard is dismissed interactively with the drag and moves in synchrony with the touch, dragging upwards cancels the dismissal. On Android this is not supported and it will have the same behavior as `'none'`.
 
-| Type                                   | Required |
-| -------------------------------------- | -------- |
-| enum('none', 'on-drag', 'interactive') | No       |
+| Type                                                                                                                                                            | Default  |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| enum(`'none'`, `'on-drag'`) <div className="label android">Android</div><hr />enum(`'none'`, `'on-drag'`, `'interactive'`) <div className="label ios">iOS</div> | `'none'` |
 
 ---
 
@@ -317,19 +325,19 @@ _iOS Only_
 
 Determines when the keyboard should stay visible after a tap.
 
-- `'never'` (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
+- `'never'` tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
 - `'always'`, the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
 - `'handled'`, the keyboard will not dismiss automatically when the tap was handled by children of the scroll view (or captured by an ancestor).
-- `false`, **_deprecated_**, use 'never' instead
-- `true`, **_deprecated_**, use 'always' instead
+- `false`, **_deprecated_**, use `'never'` instead
+- `true`, **_deprecated_**, use `'always'` instead
 
-| Type                                            | Required |
-| ----------------------------------------------- | -------- |
-| enum('always', 'never', 'handled', false, true) | No       |
+| Type                                                      | Default  |
+| --------------------------------------------------------- | -------- |
+| enum(`'always'`, `'never'`, `'handled'`, `false`, `true`) | 'never'` |
 
 ---
 
-### `maintainVisibleContentPosition`
+### `maintainVisibleContentPosition` <div class="label ios">iOS</div>
 
 When set, the scroll view will adjust the scroll position so that the first child that is currently visible and at or beyond `minIndexForVisible` will not change position. This is useful for lists that are loading content in both directions, e.g. a chat thread, where new messages coming in might otherwise cause the scroll position to jump. A value of 0 is common, but other values such as 1 can be used to skip loading spinners or other content that should not maintain position.
 
@@ -339,39 +347,41 @@ Caveat 1: Reordering elements in the scrollview with this enabled will probably 
 
 Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute visibility. Occlusion, transforms, and other complexity won't be taken into account as to whether content is "visible" or not.
 
-| Type                                                                     | Required | Platform |
-| ------------------------------------------------------------------------ | -------- | -------- |
-| object: { minIndexForVisible: number, autoscrollToTopThreshold: number } | No       | iOS      |
+| Type                                                                     |
+| ------------------------------------------------------------------------ |
+| object: { minIndexForVisible: number, autoscrollToTopThreshold: number } |
 
 ---
 
-### `maximumZoomScale`
+### `maximumZoomScale` <div class="label ios">iOS</div>
 
-The maximum allowed zoom scale. The default value is 1.0.
+The maximum allowed zoom scale.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
-
----
-
-### `minimumZoomScale`
-
-The minimum allowed zoom scale. The default value is 1.0.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   | Default |
+| ------ | ------- |
+| number | `1.0`   |
 
 ---
 
-### `nestedScrollEnabled`
+### `minimumZoomScale` <div class="label ios">iOS</div>
 
-Enables nested scrolling for Android API level 21+. Nested scrolling is supported by default on iOS.
+The minimum allowed zoom scale.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type   | Default |
+| ------ | ------- |
+| number | `1.0`   |
+
+---
+
+### `nestedScrollEnabled` <div class="label android">Android</div>
+
+Enables nested scrolling for Android API level 21+.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
 
 ### `onContentSizeChange`
 
@@ -381,9 +391,9 @@ Handler function is passed the content width and content height as parameters: `
 
 It's implemented using onLayout handler attached to the content container which this ScrollView renders.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -391,9 +401,9 @@ It's implemented using onLayout handler attached to the content container which 
 
 Called when the momentum scroll starts (scroll which occurs as the ScrollView starts gliding).
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -401,9 +411,9 @@ Called when the momentum scroll starts (scroll which occurs as the ScrollView st
 
 Called when the momentum scroll ends (scroll which occurs as the ScrollView glides to a stop).
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -423,9 +433,9 @@ Fires at most once per frame during scrolling. The frequency of the events can b
 }
 ```
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -433,9 +443,9 @@ Fires at most once per frame during scrolling. The frequency of the events can b
 
 Called when the user begins to drag the scroll view.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -443,67 +453,67 @@ Called when the user begins to drag the scroll view.
 
 Called when the user stops dragging the scroll view and it either stops or begins to glide.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
-### `onScrollToTop`
+### `onScrollToTop` <div class="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
-| Type     | Required | Platform |
-| -------- | -------- | -------- |
-| function | No       | iOS      |
+| Type     |
+| -------- |
+| function |
 
 ---
 
-### `overScrollMode`
+### `overScrollMode` <div class="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
 Possible values:
 
-- `'auto'` - Default value, allow a user to over-scroll this view only if the content is large enough to meaningfully scroll.
+- `'auto'` - Allow a user to over-scroll this view only if the content is large enough to meaningfully scroll.
 - `'always'` - Always allow a user to over-scroll this view.
 - `'never'` - Never allow a user to over-scroll this view.
 
-| Type                            | Required | Platform |
-| ------------------------------- | -------- | -------- |
-| enum('auto', 'always', 'never') | No       | Android  |
+| Type                                  | Default  |
+| ------------------------------------- | -------- |
+| enum(`'auto'`, `'always'`, `'never'`) | `'auto'` |
 
 ---
 
 ### `pagingEnabled`
 
-When true, the scroll view stops on multiples of the scroll view's size when scrolling. This can be used for horizontal pagination. The default value is false.
+When true, the scroll view stops on multiples of the scroll view's size when scrolling. This can be used for horizontal pagination.
 
-Note: Vertical pagination is not supported on Android.
+> Note: Vertical pagination is not supported on Android.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
-
----
-
-### `persistentScrollbar`
-
-Causes the scrollbars not to turn transparent when they are not in use. The default value is false.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Android  |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
-### `pinchGestureEnabled`
+### `persistentScrollbar` <div class="label android">Android</div>
 
-When true, ScrollView allows use of pinch gestures to zoom in and out. The default value is true.
+Causes the scrollbars not to turn transparent when they are not in use.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
+
+---
+
+### `pinchGestureEnabled` <div class="label ios">iOS</div>
+
+When true, ScrollView allows use of pinch gestures to zoom in and out.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
@@ -511,140 +521,140 @@ When true, ScrollView allows use of pinch gestures to zoom in and out. The defau
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](refreshcontrol.md).
+See [RefreshControl](refreshcontrol).
 
-| Type    | Required |
-| ------- | -------- |
-| element | No       |
+| Type    |
+| ------- |
+| element |
 
 ---
 
 ### `removeClippedSubviews`
 
-Experimental: When true, offscreen child views (whose `overflow` value is `hidden`) are removed from their native backing superview when offscreen. This can improve scrolling performance on long lists.
+Experimental: When `true`, offscreen child views (whose `overflow` value is `hidden`) are removed from their native backing superview when offscreen. This can improve scrolling performance on long lists.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
-### `scrollBarThumbImage`
+### `scrollBarThumbImage` <div class="label tv">VR</div>
 
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of 0 in the color to avoid seeing it while the image is loading.
+Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of `0` in the color to avoid seeing it while the image is loading.
 
 - `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
 - `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | VR       |
+| Type           |
+| -------------- |
+| string, number |
 
 ---
 
 ### `scrollEnabled`
 
-When false, the view cannot be scrolled via touch interaction. The default value is true.
+When false, the view cannot be scrolled via touch interaction.
 
 Note that the view can always be scrolled by calling `scrollTo`.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
-### `scrollEventThrottle`
+### `scrollEventThrottle` <div class="label ios">iOS</div>
 
 This controls how often the scroll event will be fired while scrolling (as a time interval in ms). A lower number yields better accuracy for code that is tracking the scroll position, but can lead to scroll performance problems due to the volume of information being sent over the bridge. You will not notice a difference between values set between 1-16 as the JS run loop is synced to the screen refresh rate. If you do not need precise scroll position tracking, set this value higher to limit the information being sent across the bridge. The default value is zero, which results in the scroll event being sent only once each time the view is scrolled.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   | Default |
+| ------ | ------- |
+| number | `50`    |
 
 ---
 
-### `scrollIndicatorInsets`
+### `scrollIndicatorInsets` <div class="label ios">iOS</div>
 
-The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`. Defaults to `{0, 0, 0, 0}`.
+The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
-| Type                                                               | Required | Platform |
-| ------------------------------------------------------------------ | -------- | -------- |
-| object: {top: number, left: number, bottom: number, right: number} | No       | iOS      |
+| Type                                                               | Default        |
+| ------------------------------------------------------------------ | -------------- |
+| object: {top: number, left: number, bottom: number, right: number} | `{0, 0, 0, 0}` |
 
 ---
 
-### `scrollPerfTag`
+### `scrollPerfTag` <div class="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | Android  |
+| Type   |
+| ------ |
+| string |
 
 ---
 
-### `scrollToOverflowEnabled`
+### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
 
-When true, the scroll view can be programmatically scrolled beyond its content size. The default value is false.
+When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
 
 ---
 
-### `scrollsToTop`
+### `scrollsToTop` <div class="label ios">iOS</div>
 
-When true, the scroll view scrolls to top when the status bar is tapped. The default value is true.
+When true, the scroll view scrolls to top when the status bar is tapped.
 
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
 ### `showsHorizontalScrollIndicator`
 
-When true, shows a horizontal scroll indicator. The default value is true.
+When `true`, shows a horizontal scroll indicator.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
 ### `showsVerticalScrollIndicator`
 
-When true, shows a vertical scroll indicator. The default value is true.
+When `true`, shows a vertical scroll indicator.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
-### `snapToAlignment`
+### `snapToAlignment` <div class="label ios">iOS</div>
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 
-- `'start'` (the default) will align the snap at the left (horizontal) or top (vertical).
+- `'start'` will align the snap at the left (horizontal) or top (vertical).
 - `'center'` will align the snap in the center.
 - `'end'` will align the snap at the right (horizontal) or bottom (vertical).
 
-| Type                           | Required | Platform |
-| ------------------------------ | -------- | -------- |
-| enum('start', 'center', 'end') | No       | iOS      |
+| Type                           | Default   |
+| ------------------------------ | --------- |
+| enum('start', 'center', 'end') | `'start'` |
 
 ---
 
 ### `snapToEnd`
 
-Use in conjunction with `snapToOffsets`. By default, the end of the list counts as a snap offset. Set `snapToEnd` to false to disable this behavior and allow the list to scroll freely between its end and the last `snapToOffsets` offset. The default value is true.
+Use in conjunction with `snapToOffsets`. By default, the end of the list counts as a snap offset. Set `snapToEnd` to false to disable this behavior and allow the list to scroll freely between its end and the last `snapToOffsets` offset.
 
-| Type    | Required |
-| ------- | -------- |
-| boolean | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
@@ -652,9 +662,9 @@ Use in conjunction with `snapToOffsets`. By default, the end of the list counts 
 
 When set, causes the scroll view to stop at multiples of the value of `snapToInterval`. This can be used for paginating through children that have lengths smaller than the scroll view. Typically used in combination with `snapToAlignment` and `decelerationRate="fast"`. Overrides less configurable `pagingEnabled` prop.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
@@ -662,19 +672,19 @@ When set, causes the scroll view to stop at multiples of the value of `snapToInt
 
 When set, causes the scroll view to stop at the defined offsets. This can be used for paginating through variously sized children that have lengths smaller than the scroll view. Typically used in combination with `decelerationRate="fast"`. Overrides less configurable `pagingEnabled` and `snapToInterval` props.
 
-| Type            | Required |
-| --------------- | -------- |
-| array of number | No       |
+| Type            |
+| --------------- |
+| array of number |
 
 ---
 
 ### `snapToStart`
 
-Use in conjunction with `snapToOffsets`. By default, the beginning of the list counts as a snap offset. Set `snapToStart` to false to disable this behavior and allow the list to scroll freely between its start and the first `snapToOffsets` offset. The default value is true.
+Use in conjunction with `snapToOffsets`. By default, the beginning of the list counts as a snap offset. Set `snapToStart` to `false` to disable this behavior and allow the list to scroll freely between its start and the first `snapToOffsets` offset.
 
-| Type    | Required |
-| ------- | -------- |
-| boolean | No       |
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
 
 ---
 
@@ -682,19 +692,21 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 An array of child indices determining which children get docked to the top of the screen when scrolling. For example, passing `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the top of the scroll view. You can also use like [x,y,z] to make multiple items sticky when they are at the top. This property is not supported in conjunction with `horizontal={true}`.
 
-| Type            | Required |
-| --------------- | -------- |
-| array of number | No       |
+| Type            |
+| --------------- |
+| array of number |
 
 ---
 
-### `zoomScale`
+### `zoomScale` <div class="label ios">iOS</div>
 
-The current scale of the scroll view content. The default value is 1.0.
+The current scale of the scroll view content. The default value is .
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | iOS      |
+| Type   | Default |
+| ------ | ------- |
+| number | `1.0`   |
+
+---
 
 ## Methods
 
@@ -724,7 +736,7 @@ Example:
 
 `scrollTo({x: 0, y: 0, animated: true})`
 
-Note: The weird function signature is due to the fact that, for historical reasons, the function also accepts separate arguments as an alternative to the options object. This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
+> Note: The weird function signature is due to the fact that, for historical reasons, the function also accepts separate arguments as an alternative to the options object. This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
 
 ---
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -539,7 +539,7 @@ Experimental: When `true`, offscreen child views (whose `overflow` value is `hid
 
 ---
 
-### `scrollBarThumbImage` <div class="label tv">VR</div>
+### `scrollBarThumbImage` <div class="label vr">VR</div>
 
 Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of `0` in the color to avoid seeing it while the image is loading.
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -94,7 +94,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ### `alwaysBounceVertical` <div class="label ios">iOS</div>
 
-When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself. The default value is false when `vertical={true}` and true otherwise.
+When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
 | Type | Default                                             |
 | ---- | --------------------------------------------------- |
@@ -331,9 +331,9 @@ Determines when the keyboard should stay visible after a tap.
 - `false`, **_deprecated_**, use `'never'` instead
 - `true`, **_deprecated_**, use `'always'` instead
 
-| Type                                                      | Default  |
-| --------------------------------------------------------- | -------- |
-| enum(`'always'`, `'never'`, `'handled'`, `false`, `true`) | 'never'` |
+| Type                                                      | Default   |
+| --------------------------------------------------------- | --------- |
+| enum(`'always'`, `'never'`, `'handled'`, `false`, `true`) | `'never'` |
 
 ---
 
@@ -566,11 +566,11 @@ Note that the view can always be scrolled by calling `scrollTo`.
 
 ### `scrollEventThrottle` <div class="label ios">iOS</div>
 
-This controls how often the scroll event will be fired while scrolling (as a time interval in ms). A lower number yields better accuracy for code that is tracking the scroll position, but can lead to scroll performance problems due to the volume of information being sent over the bridge. You will not notice a difference between values set between 1-16 as the JS run loop is synced to the screen refresh rate. If you do not need precise scroll position tracking, set this value higher to limit the information being sent across the bridge. The default value is zero, which results in the scroll event being sent only once each time the view is scrolled.
+This controls how often the scroll event will be fired while scrolling (as a time interval in ms). A lower number yields better accuracy for code that is tracking the scroll position, but can lead to scroll performance problems due to the volume of information being sent over the bridge. You will not notice a difference between values set between 1-16 as the JS run loop is synced to the screen refresh rate. If you do not need precise scroll position tracking, set this value higher to limit the information being sent across the bridge. The default value is `0`, which results in the scroll event being sent only once each time the view is scrolled.
 
 | Type   | Default |
 | ------ | ------- |
-| number | `50`    |
+| number | `0`     |
 
 ---
 
@@ -578,9 +578,9 @@ This controls how often the scroll event will be fired while scrolling (as a tim
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
-| Type                                                               | Default        |
-| ------------------------------------------------------------------ | -------------- |
-| object: {top: number, left: number, bottom: number, right: number} | `{0, 0, 0, 0}` |
+| Type                                                               | Default                                  |
+| ------------------------------------------------------------------ | ---------------------------------------- |
+| object: {top: number, left: number, bottom: number, right: number} | `{top: 0, left: 0, bottom: 0, right: 0}` |
 
 ---
 
@@ -606,7 +606,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ### `scrollsToTop` <div class="label ios">iOS</div>
 
-When true, the scroll view scrolls to top when the status bar is tapped.
+When `true`, the scroll view scrolls to top when the status bar is tapped.
 
 | Type | Default |
 | ---- | ------- |
@@ -638,13 +638,15 @@ When `true`, shows a vertical scroll indicator.
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 
+Possible values:
+
 - `'start'` will align the snap at the left (horizontal) or top (vertical).
 - `'center'` will align the snap in the center.
 - `'end'` will align the snap at the right (horizontal) or bottom (vertical).
 
-| Type                           | Default   |
-| ------------------------------ | --------- |
-| enum('start', 'center', 'end') | `'start'` |
+| Type                                 | Default   |
+| ------------------------------------ | --------- |
+| enum(`'start'`, `'center'`, `'end'`) | `'start'` |
 
 ---
 
@@ -700,7 +702,7 @@ An array of child indices determining which children get docked to the top of th
 
 ### `zoomScale` <div class="label ios">iOS</div>
 
-The current scale of the scroll view content. The default value is .
+The current scale of the scroll view content.
 
 | Type   | Default |
 | ------ | ------- |
@@ -724,7 +726,7 @@ Displays the scroll indicators momentarily.
 
 ```jsx
 scrollTo(
-  options?: {x?: number, y?: number, animated?: boolean} | number,
+  options?: { x?: number, y?: number, animated?: boolean } | number,
   deprecatedX?: number,
 	deprecatedAnimated?: boolean,
 );
@@ -732,9 +734,9 @@ scrollTo(
 
 Scrolls to a given x, y offset, either immediately, with a smooth animation.
 
-Example:
+**Example:**
 
-`scrollTo({x: 0, y: 0, animated: true})`
+`scrollTo({ x: 0, y: 0, animated: true })`
 
 > Note: The weird function signature is due to the fact that, for historical reasons, the function also accepts separate arguments as an alternative to the options object. This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
 
@@ -748,7 +750,7 @@ scrollToEnd(([options]: { animated: boolean, duration: number }));
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({duration: 500})` for a controlled duration scroll. If no options are passed, `animated` defaults to true.
+Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({ duration: 500 })` for a controlled duration scroll. If no options are passed, `animated` defaults to `true`.
 
 ---
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -74,7 +74,7 @@ Inherits [View Props](view#props).
 
 ### `StickyHeaderComponent`
 
-A React Component that will be used to render sticky headers, should be used together with `stickyHeaderIndices`. You may need to set this component if your sticky header uses custom transforms, for example, when you want your list to have an animated and hidable header.
+A React Component that will be used to render sticky headers, should be used together with `stickyHeaderIndices`. You may need to set this component if your sticky header uses custom transforms, for example, when you want your list to have an animated and hidable header. If component have not been provided, the default [`ScrollViewStickyHeader`](https://github.com/facebook/react-native/blob/master/Libraries/Components/ScrollView/ScrollViewStickyHeader.js) component will be used.
 
 | Type               |
 | ------------------ |

--- a/docs/text.md
+++ b/docs/text.md
@@ -567,9 +567,9 @@ The highlight color of the text.
 
 ### `style`
 
-| Type                                                                       |
-| -------------------------------------------------------------------------- |
-| [Text Style Props](text-style-props), [View Style Props](view-style-props) |
+| Type                                                                 |
+| -------------------------------------------------------------------- |
+| [Text Style](text-style-props), [View Style Props](view-style-props) |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -505,9 +505,9 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ### `style`
 
-| Type                               | Required |
-| ---------------------------------- | -------- |
-| [view styles](view-style-props.md) | No       |
+| Type                              | Required |
+| --------------------------------- | -------- |
+| [View Style](view-style-props.md) | No       |
 
 ---
 

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -211,9 +211,9 @@ Rendered at the top of all the items. Can be a React Component (e.g. `SomeCompon
 
 Styling for internal View for `ListHeaderComponent`.
 
-| Type                                 |
-| ------------------------------------ |
-| [View Style Props](view-style-props) |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ---
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1035,6 +1035,14 @@ td .color-box {
     }
   }
 
+  &.vr {
+    background: #a05fc1;
+
+    &:before {
+      border-right-color: #a05fc1;
+    }
+  }
+
   &.required {
     margin-left: 0;
     margin-right: 16px;

--- a/website/versioned_docs/version-0.63/scrollview.md
+++ b/website/versioned_docs/version-0.63/scrollview.md
@@ -72,7 +72,7 @@ Inherits [View Props](view.md#props).
 
 ### `StickyHeaderComponent`
 
-A React Component that will be used to render sticky headers, should be used together with `stickyHeaderIndices`. You may need to set this component if your sticky header uses custom transforms, for example, when you want your list to have an animated and hidable header.
+A React Component that will be used to render sticky headers, should be used together with `stickyHeaderIndices`. You may need to set this component if your sticky header uses custom transforms, for example, when you want your list to have an animated and hidable header. If component have not been provided, the default [`ScrollViewStickyHeader`](https://github.com/facebook/react-native/blob/master/Libraries/Components/ScrollView/ScrollViewStickyHeader.js) component will be used.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/website/versioned_docs/version-0.63/scrollview.md
+++ b/website/versioned_docs/version-0.63/scrollview.md
@@ -68,6 +68,18 @@ export default App;
 
 Inherits [View Props](view.md#props).
 
+---
+
+### `StickyHeaderComponent`
+
+A React Component that will be used to render sticky headers, should be used together with `stickyHeaderIndices`. You may need to set this component if your sticky header uses custom transforms, for example, when you want your list to have an animated and hidable header.
+
+| Type               | Required |
+| ------------------ | -------- |
+| component, element | No       |
+
+---
+
 ### `alwaysBounceHorizontal`
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself. The default value is true when `horizontal={true}` and false otherwise.


### PR DESCRIPTION
Fixes: #2179

This PR updates the ScrollView page, adds platform labels, missing defaults and one missing prop, reported earlier in issue mentioned above. Also I have removed the deprecated prop `DEPRECATED_sendUpdatedChildFrames` from the base (`next`) docs because the property will be removed in upcoming `0.64` release - https://github.com/facebook/react-native/commit/345d0c1abb1afe937a06982c4328caee57820832.

Besides that I have normalized the `View Style` type naming across all of base docs files.

### Preview
<img width="1123" alt="Screenshot 2021-02-06 140456" src="https://user-images.githubusercontent.com/719641/107118919-57074c80-6884-11eb-934c-5168047b6c2c.png">
