### PR TITLE
Update note about RCTLinking to account for the addition of auto-linking in 0.60

### DIFF
--- a/website/versioned_docs/version-0.63/linking.md
+++ b/website/versioned_docs/version-0.63/linking.md
@@ -53,7 +53,7 @@ If you wish to receive the intent in an existing instance of MainActivity, you m
 </TabItem>
 <TabItem value="ios">
 
-> **NOTE:** On iOS, you'll need to link `RCTLinking` to your project by following the steps described [here](linking-libraries-ios.md#manual-linking). If you also want to listen to incoming app links during your app's execution, you'll need to add the following lines to your `*AppDelegate.m`:
+> **NOTE:** On iOS, you'll need to add the `LinkingIOS` folder into your header search paths as described in step 3 [here](linking-libraries-ios#step-3). If you also want to listen to incoming app links during your app's execution, you'll need to add the following lines to your `*AppDelegate.m`:
 
 ```objectivec
 // iOS 9.x or newer


### PR DESCRIPTION
## Problem
The note telling people to "link RCTLinking to your project" is out of date due to the introduction of [auto-linking](https://reactnative.dev/blog/2019/07/03/version-60#native-modules-are-now-autolinked) in React Native 0.60.

The note is quite confusing for users who are simply directed to [this](https://reactnative.dev/docs/linking-libraries-ios#manual-linking) article explaining how to link a now nonexistent `.xcodeproj` file to their main Xcode project.

## Solution
[Step 3](https://reactnative.dev/docs/linking-libraries-ios#step-3) from the referenced article is still required as auto-linking will not add the header files for RCTLinkingManager (located in the LinkingIOS folder) into the header search paths. As such I have tweaked the wording of the note and updated the link to point to step 3.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
