### PR TITLE
fix and generalize shared event types definitions

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -112,9 +112,9 @@ export default App;
 
 Handler to be called when the user taps the button.
 
-| Type                               |
-| ---------------------------------- |
-| function([PressEvent](pressevent)) |
+| Type                                        |
+| ------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) |
 
 ---
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -293,9 +293,9 @@ Similarly to `source`, this property represents the resource used to render the 
 
 Invoked on load error.
 
-| Type                                           |
-| ---------------------------------------------- |
-| function(`{ nativeEvent: { error } }`) => void |
+| Type                                   |
+| -------------------------------------- |
+| (`{ nativeEvent: { error } }`) => void |
 
 ---
 
@@ -303,9 +303,9 @@ Invoked on load error.
 
 Invoked on mount and on layout changes.
 
-| Type                                         |
-| -------------------------------------------- |
-| function([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
@@ -313,9 +313,9 @@ Invoked on mount and on layout changes.
 
 Invoked when load completes successfully.
 
-| Type                                                     |
-| -------------------------------------------------------- |
-| function([ImageLoadEvent](image#imageloadevent)) => void |
+| Type                                             |
+| ------------------------------------------------ |
+| ([ImageLoadEvent](image#imageloadevent)) => void |
 
 ---
 
@@ -323,9 +323,9 @@ Invoked when load completes successfully.
 
 Invoked when load either succeeds or fails.
 
-| Type               |
-| ------------------ |
-| function() => void |
+| Type       |
+| ---------- |
+| () => void |
 
 ---
 
@@ -335,9 +335,9 @@ Invoked on load start.
 
 **Example:** `onLoadStart={() => this.setState({loading: true})}`
 
-| Type               |
-| ------------------ |
-| function() => void |
+| Type       |
+| ---------- |
+| () => void |
 
 ---
 
@@ -345,9 +345,9 @@ Invoked on load start.
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
-| Type               |
-| ------------------ |
-| function() => void |
+| Type       |
+| ---------- |
+| () => void |
 
 ---
 
@@ -355,9 +355,9 @@ Invoked when a partial load of the image is complete. The definition of what con
 
 Invoked on download progress.
 
-| Type                                                   |
-| ------------------------------------------------------ |
-| function(`{ nativeEvent: { loaded, total } }`) => void |
+| Type                                           |
+| ---------------------------------------------- |
+| (`{ nativeEvent: { loaded, total } }`) => void |
 
 ---
 

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -391,7 +391,7 @@ Launch an Android intent with extras.
 
 **Parameters:**
 
-| Name                                                        | Type                                                     |
-| ----------------------------------------------------------- | -------------------------------------------------------- |
-| action <div className="label basic required">Required</div> | string                                                   |
+| Name                                                        | Type                                                         |
+| ----------------------------------------------------------- | ------------------------------------------------------------ |
+| action <div className="label basic required">Required</div> | string                                                       |
 | extras                                                      | array of `{key: string, value: string \| number \| boolean}` |

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -113,113 +113,113 @@ export default App;
 
 If true, doesn't play Android system sound on press.
 
-| Type    | Required | Default |
-| ------- | -------- | ------- |
-| boolean | No       | `false` |
+| Type    | Default |
+| ------- | ------- |
+| boolean | `false` |
 
 ### `android_ripple` <div class="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 
-| Type                                   | Required |
-| -------------------------------------- | -------- |
-| [RippleConfig](pressable#rippleconfig) | No       |
+| Type                                   |
+| -------------------------------------- |
+| [RippleConfig](pressable#rippleconfig) |
 
 ### `children`
 
 Either children or a function that receives a boolean reflecting whether the component is currently pressed.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [React Node](react-node) | No       |
+| Type                     |
+| ------------------------ |
+| [React Node](react-node) |
 
 ### `unstable_pressDelay`
 
 Duration (in milliseconds) to wait after press down before calling `onPressIn`.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ### `delayLongPress`
 
 Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
 
-| Type   | Required | Default |
-| ------ | -------- | ------- |
-| number | No       | `500`   |
+| Type   | Default |
+| ------ | ------- |
+| number | `500`   |
 
 ### `disabled`
 
 Whether the press behavior is disabled.
 
-| Type    | Required | Default |
-| ------- | -------- | ------- |
-| boolean | No       | `false` |
+| Type    | Default |
+| ------- | ------- |
+| boolean | `false` |
 
 ### `hitSlop`
 
 Sets additional distance outside of element in which a press can be detected.
 
-| Type                   | Required |
-| ---------------------- | -------- |
-| [Rect](rect) or number | No       |
+| Type                   |
+| ---------------------- |
+| [Rect](rect) or number |
 
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `onPress`
 
 Called after `onPressOut`.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `onPressIn`
 
 Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `onPressOut`
 
 Called when a touch is released.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `pressRetentionOffset`
 
 Additional distance outside of this view in which a touch is considered a press before `onPressOut` is triggered.
 
-| Type                   | Required | Default                                        |
-| ---------------------- | -------- | ---------------------------------------------- |
-| [Rect](rect) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
+| Type                   | Default                                        |
+| ---------------------- | ---------------------------------------------- |
+| [Rect](rect) or number | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
 
 ### `style`
 
 Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [View Style](view-style-props) | No       |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ### `testOnly_pressed`
 
 Used only for documentation or testing (e.g. snapshot testing).
 
-| Type    | Required | Default |
-| ------- | -------- | ------- |
-| boolean | No       | `false` |
+| Type    | Default |
+| ------- | ------- |
+| boolean | `false` |
 
 ## Type Definitions
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -455,9 +455,9 @@ This prop is commonly used with `ellipsizeMode`.
 
 Invoked on mount and on layout changes.
 
-| Type                                 |
-| ------------------------------------ |
-| ([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
@@ -465,9 +465,9 @@ Invoked on mount and on layout changes.
 
 This function is called on long press.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -475,9 +475,9 @@ This function is called on long press.
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-| Type                                  |
-| ------------------------------------- |
-| ([PressEvent](pressevent)) => boolean |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -485,9 +485,9 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 This function is called on press.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -495,9 +495,9 @@ This function is called on press.
 
 The View is now responding to touch events. This is the time to highlight and show the user what is happening.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -505,9 +505,9 @@ The View is now responding to touch events. This is the time to highlight and sh
 
 The user is moving their finger.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -515,9 +515,9 @@ The user is moving their finger.
 
 Fired at the end of the touch.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -525,9 +525,9 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -535,9 +535,9 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become a responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-| Type                                  |
-| ------------------------------------- |
-| ([PressEvent](pressevent)) => boolean |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -545,9 +545,9 @@ Some other `View` wants to become a responder and is asking this `View` to relea
 
 If a parent `View` wants to prevent a child `View` from becoming a responder on a touch start, it should have this handler which returns `true`.
 
-| Type                                  |
-| ------------------------------------- |
-| ([PressEvent](pressevent)) => boolean |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -469,11 +469,11 @@ Callback that is called when the text input is blurred.
 
 ### `onChange`
 
-Callback that is called when the text input's text changes. This will be called with `{ nativeEvent: { eventCount, target, text} }`
+Callback that is called when the text input's text changes.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| (`{ nativeEvent: { eventCount, target, text} }`) => void |
 
 ---
 
@@ -489,13 +489,13 @@ Callback that is called when the text input's text changes. Changed text is pass
 
 ### `onContentSizeChange`
 
-Callback that is called when the text input's content size changes. This will be called with `{ nativeEvent: { contentSize: { width, height } } }`.
+Callback that is called when the text input's content size changes.
 
 Only called for multiline text inputs.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                            |
+| --------------------------------------------------------------- |
+| (`{ nativeEvent: { contentSize: { width, height } } }`) => void |
 
 ---
 
@@ -513,9 +513,9 @@ Callback that is called when text input ends.
 
 Callback that is called when a touch is engaged.
 
-| Type                     |
-| ------------------------ |
-| [PressEvent](pressevent) |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -523,29 +523,29 @@ Callback that is called when a touch is engaged.
 
 Callback that is called when a touch is released.
 
-| Type                     |
-| ------------------------ |
-| [PressEvent](pressevent) |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
 ### `onFocus`
 
-Callback that is called when the text input is focused. This is called with `{ nativeEvent: { target } }`.
+Callback that is called when the text input is focused.
 
-| Type                                 |
-| ------------------------------------ |
-| ([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
 ### `onKeyPress`
 
-Callback that is called when a key is pressed. This will be called with `{ nativeEvent: { key: keyValue } }` where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and the typed-in character otherwise including `' '` for space. Fires before `onChange` callbacks. Note: on Android only the inputs from soft keyboard are handled, not the hardware keyboard inputs.
+Callback that is called when a key is pressed. This will be called with object where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and the typed-in character otherwise including `' '` for space. Fires before `onChange` callbacks. Note: on Android only the inputs from soft keyboard are handled, not the hardware keyboard inputs.
 
-| Type     |
-| -------- |
-| function |
+| Type                                           |
+| ---------------------------------------------- |
+| (`{ nativeEvent: { key: keyValue } }`) => void |
 
 ---
 
@@ -553,39 +553,39 @@ Callback that is called when a key is pressed. This will be called with `{ nativ
 
 Invoked on mount and on layout changes.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
 ### `onScroll`
 
-Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`. May also contain other properties from ScrollEvent but on Android contentSize is not provided for performance reasons.
+Invoked on content scroll. May also contain other properties from `ScrollEvent` but on Android `contentSize` is not provided for performance reasons.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| (`{ nativeEvent: { contentOffset: { x, y } } }`) => void |
 
 ---
 
 ### `onSelectionChange`
 
-Callback that is called when the text input selection is changed. This will be called with `{ nativeEvent: { selection: { start, end } } }`. This prop requires `multiline={true}` to be set.
+Callback that is called when the text input selection is changed. This prop requires `multiline={true}` to be set.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                       |
+| ---------------------------------------------------------- |
+| (`{ nativeEvent: { selection: { start, end } } }`) => void |
 
 ---
 
 ### `onSubmitEditing`
 
-Callback that is called when the text input's submit button is pressed with the argument `{nativeEvent: {text, eventCount, target}}`.
+Callback that is called when the text input's submit button is pressed.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| (`{ nativeEvent: { text, eventCount, target }}`) => void |
 
 Note that on iOS this method isn't called when using `keyboardType="phone-pad"`.
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -281,9 +281,9 @@ Invoked when the item receives focus.
 
 Invoked on mount and on layout changes.
 
-| Type                                 |
-| ------------------------------------ |
-| ([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -591,8 +591,8 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ### `style`
 
-| Type                              |
-| --------------------------------- |
+| Type                           |
+| ------------------------------ |
 | [View Style](view-style-props) |
 
 ---

--- a/docs/view.md
+++ b/docs/view.md
@@ -401,9 +401,9 @@ Invoked on mount and on layout changes.
 
 This event is fired immediately once the layout has been calculated, but the new layout may not yet be reflected on the screen at the time the event is received, especially if a layout animation is in progress.
 
-| Type                                 |
-| ------------------------------------ |
-| ([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
@@ -421,11 +421,9 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -433,11 +431,9 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a move, it should have this handler which returns `true`.
 
-`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -445,11 +441,9 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 The View is now responding for touch events. This is the time to highlight and show the user what is happening.
 
-`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -457,11 +451,9 @@ The View is now responding for touch events. This is the time to highlight and s
 
 The user is moving their finger.
 
-`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -469,11 +461,9 @@ The user is moving their finger.
 
 Another responder is already active and will not release it to that `View` asking to be the responder.
 
-`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -481,11 +471,9 @@ Another responder is already active and will not release it to that `View` askin
 
 Fired at the end of the touch.
 
-`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -493,11 +481,9 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -505,11 +491,9 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -517,11 +501,9 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 Does this view want to become responder on the start of a touch?
 
-`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -529,11 +511,9 @@ Does this view want to become responder on the start of a touch?
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a touch start, it should have this handler which returns `true`.
 
-`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     |
-| -------- |
-| function |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -613,7 +593,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props) |
 
 ---
 

--- a/website/versioned_docs/version-0.65/button.md
+++ b/website/versioned_docs/version-0.65/button.md
@@ -112,9 +112,9 @@ export default App;
 
 Handler to be called when the user taps the button.
 
-| Type                               |
-| ---------------------------------- |
-| function([PressEvent](pressevent)) |
+| Type                                        |
+| ------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) |
 
 ---
 

--- a/website/versioned_docs/version-0.65/image.md
+++ b/website/versioned_docs/version-0.65/image.md
@@ -293,9 +293,9 @@ Similarly to `source`, this property represents the resource used to render the 
 
 Invoked on load error.
 
-| Type                                           |
-| ---------------------------------------------- |
-| function(`{ nativeEvent: { error } }`) => void |
+| Type                                   |
+| -------------------------------------- |
+| (`{ nativeEvent: { error } }`) => void |
 
 ---
 
@@ -303,9 +303,9 @@ Invoked on load error.
 
 Invoked on mount and on layout changes.
 
-| Type                                         |
-| -------------------------------------------- |
-| function([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
@@ -313,9 +313,9 @@ Invoked on mount and on layout changes.
 
 Invoked when load completes successfully.
 
-| Type                                                     |
-| -------------------------------------------------------- |
-| function([ImageLoadEvent](image#imageloadevent)) => void |
+| Type                                             |
+| ------------------------------------------------ |
+| ([ImageLoadEvent](image#imageloadevent)) => void |
 
 ---
 
@@ -323,9 +323,9 @@ Invoked when load completes successfully.
 
 Invoked when load either succeeds or fails.
 
-| Type               |
-| ------------------ |
-| function() => void |
+| Type       |
+| ---------- |
+| () => void |
 
 ---
 
@@ -335,9 +335,9 @@ Invoked on load start.
 
 **Example:** `onLoadStart={() => this.setState({loading: true})}`
 
-| Type               |
-| ------------------ |
-| function() => void |
+| Type       |
+| ---------- |
+| () => void |
 
 ---
 
@@ -345,9 +345,9 @@ Invoked on load start.
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
-| Type               |
-| ------------------ |
-| function() => void |
+| Type       |
+| ---------- |
+| () => void |
 
 ---
 
@@ -355,9 +355,9 @@ Invoked when a partial load of the image is complete. The definition of what con
 
 Invoked on download progress.
 
-| Type                                                   |
-| ------------------------------------------------------ |
-| function(`{ nativeEvent: { loaded, total } }`) => void |
+| Type                                           |
+| ---------------------------------------------- |
+| (`{ nativeEvent: { loaded, total } }`) => void |
 
 ---
 

--- a/website/versioned_docs/version-0.65/pressable.md
+++ b/website/versioned_docs/version-0.65/pressable.md
@@ -113,113 +113,113 @@ export default App;
 
 If true, doesn't play Android system sound on press.
 
-| Type    | Required | Default |
-| ------- | -------- | ------- |
-| boolean | No       | `false` |
+| Type    | Default |
+| ------- | ------- |
+| boolean | `false` |
 
 ### `android_ripple` <div class="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 
-| Type                                   | Required |
-| -------------------------------------- | -------- |
-| [RippleConfig](pressable#rippleconfig) | No       |
+| Type                                   |
+| -------------------------------------- |
+| [RippleConfig](pressable#rippleconfig) |
 
 ### `children`
 
 Either children or a function that receives a boolean reflecting whether the component is currently pressed.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [React Node](react-node) | No       |
+| Type                     |
+| ------------------------ |
+| [React Node](react-node) |
 
 ### `unstable_pressDelay`
 
 Duration (in milliseconds) to wait after press down before calling `onPressIn`.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ### `delayLongPress`
 
 Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
 
-| Type   | Required | Default |
-| ------ | -------- | ------- |
-| number | No       | `500`   |
+| Type   | Default |
+| ------ | ------- |
+| number | `500`   |
 
 ### `disabled`
 
 Whether the press behavior is disabled.
 
-| Type    | Required | Default |
-| ------- | -------- | ------- |
-| boolean | No       | `false` |
+| Type    | Default |
+| ------- | ------- |
+| boolean | `false` |
 
 ### `hitSlop`
 
 Sets additional distance outside of element in which a press can be detected.
 
-| Type                   | Required |
-| ---------------------- | -------- |
-| [Rect](rect) or number | No       |
+| Type                   |
+| ---------------------- |
+| [Rect](rect) or number |
 
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `onPress`
 
 Called after `onPressOut`.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `onPressIn`
 
 Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `onPressOut`
 
 Called when a touch is released.
 
-| Type                     | Required |
-| ------------------------ | -------- |
-| [PressEvent](pressevent) | No       |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ### `pressRetentionOffset`
 
 Additional distance outside of this view in which a touch is considered a press before `onPressOut` is triggered.
 
-| Type                   | Required | Default                                        |
-| ---------------------- | -------- | ---------------------------------------------- |
-| [Rect](rect) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
+| Type                   | Default                                        |
+| ---------------------- | ---------------------------------------------- |
+| [Rect](rect) or number | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
 
 ### `style`
 
 Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.
 
-| Type                           | Required |
-| ------------------------------ | -------- |
-| [View Style](view-style-props) | No       |
+| Type                           |
+| ------------------------------ |
+| [View Style](view-style-props) |
 
 ### `testOnly_pressed`
 
 Used only for documentation or testing (e.g. snapshot testing).
 
-| Type    | Required | Default |
-| ------- | -------- | ------- |
-| boolean | No       | `false` |
+| Type    | Default |
+| ------- | ------- |
+| boolean | `false` |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.65/text.md
+++ b/website/versioned_docs/version-0.65/text.md
@@ -431,9 +431,9 @@ This prop is commonly used with `ellipsizeMode`.
 
 Invoked on mount and on layout changes.
 
-| Type                                 |
-| ------------------------------------ |
-| ([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
@@ -441,9 +441,9 @@ Invoked on mount and on layout changes.
 
 This function is called on long press.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -451,9 +451,9 @@ This function is called on long press.
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-| Type                                  |
-| ------------------------------------- |
-| ([PressEvent](pressevent)) => boolean |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -461,9 +461,9 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 This function is called on press.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -471,9 +471,9 @@ This function is called on press.
 
 The View is now responding to touch events. This is the time to highlight and show the user what is happening.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -481,9 +481,9 @@ The View is now responding to touch events. This is the time to highlight and sh
 
 The user is moving their finger.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -491,9 +491,9 @@ The user is moving their finger.
 
 Fired at the end of the touch.
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -501,9 +501,9 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-| Type                               |
-| ---------------------------------- |
-| ([PressEvent](pressevent)) => void |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -511,9 +511,9 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become a responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-| Type                                  |
-| ------------------------------------- |
-| ([PressEvent](pressevent)) => boolean |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 
@@ -521,9 +521,9 @@ Some other `View` wants to become a responder and is asking this `View` to relea
 
 If a parent `View` wants to prevent a child `View` from becoming a responder on a touch start, it should have this handler which returns `true`.
 
-| Type                                  |
-| ------------------------------------- |
-| ([PressEvent](pressevent)) => boolean |
+| Type                                                   |
+| ------------------------------------------------------ |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean |
 
 ---
 

--- a/website/versioned_docs/version-0.65/textinput.md
+++ b/website/versioned_docs/version-0.65/textinput.md
@@ -445,11 +445,11 @@ Callback that is called when the text input is blurred.
 
 ### `onChange`
 
-Callback that is called when the text input's text changes. This will be called with `{ nativeEvent: { eventCount, target, text} }`
+Callback that is called when the text input's text changes.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| (`{ nativeEvent: { eventCount, target, text} }`) => void |
 
 ---
 
@@ -465,13 +465,13 @@ Callback that is called when the text input's text changes. Changed text is pass
 
 ### `onContentSizeChange`
 
-Callback that is called when the text input's content size changes. This will be called with `{ nativeEvent: { contentSize: { width, height } } }`.
+Callback that is called when the text input's content size changes.
 
 Only called for multiline text inputs.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                            |
+| --------------------------------------------------------------- |
+| (`{ nativeEvent: { contentSize: { width, height } } }`) => void |
 
 ---
 
@@ -489,9 +489,9 @@ Callback that is called when text input ends.
 
 Callback that is called when a touch is engaged.
 
-| Type                     |
-| ------------------------ |
-| [PressEvent](pressevent) |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
@@ -499,29 +499,29 @@ Callback that is called when a touch is engaged.
 
 Callback that is called when a touch is released.
 
-| Type                     |
-| ------------------------ |
-| [PressEvent](pressevent) |
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void |
 
 ---
 
 ### `onFocus`
 
-Callback that is called when the text input is focused. This is called with `{ nativeEvent: { target } }`.
+Callback that is called when the text input is focused.
 
-| Type                                 |
-| ------------------------------------ |
-| ([LayoutEvent](layoutevent)) => void |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
 ### `onKeyPress`
 
-Callback that is called when a key is pressed. This will be called with `{ nativeEvent: { key: keyValue } }` where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and the typed-in character otherwise including `' '` for space. Fires before `onChange` callbacks. Note: on Android only the inputs from soft keyboard are handled, not the hardware keyboard inputs.
+Callback that is called when a key is pressed. This will be called with object where `keyValue` is `'Enter'` or `'Backspace'` for respective keys and the typed-in character otherwise including `' '` for space. Fires before `onChange` callbacks. Note: on Android only the inputs from soft keyboard are handled, not the hardware keyboard inputs.
 
-| Type     |
-| -------- |
-| function |
+| Type                                           |
+| ---------------------------------------------- |
+| (`{ nativeEvent: { key: keyValue } }`) => void |
 
 ---
 
@@ -529,39 +529,39 @@ Callback that is called when a key is pressed. This will be called with `{ nativ
 
 Invoked on mount and on layout changes.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
 ### `onScroll`
 
-Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`. May also contain other properties from ScrollEvent but on Android contentSize is not provided for performance reasons.
+Invoked on content scroll. May also contain other properties from `ScrollEvent` but on Android `contentSize` is not provided for performance reasons.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| (`{ nativeEvent: { contentOffset: { x, y } } }`) => void |
 
 ---
 
 ### `onSelectionChange`
 
-Callback that is called when the text input selection is changed. This will be called with `{ nativeEvent: { selection: { start, end } } }`. This prop requires `multiline={true}` to be set.
+Callback that is called when the text input selection is changed. This prop requires `multiline={true}` to be set.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                       |
+| ---------------------------------------------------------- |
+| (`{ nativeEvent: { selection: { start, end } } }`) => void |
 
 ---
 
 ### `onSubmitEditing`
 
-Callback that is called when the text input's submit button is pressed with the argument `{nativeEvent: {text, eventCount, target}}`.
+Callback that is called when the text input's submit button is pressed.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| (`{ nativeEvent: { text, eventCount, target }}`) => void |
 
 Note that on iOS this method isn't called when using `keyboardType="phone-pad"`.
 

--- a/website/versioned_docs/version-0.65/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.65/touchablewithoutfeedback.md
@@ -83,9 +83,9 @@ export default TouchableWithoutFeedbackExample;
 
 ### `accessibilityIgnoresInvertColors`
 
-| Type    | Required |
-| ------- | -------- |
-| Boolean | No       |
+| Type    |
+| ------- |
+| Boolean |
 
 ---
 
@@ -93,9 +93,9 @@ export default TouchableWithoutFeedbackExample;
 
 When `true`, indicates that the view is an accessibility element. By default, all the touchable elements are accessible.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type |
+| ---- |
+| bool |
 
 ---
 
@@ -103,9 +103,9 @@ When `true`, indicates that the view is an accessibility element. By default, al
 
 Overrides the text that's read by the screen reader when the user interacts with the element. By default, the label is constructed by traversing all the children and accumulating all the `Text` nodes separated by space.
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   |
+| ------ |
+| string |
 
 ---
 
@@ -113,9 +113,9 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not clear from the accessibility label.
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   |
+| ------ |
+| string |
 
 ---
 
@@ -153,9 +153,9 @@ An accessibility hint helps users understand what will happen when they perform 
 - `'timer'` - Used to represent a timer.
 - `'toolbar'` - Used to represent a tool bar (a container of action buttons or components).
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   |
+| ------ |
+| string |
 
 ---
 
@@ -165,9 +165,9 @@ Describes the current state of a component to the user of an assistive technolog
 
 See the [Accessibility guide](accessibility.md#accessibilitystate-ios-android) for more information.
 
-| Type                                                                                           | Required |
-| ---------------------------------------------------------------------------------------------- | -------- |
-| object: {disabled: bool, selected: bool, checked: bool or 'mixed', busy: bool, expanded: bool} | No       |
+| Type                                                                                           |
+| ---------------------------------------------------------------------------------------------- |
+| object: {disabled: bool, selected: bool, checked: bool or 'mixed', busy: bool, expanded: bool} |
 
 ---
 
@@ -177,9 +177,9 @@ Accessibility actions allow an assistive technology to programmatically invoke t
 
 See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
-| Type  | Required |
-| ----- | -------- |
-| array | No       |
+| Type  |
+| ----- |
+| array |
 
 ---
 
@@ -189,9 +189,9 @@ Invoked when the user performs the accessibility actions. The only argument to t
 
 See the [Accessibility guide](accessibility.md#accessibility-actions) for more information.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -201,9 +201,9 @@ Represents the current value of a component. It can be a textual description of 
 
 See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) for more information.
 
-| Type                                                          | Required |
-| ------------------------------------------------------------- | -------- |
-| object: {min: number, max: number, now: number, text: string} | No       |
+| Type                                                          |
+| ------------------------------------------------------------- |
+| object: {min: number, max: number, now: number, text: string} |
 
 ---
 
@@ -211,9 +211,9 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
@@ -221,9 +221,9 @@ Duration (in milliseconds) from `onPressIn` before `onLongPress` is called.
 
 Duration (in milliseconds), from the start of the touch, before `onPressIn` is called.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
@@ -231,9 +231,9 @@ Duration (in milliseconds), from the start of the touch, before `onPressIn` is c
 
 Duration (in milliseconds), from the release of the touch, before `onPressOut` is called.
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type   |
+| ------ |
+| number |
 
 ---
 
@@ -241,9 +241,9 @@ Duration (in milliseconds), from the release of the touch, before `onPressOut` i
 
 If true, disable all interactions for this component.
 
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
+| Type |
+| ---- |
+| bool |
 
 ---
 
@@ -253,17 +253,17 @@ This defines how far your touch can start away from the button. This is added to
 
 > The touch area never extends past the parent view bounds and the Z-index of sibling views always takes precedence if a touch hits two overlapping views.
 
-| Type                   | Required |
-| ---------------------- | -------- |
-| [Rect](rect) or number | No       |
+| Type                   |
+| ---------------------- |
+| [Rect](rect) or number |
 
 ### `onBlur`
 
 Invoked when the item loses focus.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -271,9 +271,9 @@ Invoked when the item loses focus.
 
 Invoked when the item receives focus.
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -281,9 +281,9 @@ Invoked when the item receives focus.
 
 Invoked on mount and on layout changes.
 
-| Type                                 | Required |
-| ------------------------------------ | -------- |
-| ([LayoutEvent](layoutevent)) => void | No       |
+| Type                                                  |
+| ----------------------------------------------------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void |
 
 ---
 
@@ -291,9 +291,9 @@ Invoked on mount and on layout changes.
 
 Called if the time after `onPressIn` lasts longer than 370 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -301,9 +301,9 @@ Called if the time after `onPressIn` lasts longer than 370 milliseconds. This ti
 
 Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent).
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -311,9 +311,9 @@ Called when the touch is released, but not if cancelled (e.g. by a scroll that s
 
 Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent).
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -321,9 +321,9 @@ Called as soon as the touchable element is pressed and invoked even before onPre
 
 Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent).
 
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type     |
+| -------- |
+| function |
 
 ---
 
@@ -331,17 +331,17 @@ Called as soon as the touch is released even before onPress. The first function 
 
 When the scroll view is disabled, this defines how far your touch may move off of the button, before deactivating the button. Once deactivated, try moving it back and you'll see that the button is once again reactivated! Move it back and forth several times while the scroll view is disabled. Ensure you pass in a constant to reduce memory allocations.
 
-| Type                   | Required |
-| ---------------------- | -------- |
-| [Rect](rect) or number | No       |
+| Type                   |
+| ---------------------- |
+| [Rect](rect) or number |
 
 ---
 
 ### `nativeID`
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   |
+| ------ |
+| string |
 
 ---
 
@@ -349,16 +349,16 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 Used to locate this view in end-to-end tests.
 
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
+| Type   |
+| ------ |
+| string |
 
 ---
 
-### `touchSoundDisabled`
+### `touchSoundDisabled` <div class="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 
-| Type    | Required | Platform |
-| ------- | -------- | -------- |
-| Boolean | No       | Android  |
+| Type    |
+| ------- |
+| Boolean |

--- a/website/versioned_docs/version-0.65/view.md
+++ b/website/versioned_docs/version-0.65/view.md
@@ -343,9 +343,9 @@ Invoked on mount and on layout changes.
 
 This event is fired immediately once the layout has been calculated, but the new layout may not yet be reflected on the screen at the time the event is received, especially if a layout animation is in progress.
 
-| Type                                 | Required |
-| ------------------------------------ | -------- |
-| ([LayoutEvent](layoutevent)) => void | No       |
+| Type                                                  | Required |
+| ----------------------------------------------------- | -------- |
+| ({ nativeEvent: [LayoutEvent](layoutevent) }) => void | No       |
 
 ---
 
@@ -353,11 +353,9 @@ This event is fired immediately once the layout has been calculated, but the new
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                   | Required |
+| ------------------------------------------------------ | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean | No       |
 
 ---
 
@@ -365,11 +363,9 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a move, it should have this handler which returns `true`.
 
-`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                   | Required |
+| ------------------------------------------------------ | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean | No       |
 
 ---
 
@@ -377,11 +373,9 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 The View is now responding for touch events. This is the time to highlight and show the user what is happening.
 
-`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                | Required |
+| --------------------------------------------------- | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void | No       |
 
 ---
 
@@ -389,11 +383,9 @@ The View is now responding for touch events. This is the time to highlight and s
 
 The user is moving their finger.
 
-`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                | Required |
+| --------------------------------------------------- | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void | No       |
 
 ---
 
@@ -401,11 +393,9 @@ The user is moving their finger.
 
 Another responder is already active and will not release it to that `View` asking to be the responder.
 
-`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                | Required |
+| --------------------------------------------------- | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void | No       |
 
 ---
 
@@ -413,11 +403,9 @@ Another responder is already active and will not release it to that `View` askin
 
 Fired at the end of the touch.
 
-`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                | Required |
+| --------------------------------------------------- | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void | No       |
 
 ---
 
@@ -425,11 +413,9 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                | Required |
+| --------------------------------------------------- | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void | No       |
 
 ---
 
@@ -437,11 +423,9 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                | Required |
+| --------------------------------------------------- | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => void | No       |
 
 ---
 
@@ -449,11 +433,9 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a touch start, it should have this handler which returns `true`.
 
-`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent).
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
+| Type                                                   | Required |
+| ------------------------------------------------------ | -------- |
+| ({ nativeEvent: [PressEvent](pressevent) }) => boolean | No       |
 
 ---
 


### PR DESCRIPTION
Fixes #2769

This PR is mostly inspired by the issue report, besides fixing the regression introduced by extracting shared types to the separate pages it also clean up those types on other pages and ensures that type definitions using shared types are formatted in the same way everywhere.

I have also made a small tweaks to the few other event types and removed the redundant with new design "Required" column form the `Pressable` page.

The changes also have been backported to the `0.65` docs.

## Test plan

The changes has been tested by running website on `localhost`. 

Also `yarn lint` and `yarn lint:versioned` checks did not output any warnings or errors.