### PR TITLE
Add "React Native Is Hiring Managers" blog post

### DIFF
--- a/website/blog/2021-08-30-react-native-is-hiring-managers.md
+++ b/website/blog/2021-08-30-react-native-is-hiring-managers.md
@@ -1,0 +1,28 @@
+---
+title: React Native Is Hiring Managers, To Expand Beyond Mobile
+author: Eli White
+authorTitle: Engineering Manager on React Native
+authorURL: https://twitter.com/Eli_White
+authorImageURL: https://avatars.githubusercontent.com/u/249164?v=4
+authorTwitter: Eli_White
+tags: [hiring]
+date: 2021-08-30
+---
+
+We recently shared [React Native’s Many Platform Vision](https://reactnative.dev/blog/2021/08/26/many-platform-vision) for how expanding React to other platforms improves the framework for everyone else. We’ve been making significant progress on this vision over the last couple years by partnering with Microsoft on React Native for Windows and macOS, and Oculus on React Native in VR.
+
+![Screenshot of the Messenger app on macOS](/blog/assets/many-platform-vision-messenger-desktop.png)
+
+<div class="text--center text--italic margin-bottom--lg">
+React Native powers Video Calling in Messenger for Windows and macOS.
+</div>
+
+![Screenshot of Oculus Home in virtual reality](/blog/assets/many-platform-vision-oculus-home.png)
+
+<div class="text--center text--italic margin-bottom--lg">
+React and Relay power the Oculus Home and many other virtual reality experiences.
+</div>
+
+As [part of our plans beginning earlier this year](https://reactnative.dev/blog/2021/08/19/h2-2021), we are growing our focus on these platforms and growing our teams to help us achieve our vision. In order to support our new teammates, and many more to come, **we are hiring two Engineering Managers: one to help support React Native for Desktop, and one to support React Native for VR**.
+
+We are looking for managers who will care deeply about the growth and success of our engineers, and are excited about our vision. Previous React or React Native experience is not required. This role is open to anyone in the United States. If this sounds like an interesting opportunity and you are interested in learning more, please apply on [Facebook’s Career’s Page](https://www.facebook.com/careers/v2/jobs/438516437547870). We look forward to hearing from you!


### PR DESCRIPTION
Adds a new blog post to the React Native website titled, "React Native Is Hiring Managers, To Expand Beyond Mobile".

**Test Plan:**
Verify formatting and lint cleanliness:

```
cd react-native-website/website
../node_modules/.bin/prettier -w blog/2021-08-26-many-platform-vision.md
node_modules/.bin/alex blog/2021-08-26-many-platform-vision.md
```

Follow [the Contributing instructions in README.md](https://github.com/facebook/react-native-website#-contributing) to test visually inspect the blog post locally.

![Screenshot of the entire blog post](https://user-images.githubusercontent.com/55161/131374297-401965c0-d384-4c53-957f-03731ff84156.png)
