### PR TITLE
Update the typescript template shell command

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -14,7 +14,7 @@ If you're starting a new project, there are a few different ways to get started.
 You can use the [TypeScript template][ts-template]:
 
 ```shell
-npx react-native init MyApp --template react-native-template-typescript
+npx react-native init MyApp --template typescript
 ```
 
 > **Note:** If the above command is failing, you may have an old version of `react-native` or `react-native-cli` installed globally on your system. To fix the issue try uninstalling the CLI:


### PR DESCRIPTION
Yarn adds the `react-native-template` prefix, so the `--template` argument should not contain it.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
