### PR TITLE
Remove react-native-dom from list of out-of-tree platforms

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -7,7 +7,6 @@ React Native is not only for Android and iOS - there are community-supported pro
 
 - [React Native Windows](https://github.com/Microsoft/react-native-windows) - React Native support for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
-- [React Native DOM](https://github.com/vincentriemer/react-native-dom) - An experimental, comprehensive port of React Native to the web. (Not to be confused with [React Native Web](https://github.com/necolas/react-native-web), which has different goals)
 - [React Native Turbolinks](https://github.com/lazaronixon/react-native-turbolinks) - React Native adapter for building hybrid apps with Turbolinks 5.
 - [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
 - [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS

--- a/website/versioned_docs/version-0.64/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.64/out-of-tree-platforms.md
@@ -7,7 +7,6 @@ React Native is not only for Android and iOS - there are community-supported pro
 
 - [React Native Windows](https://github.com/Microsoft/react-native-windows) - React Native support for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
-- [React Native DOM](https://github.com/vincentriemer/react-native-dom) - An experimental, comprehensive port of React Native to the web. (Not to be confused with [React Native Web](https://github.com/necolas/react-native-web), which has different goals)
 - [React Native Turbolinks](https://github.com/lazaronixon/react-native-turbolinks) - React Native adapter for building hybrid apps with Turbolinks 5.
 - [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
 - [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS


### PR DESCRIPTION
I haven't worked/maintained react-native-dom for a year or two now and don't think it makes sense to direct people over to the project anymore. This commit removes it from the list.
