### PR TITLE
Update the documentation of ActionSheetIOS

### DIFF
--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -69,7 +69,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 
 - `options` (array of strings) - a list of button titles (required)
 - `cancelButtonIndex` (int) - index of cancel button in `options`
-- `destructiveButtonIndex` (int) - index of destructive button in `options`
+- `destructiveButtonIndex` (int or array of ints) - indices of destructive buttons in `options`
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)

--- a/website/versioned_docs/version-0.64/actionsheetios.md
+++ b/website/versioned_docs/version-0.64/actionsheetios.md
@@ -69,7 +69,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 
 - `options` (array of strings) - a list of button titles (required)
 - `cancelButtonIndex` (int) - index of cancel button in `options`
-- `destructiveButtonIndex` (int) - index of destructive button in `options`
+- `destructiveButtonIndex` (int or array of ints) - indices of destructive buttons in `options`
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title
 - `anchor` (number) - the node to which the action sheet should be anchored (used for iPad)


### PR DESCRIPTION
Mention that the `destructiveButtonIndex` option takes either a number or an array of numbers.