### PR TITLE
extract versions for deploy preview programmatically

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,4 +1,5 @@
 const users = require('./showcase.json');
+const versions = require('./versions.json');
 
 module.exports = {
   title: 'React Native',
@@ -42,7 +43,7 @@ module.exports = {
           editCurrentVersion: true,
           onlyIncludeVersions:
             process.env.PREVIEW_DEPLOY === 'true'
-              ? ['current', '0.64', '0.63']
+              ? ['current', ...versions.slice(0,2)]
               : undefined,
         },
         blog: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -43,7 +43,7 @@ module.exports = {
           editCurrentVersion: true,
           onlyIncludeVersions:
             process.env.PREVIEW_DEPLOY === 'true'
-              ? ['current', ...versions.slice(0,2)]
+              ? ['current', ...versions.slice(0, 2)]
               : undefined,
         },
         blog: {


### PR DESCRIPTION
Refs #2557

This PR include small tweak for Netlify preview deploys - now available versions are extracted programmatically from `versions.json`, so after new version cut the values will be updated.