### PR TITLE
Bump ansi-regex to ^5.0.1 to fix CVE-2021-3807

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pretty-quick": "^3.1.0"
   },
   "resolutions": {
-    "trim": "^1.0.1"
+    "trim": "^1.0.1",
+    "ansi-regex": "^5.0.1"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -45,6 +45,7 @@
     "@docusaurus/core": "^2.0.0-beta.6",
     "@docusaurus/plugin-pwa": "^2.0.0-beta.6",
     "@docusaurus/preset-classic": "^2.0.0-beta.6",
+    "ansi-regex": "^5.0.1",
     "docusaurus-plugin-sass": "^0.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -45,7 +45,6 @@
     "@docusaurus/core": "^2.0.0-beta.6",
     "@docusaurus/plugin-pwa": "^2.0.0-beta.6",
     "@docusaurus/preset-classic": "^2.0.0-beta.6",
-    "ansi-regex": "^5.0.1",
     "docusaurus-plugin-sass": "^0.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,17 +2239,7 @@ ansi-html@0.0.7:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^2.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,10 +2249,10 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
As the title says, I'm adding an explicit dependency on `ansi-regex@^5.0.1`