### PR TITLE
Update Direct Manipulation docs to mention TextInput's .clear()

### DIFF
--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -143,7 +143,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-You can use the [`.clear`](https://reactnative.dev/docs/textinput#clear) method to clear the TextInput which clears the TextInput using the same approach
+You can use the [`clear`](textinput#clear) method to clear the `TextInput` which clears the current input text using the same approach.
 
 ## Avoiding conflicts with the render function
 


### PR DESCRIPTION
I noticed that the docs suggest using `setNativeProps` when it's probably simpler to just call `.clear` on a `TextInput` ref.