### PR TITLE
improve share metadata after latest update

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,11 +1,13 @@
 import React, {useEffect} from 'react';
+import GitHubButton from 'react-github-btn';
+
+import Head from '@docusaurus/Head';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
 import Layout from '@theme/Layout';
 import CodeBlock from '@theme/CodeBlock';
 import Seo from '@theme/Seo';
-import GitHubButton from 'react-github-btn';
-
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import CrossPlatformSVG from '../../static/img/homepage/cross-platform.svg';
 import {setupDissectionAnimation} from './animations/_dissectionAnimation';
@@ -524,11 +526,9 @@ const Index = () => {
     <Layout
       description="A framework for building native apps using React"
       wrapperClassName="homepage">
-      <Seo
-        {...{
-          title: 'React Native · Learn once, write anywhere',
-        }}
-      />
+      <Head>
+        <title>React Native · Learn once, write anywhere</title>
+      </Head>
       <HeaderHero />
       <NativeApps />
       <NativeCode />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -521,11 +521,12 @@ const useHomePageAnimations = () => {
 const Index = () => {
   useHomePageAnimations();
   return (
-    <Layout wrapperClassName="homepage">
+    <Layout
+      description="A framework for building native apps using React"
+      wrapperClassName="homepage">
       <Seo
         {...{
-          title:
-            'React Native · A framework for building native apps using React',
+          title: 'React Native · Learn once, write anywhere',
         }}
       />
       <HeaderHero />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -528,8 +528,14 @@ const Index = () => {
       wrapperClassName="homepage">
       <Head>
         <title>React Native · Learn once, write anywhere</title>
-        <meta property="og:title" content="React Native · Learn once, write anywhere" />
-        <meta property="twitter:title" content="React Native · Learn once, write anywhere" />
+        <meta
+          property="og:title"
+          content="React Native · Learn once, write anywhere"
+        />
+        <meta
+          property="twitter:title"
+          content="React Native · Learn once, write anywhere"
+        />
       </Head>
       <HeaderHero />
       <NativeApps />

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -528,6 +528,8 @@ const Index = () => {
       wrapperClassName="homepage">
       <Head>
         <title>React Native · Learn once, write anywhere</title>
+        <meta property="og:title" content="React Native · Learn once, write anywhere" />
+        <meta property="twitter:title" content="React Native · Learn once, write anywhere" />
       </Head>
       <HeaderHero />
       <NativeApps />

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -78,7 +78,9 @@ const Showcase = () => {
   const apps = pinnedApps.concat(featuredApps);
 
   return (
-    <Layout title="Who's using React Native?">
+    <Layout
+      title="Who's using React Native?"
+      description="Thousands of apps are using React Native, check out these apps!">
       <div className="showcaseSection">
         <div className="prose">
           <h1>Who's using React Native?</h1>

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -57,7 +57,7 @@ const Versions = () => {
   );
 
   return (
-    <Layout wrapperClassName="versions-page">
+    <Layout title="Versions" wrapperClassName="versions-page">
       <h1>React Native versions</h1>
       <p>
         Open source React Native releases follow a monthly release train that is


### PR DESCRIPTION
It looks like there were still few minor problems with share data of custom pages after update to the latest Docusaurus version.

This PR aim to solve all of them and to improve the included meta data for custom pages.
