### PR TITLE
fix warning: functions are not valid as ReactChild

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -20,7 +20,7 @@ import { Text, StyleSheet } from "react-native";
 
 const TextInANest = () => {
   const [titleText, setTitleText] = useState("Bird's Nest");
-  const bodyText = useState("This is not really a bird nest.");
+  const bodyText = "This is not really a bird nest.";
 
   const onPressTitle = () => {
     setTitleText("Bird's Nest [pressed]");


### PR DESCRIPTION
  const bodyText = useState("This is not really a bird nest.");

This code for example throughs a warning "Functions are not valid as a React child..."

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
