### PR TITLE
Removed undefined className

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -173,7 +173,7 @@ function TwoColumns({columnOne, columnTwo, reverse}) {
 function ScreenRect({className, fill, stroke}) {
   return (
     <rect
-      className={`screen ${className ? className : ''}`}
+      className={`screen ${className || ''}`}
       rx="3%"
       width="180"
       height="300"

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -173,7 +173,7 @@ function TwoColumns({columnOne, columnTwo, reverse}) {
 function ScreenRect({className, fill, stroke}) {
   return (
     <rect
-      className={`screen ${className}`}
+      className={`screen ${className ? className : ''}`}
       rx="3%"
       width="180"
       height="300"


### PR DESCRIPTION
Simple update removing the undefined className in ScreenRect function.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
