### PR TITLE
Remove ScrollView.scrollWithoutAnimationTo() documentation

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -738,13 +738,3 @@ scrollToEnd(([options]: { animated: boolean, duration: number }));
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
 Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({ duration: 500 })` for a controlled duration scroll. If no options are passed, `animated` defaults to `true`.
-
----
-
-### `scrollWithoutAnimationTo()`
-
-```jsx
-scrollWithoutAnimationTo(y, x);
-```
-
-Deprecated, use `scrollTo` instead.


### PR DESCRIPTION
The `ScrollView.scrollWithoutAnimationTo()` method was removed from the codebase a while ago in https://github.com/facebook/react-native/commit/c7e89909da70ac5290f9971080eb897567db3e43. This removes it from the documentation, too.

**Test Plan:**
Locally verified that the method is no longer documented by going to: http://localhost:3000/docs/next/scrollview#scrolltoend