### PR TITLE
fix external links to React and React Native repositories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing to React Native
 
-Thank you for your interest in contributing to the React Native website! From commenting on and triaging issues, to reviewing and sending Pull Requests, all contributions are welcome. We aim to build a vibrant and inclusive [ecosystem of partners, core contributors, and community](https://github.com/facebook/react-native/blob/master/ECOSYSTEM.md) that goes beyond the main React Native GitHub repository.
+Thank you for your interest in contributing to the React Native website! From commenting on and triaging issues, to reviewing and sending Pull Requests, all contributions are welcome. We aim to build a vibrant and inclusive [ecosystem of partners, core contributors, and community](https://github.com/facebook/react-native/blob/main/ECOSYSTEM.md) that goes beyond the main React Native GitHub repository.
 
 The [Open Source Guides](https://opensource.guide/) website has a collection of resources for individuals, communities, and companies who want to learn how to run and contribute to an open source project. Contributors and people new to open source alike will find the following guides especially useful:
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Building Welcoming Communities](https://opensource.guide/building-community/)
 
-### [Code of Conduct](https://github.com/facebook/react/blob/master/CODE_OF_CONDUCT.md)
+### [Code of Conduct](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md)
 
-As a reminder, all contributors are expected to adhere to the [Code of Conduct](https://github.com/facebook/react/blob/master/CODE_OF_CONDUCT.md).
+As a reminder, all contributors are expected to adhere to the [Code of Conduct](https://github.com/facebook/react/blob/main/CODE_OF_CONDUCT.md).
 
 ## Ways to Contribute
 
-Please see our [Contributing Guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) in the main React Native repository.
+Please see our [Contributing Guide](https://github.com/facebook/react-native/blob/main/CONTRIBUTING.md) in the main React Native repository.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -137,4 +137,4 @@ When writing step-by-step instructions (e.g. how to install something), try to f
 
 ## Resources
 
-- [React JS’s contibuting guidelines](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md#guidelines-for-text), especially the [code examples guidelines](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md#guidelines-for-code-examples)
+- [React JS’s contibuting guidelines](https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md#guidelines-for-text), especially the [code examples guidelines](https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md#guidelines-for-code-examples)

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -69,7 +69,7 @@ const Versions = () => {
           <code>react-native-releases</code>
         </a>{' '}
         repository. At the beginning of each month, a new release candidate is
-        created off the master branch of{' '}
+        created off the <code>main</code> branch of{' '}
         <a href={'https://github.com/facebook/react-native'}>
           <code>facebook/react-native</code>
         </a>

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -4,7 +4,7 @@
 /docs/android-setup             /docs/getting-started
 /docs/building-for-apple-tv     /docs/building-for-tv
 /docs/building-from-source      https://github.com/facebook/react-native/wiki/Building-from-source
-/docs/contributing              https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md
+/docs/contributing              https://github.com/facebook/react-native/blob/main/CONTRIBUTING.md
 /docs/maintainers               https://github.com/facebook/react-native/wiki/
 /docs/publishing-forks          https://github.com/facebook/react-native/wiki/Building-from-source#publish-your-own-version-of-react-native
 /docs/testing                   https://github.com/facebook/react-native/wiki/Tests


### PR DESCRIPTION
This small PR fixes the external links and references using the old main branches name of React and React Native repositories.
