### PR TITLE
fixed introduction md Tabs functionality

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -111,13 +111,8 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
-<TabItem value="web">
-
-> Web developers may be familiar with this concept.
-
-</TabItem>
 <TabItem value="android">
 
 > Android developers may be familiar with this concept.
@@ -126,6 +121,11 @@ People from many different development backgrounds are learning React Native. Yo
 <TabItem value="ios">
 
 > iOS developers may be familiar with this concept.
+
+</TabItem>
+<TabItem value="web">
+
+> Web developers may be familiar with this concept.
 
 </TabItem>
 </Tabs>

--- a/website/versioned_docs/version-0.64/introduction.md
+++ b/website/versioned_docs/version-0.64/introduction.md
@@ -111,13 +111,8 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
-<TabItem value="web">
-
-> Web developers may be familiar with this concept.
-
-</TabItem>
 <TabItem value="android">
 
 > Android developers may be familiar with this concept.
@@ -126,6 +121,11 @@ People from many different development backgrounds are learning React Native. Yo
 <TabItem value="ios">
 
 > iOS developers may be familiar with this concept.
+
+</TabItem>
+<TabItem value="web">
+
+> Web developers may be familiar with this concept.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
In the getting-started page (introduction.md) the Tabs bar is not working properly -
 when I click on web it opens ios, 
when I click on ios  it opens android
and when I click on android it opens web.
The problem seemed to be that the tabs weren't organized in the same order as the getDevNotesTabs array (which was the values for the Tabs element).