### PR TITLE
Add MDN link for aspectRatio

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -203,7 +203,7 @@ export default App;
 
 ### `aspectRatio`
 
-Aspect ratio controls the size of the undefined dimension of a node. Aspect ratio is a non-standard property only available in React Native and not CSS.
+Aspect ratio controls the size of the undefined dimension of a node. See https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio for more details.
 
 - On a node with a set width/height, aspect ratio controls the size of the unset dimension
 - On a node with a set flex basis, aspect ratio controls the size of the node in the cross axis if unset


### PR DESCRIPTION
`aspect-ratio` is now a CSS property with decent [support](https://caniuse.com/mdn-css_properties_aspect-ratio) and an [MDN link](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio). I haven't compared the implementation of `aspectRatio` in RN vs. `aspect-ratio` in the CSS spec in detail, so if they diverge we may want to just remove the comment about `aspect-ratio` being non-standard. Let me know and I can update my PR.