### PR TITLE
fix react-native issue #30326 - Text numberOfLines={2} and other than ellipsizeMode="tail" breaks on Android

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -373,7 +373,7 @@ This can be one of the following values:
 - `tail` - The line is displayed so that the beginning fits in the container and the missing text at the end of the line is indicated by an ellipsis glyph. e.g., "abcd..."
 - `clip` - Lines are not drawn past the edge of the text container.
 
-Only `tail` is supported when using `numberOfLines` higher then 1.
+> On Android, when `numberOfLines` is set to value higher then `1`, only `tail` value will work correctly.
 
 | Type                                           | Default |
 | ---------------------------------------------- | ------- |

--- a/docs/text.md
+++ b/docs/text.md
@@ -373,6 +373,8 @@ This can be one of the following values:
 - `tail` - The line is displayed so that the beginning fits in the container and the missing text at the end of the line is indicated by an ellipsis glyph. e.g., "abcd..."
 - `clip` - Lines are not drawn past the edge of the text container.
 
+Only `tail` is supported when using `numberOfLines` higher then 1.
+
 | Type                                           | Default |
 | ---------------------------------------------- | ------- |
 | enum(`'head'`, `'middle'`, `'tail'`, `'clip'`) | `tail`  |


### PR DESCRIPTION
This update in the documentation fixes a react-native issue, fixes https://github.com/facebook/react-native/issues/30326 

`ellipsizeMode="middle"` does not work when using `numberOfLines` higher then 1.

```javascript
<Text numberOfLines={2} ellipsizeMode="middle" >Some long text</Text>
```

It is a limitation from the Android Open Source Project `TextView` class

https://github.com/aosp-mirror/platform_frameworks_base/blob/523e3b9b7922685cff53d046884e0037004dcea7/core/java/android/widget/TextView.java#L10372-L10375
https://developer.android.com/reference/android/widget/TextView#setEllipsize(android.text.TextUtils.TruncateAt)

```java
  * If {@link #setMaxLines} has been used to set two or more lines,
  * only {@link android.text.TextUtils.TruncateAt#END} and
  * {@link android.text.TextUtils.TruncateAt#MARQUEE} are supported
  * (other ellipsizing types will not do anything).
  public void setEllipsize(TextUtils.TruncateAt where) {
```

The value `tail` corresponds to `TextUtils.TruncateAt.END` in the ReactAndroid API

https://github.com/facebook/react-native/blob/eeb36f470929c2fdd8e1ed69898a5ba9144b8715/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java#L54-L56

```java
    if (ellipsizeMode == null || ellipsizeMode.equals("tail")) {
      view.setEllipsizeLocation(TextUtils.TruncateAt.END);
    } else if (ellipsizeMode.equals("head")) {
```