### PR TITLE
Fix broken mozilla.org link in timers.md

### DIFF
--- a/docs/timers.md
+++ b/docs/timers.md
@@ -3,7 +3,7 @@ id: timers
 title: Timers
 ---
 
-Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Timers).
+Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/Timers).
 
 ## Timers
 

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -3,7 +3,7 @@ id: timers
 title: Timers
 ---
 
-Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/Timers).
+Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Timeouts_and_intervals).
 
 ## Timers
 

--- a/website/versioned_docs/version-0.64/timers.md
+++ b/website/versioned_docs/version-0.64/timers.md
@@ -3,7 +3,7 @@ id: timers
 title: Timers
 ---
 
-Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Timers).
+Timers are an important part of an application and React Native implements the [browser timers](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Timeouts_and_intervals).
 
 ## Timers
 


### PR DESCRIPTION
The link would lead to a "Page not found" as the content have been archived
Updated the link to point to the archive

Maybe this should be redacted or point to a more up to date example
As a momentary fix it would at least show the original content behind this link

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
