### PR TITLE
Update Algolia DocSearch appId / apiKey

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -303,7 +303,8 @@ const lastVersion = versions[0];
         copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
       },
       algolia: {
-        apiKey: '2c98749b4a1e588efec53b2acec13025',
+        appId: '8TDSE0OHGQ',
+        apiKey: '83cd239c72f9f8b0ed270a04b1185288',
         indexName: 'react-native-v2',
         contextualSearch: true,
       },


### PR DESCRIPTION
Algolia DocSearch is migrating to a new system. 

All DocSearch sites will need to upgrade in the next months.

See also https://github.com/facebook/docusaurus/pull/5632