### PR TITLE
Select a template on initializing project

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ npm start # you can also use: expo start
 <TabItem value="yarn">
 
 ```shell
-expo init AwesomeProject
+expo init AwesomeProject //You will be asked to choose a template, use arrow keys and select one. For now, you can go with "blank"
 
 cd AwesomeProject
 yarn start # you can also use: expo start


### PR DESCRIPTION
Added comment to select a template after running "expo init AwesomeProject" at Line 55.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
