### PR TITLE
fix preview deploy failure due to links in older blog posts

### DIFF
--- a/website/blog/2018-01-18-implementing-twitters-app-loading-animation-in-react-native.md
+++ b/website/blog/2018-01-18-implementing-twitters-app-loading-animation-in-react-native.md
@@ -82,7 +82,7 @@ They say a picture is worth 1,000 words. How many words is an interactive visual
 
 Alrighty. Now that we know what we are building and how the animation works, we can get down to the code — the reason you are really here.
 
-The main piece of this puzzle is [MaskedViewIOS](/docs/0.63/maskedviewios), a core React Native component.
+The main piece of this puzzle is [MaskedViewIOS](https://reactnative.dev/docs/0.63/maskedviewios), a core React Native component.
 
 ```jsx
 import { MaskedViewIOS } from 'react-native';

--- a/website/blog/2018-08-27-wkwebview.md
+++ b/website/blog/2018-08-27-wkwebview.md
@@ -10,7 +10,7 @@ For a long time now, Apple has discouraged using UIWebViews in favor of WKWebVie
 
 The tail end of these changes were landed in [this commit](https://github.com/facebook/react-native/commit/33b353c97c31190439a22febbd3d2a9ead49d3c9), and will become available in the 0.57 release.
 
-To opt into this new implementation, please use the [`useWebKit`](/docs/0.63/webview#usewebkit) prop:
+To opt into this new implementation, please use the [`useWebKit`](https://reactnative.dev/docs/0.63/webview#usewebkit) prop:
 
 ```js
 <WebView

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -53,7 +53,7 @@ const lastVersion = versions[0];
           editCurrentVersion: true,
           onlyIncludeVersions:
             process.env.PREVIEW_DEPLOY === 'true'
-              ? ['current', ...versions.slice(0, 3)]
+              ? ['current', ...versions.slice(0, 2)]
               : undefined,
           versions: {
             [lastVersion]: {


### PR DESCRIPTION
This PR fixes the errors at end of deploy preview build, which were related to couple of links in the older blog posts.

For now it should be fine to just replace the links with absolute URLs, but in a long term, it would be nice to have the option for the blogpost (similar to docs `onlyIncludeVersions` field), which should not include older posts than decaled date or time span, which should fix the issue in a long term. CC @slorber 