### PR TITLE
add section of `stickyHeaderHiddenOnScroll` option

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -689,7 +689,7 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 ### `stickyHeaderHiddenOnScroll`
 
-When true, Sticky header is hidden when scrolling down, and dock at the top when scrolling up.
+When set to `true`, sticky header will be hidden when scrolling down the list, and it will dock at the top of the list when scrolling up.
 
 | Type | Default |
 | ---- | ------- |

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -693,7 +693,7 @@ When true, Sticky header is hidden when scrolling down, and dock at the top when
 
 | Type | Default |
 | ---- | ------- |
-| bool | `false`  |
+| bool | `false` |
 
 ---
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -687,6 +687,16 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 ---
 
+### `stickyHeaderHiddenOnScroll`
+
+When true, Sticky header is hidden when scrolling down, and dock at the top when scrolling up.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `false`  |
+
+---
+
 ### `stickyHeaderIndices`
 
 An array of child indices determining which children get docked to the top of the screen when scrolling. For example, passing `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the top of the scroll view. You can also use like [x,y,z] to make multiple items sticky when they are at the top. This property is not supported in conjunction with `horizontal={true}`.

--- a/website/versioned_docs/version-0.65/scrollview.md
+++ b/website/versioned_docs/version-0.65/scrollview.md
@@ -683,7 +683,7 @@ When true, Sticky header is hidden when scrolling down, and dock at the top when
 
 | Type | Default |
 | ---- | ------- |
-| bool | `false`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.65/scrollview.md
+++ b/website/versioned_docs/version-0.65/scrollview.md
@@ -677,6 +677,16 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 ---
 
+### `stickyHeaderHiddenOnScroll`
+
+When true, Sticky header is hidden when scrolling down, and dock at the top when scrolling up.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `false`  |
+
+---
+
 ### `stickyHeaderIndices`
 
 An array of child indices determining which children get docked to the top of the screen when scrolling. For example, passing `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the top of the scroll view. You can also use like [x,y,z] to make multiple items sticky when they are at the top. This property is not supported in conjunction with `horizontal={true}`.

--- a/website/versioned_docs/version-0.65/scrollview.md
+++ b/website/versioned_docs/version-0.65/scrollview.md
@@ -679,7 +679,7 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 ### `stickyHeaderHiddenOnScroll`
 
-When true, Sticky header is hidden when scrolling down, and dock at the top when scrolling up.
+When set to `true`, sticky header will be hidden when scrolling down the list, and it will dock at the top of the list when scrolling up.
 
 | Type | Default |
 | ---- | ------- |

--- a/website/versioned_docs/version-0.66/scrollview.md
+++ b/website/versioned_docs/version-0.66/scrollview.md
@@ -689,7 +689,7 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 ### `stickyHeaderHiddenOnScroll`
 
-When true, Sticky header is hidden when scrolling down, and dock at the top when scrolling up.
+When set to `true`, sticky header will be hidden when scrolling down the list, and it will dock at the top of the list when scrolling up.
 
 | Type | Default |
 | ---- | ------- |

--- a/website/versioned_docs/version-0.66/scrollview.md
+++ b/website/versioned_docs/version-0.66/scrollview.md
@@ -693,7 +693,7 @@ When true, Sticky header is hidden when scrolling down, and dock at the top when
 
 | Type | Default |
 | ---- | ------- |
-| bool | `false`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.66/scrollview.md
+++ b/website/versioned_docs/version-0.66/scrollview.md
@@ -687,6 +687,16 @@ Use in conjunction with `snapToOffsets`. By default, the beginning of the list c
 
 ---
 
+### `stickyHeaderHiddenOnScroll`
+
+When true, Sticky header is hidden when scrolling down, and dock at the top when scrolling up.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `false`  |
+
+---
+
 ### `stickyHeaderIndices`
 
 An array of child indices determining which children get docked to the top of the screen when scrolling. For example, passing `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the top of the scroll view. You can also use like [x,y,z] to make multiple items sticky when they are at the top. This property is not supported in conjunction with `horizontal={true}`.


### PR DESCRIPTION
Added an entry for the `ScrollView` option` stickyHeaderHiddenOnScroll `to the documentation.
https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#added-1
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
