### PR TITLE
chore: fix link in showcase

### DIFF
--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -99,7 +99,9 @@ const Showcase = () => {
         </a>
         <p>
           A curated list of{' '}
-          <a href="https://github.com/ReactNativeNews/React-Native-Apps/#readme">
+          <a
+            key="demo-apps"
+            href="https://github.com/ReactNativeNews/React-Native-Apps">
             open source React Native apps
           </a>{' '}
           is also being kept by <a href="https://infinite.red">Infinite Red</a>.

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -99,11 +99,13 @@ const Showcase = () => {
         </a>
         <p>
           A curated list of{' '}
-          <a
-            key="demo-apps"
-            href="https://github.com/ReactNativeNews/React-Native-Apps">
-            open source React Native apps
-          </a>{' '}
+          <span>
+            <a
+              key="demo-apps"
+              href="https://github.com/ReactNativeNews/React-Native-Apps">
+              open source React Native apps
+            </a>
+          </span>{' '}
           is also being kept by <a href="https://infinite.red">Infinite Red</a>.
         </p>
       </div>

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -99,11 +99,10 @@ const Showcase = () => {
         </a>
         <p>
           A curated list of{' '}
-          <a href="https://github.com/ReactNativeNews/React-Native-Apps/">
+          <a href="https://github.com/ReactNativeNews/React-Native-Apps/#readme">
             open source React Native apps
           </a>{' '}
-          is also being kept by <a href="https://infinite.red/">Infinite Red</a>
-          .
+          is also being kept by <a href="https://infinite.red">Infinite Red</a>.
         </p>
       </div>
     </Layout>

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -99,7 +99,7 @@ const Showcase = () => {
         </a>
         <p>
           A curated list of{' '}
-          <a href="https://github.com/ReactNativeNews/React-Native-Apps">
+          <a href="https://github.com/ReactNativeNews/React-Native-Apps/">
             open source React Native apps
           </a>{' '}
           is also being kept by <a href="https://infinite.red/">Infinite Red</a>


### PR DESCRIPTION
this PR fix link in showcase for React Native open source apps, something weird happen in dev works but in production still infinite red link home page!.

cc: @Simek 

