### PR TITLE
docs: add missing Android Permissions to respective releases

### DIFF
--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -153,6 +153,7 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `GET_ACCOUNTS`: 'android.permission.GET_ACCOUNTS'
 - `ACCESS_FINE_LOCATION`: 'android.permission.ACCESS_FINE_LOCATION'
 - `ACCESS_COARSE_LOCATION`: 'android.permission.ACCESS_COARSE_LOCATION'
+- `ACCESS_BACKGROUND_LOCATION`: 'android.permission.ACCESS_BACKGROUND_LOCATION'
 - `RECORD_AUDIO`: 'android.permission.RECORD_AUDIO'
 - `READ_PHONE_STATE`: 'android.permission.READ_PHONE_STATE'
 - `CALL_PHONE`: 'android.permission.CALL_PHONE'
@@ -169,6 +170,10 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `RECEIVE_MMS`: 'android.permission.RECEIVE_MMS'
 - `READ_EXTERNAL_STORAGE`: 'android.permission.READ_EXTERNAL_STORAGE'
 - `WRITE_EXTERNAL_STORAGE`: 'android.permission.WRITE_EXTERNAL_STORAGE'
+- `BLUETOOTH_CONNECT`: 'android.permission.BLUETOOTH_CONNECT'
+- `BLUETOOTH_SCAN`: 'android.permission.BLUETOOTH_SCAN'
+- `BLUETOOTH_ADVERTISE`: 'android.permission.BLUETOOTH_ADVERTISE'
+- `ACCESS_MEDIA_LOCATION`: 'android.permission.ACCESS_MEDIA_LOCATION'
 
 ### Result strings for requesting permissions
 

--- a/website/versioned_docs/version-0.62/permissionsandroid.md
+++ b/website/versioned_docs/version-0.62/permissionsandroid.md
@@ -153,6 +153,7 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `GET_ACCOUNTS`: 'android.permission.GET_ACCOUNTS'
 - `ACCESS_FINE_LOCATION`: 'android.permission.ACCESS_FINE_LOCATION'
 - `ACCESS_COARSE_LOCATION`: 'android.permission.ACCESS_COARSE_LOCATION'
+- `ACCESS_BACKGROUND_LOCATION`: 'android.permission.ACCESS_BACKGROUND_LOCATION'
 - `RECORD_AUDIO`: 'android.permission.RECORD_AUDIO'
 - `READ_PHONE_STATE`: 'android.permission.READ_PHONE_STATE'
 - `CALL_PHONE`: 'android.permission.CALL_PHONE'

--- a/website/versioned_docs/version-0.63/permissionsandroid.md
+++ b/website/versioned_docs/version-0.63/permissionsandroid.md
@@ -153,6 +153,7 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `GET_ACCOUNTS`: 'android.permission.GET_ACCOUNTS'
 - `ACCESS_FINE_LOCATION`: 'android.permission.ACCESS_FINE_LOCATION'
 - `ACCESS_COARSE_LOCATION`: 'android.permission.ACCESS_COARSE_LOCATION'
+- `ACCESS_BACKGROUND_LOCATION`: 'android.permission.ACCESS_BACKGROUND_LOCATION'
 - `RECORD_AUDIO`: 'android.permission.RECORD_AUDIO'
 - `READ_PHONE_STATE`: 'android.permission.READ_PHONE_STATE'
 - `CALL_PHONE`: 'android.permission.CALL_PHONE'

--- a/website/versioned_docs/version-0.64/permissionsandroid.md
+++ b/website/versioned_docs/version-0.64/permissionsandroid.md
@@ -153,6 +153,7 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `GET_ACCOUNTS`: 'android.permission.GET_ACCOUNTS'
 - `ACCESS_FINE_LOCATION`: 'android.permission.ACCESS_FINE_LOCATION'
 - `ACCESS_COARSE_LOCATION`: 'android.permission.ACCESS_COARSE_LOCATION'
+- `ACCESS_BACKGROUND_LOCATION`: 'android.permission.ACCESS_BACKGROUND_LOCATION'
 - `RECORD_AUDIO`: 'android.permission.RECORD_AUDIO'
 - `READ_PHONE_STATE`: 'android.permission.READ_PHONE_STATE'
 - `CALL_PHONE`: 'android.permission.CALL_PHONE'

--- a/website/versioned_docs/version-0.65/permissionsandroid.md
+++ b/website/versioned_docs/version-0.65/permissionsandroid.md
@@ -153,6 +153,7 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `GET_ACCOUNTS`: 'android.permission.GET_ACCOUNTS'
 - `ACCESS_FINE_LOCATION`: 'android.permission.ACCESS_FINE_LOCATION'
 - `ACCESS_COARSE_LOCATION`: 'android.permission.ACCESS_COARSE_LOCATION'
+- `ACCESS_BACKGROUND_LOCATION`: 'android.permission.ACCESS_BACKGROUND_LOCATION'
 - `RECORD_AUDIO`: 'android.permission.RECORD_AUDIO'
 - `READ_PHONE_STATE`: 'android.permission.READ_PHONE_STATE'
 - `CALL_PHONE`: 'android.permission.CALL_PHONE'

--- a/website/versioned_docs/version-0.66/permissionsandroid.md
+++ b/website/versioned_docs/version-0.66/permissionsandroid.md
@@ -153,6 +153,7 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `GET_ACCOUNTS`: 'android.permission.GET_ACCOUNTS'
 - `ACCESS_FINE_LOCATION`: 'android.permission.ACCESS_FINE_LOCATION'
 - `ACCESS_COARSE_LOCATION`: 'android.permission.ACCESS_COARSE_LOCATION'
+- `ACCESS_BACKGROUND_LOCATION`: 'android.permission.ACCESS_BACKGROUND_LOCATION'
 - `RECORD_AUDIO`: 'android.permission.RECORD_AUDIO'
 - `READ_PHONE_STATE`: 'android.permission.READ_PHONE_STATE'
 - `CALL_PHONE`: 'android.permission.CALL_PHONE'
@@ -169,6 +170,9 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `RECEIVE_MMS`: 'android.permission.RECEIVE_MMS'
 - `READ_EXTERNAL_STORAGE`: 'android.permission.READ_EXTERNAL_STORAGE'
 - `WRITE_EXTERNAL_STORAGE`: 'android.permission.WRITE_EXTERNAL_STORAGE'
+- `BLUETOOTH_CONNECT`: 'android.permission.BLUETOOTH_CONNECT'
+- `BLUETOOTH_SCAN`: 'android.permission.BLUETOOTH_SCAN'
+- `BLUETOOTH_ADVERTISE`: 'android.permission.BLUETOOTH_ADVERTISE'
 
 ### Result strings for requesting permissions
 


### PR DESCRIPTION
I diffed the permissions in the docs compared to the code and found a few things different.

 * `ACCESS_BACKGROUND_LOCATION` was added in v62 and never in docs - https://github.com/facebook/react-native/pull/26562 - so added to v62 and pushed forward
 * `BLUETOOTH_[CONNECT/SCAN/ADVERTISE]` was added in v66 and never in docs (I did those PRs, so this is my fault) - https://github.com/facebook/react-native/pull/31488 and https://github.com/facebook/react-native/pull/32079
 * `ACCESS_MEDIA_LOCATION` is actually a pretty old dangerous permission that was just noticed missing so a PR was already merged into master, so I only targeted it for next release - https://github.com/facebook/react-native/pull/32282
 
 I might now audit the actual list of dangerous permissions on AOSP to see if any others are missing.