### PR TITLE
height and width are not the same on different screens

### DIFF
--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -32,7 +32,7 @@ const FixedDimensionsBasics = () => {
 export default FixedDimensionsBasics;
 ```
 
-Setting dimensions this way is common for components that should always render at exactly the same size, regardless of screen dimensions.
+Setting dimensions this way is common for components whose size should always be fixed to a number of points and not calculated based on screen size. Note, that there is no universal mapping from points to physical units of measurement. This means that a component with fixed dimensions might not have the same physical size, across different devices and screen sizes. However, this difference is unnoticable for most use cases.
 
 ## Flex Dimensions
 

--- a/website/versioned_docs/version-0.63/height-and-width.md
+++ b/website/versioned_docs/version-0.63/height-and-width.md
@@ -26,6 +26,9 @@ const FixedDimensionsBasics = () => {
 export default FixedDimensionsBasics;
 ```
 
+Setting dimensions this way is common for components whose size should always be fixed to a number of points and not calculated based on screen size. Note, that there is no universal mapping from points to physical units of measurement. This means that a component with fixed dimensions might not have the same physical size, across different devices and screen sizes. However, this difference is unnoticable for most use cases.
+
+
 ## Flex Dimensions
 
 Use `flex` in a component's style to have the component expand and shrink dynamically based on available space. Normally you will use `flex: 1`, which tells a component to fill all available space, shared evenly amongst other components with the same parent. The larger the `flex` given, the higher the ratio of space a component will take compared to its siblings.

--- a/website/versioned_docs/version-0.63/height-and-width.md
+++ b/website/versioned_docs/version-0.63/height-and-width.md
@@ -26,8 +26,6 @@ const FixedDimensionsBasics = () => {
 export default FixedDimensionsBasics;
 ```
 
-Setting dimensions this way is common for components that should always render at exactly the same size, regardless of screen dimensions.
-
 ## Flex Dimensions
 
 Use `flex` in a component's style to have the component expand and shrink dynamically based on available space. Normally you will use `flex: 1`, which tells a component to fill all available space, shared evenly amongst other components with the same parent. The larger the `flex` given, the higher the ratio of space a component will take compared to its siblings.

--- a/website/versioned_docs/version-0.63/height-and-width.md
+++ b/website/versioned_docs/version-0.63/height-and-width.md
@@ -28,7 +28,6 @@ export default FixedDimensionsBasics;
 
 Setting dimensions this way is common for components whose size should always be fixed to a number of points and not calculated based on screen size. Note, that there is no universal mapping from points to physical units of measurement. This means that a component with fixed dimensions might not have the same physical size, across different devices and screen sizes. However, this difference is unnoticable for most use cases.
 
-
 ## Flex Dimensions
 
 Use `flex` in a component's style to have the component expand and shrink dynamically based on available space. Normally you will use `flex: 1`, which tells a component to fill all available space, shared evenly amongst other components with the same parent. The larger the `flex` given, the higher the ratio of space a component will take compared to its siblings.


### PR DESCRIPTION
As I learned here:
https://github.com/facebook/react-native/issues/30716

height and width render significantly differently on different screens, and that's to be expected.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
