### PR TITLE
Add NerdWallet blog link

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -92,8 +92,8 @@
     "icon": "nerdwallet.png",
     "linkAppStore": "https://apps.apple.com/us/app/nerdwallet/id1174471607",
     "linkPlayStore": "https://play.google.com/store/apps/details?id=com.mobilecreditcards&hl=en_US",
-    "infoLink": "https://www.nerdwallet.com/",
-    "infoTitle": "",
+    "infoLink": "https://www.nerdwallet.com/blog/engineering/beyond-the-browser-how-nerdwallet-went-native/",
+    "infoTitle": "Beyond the Browser: How NerdWallet Went Native",
     "pinned": true
   },
   {


### PR DESCRIPTION
Add link to NerdWallet blog link: https://www.nerdwallet.com/blog/engineering/beyond-the-browser-how-nerdwallet-went-native/

![image](https://user-images.githubusercontent.com/8042156/109858475-bd2b8900-7c10-11eb-94c0-f513e9303540.png)
