### PR TITLE
Disable web-preview for TextStyleProps example

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -5,7 +5,7 @@ title: Text Style Props
 
 ### Example
 
-```SnackPlayer name=TextStyleProps
+```SnackPlayer name=TextStyleProps&supportedPlatforms=ios,android
 import React, { useState } from "react";
 import { FlatList, Platform, ScrollView, Slider, StatusBar, StyleSheet, Switch, Text, TouchableWithoutFeedback, View } from "react-native";
 

--- a/website/versioned_docs/version-0.64/text-style-props.md
+++ b/website/versioned_docs/version-0.64/text-style-props.md
@@ -5,7 +5,7 @@ title: Text Style Props
 
 ### Example
 
-```SnackPlayer name=TextStyleProps
+```SnackPlayer name=TextStyleProps&supportedPlatforms=ios,android
 import React, { useState } from "react";
 import { FlatList, Platform, ScrollView, Slider, StatusBar, StyleSheet, Switch, Text, TouchableWithoutFeedback, View } from "react-native";
 


### PR DESCRIPTION
# Why

`react-native-web` does not support the deprecated `Slider` component causing the `TextStyleProps` example to fail with a React minified error upon loading the page.

As discussed here:
https://github.com/facebook/react-native-website/pull/2476#issuecomment-864892954
@Simek 

**before**

![image](https://user-images.githubusercontent.com/6184593/123236779-61e21700-d4dd-11eb-8064-1e9bbaaab05d.png)

**after**

![image](https://user-images.githubusercontent.com/6184593/123236838-6c9cac00-d4dd-11eb-938c-f48ddc5ebdaa.png)

# How

- Make example only available on `ios` and `android`

# Why

- See screenshot
- Ran `yarn prettier` to verify the file doesn't contain any styling issues
