### PR TITLE
Add a note about the chrome debugger causing useColorScheme to always return "light"

### DIFF
--- a/docs/usecolorscheme.md
+++ b/docs/usecolorscheme.md
@@ -15,6 +15,8 @@ The `useColorScheme` React hook provides and subscribes to color scheme updates 
 - `"dark"`: The user prefers a dark color theme.
 - `null`: The user has not indicated a preferred color theme.
 
+> **Note:** currently due to technical constraints, when the Chrome debugger is enabled, this hook will _always_ return `"light"`.
+
 ---
 
 ## Example

--- a/docs/usecolorscheme.md
+++ b/docs/usecolorscheme.md
@@ -15,7 +15,7 @@ The `useColorScheme` React hook provides and subscribes to color scheme updates 
 - `"dark"`: The user prefers a dark color theme.
 - `null`: The user has not indicated a preferred color theme.
 
-> **Note:** currently due to technical constraints, when the Chrome debugger is enabled, this hook will _always_ return `"light"`.
+> **Note:** Currently due to technical constraints, when the Chrome debugger is enabled, this hook will _always_ return `"light"`.
 
 ---
 

--- a/website/versioned_docs/version-0.64/usecolorscheme.md
+++ b/website/versioned_docs/version-0.64/usecolorscheme.md
@@ -15,6 +15,8 @@ The `useColorScheme` React hook provides and subscribes to color scheme updates 
 - `"dark"`: The user prefers a dark color theme.
 - `null`: The user has not indicated a preferred color theme.
 
+> **Note:** Currently due to technical constraints, when the Chrome debugger is enabled, this hook will _always_ return `"light"`.
+
 ---
 
 ## Example


### PR DESCRIPTION
I discovered this via [this Stack Overflow answer](https://stackoverflow.com/a/61124384/3098651) which points to [this `react-native` PR](https://github.com/facebook/react-native/commit/f7b90336be25b78935549aa140131d4d6d133f7b).