### PR TITLE
remove VR platform props from docs

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -539,19 +539,6 @@ Experimental: When `true`, offscreen child views (whose `overflow` value is `hid
 
 ---
 
-### `scrollBarThumbImage` <div class="label vr">VR</div>
-
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of `0` in the color to avoid seeing it while the image is loading.
-
-- `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
-- `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
-
-| Type           |
-| -------------- |
-| string, number |
-
----
-
 ### `scrollEnabled`
 
 When false, the view cannot be scrolled via touch interaction.

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1098,14 +1098,6 @@ td .color-box {
     }
   }
 
-  &.vr {
-    background: #a05fc1;
-
-    &:before {
-      border-right-color: #a05fc1;
-    }
-  }
-
   &.required {
     margin-left: 0;
     margin-right: 16px;

--- a/website/versioned_docs/version-0.60/scrollview.md
+++ b/website/versioned_docs/version-0.60/scrollview.md
@@ -500,19 +500,6 @@ Experimental: When true, offscreen child views (whose `overflow` value is `hidde
 
 ---
 
-### `scrollBarThumbImage`
-
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of 0 in the color to avoid seeing it while the image is loading.
-
-- `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
-- `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | VR       |
-
----
-
 ### `scrollEnabled`
 
 When false, the view cannot be scrolled via touch interaction. The default value is true.

--- a/website/versioned_docs/version-0.61/scrollview.md
+++ b/website/versioned_docs/version-0.61/scrollview.md
@@ -500,19 +500,6 @@ Experimental: When true, offscreen child views (whose `overflow` value is `hidde
 
 ---
 
-### `scrollBarThumbImage`
-
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of 0 in the color to avoid seeing it while the image is loading.
-
-- `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
-- `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | VR       |
-
----
-
 ### `scrollEnabled`
 
 When false, the view cannot be scrolled via touch interaction. The default value is true.

--- a/website/versioned_docs/version-0.62/scrollview.md
+++ b/website/versioned_docs/version-0.62/scrollview.md
@@ -524,19 +524,6 @@ Experimental: When true, offscreen child views (whose `overflow` value is `hidde
 
 ---
 
-### `scrollBarThumbImage`
-
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of 0 in the color to avoid seeing it while the image is loading.
-
-- `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
-- `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | VR       |
-
----
-
 ### `scrollEnabled`
 
 When false, the view cannot be scrolled via touch interaction. The default value is true.

--- a/website/versioned_docs/version-0.63/scrollview.md
+++ b/website/versioned_docs/version-0.63/scrollview.md
@@ -537,19 +537,6 @@ Experimental: When true, offscreen child views (whose `overflow` value is `hidde
 
 ---
 
-### `scrollBarThumbImage`
-
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of 0 in the color to avoid seeing it while the image is loading.
-
-- `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
-- `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
-
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| number | No       | VR       |
-
----
-
 ### `scrollEnabled`
 
 When false, the view cannot be scrolled via touch interaction. The default value is true.

--- a/website/versioned_docs/version-0.64/scrollview.md
+++ b/website/versioned_docs/version-0.64/scrollview.md
@@ -539,19 +539,6 @@ Experimental: When `true`, offscreen child views (whose `overflow` value is `hid
 
 ---
 
-### `scrollBarThumbImage` <div class="label vr">VR</div>
-
-Optionally an image can be used for the scroll bar thumb. This will override the color. While the image is loading or the image fails to load the color will be used instead. Use an alpha of `0` in the color to avoid seeing it while the image is loading.
-
-- `uri`, a string representing the resource identifier for the image, which should be either a local file path or the name of a static image resource.
-- `number`, opaque type returned by something like `import IMAGE from './image.jpg'`.
-
-| Type           |
-| -------------- |
-| string, number |
-
----
-
 ### `scrollEnabled`
 
 When false, the view cannot be scrolled via touch interaction.


### PR DESCRIPTION
This PR removes props available only for VR platform, to avoid documentation users confusion. VR platform is not open source and it's used mainly by FB and other partners internally.

The changes are applied to `next` and all versioned docs. Additionally the styles for VR platform tag has been removed from SCSS.