### PR TITLE
docs: add fragment to native-components-android.md

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -311,10 +311,10 @@ public class MyFragment extends Fragment {
   /**
    * Setup layout
    */
-  public void setupLayout(ViewGroup view) {
+  public void setupLayout(View view) {
     Choreographer.getInstance().postFrameCallback(new Choreographer.FrameCallback() {
       @Override
-      public void doFrame(long l) {
+      public void doFrame(long frameTimeNanos) {
         manuallyLayoutChildren(view);
         view.getViewTreeObserver().dispatchOnGlobalLayout();
         Choreographer.getInstance().postFrameCallback(this);
@@ -325,15 +325,16 @@ public class MyFragment extends Fragment {
   /**
    * Layout all children properly
    */
-  public void manuallyLayoutChildren(ViewGroup view) {
-    for (int i = 0; i < view.getChildCount(); i++) {
-      View child = view.getChildAt(i);
+  public void manuallyLayoutChildren(View view) {
+      // propWidth and propHeight coming from react-native props
+      int width = propWidth;
+      int height = propHeight;
 
-      child.measure(
-              View.MeasureSpec.makeMeasureSpec(view.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
-              View.MeasureSpec.makeMeasureSpec(view.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
-      child.layout(0, 0, child.getMeasuredWidth(), child.getMeasuredHeight());
-    }
+      view.measure(
+              View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+              View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+
+      view.layout(0, 0, width, height);
   }
 ```
 

--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -198,6 +198,18 @@ In order to integrate existing Native UI elements to your React Native app, you 
 `MyFragment.java`
 
 ```java
+// replace with your package
+package com.mypackage;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.fragment.app.Fragment;
+
+// replace with your view's import
+import com.mypackage.CustomView;
+
 public class MyFragment extends Fragment {
     CustomView customView;
 
@@ -243,7 +255,28 @@ public class MyFragment extends Fragment {
 `MyViewManager.java`
 
 ```java
- public class MyViewManager extends ViewGroupManager<FrameLayout> {
+// replace with your package
+package com.mypackage;
+
+import android.view.Choreographer;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.annotations.ReactPropGroup;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import java.util.Map;
+
+public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
   public static final String REACT_CLASS = "MyViewManager";
   public final int COMMAND_CREATE = 1;
@@ -297,8 +330,8 @@ public class MyFragment extends Fragment {
    * Replace your React Native view with a custom fragment
    */
   public void createFragment(FrameLayout root, int reactNativeViewId) {
-    View parentView = (ViewGroup) root.findViewById(reactNativeViewId).getParent();
-    setupLayout((ViewGroup) parentView);
+    ViewGroup parentView = (ViewGroup) root.findViewById(reactNativeViewId).getParent();
+    setupLayout(parentView);
 
     final MyFragment myFragment = new MyFragment();
     FragmentActivity activity = (FragmentActivity) reactContext.getCurrentActivity();
@@ -308,9 +341,6 @@ public class MyFragment extends Fragment {
             .commit();
   }
 
-  /**
-   * Setup layout
-   */
   public void setupLayout(View view) {
     Choreographer.getInstance().postFrameCallback(new Choreographer.FrameCallback() {
       @Override
@@ -343,6 +373,16 @@ public class MyFragment extends Fragment {
 `MyPackage.java`
 
 ```java
+// replace with your package
+package com.mypackage;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Arrays;
+import java.util.List;
+
 public class MyPackage implements ReactPackage {
 
    @Override

--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -191,7 +191,7 @@ var RCTMyCustomView = requireNativeComponent(`RCTMyCustomView`);
 
 # Integration with an Android Fragment Example
 
-In order to integrate existing Native UI elements to your React Native app, you might need to use Android Fragments to give you a more granular control over your native component than just returning a `View` from your `ViewManager`. You will need this if you want to add custom logic that is tied to your view with the help of [lifecycle methods](https://developer.android.com/guide/fragments/lifecycle), such as `onViewCreated`, `onPause`, `onResume`. The following steps will show you how to do it:
+In order to integrate existing Native UI elements to your React Native app, you might need to use Android Fragments to give you a more granular control over your native component than returning a `View` from your `ViewManager`. You will need this if you want to add custom logic that is tied to your view with the help of [lifecycle methods](https://developer.android.com/guide/fragments/lifecycle), such as `onViewCreated`, `onPause`, `onResume`. The following steps will show you how to do it:
 
 ## 1. Create a `Fragment`
 

--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -188,9 +188,10 @@ MyCustomView.propTypes = {
 
 var RCTMyCustomView = requireNativeComponent(`RCTMyCustomView`);
 ```
+
 # Integration with an Android Fragment Example
 
-In order to integrate existing Native UI elements to your React Native app, you might need to use Android Fragments to give you a more granular control over your native component than simply returning a `View` from your `ViewManager`. You will need this if you want to add custom logic that is tied to your view with the help of [lifecycle methods](https://developer.android.com/guide/fragments/lifecycle), such as `onViewCreated`, `onPause`, `onResume`. The following steps will show you how to do it:
+In order to integrate existing Native UI elements to your React Native app, you might need to use Android Fragments to give you a more granular control over your native component than just returning a `View` from your `ViewManager`. You will need this if you want to add custom logic that is tied to your view with the help of [lifecycle methods](https://developer.android.com/guide/fragments/lifecycle), such as `onViewCreated`, `onPause`, `onResume`. The following steps will show you how to do it:
 
 ## 1. Create a `Fragment`
 
@@ -291,7 +292,7 @@ public class MyFragment extends Fragment {
       default: {}
     }
   }
-  
+
   /**
    * Replace your React Native view with a custom fragment
    */
@@ -367,16 +368,16 @@ public class MyPackage implements ReactPackage {
     }
 ```
 
-
 ## 5. Implement the JavaScript module
 
 I. `MyViewManager.jsx`
 
-
 ```jsx
 import { requireNativeComponent } from 'react-native';
 
-export const MyViewManager = requireNativeComponent('MyViewManager');
+export const MyViewManager = requireNativeComponent(
+  'MyViewManager'
+);
 ```
 
 II. ` MyView.jsx` calling the `create` method


### PR DESCRIPTION
As a Javascript / React-Native developer I had a hard time figuring out how to integrate a custom native SDK with React Native using Android Fragments. Please correct anything that you wish. This information took me 3 days to figure out, especially the part with `setupLayout` and `manuallyLayoutChildren` so I wish an example like this was available in the official documentation. And I think I am not alone. I was expecting the code without `setupLayout` and `manuallyLayoutChildren` to work but i had no luck. If somebody has any better solution in your team, or any explanation, it would also be really nice to state in the documentation. Thank you for React Native, I love it.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
