### PR TITLE
Remove blog date fields and fix filename discrepancy

### DIFF
--- a/website/blog/2021-08-17-version-065.md
+++ b/website/blog/2021-08-17-version-065.md
@@ -2,7 +2,6 @@
 title: Announcing React Native 0.65
 authors: [lunaleaps]
 tags: [announcement, release]
-date: 2021-08-17
 ---
 
 Today we’re releasing React Native version 0.65 with a new version of Hermes, improvements to accessibility, package upgrades, and more.

--- a/website/blog/2021-08-19-h2-2021.md
+++ b/website/blog/2021-08-19-h2-2021.md
@@ -2,7 +2,6 @@
 title: React Native in H2 2021
 authors: [lunaleaps]
 tags: [announcement]
-date: 2021-08-19
 ---
 
 Over the past year so much has changed in our world, React Native being no exception. We've welcomed new members to our team (whom we are excited to eventually meet in person!), our projects have matured and new opportunities have arisen. We're excited to share all this with you in this post and others to come!

--- a/website/blog/2021-08-26-many-platform-vision/index.md
+++ b/website/blog/2021-08-26-many-platform-vision/index.md
@@ -2,7 +2,6 @@
 title: React Native's Many Platform Vision
 authors: [abernathyca, Eli_White, lunaleaps, yungsters]
 tags: [announcement]
-date: 2021-08-26
 ---
 
 React Native has been very successful at raising the bar for mobile development, both at Facebook and elsewhere in the industry. As we interact with computers in new ways and as new devices are invented, we want React Native to be there for everyone. Although React Native was originally created to build mobile apps, we believe that focusing on many platforms and building to each platform’s strengths and constraints has a symbiotic effect. We have seen huge benefits when we extended this technology to desktop and virtual reality, and we're excited to share what this means for the future of React Native.

--- a/website/blog/2021-08-30-react-native-is-hiring-managers.md
+++ b/website/blog/2021-08-30-react-native-is-hiring-managers.md
@@ -2,7 +2,6 @@
 title: React Native Is Hiring Managers, To Expand Beyond Mobile
 authors: [Eli_White]
 tags: [hiring]
-date: 2021-08-30
 ---
 
 We recently shared [React Native’s Many Platform Vision](https://reactnative.dev/blog/2021/08/26/many-platform-vision) for how expanding React to other platforms improves the framework for everyone else. We’ve been making significant progress on this vision over the last couple years by partnering with Microsoft on React Native for Windows and macOS, and Oculus on React Native in VR.

--- a/website/blog/2021-09-01-preparing-your-app-for-iOS-15-and-android-12.md
+++ b/website/blog/2021-09-01-preparing-your-app-for-iOS-15-and-android-12.md
@@ -2,7 +2,6 @@
 title: Preparing Your App for iOS 15 and Android 12
 authors: [SamuelSusla]
 tags: [engineering]
-date: 2021-09-01
 ---
 
 # Preparing Your App for iOS 15 and Android 12


### PR DESCRIPTION
Docusaurus parses the date of a blog post from the filename and not the `date` field. This removes the `date` fields from existing blog posts that have it, and it fixes the filename of the "Announcing React Native 0.65" blog post.

The last point will fix the bug report tweeted here: https://twitter.com/madebyjonny/status/1435605294164414477