### PR TITLE
small deps bumps, fix mankypkg CLI check warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are looking for the source code of the [React Native Archive website](htt
 ### Prerequisites
 
 1.  [Git](https://git-scm.com/downloads).
-1.  [Node](https://nodejs.org/en/download/) _(version 10 or greater)_.
+1.  [Node](https://nodejs.org/en/download/) _(version 12 or greater)_.
 1.  [Yarn](https://yarnpkg.com/lang/en/docs/install/) _(version 1.5 or greater)_.
 1.  A fork of the repo _(for any contributions)_.
 1.  A clone of the `react-native-website` repo.

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,9 @@
   base    = ""
   publish = "website/build"
   command = "export NODE_OPTIONS=--max_old_space_size=4096 && yarn && cd website && sed -i -e \"s|const baseUrl .*|const baseUrl = '/'|g\" docusaurus.config.js && yarn build"
+
+[context.production.environment]
+  NODE_VERSION = "14.16.0"
+
+[context.deploy-preview.environment]
+  NODE_VERSION = "14.16.0"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "react-native-website-monorepo",
   "private": true,
   "workspaces": [
     "website",
@@ -14,8 +15,8 @@
       "pre-commit": "pretty-quick --staged"
     }
   },
-  "devDependencies": {
-    "husky": "^4.2.5",
+  "dependencies": {
+    "husky": "^4.3.8",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0"
   }

--- a/website/core/PrismTheme.js
+++ b/website/core/PrismTheme.js
@@ -4,25 +4,22 @@ var theme = {
     background: '#282C34',
   },
   styles: [
-    // other modifications
     {
       types: ['property'],
       style: {
         color: '#2aa198',
       },
     },
-    // solarized-dark theme
     {
       types: ['attr-name', 'comment', 'prolog', 'doctype', 'cdata'],
       style: {
         color: '#93a1a1',
       },
     },
-
     {
       types: ['punctuation'],
       style: {
-        color: '#657b83' /* base00 */,
+        color: '#657b83',
       },
     },
     {
@@ -34,25 +31,25 @@ var theme = {
     {
       types: ['selector', 'char', 'builtin', 'url'],
       style: {
-        color: '#2aa198' /* cyan */,
+        color: '#2aa198',
       },
     },
     {
       types: ['entity'],
       style: {
-        color: '#2aa198' /* cyan */,
+        color: '#2aa198',
       },
     },
     {
       types: ['atrule', 'inserted'],
       style: {
-        color: '#859900' /* yellow */,
+        color: '#859900',
       },
     },
     {
       types: ['important', 'variable', 'deleted'],
       style: {
-        color: '#cb4b16' /* orange */,
+        color: '#cb4b16',
       },
     },
     {

--- a/website/package.json
+++ b/website/package.json
@@ -34,15 +34,15 @@
     "@docusaurus/core": "2.0.0-alpha.70",
     "@docusaurus/preset-classic": "2.0.0-alpha.70",
     "docusaurus-plugin-sass": "^0.1.11",
-    "react": "^16.10.2",
-    "react-dom": "^16.10.2",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "react-github-btn": "^1.2.0"
   },
   "devDependencies": {
     "alex": "^9.1.0",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
-    "glob-promise": "^3.4.0",
+    "glob-promise": "^4.1.0",
     "path": "^0.12.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,7 +1702,7 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
-"@types/glob@*", "@types/glob@^7.1.1":
+"@types/glob@^7.1.1", "@types/glob@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
   integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
@@ -5192,12 +5192,12 @@ glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-promise@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-3.4.0.tgz#b6b8f084504216f702dc2ce8c9bc9ac8866fdb20"
-  integrity sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==
+glob-promise@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-4.1.0.tgz#cde1692fd7442ce24b50e123dfe8b5f8428f35a3"
+  integrity sha512-wOdaX1+QJi3ldbjq4fXX/BbGSjhsG6eGXqMnBjQj9ubDiDLvrXbbXRj02rA0CXbMMM7J58dajiQ72va63D7pNw==
   dependencies:
-    "@types/glob" "*"
+    "@types/glob" "^7.1.3"
 
 glob-to-regexp@^0.3.0:
   version "0.3.0"
@@ -5826,7 +5826,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^4.2.5:
+husky@^4.3.8:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
   integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
@@ -9485,7 +9485,7 @@ react-docgen-renderer-template@^0.1.0:
   resolved "https://registry.yarnpkg.com/react-docgen-renderer-template/-/react-docgen-renderer-template-0.1.0.tgz#29340c947ab42b0060aa8e1c64e379a822e2733e"
   integrity sha512-3GyuFI9pBf3E2lW6oX6j3DvTQv55Wc9pWNKwDVcUFf8kDfpDyWmTeAYWPxoSEhSZxhEP+LV/1Tr4DLwE4CULQQ==
 
-react-dom@^16.10.2:
+react-dom@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -9611,7 +9611,7 @@ react-toggle@^4.1.1:
   dependencies:
     classnames "^2.2.5"
 
-react@^16.10.2:
+react@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
This PR bumps the `glob-promise` package (also update the version of already bumped in the lock packages) and fixes few warning reported by `@manypkg/cli` check.

Additionally I have also cleaned up the `PrismTheme` comments, they were a legacy of the migration, most of them were outdated or incorrect anyway.
