### PR TITLE
Added accessiblity documentation for Button and Text component

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -138,6 +138,30 @@ Text to display for blindness accessibility features.
 
 ---
 
+### `accessibilityActions`
+
+Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.
+
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
+
+| Type  | Required |
+| ----- | -------- |
+| array | No       |
+
+---
+
+### `onAccessibilityAction`
+
+Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.
+
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
 ### `color`
 
 Color of the text (iOS), or background color of the button (Android).

--- a/docs/text.md
+++ b/docs/text.md
@@ -298,6 +298,30 @@ You can provide one state, no state, or multiple states. The states must be pass
 
 ---
 
+### `accessibilityActions`
+
+Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.
+
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
+
+| Type  | Required |
+| ----- | -------- |
+| array | No       |
+
+---
+
+### `onAccessibilityAction`
+
+Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.
+
+See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
 ### `accessible`
 
 When set to `true`, indicates that the view is an accessibility element.


### PR DESCRIPTION
Update Accessibility Documentation (#2679) 
Added _AccessibilityActions_ and _onAccessibilityAction_  props for [Button](https://reactnative.dev/docs/next/button) and [Text](https://reactnative.dev/docs/next/text) component. 

![Screenshot from 2021-07-16 02-14-19](https://user-images.githubusercontent.com/55653617/125859284-a666e951-fd76-4227-a042-d48ba4a9ad22.png)

![Screenshot from 2021-07-16 02-14-31](https://user-images.githubusercontent.com/55653617/125859288-2a8e31e3-9148-4d3e-8653-0d70f208a237.png)
