### PR TITLE
Remove the link to 2021 React Community Survey

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -142,14 +142,6 @@ const lastVersion = versions[0];
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      announcementBar: {
-        id: 'survey-2021-announcement',
-        content:
-          'We want to hear from you! <a href="https://surveys.savanta.com/survey/selfserve/21e3/210643?list=2" target="_blank" rel="noopener noreferrer">Take the 2021 React Community Survey!</a>',
-        backgroundColor: '#20232a', // var(--deepdark)
-        textColor: '#fff',
-        isCloseable: true,
-      },
       prism: {
         defaultLanguage: 'jsx',
         theme: require('./core/PrismTheme'),


### PR DESCRIPTION
When you click on it, it says the survey is already closed.

![Снимок экрана 2021-09-18 в 13 25 26](https://user-images.githubusercontent.com/1449338/133885660-16d20dd7-6e36-455d-be4a-246fef36ea70.png)

