### PR TITLE
Clarify note about Hermes + RAM Bundles

### DIFF
--- a/docs/ram-bundles-inline-requires.md
+++ b/docs/ram-bundles-inline-requires.md
@@ -96,7 +96,7 @@ project.ext.react = [
 ]
 ```
 
-> **_Note_**: If using the [Hermes JS Engine](https://github.com/facebook/hermes), **do not** manually enable RAM bundles.  Hermes has an incompatible mechanism for doing the same thing, which is enabled by default:  When loading the bytecode, `mmap` ensures that the entire file is not loaded.
+> **_Note_**: If you are using [Hermes JS Engine](https://github.com/facebook/hermes), you **should not** have RAM bundles feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, becouse those mechanisms are not compatible with each other.
 
 ## Configure Preloading and Inline Requires
 

--- a/docs/ram-bundles-inline-requires.md
+++ b/docs/ram-bundles-inline-requires.md
@@ -96,7 +96,7 @@ project.ext.react = [
 ]
 ```
 
-> **_Note_**: If you are using [Hermes JS Engine](https://github.com/facebook/hermes), you do not need RAM bundles. When loading the bytecode, `mmap` ensures that the entire file is not loaded.
+> **_Note_**: If using the [Hermes JS Engine](https://github.com/facebook/hermes), **do not** manually enable RAM bundles.  Hermes has an incompatible mechanism for doing the same thing, which is enabled by default:  When loading the bytecode, `mmap` ensures that the entire file is not loaded.
 
 ## Configure Preloading and Inline Requires
 

--- a/website/versioned_docs/version-0.64/ram-bundles-inline-requires.md
+++ b/website/versioned_docs/version-0.64/ram-bundles-inline-requires.md
@@ -96,7 +96,7 @@ project.ext.react = [
 ]
 ```
 
-> **_Note_**: If you are using [Hermes JS Engine](https://github.com/facebook/hermes), you do not need RAM bundles. When loading the bytecode, `mmap` ensures that the entire file is not loaded.
+> **_Note_**: If you are using [Hermes JS Engine](https://github.com/facebook/hermes), you **should not** have RAM bundles feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, becouse those mechanisms are not compatible with each other.
 
 ## Configure Preloading and Inline Requires
 


### PR DESCRIPTION
Devs in the community including myself are getting tripped up because it seems `export BUNDLE_COMMAND=ram-bundle` is merely *redundant* with Hermes enabled -- when in fact, it is incompatible.  To successfully build with Hermes, `ram-bundle` must NOT be specified as the bundle command.

e.g.: https://github.com/fastlane/fastlane/issues/17657#issuecomment-732764675

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
