### PR TITLE
Force `trim@^1.0.1` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "netlify-plugin-cache": "^1.0.3",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0"
+  },
+  "resolutions": {
+    "trim": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9907,10 +9907,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
+  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Addresses this vulnerability:

- https://github.com/advisories/GHSA-w5p7-h5w8-2hfq

The `trim` breaking change at 1.0.0 was a license change:

- https://github.com/Trott/trim/blob/main/CHANGELOG.md