### PR TITLE
Fix typos in 0.64 blog post

### DIFF
--- a/website/blog/2021-03-11-version-0.64.md
+++ b/website/blog/2021-03-11-version-0.64.md
@@ -40,7 +40,7 @@ Inline Requires is a Babel transform that takes module imports and converts them
 import { MyFunction } from 'my-module';
 
 const MyComponent = (props) => {
-  const result = myFunction();
+  const result = MyFunction();
 
   return (<Text>{result}</Text>);
 };
@@ -60,7 +60,7 @@ More information about Inline Requires is available in the [Performance document
 
 ## View Hermes traces with Chrome
 
-Over the last year Facebook has sponsored the [Major League Hacking fellowship](https://fellowship.mlh.io/), supporting contributions to React Native. [Jessie Nguyen](https://twitter.com/jessie_anh_ng) and [Saphal Patro](https://twitter.com/saphalinsaan) added the ability to use the Performance tab on Chrome Devtools to visualize the execution of your application when it is using Hermes.
+Over the last year Facebook has sponsored the [Major League Hacking fellowship](https://fellowship.mlh.io/), supporting contributions to React Native. [Jessie Nguyen](https://twitter.com/jessie_anh_ng) and [Saphal Patro](https://twitter.com/saphalinsaan) added the ability to use the Performance tab on Chrome DevTools to visualize the execution of your application when it is using Hermes.
 
 For more information, check out the [new documentation page](/docs/profile-hermes#record-a-hermes-sampling-profile).
 


### PR DESCRIPTION
A couple of typos: Devtools -> DevTools, plus a case mismatch in the Inline Requires snippet.