### PR TITLE
Update iOS path to use a different port

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ You can configure the bundler to use a port other than 8081 by using the `port` 
 npx react-native start --port=8088
 ```
 
-You will also need to update your applications to load the JavaScript bundle from the new port. If running on device from Xcode, you can do this by updating occurrences of `8081` to your chosen port in the `node_modules/react-native/React/React.xcodeproj/project.pbxproj` file.
+You will also need to update your applications to load the JavaScript bundle from the new port. If running on device from Xcode, you can do this by updating occurrences of `8081` to your chosen port in the `ios/__App_Name__.xcodeproj/project.pbxproj` file.
 
 ### NPM locking error
 


### PR DESCRIPTION
- Changed the path to use latest file and folder structure as per react-native@0.65.1

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
