### PR TITLE
attempt to fix CI test pipeline job timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,10 @@ jobs:
       - run: yarn ci-check
       - run: export NODE_OPTIONS=--max_old_space_size=4096
       - run: export TERSER_PARALLEL=false
-      - run: yarn test
+      - run: 
+          name: Compile and run website build
+          command: yarn test
+          no_output_timeout: 15m
       - run:
           name: Check for missing index.html (build errors)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - run: 
           name: Compile and run website build
           command: yarn test
-          no_output_timeout: 15m
+          no_output_timeout: 20m
       - run:
           name: Check for missing index.html (build errors)
           command: |


### PR DESCRIPTION
This PR adds increased `no_output_timeout` value to the CI `test` pipeline to prevent lately appearing timeouts:
> Too long with no output (exceeded 10m0s): context deadline exceeded

* https://app.circleci.com/pipelines/github/facebook/react-native-website/3540/workflows/a569353a-f917-4cdd-bb55-0466e5644bd7/jobs/16802

---

Refs: 
* https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
