### PR TITLE
The intent of StyleSheet.create

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -40,6 +40,7 @@ const styles = StyleSheet.create({
 
 export default LotsOfStyles;
 ```
+> `StyleSheet.create` is the preferred way to define styles. While it would be possible to define styles using a plain object, `StyleSheet.create` validates each style property, so errors are reported at compile time. Additionally, there are performance gains, as a unique ID is created for each style object, and communication over the bridge utilizes this ID.
 
 One common pattern is to make your component accept a `style` prop which in turn is used to style subcomponents. You can use this to make styles "cascade" the way they do in CSS.
 


### PR DESCRIPTION
It is not clear why StyleSheet.create would be required when a plain object could be used in its place. I have referred this https://stackoverflow.com/questions/38886020/what-is-the-point-of-stylesheet-create to add some details.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
