### PR TITLE
Update platform-specific-code.md

### DIFF
--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -84,7 +84,7 @@ if (Platform.Version === 25) {
 }
 ```
 
-**Pro·tip**: this is the Android API version not the OS version. To find a mapping please refer to: [Android Version History](https://en.wikipedia.org/wiki/Android_version_history)
+**Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
 ### Detecting the iOS version
 

--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -84,6 +84,8 @@ if (Platform.Version === 25) {
 }
 ```
 
+***Pro tip***: this is the Android API version not the OS version. To find a mapping please refer to: [Android Version History](https://en.wikipedia.org/wiki/Android_version_history)
+
 ### Detecting the iOS version
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:

--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -84,7 +84,7 @@ if (Platform.Version === 25) {
 }
 ```
 
-***Pro tip***: this is the Android API version not the OS version. To find a mapping please refer to: [Android Version History](https://en.wikipedia.org/wiki/Android_version_history)
+**Pro·tip**: this is the Android API version not the OS version. To find a mapping please refer to: [Android Version History](https://en.wikipedia.org/wiki/Android_version_history)
 
 ### Detecting the iOS version
 


### PR DESCRIPTION
Update the Docs to:

- reflect that Platform.Version references the Android API version not Android OS version
- link to wiki providing a mapping of OS version to API version