### PR TITLE
Clearify type definition of sendIntent parameter

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -394,4 +394,4 @@ Launch an Android intent with extras.
 | Name                                                        | Type                                                     |
 | ----------------------------------------------------------- | -------------------------------------------------------- |
 | action <div className="label basic required">Required</div> | string                                                   |
-| extras                                                      | array of `{key: string, value: string, number, boolean}` |
+| extras                                                      | array of `{key: string, value: string \| number \| boolean}` |


### PR DESCRIPTION
The type definition of sendIntent is quite confusing on first glance. Properties as well as possible types of value are separated by comma. Using this notation should be clearer!

<img width="500" alt="x" src="https://user-images.githubusercontent.com/22052487/132388323-b505c714-1d8e-45d0-ab15-753b021409f2.png">


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
