### PR TITLE
Fix/Value for flexWrap

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -859,7 +859,7 @@ const FlexWrapLayout = () => {
     <PreviewLayout
       label="flexWrap"
       selectedValue={flexWrap}
-      values={["wrap", "no-wrap"]}
+      values={["wrap", "nowrap"]}
       setSelectedValue={setFlexWrap}>
       <View
         style={[styles.box, { backgroundColor: "orangered" }]}


### PR DESCRIPTION
It works on the sandbox but if you copy the code and run it you get an error.
'no-wrap'. Removed hyphen to be 'nowrap'.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
