### PR TITLE
Update handling-text-input.md

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -5,7 +5,7 @@ title: Handling Text Input
 
 [`TextInput`](textinput#content) is a [Core Component](intro-react-native-components) that allows the user to enter text. It has an `onChangeText` prop that takes a function to be called every time the text changed, and an `onSubmitEditing` prop that takes a function to be called when the text is submitted.
 
-For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕🍕🍕".
+For example, let's say that as the user types, you're translating their words into a different language. In this new language, every single word is written the same way: 🍕. So the sentence "Hello there Bob" would be translated as "🍕 🍕 🍕".
 
 ```SnackPlayer name=Handling%20Text%20Input
 import React, { useState } from 'react';


### PR DESCRIPTION
Spaces missing between pizza icons in explanation
 '🍕🍕🍕' should be '🍕 🍕 🍕'

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
