### PR TITLE
Images: Remove mention of platform-specific extensions

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -11,9 +11,9 @@ React Native provides a unified way of managing images and other media assets in
 <Image source={require('./my-icon.png')} />
 ```
 
-The image name is resolved the same way JS modules are resolved. In the example above, the bundler will look for `my-icon.png` in the same folder as the component that requires it. Also, if you have `my-icon.ios.png` and `my-icon.android.png`, the bundler will pick the correct file for the platform.
+The image name is resolved the same way JS modules are resolved. In the example above, the bundler will look for `my-icon.png` in the same folder as the component that requires it.
 
-You can also use the `@2x` and `@3x` suffixes to provide images for different screen densities. If you have the following file structure:
+You can use the `@2x` and `@3x` suffixes to provide images for different screen densities. If you have the following file structure:
 
 ```
 .


### PR DESCRIPTION
This functionality was removed in https://github.com/facebook/metro/commit/7674ca076e03483a17a37c31481807e2b67dea29, released in [Metro 0.59.0](https://github.com/facebook/metro/releases/tag/v0.59.0) and eventually in RN 0.64. This was a poorly-communicated breaking change at the time and we might want to undo it, but for now the website should reflect what actually works.

Related:
https://github.com/facebook/react-native/issues/31099
https://github.com/facebook/react-native/issues/31348
https://github.com/facebook/metro/issues/676

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
