### PR TITLE
docs: update `StatusBarIOS` deprecation message

### DIFF
--- a/docs/statusbarios.md
+++ b/docs/statusbarios.md
@@ -3,6 +3,6 @@ id: statusbarios
 title: '🚧 StatusBarIOS'
 ---
 
-> **Deprecated.** Use [`StatusBar`](statusbar.md) for mutating the status bar.
+> **Deleted.** Use [`StatusBar`](statusbar.md) for mutating the status bar.
 
 ---


### PR DESCRIPTION
`StatusBarIOS` has been removed from core in  facebook/react-native#31466