### PR TITLE
Remove unused failureCallback in example

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -392,7 +392,7 @@ There are two approaches to error handling with callbacks. The first is to follo
 
 ```java
 @ReactMethod
-public void createCalendarEvent(String name, String location, Callback myFailureCallback, Callback callBack) {
+public void createCalendarEvent(String name, String location, Callback callBack) {
     Integer eventId = ...
     callBack.invoke(null, eventId);
 }

--- a/website/versioned_docs/version-0.64/native-modules-android.md
+++ b/website/versioned_docs/version-0.64/native-modules-android.md
@@ -392,7 +392,7 @@ There are two approaches to error handling with callbacks. The first is to follo
 
 ```java
 @ReactMethod
-public void createCalendarEvent(String name, String location, Callback myFailureCallback, Callback callBack) {
+public void createCalendarEvent(String name, String location, Callback callBack) {
     Integer eventId = ...
     callBack.invoke(null, eventId);
 }


### PR DESCRIPTION
This is removing the unused and confusing failure callback in the example code. The text above the example is talking about the node callback convention with a single callback for success and error.