### PR TITLE
Add Clarification to Docs - Views are not clickable if parent has height of 0

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -37,4 +37,4 @@ There are a lot more things you might want to do with a text input. For example,
 
 Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](handling-touches.md).
 
-> The touch area never extends past the parent view bounds, on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
+> The touch area never extends past the parent view bounds and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)

--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -36,3 +36,5 @@ In this example, we store `text` in the state, because it changes over time.
 There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](textinput.md).
 
 Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](handling-touches.md).
+
+> The touch area never extends past the parent view bounds, on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)

--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -36,5 +36,3 @@ In this example, we store `text` in the state, because it changes over time.
 There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://reactjs.org/docs/forms.html#controlled-components), or the [reference docs for TextInput](textinput.md).
 
 Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](handling-touches.md).
-
-> The touch area never extends past the parent view bounds and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)

--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -5,6 +5,8 @@ title: Handling Touches
 
 Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](gesture-responder-system.md) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
 
+> The touch area never extends past the parent view bounds, the Z-index of sibling views always takes precedence if a touch hits two overlapping views and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
+
 ## Displaying a basic button
 
 [Button](button.md) provides a basic button component that is rendered nicely on all platforms. The minimal example to display a button looks like this:

--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -5,7 +5,7 @@ title: Handling Touches
 
 Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](gesture-responder-system.md) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
 
-> The touch area never extends past the parent view bounds, the Z-index of sibling views always takes precedence if a touch hits two overlapping views and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
+> The touch area never extends past the parent view bounds and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
 
 ## Displaying a basic button
 

--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -5,8 +5,6 @@ title: Handling Touches
 
 Users interact with mobile apps mainly through touch. They can use a combination of gestures, such as tapping on a button, scrolling a list, or zooming on a map. React Native provides components to handle all sorts of common gestures, as well as a comprehensive [gesture responder system](gesture-responder-system.md) to allow for more advanced gesture recognition, but the one component you will most likely be interested in is the basic Button.
 
-> The touch area never extends past the parent view bounds and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
-
 ## Displaying a basic button
 
 [Button](button.md) provides a basic button component that is rendered nicely on all platforms. The minimal example to display a button looks like this:
@@ -174,3 +172,7 @@ const styles = StyleSheet.create({
 ## Scrolling and swiping
 
 Gestures commonly used on devices with touchable screens include swipes and pans. These allow the user to scroll through a list of items, or swipe through pages of content. For these, check out the [ScrollView](scrollview.md) Core Component.
+
+## Known issues
+
+- [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162): The touch area never extends past the parent view bounds and on Android negative margin is not supported.

--- a/docs/style.md
+++ b/docs/style.md
@@ -5,6 +5,8 @@ title: Style
 
 With React Native, you style your application using JavaScript. All of the core components accept a prop named `style`. The style names and [values](colors.md) usually match how CSS works on the web, except names are written using camel casing, e.g. `backgroundColor` rather than `background-color`.
 
+> In some cases React Native does not match how CSS works on the web, for example the touch area never extends past the parent view bounds and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
+
 The `style` prop can be a plain old JavaScript object. That's what we usually use for example code. You can also pass an array of styles - the last style in the array has precedence, so you can use this to inherit styles.
 
 As a component grows in complexity, it is often cleaner to use `StyleSheet.create` to define several styles in one place. Here's an example:

--- a/docs/style.md
+++ b/docs/style.md
@@ -5,8 +5,6 @@ title: Style
 
 With React Native, you style your application using JavaScript. All of the core components accept a prop named `style`. The style names and [values](colors.md) usually match how CSS works on the web, except names are written using camel casing, e.g. `backgroundColor` rather than `background-color`.
 
-> In some cases React Native does not match how CSS works on the web, for example the touch area never extends past the parent view bounds and on Android negative margin is not supported. [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162)
-
 The `style` prop can be a plain old JavaScript object. That's what we usually use for example code. You can also pass an array of styles - the last style in the array has precedence, so you can use this to inherit styles.
 
 As a component grows in complexity, it is often cleaner to use `StyleSheet.create` to define several styles in one place. Here's an example:
@@ -48,3 +46,7 @@ One common pattern is to make your component accept a `style` prop which in turn
 There are a lot more ways to customize the text style. Check out the [Text component reference](text.md) for a complete list.
 
 Now you can make your text beautiful. The next step in becoming a style expert is to [learn how to control component size](height-and-width.md).
+
+## Known issues
+
+- [react-native#29308](https://github.com/facebook/react-native/issues/29308#issuecomment-792864162): In some cases React Native does not match how CSS works on the web, for example the touch area never extends past the parent view bounds and on Android negative margin is not supported.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

fixes https://github.com/facebook/react-native/issues/29308 fixes https://github.com/facebook/react-native/issues/25441 fixes https://github.com/facebook/react-native/issues/28694 fixes https://github.com/facebook/react-native/issues/27333

Adding further notice in the docs to help developers troubleshoot the following issues:

- The touch area never extends past the parent view bounds 
  Explanation https://github.com/facebook/react-native/issues/29308#issuecomment-792864162 
  Related issues https://github.com/facebook/react-native/issues/29308 https://github.com/facebook/react-native/issues/27333
- Negative margin is not supported on Android
  Explanation https://stackoverflow.com/a/10673572
  Related issues https://github.com/facebook/react-native/issues/25441 https://github.com/facebook/react-native/issues/28694

Hopefully adding this clarification in the docs will help developer troubleshoot their issues, the warning was included already in the [docs](https://reactnative.dev/docs/touchablewithoutfeedback#hitslop).
>The touch area never extends past the parent view bounds and the Z-index of sibling views always takes precedence if a touch hits two overlapping views.

I added the warnings in two places: 

- https://deploy-preview-2537--react-native.netlify.app/docs/next/style as noticed in https://github.com/facebook/react-native/issues/25441#issuecomment-640923390
- https://deploy-preview-2537--react-native.netlify.app/docs/next/handling-touches