### PR TITLE
Migrate recent blog posts to `authors.yml`

### DIFF
--- a/website/blog/2021-08-26-many-platform-vision/index.md
+++ b/website/blog/2021-08-26-many-platform-vision/index.md
@@ -1,6 +1,6 @@
 ---
 title: React Native's Many Platform Vision
-authors: [yungsters, lunaleaps]
+authors: [abernathyca, Eli_White, lunaleaps, yungsters]
 tags: [announcement]
 date: 2021-08-26
 ---

--- a/website/blog/2021-08-30-react-native-is-hiring-managers.md
+++ b/website/blog/2021-08-30-react-native-is-hiring-managers.md
@@ -1,10 +1,6 @@
 ---
 title: React Native Is Hiring Managers, To Expand Beyond Mobile
-author: Eli White
-authorTitle: Engineering Manager on React Native
-authorURL: https://twitter.com/Eli_White
-authorImageURL: https://avatars.githubusercontent.com/u/249164?v=4
-authorTwitter: Eli_White
+authors: [Eli_White]
 tags: [hiring]
 date: 2021-08-30
 ---

--- a/website/blog/2021-09-01-preparing-your-app-for-iOS-15-and-android-12.md
+++ b/website/blog/2021-09-01-preparing-your-app-for-iOS-15-and-android-12.md
@@ -1,10 +1,6 @@
 ---
 title: Preparing Your App for iOS 15 and Android 12
-author: Samuel Susla
-authorTitle: Software Engineer on React Native
-authorURL: https://twitter.com/SamuelSusla
-authorImageURL: https://avatars.githubusercontent.com/u/1733610?v=4
-authorTwitter: SamuelSusla
+authors: [SamuelSusla]
 tags: [engineering]
 date: 2021-09-01
 ---

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,13 +1,34 @@
-yungsters:
-  name: Timothy Yung
-  title: React Native at Facebook
-  url: https://github.com/yungsters
-  image_url: https://github.com/yungsters.png
-  twitter: yungsters
+abernathyca:
+  name: Christine Abernathy
+  title: Developer Advocate at Facebook
+  url: https://twitter.com/abernathyca
+  image_url: https://github.com/caabernathy.png
+  twitter: abernathyca
+
+Eli_White:
+  name: Eli White
+  title: Engineering Manager at Facebook
+  url: https://twitter.com/Eli_White
+  image_url: https://github.com/TheSavior.png
+  twitter: Eli_White
 
 lunaleaps:
   name: Luna Wei
-  title: Engineer at Facebook
-  url: https://github.com/lunaleaps
+  title: Software Engineer at Facebook
+  url: https://twitter.com/lunaleaps
   image_url: https://github.com/lunaleaps.png
   twitter: lunaleaps
+
+SamuelSusla:
+  name: Samuel Susla
+  title: Software Engineer at Facebook
+  url: https://twitter.com/SamuelSusla
+  image_url: https://github.com/sammy-SC.png
+  twitter: SamuelSusla
+
+yungsters:
+  name: Timothy Yung
+  title: Software Engineer at Facebook
+  url: https://twitter.com/yungsters
+  image_url: https://github.com/yungsters.png
+  twitter: yungsters

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -3,32 +3,27 @@ abernathyca:
   title: Developer Advocate at Facebook
   url: https://twitter.com/abernathyca
   image_url: https://github.com/caabernathy.png
-  twitter: abernathyca
 
 Eli_White:
   name: Eli White
   title: Engineering Manager at Facebook
   url: https://twitter.com/Eli_White
   image_url: https://github.com/TheSavior.png
-  twitter: Eli_White
 
 lunaleaps:
   name: Luna Wei
   title: Software Engineer at Facebook
   url: https://twitter.com/lunaleaps
   image_url: https://github.com/lunaleaps.png
-  twitter: lunaleaps
 
 SamuelSusla:
   name: Samuel Susla
   title: Software Engineer at Facebook
   url: https://twitter.com/SamuelSusla
   image_url: https://github.com/sammy-SC.png
-  twitter: SamuelSusla
 
 yungsters:
   name: Timothy Yung
   title: Software Engineer at Facebook
   url: https://twitter.com/yungsters
   image_url: https://github.com/yungsters.png
-  twitter: yungsters


### PR DESCRIPTION
Migrates recent blog posts to use `authors.yml` and update **React Native's Many Platform Vision** to include all of the originally intended authors. (The post was created before multiple authors were supported by Docusaurus.)

![Screenshot of the Many Platform Vision blog post displaying the four authors — Christine Abernathy, Eli White, Luna Wei, and Timothy Yung](https://user-images.githubusercontent.com/55161/132048508-a1ef7a72-7801-43d8-a517-ca9c603cede7.png)