### PR TITLE
attempt to speed up Netlify preview deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,13 @@
 [build]
   base    = ""
   publish = "website/build"
-  command = "export NODE_OPTIONS=--max_old_space_size=4096 && export PREVIEW_DEPLOY=true && yarn && cd website && yarn build"
+  command = "yarn && cd website && yarn build"
 
 [context.production.environment]
   NODE_VERSION = "14.16.0"
+  NODE_OPTIONS = "--max_old_space_size=4096"
 
 [context.deploy-preview.environment]
   NODE_VERSION = "14.16.0"
+  NODE_OPTIONS = "--max_old_space_size=4096"
+  PREVIEW_DEPLOY = "true"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base    = ""
   publish = "website/build"
-  command = "export NODE_OPTIONS=--max_old_space_size=4096 && yarn && cd website && sed -i -e \"s|const baseUrl .*|const baseUrl = '/'|g\" docusaurus.config.js && yarn build"
+  command = "export NODE_OPTIONS=--max_old_space_size=4096 && export PREVIEW_DEPLOY=true && yarn && cd website && yarn build"
 
 [context.production.environment]
   NODE_VERSION = "14.16.0"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -58,6 +58,10 @@ module.exports = {
             require.resolve('./src/css/versions.scss'),
           ],
         },
+        onlyIncludeVersions:
+          process.env.PREVIEW_DEPLOY === 'true'
+            ? ['next', '0.64', '0.63']
+            : undefined,
       },
     ],
   ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,7 +42,7 @@ module.exports = {
           editCurrentVersion: true,
           onlyIncludeVersions:
             process.env.PREVIEW_DEPLOY === 'true'
-              ? ['next', '0.64', '0.63']
+              ? ['current', '0.64', '0.63']
               : undefined,
         },
         blog: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,6 +40,10 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.json'),
           remarkPlugins: [require('@react-native-website/remark-snackplayer')],
           editCurrentVersion: true,
+          onlyIncludeVersions:
+            process.env.PREVIEW_DEPLOY === 'true'
+              ? ['next', '0.64', '0.63']
+              : undefined,
         },
         blog: {
           path: 'blog',
@@ -58,10 +62,6 @@ module.exports = {
             require.resolve('./src/css/versions.scss'),
           ],
         },
-        onlyIncludeVersions:
-          process.env.PREVIEW_DEPLOY === 'true'
-            ? ['next', '0.64', '0.63']
-            : undefined,
       },
     ],
   ],


### PR DESCRIPTION
In this PR I'm attempting to speed up the Netlify preview deploys, but reducing the number of version which Docusaurus had to process during the build. Most of the PRs are targeted for the latest version docs or `next` ones, so publishing only `next` and two latest versions should speed up the preview deployment a bit (which currently is the longest running check from PR workflow).

The changes also includes the cleanup of `netlify.toml` file, so far the build command was copied 1:1 from the old Circle CI file and it looks like Netlify allow the configuration to be a bit more readable, so why not leverage that.