### PR TITLE
update out-of-tree platforms list

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -3,15 +3,17 @@ id: out-of-tree-platforms
 title: Out-of-Tree Platforms
 ---
 
-React Native is not only for Android and iOS - there are community-supported projects that bring it to other platforms, such as:
+React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
 
-- [React Native Windows](https://github.com/Microsoft/react-native-windows) - React Native support for targeting Microsoft's Universal Windows Platform (UWP).
+__From Partners__
+- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
-- [React Native Turbolinks](https://github.com/lazaronixon/react-native-turbolinks) - React Native adapter for building hybrid apps with Turbolinks 5.
-- [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
-- [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
-- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program(微信小程序).
-- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, MacOS, and Windows forked from [Proton native](https://github.com/kusti8/proton-native) which is no longer maintained.
+
+__From Community__
+- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
+- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
+- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform
 

--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -5,11 +5,13 @@ title: Out-of-Tree Platforms
 
 React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
 
-__From Partners__
+**From Partners**
+
 - [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
 
-__From Community__
+**From Community**
+
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).

--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -3,18 +3,18 @@ id: out-of-tree-platforms
 title: Out-of-Tree Platforms
 ---
 
-React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
+React Native is not only for Android and iOS devices - our partners and the community maintain projects that bring React Native to other platforms, such as:
 
 **From Partners**
 
-- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
-- [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
+- [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native for macOS and Cocoa.
+- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native for Microsoft's Universal Windows Platform (UWP).
 
 **From Community**
 
-- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
-- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
+- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform

--- a/website/versioned_docs/version-0.64/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.64/out-of-tree-platforms.md
@@ -3,18 +3,18 @@ id: out-of-tree-platforms
 title: Out-of-Tree Platforms
 ---
 
-React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
+React Native is not only for Android and iOS devices - our partners and the community maintain projects that bring React Native to other platforms, such as:
 
 **From Partners**
 
-- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
-- [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
+- [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native for macOS and Cocoa.
+- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native for Microsoft's Universal Windows Platform (UWP).
 
 **From Community**
 
-- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
-- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
+- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform

--- a/website/versioned_docs/version-0.64/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.64/out-of-tree-platforms.md
@@ -3,15 +3,19 @@ id: out-of-tree-platforms
 title: Out-of-Tree Platforms
 ---
 
-React Native is not only for Android and iOS - there are community-supported projects that bring it to other platforms, such as:
+React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
 
-- [React Native Windows](https://github.com/Microsoft/react-native-windows) - React Native support for targeting Microsoft's Universal Windows Platform (UWP).
+**From Partners**
+
+- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
-- [React Native Turbolinks](https://github.com/lazaronixon/react-native-turbolinks) - React Native adapter for building hybrid apps with Turbolinks 5.
-- [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
-- [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
-- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program(微信小程序).
-- [Proton Native](https://github.com/kusti8/proton-native) - A wrapper for React Native, using Qt to target Linux, MacOS, and Windows.
+
+**From Community**
+
+- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
+- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
+- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform
 

--- a/website/versioned_docs/version-0.65/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.65/out-of-tree-platforms.md
@@ -3,15 +3,17 @@ id: out-of-tree-platforms
 title: Out-of-Tree Platforms
 ---
 
-React Native is not only for Android and iOS - there are community-supported projects that bring it to other platforms, such as:
+React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
 
-- [React Native Windows](https://github.com/Microsoft/react-native-windows) - React Native support for targeting Microsoft's Universal Windows Platform (UWP).
+__From Partners__
+- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
-- [React Native Turbolinks](https://github.com/lazaronixon/react-native-turbolinks) - React Native adapter for building hybrid apps with Turbolinks 5.
-- [React Native Desktop](https://github.com/status-im/react-native-desktop) - A project aiming to bring React Native to the Desktop with Qt's QML. A fork of [React Native Ubuntu](https://github.com/CanonicalLtd/react-native/), which is no longer maintained.
-- [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
-- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program(微信小程序).
-- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, MacOS, and Windows forked from [Proton native](https://github.com/kusti8/proton-native) which is no longer maintained.
+
+__From Community__
+- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
+- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
+- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform
 

--- a/website/versioned_docs/version-0.65/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.65/out-of-tree-platforms.md
@@ -5,11 +5,13 @@ title: Out-of-Tree Platforms
 
 React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
 
-__From Partners__
+**From Partners**
+
 - [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
 
-__From Community__
+**From Community**
+
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).

--- a/website/versioned_docs/version-0.65/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.65/out-of-tree-platforms.md
@@ -3,18 +3,18 @@ id: out-of-tree-platforms
 title: Out-of-Tree Platforms
 ---
 
-React Native is not only for Android and iOS devices - there are partners-supported and community-supported projects that bring it to other platforms, such as:
+React Native is not only for Android and iOS devices - our partners and the community maintain projects that bring React Native to other platforms, such as:
 
 **From Partners**
 
-- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native library for targeting Microsoft's Universal Windows Platform (UWP).
-- [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native fork targeting macOS and Cocoa.
+- [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native for macOS and Cocoa.
+- [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native for Microsoft's Universal Windows Platform (UWP).
 
 **From Community**
 
-- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
-- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native fork targeting Apple TV and Android TV devices.
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
+- [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
+- [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform


### PR DESCRIPTION
Refs https://github.com/facebook/react-native-website/pull/2684#issuecomment-900275456

This PR updates the current Out-of-tree platforms list and includes the following changes:
* `react-native-web` added to the list
* `react-native-tvos` description updated to signify Android TV support
* remove `react-native-desktop` hence it's no longer maintained
   <img width="571" alt="Screenshot 2021-08-18 at 12 46 17" src="https://user-images.githubusercontent.com/719641/129885179-1c11790e-7db3-407f-9524-550891f2029f.png">
* `react-native-turbolinks` is more similar to library than separate platform, so I have removed it from the list, ~~I will add it to the RN Directory later~~ **(EDIT: it has been added already)**

I'm not sure if the list division to Partners and Community is a good idea, can revert this part back, if requested.

CC @douglowder @necolas For the check on the entries description 🙂 

## Preview

<img width="853" alt="Screenshot 2021-08-18 at 13 02 01" src="https://user-images.githubusercontent.com/719641/129887186-928567b0-de1d-4158-bb86-d1ad32ed454f.png">
