### PR TITLE
attempt to fix share metadata

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -293,16 +293,6 @@ module.exports = {
     },
     metadatas: [
       {
-        name: 'description',
-        content: 'A framework for building native apps using React',
-      },
-      {property: 'og:title', content: 'React Native'},
-      {
-        property: 'og:description',
-        content: 'A framework for building native apps using React',
-      },
-      {property: 'og:url', content: 'https://reactnative.dev/'},
-      {
         property: 'og:image',
         content: 'https://reactnative.dev/img/logo-og.png',
       },


### PR DESCRIPTION
It looks like shared blog post have the same metadata set as the home page:

<img width="445" alt="Screenshot 2021-03-12 205951" src="https://user-images.githubusercontent.com/719641/110992296-0482e980-8376-11eb-8d9c-c92c8c90cb37.png">

The `metadatas` field has been moved from V1 and it might be possible that those entries are messing with Docusaurus logic. Official Docusaurus opted-out those tags, and their shared blog post are looking correct, let's try that.
