### PR TITLE
bump ver for Android SDK Build-Tools

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -60,7 +60,7 @@ Select the "SDK Platforms" tab from within the SDK Manager, then check the box n
 - `Android SDK Platform 29`
 - `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `29.0.2` is selected and check the "Android SDK Command-line Tools (latest)".
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `29.0.3` is selected and check the "Android SDK Command-line Tools (latest)".
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
@@ -68,7 +68,7 @@ You can also run the following command after setting ANDROID_HOME.
 
 ```shell
 sdkmanager "platforms;android-29" "system-images;android-29;default;x86_64" "system-images;android-29;google_apis;x86"
-sdkmanager "cmdline-tools;latest" "build-tools;29.0.2"
+sdkmanager "cmdline-tools;latest" "build-tools;29.0.3"
 ```
 
 <h4>3. Configure the ANDROID_HOME environment variable</h4>


### PR DESCRIPTION
from 29.0.2 to 'build-tools;29.0.3' per https://github.com/react-native-community/cli/blob/641b21f583c97e3d48ce87d5fe804f42db92fa5c/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts#L105