### PR TITLE
Update documentation for `TextInput`'s `autoCapitalize` property to c…

### DIFF
--- a/website/versioned_docs/version-0.64/textinput.md
+++ b/website/versioned_docs/version-0.64/textinput.md
@@ -115,7 +115,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ### `autoCapitalize`
 
-Tells `TextInput` to automatically capitalize certain characters. This property is not supported by some keyboard types such as `name-phone-pad`.
+Determines at what times the on-screen keyboard's Shift key is automatically pressed. This property is not supported by some keyboard types such as `name-phone-pad`.
 
 - `characters`: all characters.
 - `words`: first letter of each word.


### PR DESCRIPTION
…larify that this property merely suggests the capitalization of characters to the virtual keyboard and doesn't do any filtering/allowing/disallowing.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
