### PR TITLE
Update Snack to .dev domain

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ import GuideLinuxAndroid from './\_getting-started-linux-android.md'; import Gui
 
 This page will help you install and build your first React Native app.
 
-**If you are new to mobile development**, the easiest way to get started is with Expo CLI. Expo is a set of tools built around React Native and, while it has many [features](https://expo.io/features), the most relevant feature for us right now is that it can get you writing a React Native app within minutes. You will only need a recent version of Node.js and a phone or emulator. If you'd like to try out React Native directly in your web browser before installing any tools, you can try out [Snack](https://snack.expo.io/).
+**If you are new to mobile development**, the easiest way to get started is with Expo CLI. Expo is a set of tools built around React Native and, while it has many [features](https://expo.io/features), the most relevant feature for us right now is that it can get you writing a React Native app within minutes. You will only need a recent version of Node.js and a phone or emulator. If you'd like to try out React Native directly in your web browser before installing any tools, you can try out [Snack](https://snack.expo.dev/).
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 

--- a/plugins/remark-snackplayer/README.md
+++ b/plugins/remark-snackplayer/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Remark SnackPlayer</h1>
 
-<p align="center">Remark plugin to embed <a href="https://snack.expo.io/">Expo Snack's</a> using Code Blocks</p>
+<p align="center">Remark plugin to embed <a href="https://snack.expo.dev/">Expo Snack's</a> using Code Blocks</p>
 
 ## Usage
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
         'https://widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd8ryO5qrZo8Exadq9qmt1wtm4_2FdZGEAKHDFEt_2BBlwwM4.js',
       defer: true,
     },
-    {src: 'https://snack.expo.io/embed.js', defer: true},
+    {src: 'https://snack.expo.dev/embed.js', defer: true},
   ],
   favicon: 'img/favicon.ico',
   titleDelimiter: '·',

--- a/website/snackPlayerInitializer.js
+++ b/website/snackPlayerInitializer.js
@@ -50,7 +50,7 @@ export default (() => {
 
   // Reset snack iframes on theme changes to sync theme
   // Hacky, but no better solution for now
-  // see https://github.com/expo/snack-web/blob/master/src/client/components/EmbedCode.tsx#L60
+  // see https://github.com/expo/snack/blob/main/website/src/client/components/EmbedCode.tsx#L61
   const setupThemeSynchronization = () => {
     new MutationObserver((mutations, observer) => {
       if ('ExpoSnack' in window) {

--- a/website/versioned_docs/version-0.64/getting-started.md
+++ b/website/versioned_docs/version-0.64/getting-started.md
@@ -10,7 +10,7 @@ import GuideLinuxAndroid from './\_getting-started-linux-android.md'; import Gui
 
 This page will help you install and build your first React Native app.
 
-**If you are new to mobile development**, the easiest way to get started is with Expo CLI. Expo is a set of tools built around React Native and, while it has many [features](https://expo.io/features), the most relevant feature for us right now is that it can get you writing a React Native app within minutes. You will only need a recent version of Node.js and a phone or emulator. If you'd like to try out React Native directly in your web browser before installing any tools, you can try out [Snack](https://snack.expo.io/).
+**If you are new to mobile development**, the easiest way to get started is with Expo CLI. Expo is a set of tools built around React Native and, while it has many [features](https://expo.io/features), the most relevant feature for us right now is that it can get you writing a React Native app within minutes. You will only need a recent version of Node.js and a phone or emulator. If you'd like to try out React Native directly in your web browser before installing any tools, you can try out [Snack](https://snack.expo.dev/).
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 


### PR DESCRIPTION
# Why

Updates the Snack player and other Snack URLs to use the new `.dev` domain. *The old `.io` domain still works, but requires an additional redirect on the server.

# How

- Update Snack url in docusaurus.config
- Update Snack urls

# Test plan

- `cd website && yarn start`
- Verified that the Snack player loads as expected