### PR TITLE
docs: fix typo in link anchor

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -21,7 +21,7 @@ The [React Native CLI](https://github.com/react-native-community/cli) comes with
 
 #### 1. Run the `upgrade` command
 
-> The `upgrade` command works on top of Git by using `git apply` with 3-way merge, therefore it's required to use Git in order for this to work, if you don't use Git but still want to use this solution then you can check out how to do it in the [Troubleshooting](#i-want-to-upgrade-with-react-native-cli-but-i-don-t-use-git) section.
+> The `upgrade` command works on top of Git by using `git apply` with 3-way merge, therefore it's required to use Git in order for this to work, if you don't use Git but still want to use this solution then you can check out how to do it in the [Troubleshooting](#i-want-to-upgrade-with-react-native-cli-but-i-dont-use-git) section.
 
 Run the following command to start the process of upgrading to the latest version:
 

--- a/website/versioned_docs/version-0.63/upgrading.md
+++ b/website/versioned_docs/version-0.63/upgrading.md
@@ -21,7 +21,7 @@ The [React Native CLI](https://github.com/react-native-community/cli) comes with
 
 #### 1. Run the `upgrade` command
 
-> The `upgrade` command works on top of Git by using `git apply` with 3-way merge, therefore it's required to use Git in order for this to work, if you don't use Git but still want to use this solution then you can check out how to do it in the [Troubleshooting](#i-want-to-upgrade-with-react-native-cli-but-i-don-t-use-git) section.
+> The `upgrade` command works on top of Git by using `git apply` with 3-way merge, therefore it's required to use Git in order for this to work, if you don't use Git but still want to use this solution then you can check out how to do it in the [Troubleshooting](#i-want-to-upgrade-with-react-native-cli-but-i-dont-use-git) section.
 
 Run the following command to start the process of upgrading to the latest version:
 


### PR DESCRIPTION
Looks like the "sluggification" of link anchors changed sometimes ago, so there might be other link anchor issues.
