### PR TITLE
GAAD 1 year later blog post 5/20

### DIFF
--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -10,9 +10,9 @@ tags: [announcement]
 
 It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want to update everyone on our progress so far. Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
 
-When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
+We started with 90 outstanding gap analysis issues and from March 2021, when the project launched on Github, until now:
 
-- 10 issues have been closed by the community.
+- 11 issues have been closed by the community.
 
 - 19 issues were evaluated and closed by the React Native team.
 
@@ -40,27 +40,27 @@ One of the most prevalent issues found during the gap analysis was that some com
 
 Announces when Disabled
 
-- `Button`
+- `Button` - [#31001](https://github.com/facebook/react-native/pull/31001)
 
-- `Images`
+- `Images` - [#31252](https://github.com/facebook/react-native/pull/31252)
 
-- `ImageBackground`
+- `ImageBackground` - [#31252](https://github.com/facebook/react-native/pull/31252)
 
 Disables click functionality when the component has a disabled prop
 
-- `Button`
+- `Button` - [#31001](https://github.com/facebook/react-native/pull/31001)
 
-- `Text`
+- `Text` - [React Native Team commit](https://github.com/facebook/react-native/commit/33ff4445dcf858cd5e6ba899163fd2a76774b641)
 
-- `Pressable`
+- `Pressable` - [React Native Team commit](https://github.com/facebook/react-native/commit/1c7d9c8046099eab8db4a460bedc0b2c07ed06df)
 
-- `TouchableHighlight`
+- `TouchableHighlight` - [#31135](https://github.com/facebook/react-native/pull/31135)
 
-- `TouchableOpacity`
+- `TouchableOpacity` - [#31108](https://github.com/facebook/react-native/pull/31108)
 
-- `TouchableNativeFeedback`
+- `TouchableNativeFeedback` - [#31224](https://github.com/facebook/react-native/pull/31224)
 
-- `TouchableWithoutFeedback`
+- `TouchableWithoutFeedback` - [#31297](https://github.com/facebook/react-native/pull/31297)
 
 ### Selected State Announcement
 
@@ -68,9 +68,9 @@ There were some components that did not announce their selection when in focus. 
 
 Announces when Selected
 
-- `Button`
+- `Button` -  [#31001](https://github.com/facebook/react-native/pull/31001)
 
-- `TextInput`
+- `TextInput` -  [#31144](https://github.com/facebook/react-native/pull/31144)
 
 ### Accessibility Timeout Setting
 
@@ -84,29 +84,29 @@ The React Native documentation must be updated to reflect each addition or chang
 
 We want to thank all the contributors mentioned below who have submitted and merged pull requests as well as those who have reviewed and commented on issues.
 
-### Merged Pull Request
+### Merged Pull Requests
 
-- [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by [@huzaifaaak](https://twitter.com/huzaifaaak)
-
-- [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by [@natural_clar](https://twitter.com/natural_clar)
-
-- [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by [fabriziobertoglio1987](https://github.com/fabriziobertoglio1987)
-
-- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by [@kyamashiro73](https://twitter.com/kyamashiro73)
-
-- [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by [@huzaifaaak](https://twitter.com/huzaifaaak)
-
-- [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by [grgr-dkrk](https://twitter.com/dkrk0901)
-
-- [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by [@crloscuesta](https://twitter.com/crloscuesta)
-
-- [Accessibility Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by [fabriziobertoglio1987](https://github.com/fabriziobertoglio1987)
-
-- [Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [@chakrihacker](https://github.com/chakrihacker)
+- [@huzaifaaak](https://twitter.com/huzaifaaak) closed 3 issues with:
+  - [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001)
+  - [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189)
+- [@natural_clar](https://twitter.com/natural_clar) closed 1 issue with:
+  - [feat: set disabled accessibilityState when `TouchableHighlight` is disabled #31135](https://github.com/facebook/react-native/pull/31135)
+- [fabriziobertoglio1987](https://github.com/fabriziobertoglio1987) closed 2 issues with:
+  - [[Android] Selected State does not annonce when `TextInput` Component selected #31144](https://github.com/facebook/react-native/pull/31144)
+  - [Accessibility Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252)
+- [@kyamashiro73](https://twitter.com/kyamashiro73) closed 1 issue with:
+  - [Added talkback support for `TouchableNativeFeedback` accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224)
+- [grgr-dkrk](https://twitter.com/dkrk0901) closed 1 issue and added to the React Native documentation with:
+  - [add `getRecommendedTimeoutMillis` to AccessibilityInfo #31063](https://github.com/facebook/react-native/pull/31063)
+  - [feat: add `getRecommendedTimeoutMillis` section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581)
+- [@crloscuesta](https://twitter.com/crloscuesta) closed 1 issue with:
+  - [Disable accessibilityState when `TouchableWithoutFeedback` is disabled #31297](https://github.com/facebook/react-native/pull/31297)
+- [@crloscuesta](https://twitter.com/crloscuesta) closed 1 issue with:
+  - [Disable `TouchableOpacity` when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108)
 
 Thank you to the community members who gave their time in other ways!
 
-Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao and Waltari10
+[Simek](https://github.com/Simek), [saurabhkacholiya](https://github.com/saurabhkacholiya), [meehawk](https://github.com/meehawk), [intergalacticspacehighway](https://github.com/intergalacticspacehighway), [chrisglein](https://github.com/chrisglein), [jychiao](https://github.com/jychiao) and [Waltari10](https://github.com/Waltari10)
 
 ## Get Involved!
 

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -8,7 +8,7 @@ authorTwitter: alexmarlette
 tags: [announcement]
 ---
 
-It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want  to update everyone on our progress so far.  Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
+It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want to update everyone on our progress so far.  Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
 
 When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
 
@@ -23,6 +23,7 @@ When we started there were 90 issues identified, since March when the gap analys
 We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year.Every contributor's effort has counted in making progress on improving React Native Accessibility.
 
 ## Fixes
+
 Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the [# of closed/merged PRs].
 
 - An issue with Disabled state has been addressed in seven components
@@ -71,7 +72,7 @@ Announces when Selected
 
 ### Accessibility Timeout Setting
 
-There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses. 
+There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses.
 
 ## Documentation Additions
 
@@ -79,7 +80,7 @@ The React Native documentation must be updated to reflect each addition or chang
 
 ## Community Involvement
 
-We want to thank all the contributors mentioned below who have submitted and merged pull requests as well as those who have reviewed and commented on issues. 
+We want to thank all the contributors mentioned below who have submitted and merged pull requests as well as those who have reviewed and commented on issues.
 
 ### Merged Pull Request
 
@@ -107,6 +108,6 @@ Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao
 
 ## Get Involved!
 
-We've come a long way but we're not done yet. We need your support to reach the finish line.  Facebook's React Native team has committed to supporting contributors working on gap analysis issues. They will continue to respond to comments on Accessibility issues and triage pull requests. The React Native team is also tackling some of the toughest gap analysis issues. This work includes the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
+We've come a long way but we're not done yet. We need your support to reach the finish line. Facebook's React Native team has committed to supporting contributors working on gap analysis issues. They will continue to respond to comments on Accessibility issues and triage pull requests. The React Native team is also tackling some of the toughest gap analysis issues. This work includes the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
 
 Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -8,7 +8,7 @@ authorTwitter: alexmarlette
 tags: [announcement]
 ---
 
-It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want to update everyone on our progress so far.  Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
+It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want to update everyone on our progress so far. Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
 
 When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
 

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -11,50 +11,18 @@ It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GA
 
 When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
 
--   11 issues have been closed by the community
+-   11 issues have been closed by the community.
 
--   19 issues were evaluated and closed by the React Native team
+-   19 issues were evaluated and closed by the React Native team.
 
--   9 Pull request were merged
+-   9 pull requests were merged.
 
--   1 Pull request has been committed to the React Native docs.
+-   1 pull request was merged into the React Native docs.
 
-We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year. Contributors have advanced this work by writing pull requests and commenting on issues, along with highlighting missing information on issues and contributing input on difficult problems. Every contributor's effort has counted in making progress on improving React Native Accessibility.
-
-<!--truncate-->
-
-Community Involvement
----------------------
-
-To recognize the work of all contributors who have helped the Improved React Native Accessibility project. Any contributors who have submitted and merged PRs or those who have helped in comments or reviews are highlighted below.
-
-### Closed Pull Request
-
--   [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by [@huzaifaaak](https://twitter.com/huzaifaaak)
-
--   [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[@natural_clar](https://twitter.com/natural_clar)
-
--   [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[fabriziobertoglio1987](http://fabriziobertoglio1987)
-
--   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[@kyamashiro73](https://twitter.com/kyamashiro73)
-
--   [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
-
--   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by [grgr-dkrk](https://twitter.com/dkrk0901)
-
--   [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) closed by [grgr-dkrk](https://twitter.com/dkrk0901)
-
--   [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by [@crloscuesta](https://twitter.com/crloscuesta)
-
--   [[Accessibility] Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by [fabriziobertoglio1987](http://fabriziobertoglio1987)
-
-Community members who gave their time in other ways:
-
-Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao, Waltari10
+We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year.Every contributor's effort has counted in making progress on improving React Native Accessibility.
 
 Fixes
 -----
-
 Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the [# of closed/merged PRs].
 
 -   An issue with Disabled state has been addressed in seven components
@@ -93,9 +61,9 @@ Disables click functionality when the component has a disabled prop
 
 ### Selected State Announcement
 
-Another multi-component issue, Selected State would not announce when focused on. Now upon focus if the AccessibilityState is set to selected or if the component is changed to selected, it will announce selected.
+There were some components that did not announce their selection when in focus. This behavior has now been fixed when the component is in focus and the AccessibilityState is set to selected or the component is changed to selected.
 
-Announces when Disabled
+Announces when Selected
 
 -   Button
 
@@ -103,19 +71,44 @@ Announces when Disabled
 
 ### Accessibility Timeout Setting
 
-This issue added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses. Prior to this there was no way to query this with the AccessibilityInfo API on Android.
+There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses. 
 
 Documentation Additions
 -----------------------
+The React Native documentation must be updated to reflect each addition or change to the available APIs. The new addition to the React Native documentation covered the addition of [getRecommendedTimeoutMillis()](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) to AccessibilityInfo.
 
-With every new addition to React Native the documentation must be updated to reflect those additions or changes. New additions to the React Native website as part of this initiative are listed below.
+Community Involvement
+---------------------
+We want to thank all the contributors mentioned below who have submitted and merged pull requests as well as those who have reviewed and commented on issues. 
 
--   [AccessibilityInfo: getRecommendedTimeoutMillis()](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android)
+### Merged Pull Request
+
+-   [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
+
+-   [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[ @natural_clar](https://twitter.com/natural_clar)
+
+-   [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
+
+-   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[ @kyamashiro73](https://twitter.com/kyamashiro73)
+
+-   [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
+
+-   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
+
+-   f[eat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
+
+-   [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by[  @crloscuesta](https://twitter.com/crloscuesta)
+
+-   [[Accessibility] Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
+
+-   [Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [chakrihacker](https://github.com/chakrihacker)
+
+Community members who gave their time in other ways:
+
+Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao, Waltari10
 
 Get Involved!
 -------------
+We've come a long way but we're not done yet. We need your support to reach the finish line.  Facebook's React Native team has committed to supporting contributors working on gap analysis issues. They will continue to respond to comments on Accessibility issues and triage pull requests. The React Native team is also tackling some of the toughest gap analysis issues. This work includes the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
 
-We're not done yet!  We've come far, but work still remains to reach the finish line, and React Native needs the continuing support of its community. Facebook's React Native team has committed to supporting contributors working on gap analysis issues and they will continue to respond to comments on Accessibility issues and triage new RN Accessibility pull requests. In addition, the React Native team is tackling some of the toughest gap analysis issues. Such as the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
-
-Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility Initiative Project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.
-
+Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -21,6 +21,7 @@ When we started there were 90 issues identified, since March when the gap analys
 - 1 pull request was merged into the React Native docs.
 
 We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year. Every contributor's effort has counted in making progress on improving React Native Accessibility.
+
 <!--truncate-->
 
 ## Fixes
@@ -115,4 +116,4 @@ Join us in tackling the rest. There are still open accessibility issues on the [
 
 ### Learn More
 
-Read about how the gap analysis was conducted on the [Facebook Tech blog](https://tech.fb.com/react-native-accessibility/) or about the launch of the Github issues on the [React Native Blog](https://reactnative.dev/blog/2021/03/08/GAAD-React-Native-Accessibility). 
+Read about how the gap analysis was conducted on the [Facebook Tech blog](https://tech.fb.com/react-native-accessibility/) or about the launch of the Github issues on the [React Native Blog](https://reactnative.dev/blog/2021/03/08/GAAD-React-Native-Accessibility).

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -68,9 +68,9 @@ There were some components that did not announce their selection when in focus. 
 
 Announces when Selected
 
-- `Button` -  [#31001](https://github.com/facebook/react-native/pull/31001)
+- `Button` - [#31001](https://github.com/facebook/react-native/pull/31001)
 
-- `TextInput` -  [#31144](https://github.com/facebook/react-native/pull/31144)
+- `TextInput` - [#31144](https://github.com/facebook/react-native/pull/31144)
 
 ### Accessibility Timeout Setting
 
@@ -96,7 +96,7 @@ We want to thank all the contributors mentioned below who have submitted and mer
   - [Accessibility Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252)
 - [@kyamashiro73](https://twitter.com/kyamashiro73) closed 1 issue with:
   - [Added talkback support for `TouchableNativeFeedback` accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224)
-- [grgr-dkrk](https://twitter.com/dkrk0901) closed 1 issue and added to the React Native documentation with:
+- [@grgr-dkrk](https://twitter.com/dkrk0901) closed 1 issue and added to the React Native documentation with:
   - [add `getRecommendedTimeoutMillis` to AccessibilityInfo #31063](https://github.com/facebook/react-native/pull/31063)
   - [feat: add `getRecommendedTimeoutMillis` section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581)
 - [@crloscuesta](https://twitter.com/crloscuesta) closed 1 issue with:

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -12,7 +12,7 @@ It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GA
 
 When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
 
-- 11 issues have been closed by the community.
+- 10 issues have been closed by the community.
 
 - 19 issues were evaluated and closed by the React Native team.
 
@@ -20,11 +20,12 @@ When we started there were 90 issues identified, since March when the gap analys
 
 - 1 pull request was merged into the React Native docs.
 
-We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year.Every contributor's effort has counted in making progress on improving React Native Accessibility.
+We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year. Every contributor's effort has counted in making progress on improving React Native Accessibility.
+<!--truncate-->
 
 ## Fixes
 
-Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the [# of closed/merged PRs].
+Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the 9 pull requests.
 
 - An issue with Disabled state has been addressed in seven components
 
@@ -38,27 +39,27 @@ One of the most prevalent issues found during the gap analysis was that some com
 
 Announces when Disabled
 
-- Button
+- `Button`
 
-- Images
+- `Images`
 
-- ImageBackground
+- `ImageBackground`
 
 Disables click functionality when the component has a disabled prop
 
-- Button
+- `Button`
 
-- Text
+- `Text`
 
-- Pressable
+- `Pressable`
 
-- TouchableHighlight
+- `TouchableHighlight`
 
-- TouchableOpacity
+- `TouchableOpacity`
 
-- TouchableNativeFeedback
+- `TouchableNativeFeedback`
 
-- TouchableWithoutFeedback
+- `TouchableWithoutFeedback`
 
 ### Selected State Announcement
 
@@ -66,17 +67,17 @@ There were some components that did not announce their selection when in focus. 
 
 Announces when Selected
 
-- Button
+- `Button`
 
-- TextInput
+- `TextInput`
 
 ### Accessibility Timeout Setting
 
-There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses.
+There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query `AccessibilityManager.getRecommendedTimeoutMillis()`. This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses.
 
 ## Documentation Additions
 
-The React Native documentation must be updated to reflect each addition or change to the available APIs. The new addition to the React Native documentation covered the addition of [getRecommendedTimeoutMillis()](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) to AccessibilityInfo.
+The React Native documentation must be updated to reflect each addition or change to the available APIs. The [new addition to the React Native documentation](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) covered the addition of `getRecommendedTimeoutMillis()` to AccessibilityInfo.
 
 ## Community Involvement
 
@@ -84,30 +85,34 @@ We want to thank all the contributors mentioned below who have submitted and mer
 
 ### Merged Pull Request
 
-- [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by[@huzaifaaak](https://twitter.com/huzaifaaak)
+- [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by [@huzaifaaak](https://twitter.com/huzaifaaak)
 
-- [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[@natural_clar](https://twitter.com/natural_clar)
+- [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by [@natural_clar](https://twitter.com/natural_clar)
 
-- [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[fabriziobertoglio1987](http://fabriziobertoglio1987)
+- [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by [fabriziobertoglio1987](https://github.com/fabriziobertoglio1987)
 
-- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[@kyamashiro73](https://twitter.com/kyamashiro73)
+- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by [@kyamashiro73](https://twitter.com/kyamashiro73)
 
-- [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[@huzaifaaak](https://twitter.com/huzaifaaak)
+- [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by [@huzaifaaak](https://twitter.com/huzaifaaak)
 
-- [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by[grgr-dkrk](https://twitter.com/dkrk0901)
+- [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by [grgr-dkrk](https://twitter.com/dkrk0901)
 
-- [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by[@crloscuesta](https://twitter.com/crloscuesta)
+- [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by [@crloscuesta](https://twitter.com/crloscuesta)
 
-- [Accessibility Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by[fabriziobertoglio1987](http://fabriziobertoglio1987)
+- [Accessibility Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by [fabriziobertoglio1987](https://github.com/fabriziobertoglio1987)
 
--[Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [chakrihacker](https://github.com/chakrihacker)
+- [Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [@chakrihacker](https://github.com/chakrihacker)
 
-Community members who gave their time in other ways:
+Thank you to the community members who gave their time in other ways!
 
-Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao, Waltari10
+Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao and Waltari10
 
 ## Get Involved!
 
 We've come a long way but we're not done yet. We need your support to reach the finish line. Facebook's React Native team has committed to supporting contributors working on gap analysis issues. They will continue to respond to comments on Accessibility issues and triage pull requests. The React Native team is also tackling some of the toughest gap analysis issues. This work includes the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
 
 Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.
+
+### Learn More
+
+Read about how the gap analysis was conducted on the [Facebook Tech blog](https://tech.fb.com/react-native-accessibility/) or about the launch of the Github issues on the [React Native Blog](https://reactnative.dev/blog/2021/03/08/GAAD-React-Native-Accessibility). 

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -25,11 +25,11 @@ Fixes
 -----
 Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the [# of closed/merged PRs].
 
--   An issue with Disabled state has been addressed in seven components
+- An issue with Disabled state has been addressed in seven components
 
--   An issue with Selected state was addressed in two components
+- An issue with Selected state was addressed in two components
 
--   A new addition to the React Native API added the ability to query AccessibilityManager.getRecommendedTimeoutMillis().
+- A new addition to the React Native API added the ability to query AccessibilityManager.getRecommendedTimeoutMillis().
 
 ### Disabled State Announcement and Disable function
 
@@ -37,27 +37,27 @@ One of the most prevalent issues found during the gap analysis was that some com
 
 Announces when Disabled
 
--   Button
+- Button
 
--   Images
+- Images
 
--   ImageBackground
+- ImageBackground
 
 Disables click functionality when the component has a disabled prop
 
--   Button
+- Button
 
--   Text
+- Text
 
--   Pressable
+- Pressable
 
--   TouchableHighlight
+- TouchableHighlight
 
--   TouchableOpacity
+- TouchableOpacity
 
--   TouchableNativeFeedback
+- TouchableNativeFeedback
 
--   TouchableWithoutFeedback
+- TouchableWithoutFeedback
 
 ### Selected State Announcement
 
@@ -65,50 +65,46 @@ There were some components that did not announce their selection when in focus. 
 
 Announces when Selected
 
--   Button
+- Button
 
--   TextInput
+- TextInput
 
 ### Accessibility Timeout Setting
 
 There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses. 
 
-Documentation Additions
------------------------
+## Documentation Additions
 The React Native documentation must be updated to reflect each addition or change to the available APIs. The new addition to the React Native documentation covered the addition of [getRecommendedTimeoutMillis()](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) to AccessibilityInfo.
 
-Community Involvement
----------------------
+## Community Involvement
 We want to thank all the contributors mentioned below who have submitted and merged pull requests as well as those who have reviewed and commented on issues. 
 
 ### Merged Pull Request
+- [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
 
--   [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
+- [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[ @natural_clar](https://twitter.com/natural_clar)
 
--   [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[ @natural_clar](https://twitter.com/natural_clar)
+- [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
 
--   [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
+- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[ @kyamashiro73](https://twitter.com/kyamashiro73)
 
--   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[ @kyamashiro73](https://twitter.com/kyamashiro73)
+- [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
 
--   [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
+- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
 
--   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
+- [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
 
--   f[eat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
+- [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by[  @crloscuesta](https://twitter.com/crloscuesta)
 
--   [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by[  @crloscuesta](https://twitter.com/crloscuesta)
+- [[Accessibility] Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
 
--   [[Accessibility] Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
-
--   [Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [chakrihacker](https://github.com/chakrihacker)
+- [Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [chakrihacker](https://github.com/chakrihacker)
 
 Community members who gave their time in other ways:
 
 Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao, Waltari10
 
-Get Involved!
--------------
+## Get Involved!
 We've come a long way but we're not done yet. We need your support to reach the finish line.  Facebook's React Native team has committed to supporting contributors working on gap analysis issues. They will continue to respond to comments on Accessibility issues and triage pull requests. The React Native team is also tackling some of the toughest gap analysis issues. This work includes the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
 
 Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -1,0 +1,121 @@
+---
+title: The GAAD Pledge - One Year Later
+author: Alexandra Marlette
+authorTitle: GAAD Pledge Open Source Accessibility Community Manager for React Native
+authorURL: 'https://twitter.com/alexmarlette'
+authorImageURL: 'https://avatars.githubusercontent.com/u/10052470?s=460&u=7f2304cb929d1de703856717af86324c66728f3a&v=4'
+authorTwitter: alexmarlette
+tags: [announcement]
+---
+It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want  to update everyone on our progress so far.  Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
+
+When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
+
+-   11 issues have been closed by the community
+
+-   19 issues were evaluated and closed by the React Native team
+
+-   9 Pull request were merged
+
+-   1 Pull request has been committed to the React Native docs.
+
+We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year. Contributors have advanced this work by writing pull requests and commenting on issues, along with highlighting missing information on issues and contributing input on difficult problems. Every contributor's effort has counted in making progress on improving React Native Accessibility.
+
+<!--truncate-->
+
+Community Involvement
+---------------------
+
+To recognize the work of all contributors who have helped the Improved React Native Accessibility project. Any contributors who have submitted and merged PRs or those who have helped in comments or reviews are highlighted below.
+
+### Closed Pull Request
+
+-   [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by [@huzaifaaak](https://twitter.com/huzaifaaak)
+
+-   [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[@natural_clar](https://twitter.com/natural_clar)
+
+-   [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[fabriziobertoglio1987](http://fabriziobertoglio1987)
+
+-   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[@kyamashiro73](https://twitter.com/kyamashiro73)
+
+-   [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
+
+-   [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by [grgr-dkrk](https://twitter.com/dkrk0901)
+
+-   [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) closed by [grgr-dkrk](https://twitter.com/dkrk0901)
+
+-   [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by [@crloscuesta](https://twitter.com/crloscuesta)
+
+-   [[Accessibility] Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by [fabriziobertoglio1987](http://fabriziobertoglio1987)
+
+Community members who gave their time in other ways:
+
+Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao, Waltari10
+
+Fixes
+-----
+
+Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the [# of closed/merged PRs].
+
+-   An issue with Disabled state has been addressed in seven components
+
+-   An issue with Selected state was addressed in two components
+
+-   A new addition to the React Native API added the ability to query AccessibilityManager.getRecommendedTimeoutMillis().
+
+### Disabled State Announcement and Disable function
+
+One of the most prevalent issues found during the gap analysis was that some components do not announce or disable functionality. Now seven components announce their disabled state or disable click functionality.
+
+Announces when Disabled
+
+-   Button
+
+-   Images
+
+-   ImageBackground
+
+Disables click functionality when the component has a disabled prop
+
+-   Button
+
+-   Text
+
+-   Pressable
+
+-   TouchableHighlight
+
+-   TouchableOpacity
+
+-   TouchableNativeFeedback
+
+-   TouchableWithoutFeedback
+
+### Selected State Announcement
+
+Another multi-component issue, Selected State would not announce when focused on. Now upon focus if the AccessibilityState is set to selected or if the component is changed to selected, it will announce selected.
+
+Announces when Disabled
+
+-   Button
+
+-   TextInput
+
+### Accessibility Timeout Setting
+
+This issue added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses. Prior to this there was no way to query this with the AccessibilityInfo API on Android.
+
+Documentation Additions
+-----------------------
+
+With every new addition to React Native the documentation must be updated to reflect those additions or changes. New additions to the React Native website as part of this initiative are listed below.
+
+-   [AccessibilityInfo: getRecommendedTimeoutMillis()](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android)
+
+Get Involved!
+-------------
+
+We're not done yet!  We've come far, but work still remains to reach the finish line, and React Native needs the continuing support of its community. Facebook's React Native team has committed to supporting contributors working on gap analysis issues and they will continue to respond to comments on Accessibility issues and triage new RN Accessibility pull requests. In addition, the React Native team is tackling some of the toughest gap analysis issues. Such as the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
+
+Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility Initiative Project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.
+

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -7,22 +7,22 @@ authorImageURL: 'https://avatars.githubusercontent.com/u/10052470?s=460&u=7f2304
 authorTwitter: alexmarlette
 tags: [announcement]
 ---
+
 It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want  to update everyone on our progress so far.  Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
 
 When we started there were 90 issues identified, since March when the gap analysis issues launched on Github:
 
--   11 issues have been closed by the community.
+- 11 issues have been closed by the community.
 
--   19 issues were evaluated and closed by the React Native team.
+- 19 issues were evaluated and closed by the React Native team.
 
--   9 pull requests were merged.
+- 9 pull requests were merged.
 
--   1 pull request was merged into the React Native docs.
+- 1 pull request was merged into the React Native docs.
 
 We want to recognize and thank the React Native community for the significant progress towards a more accessible React Native over the past year.Every contributor's effort has counted in making progress on improving React Native Accessibility.
 
-Fixes
------
+## Fixes
 Two types of issues have been fixed in multiple components and one new functionality has been added to the API by the [# of closed/merged PRs].
 
 - An issue with Disabled state has been addressed in seven components
@@ -74,37 +74,39 @@ Announces when Selected
 There was previously no way to query the accessibility timeout setting on Android. The fix added the ability to query AccessibilityManager.getRecommendedTimeoutMillis(). This queries the "Time to take action" before the UI elements auto-dismisses or auto-progresses. 
 
 ## Documentation Additions
+
 The React Native documentation must be updated to reflect each addition or change to the available APIs. The new addition to the React Native documentation covered the addition of [getRecommendedTimeoutMillis()](https://reactnative.dev/docs/next/accessibilityinfo#getrecommendedtimeoutmillis-android) to AccessibilityInfo.
 
 ## Community Involvement
+
 We want to thank all the contributors mentioned below who have submitted and merged pull requests as well as those who have reviewed and commented on issues. 
 
 ### Merged Pull Request
-- [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
 
-- [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[ @natural_clar](https://twitter.com/natural_clar)
+- [Added talkback support for button accessibility: disabled prop #31001](https://github.com/facebook/react-native/pull/31001) - closed by[@huzaifaaak](https://twitter.com/huzaifaaak)
 
-- [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
+- [feat: set disabled accessibilityState when TouchableHighlight is disabled #31135](https://github.com/facebook/react-native/pull/31135) closed by[@natural_clar](https://twitter.com/natural_clar)
 
-- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[ @kyamashiro73](https://twitter.com/kyamashiro73)
+- [[Android] Selected State does not annonce when TextInput Component selected #31144](https://github.com/facebook/react-native/pull/31144) closed by[fabriziobertoglio1987](http://fabriziobertoglio1987)
 
-- [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[ @huzaifaaak](https://twitter.com/huzaifaaak)
+- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[@kyamashiro73](https://twitter.com/kyamashiro73)
 
-- [Added talkback support for TouchableNativeFeedback accessibility: disabled prop #31224](https://github.com/facebook/react-native/pull/31224) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
+- [Accessibility/button test #31189](https://github.com/facebook/react-native/pull/31189) closed by[@huzaifaaak](https://twitter.com/huzaifaaak)
 
-- [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by[  grgr-dkrk](https://twitter.com/dkrk0901)
+- [feat: add getRecommendedTimeoutMillis section on accessibilityInfo #2581](https://github.com/facebook/react-native-website/pull/2581) closed by[grgr-dkrk](https://twitter.com/dkrk0901)
 
-- [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by[  @crloscuesta](https://twitter.com/crloscuesta)
+- [Disable accessibilityState when TouchableWithoutFeedback is disabled #31297](https://github.com/facebook/react-native/pull/31297) by[@crloscuesta](https://twitter.com/crloscuesta)
 
-- [[Accessibility] Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by[ fabriziobertoglio1987](http://fabriziobertoglio1987)
+- [Accessibility Fix Image does not announce "disabled" #31252](https://github.com/facebook/react-native/pull/31252) closed by[fabriziobertoglio1987](http://fabriziobertoglio1987)
 
-- [Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [chakrihacker](https://github.com/chakrihacker)
+-[Disable TouchableOpacity when accessibility disabled is set #31108](https://github.com/facebook/react-native/pull/31108) closed by [chakrihacker](https://github.com/chakrihacker)
 
 Community members who gave their time in other ways:
 
 Simek, saurabhkacholiya, meehawk, intergalacticspacehighway, chrisglein, jychiao, Waltari10
 
 ## Get Involved!
+
 We've come a long way but we're not done yet. We need your support to reach the finish line.  Facebook's React Native team has committed to supporting contributors working on gap analysis issues. They will continue to respond to comments on Accessibility issues and triage pull requests. The React Native team is also tackling some of the toughest gap analysis issues. This work includes the correct translation of accessibilityRoles to other languages and specifying error text for specific components.
 
 Join us in tackling the rest. There are still open accessibility issues on the [Improved React Native Accessibility project board](https://github.com/facebook/react-native/projects/15). Issues with [Checked/Unchecked State](https://github.com/facebook/react-native/issues/30843), [Entrance/exit from Collection](https://github.com/facebook/react-native/issues/30861), and [Position in Collection](https://github.com/facebook/react-native/issues/30977) are great opportunities for current and new contributors to contribute to a more accessible React Native.


### PR DESCRIPTION
**To be released on May 20th**

This Pull request is for the one year anniversary of React Native taking the GAAD pledge to reflect on the progress made towards a more accessible React Native. 

All feedback is welcome!

