### PR TITLE
allow wrapping code blocks content in tables

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -208,6 +208,7 @@ hr {
 
       pre code {
         padding: 12px 16px;
+        white-space: break-spaces;
       }
 
       button {


### PR DESCRIPTION
Refs #2676

This small PR adds `white-space: break-spaces;` property to the `code` block in `table`s, which allow the code block content wrapping, if there is not enough space in the page container to fit the line. This mostly applies for the mobile devices and in most cases should prevent the horizontal page overflow and horizontal scrollbars.