### PR TITLE
Update minimal node requirement to 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you are looking for the source code of the [React Native Archive website](htt
 ### Prerequisites
 
 1.  [Git](https://git-scm.com/downloads).
-1.  [Node](https://nodejs.org/en/download/) _(version 12 or greater)_.
+1.  [Node](https://nodejs.org/en/download/) _(version 14 or greater)_.
 1.  [Yarn](https://yarnpkg.com/lang/en/docs/install/) _(version 1.5 or greater)_.
 1.  A fork of the repo _(for any contributions)_.
 1.  A clone of the `react-native-website` repo.


### PR DESCRIPTION
Updates the minimal node requirement in README to node 14.

Node 12 no longer works and throws certain errors:

```
 sync-api-docs % yarn sync
yarn run v1.22.10
$ node sync-api-docs ../../react-native
/Users/hein/repos/Expo/react-native-website/sync-api-docs/generateMarkdown.js:85
  if (method?.params[0]?.type?.raw) {
             ^

SyntaxError: Unexpected token '.'
```
