### PR TITLE
Fix `createCalendarEvent ` callback example

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -392,7 +392,7 @@ There are two approaches to error handling with callbacks. The first is to follo
 
 ```java
 @ReactMethod
-public void createCalendarEvent(String name, String location, Callback myFailureCallback, Callback callBack) {
+public void createCalendarEvent(String name, String location, Callback callBack) {
     Integer eventId = ...
     callBack.invoke(null, eventId);
 }


### PR DESCRIPTION
Fix `createCalendarEvent ` callback example. Remove the `myFailureCallback ` as that's confusing and not used in the example JS.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
