### PR TITLE
Potentially confusing extraData flatlist docs

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -88,7 +88,7 @@ More complex, selectable example below.
 - `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
 
 ```SnackPlayer name=flatlist-selectable
-import React, { useState } from "react";
+import React, { useCallback, useState, useRef } from "react";
 import { FlatList, SafeAreaView, StatusBar, StyleSheet, Text, TouchableOpacity } from "react-native";
 
 const DATA = [
@@ -113,29 +113,37 @@ const Item = ({ item, onPress, backgroundColor, textColor }) => (
 );
 
 const App = () => {
-  const [selectedId, setSelectedId] = useState(null);
+  const [extraData, setExtraData] = useState(null);
+  const selectIdRef = useRef();
 
-  const renderItem = ({ item }) => {
-    const backgroundColor = item.id === selectedId ? "#6e3b6e" : "#f9c2ff";
-    const color = item.id === selectedId ? 'white' : 'black';
+  const renderItem = useCallback(({ item }) => {
+    const backgroundColor =
+      item.id === selectIdRef.current ? '#6e3b6e' : '#f9c2ff';
+    const color = item.id === selectIdRef.current ? 'white' : 'black';
+    const onPress = () => {
+      selectIdRef.current = item.id;
+      setExtraData(item.id);
+    };
 
     return (
       <Item
         item={item}
-        onPress={() => setSelectedId(item.id)}
-        backgroundColor={{ backgroundColor }}
-        textColor={{ color }}
+        onPress={onPress}
+        backgroundColor={{backgroundColor}}
+        textColor={{color}}
       />
     );
-  };
+  }, []);
+
+  const keyExtractor = useCallback(item => item.id, []);
 
   return (
     <SafeAreaView style={styles.container}>
       <FlatList
         data={DATA}
         renderItem={renderItem}
-        keyExtractor={(item) => item.id}
-        extraData={selectedId}
+        keyExtractor={keyExtractor}
+        extraData={extraData}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
**Summary**

The current example for using extraData in the flatlist does not actually require the extraData prop to rerender the selectedId. This commit is to contrive an example where extraData in the flatList makes a difference. However, another alternative solution that I might suggest is to remove it from the documentation entirely because extraData seems less relevant to the functional paradigm. I'm also relatively new to RN so perhaps there's something that I'm missing as well.

**Details**

The existing example runs fine without the extraData prop at all because the functional component re-creates the renderItem function reference on every call to the App function when the selectId state is set. Since the renderItem reference changes to the flatList, it re-renders.

I'm not sure the modifications are a good example because in order to contrive the simplest possible example I could imagine I needed to additionally use the useCallback and useRef hooks. (You could of course pass a renderItem without the callback dependency of selectId, but I think that's worse pedantically). This means increasing the complexity of the example, but I'm not sure otherwise how to contrive an example that actually uses extraData in the functional paradigm.

I'm curious if anyone has a better example - my feeling is that the extraData prop was something beginners would run into much more often in the class paradigm because you could pass non-reactive persistent state which lived on the class to the list.

However, in the functional paradigm I don't think this is possible because the useRef hook (which to my understanding serves as this replacement for mutable class state) requires the .current property getter to fetch data, which is then assigned a reference if passed into the flatlist as data, and hence would change on every render cycle. Similarly, if you are passing data in state the flatlist will also rerender every cycle. So unless I'm misunderstanding something in how the functional paradigm works (which is totally possible, I'm pretty new to RN) then it seems like the usage of extraData would never arise in normal circumstances. I think you only run into it if you pass some form of data to a renderItem method wrapped in a callback, which I can imagine might be relevant for some performance optimization.
