### PR TITLE
feat: add next RN permissions (android)

### DIFF
--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -174,6 +174,11 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `BLUETOOTH_SCAN`: 'android.permission.BLUETOOTH_SCAN'
 - `BLUETOOTH_ADVERTISE`: 'android.permission.BLUETOOTH_ADVERTISE'
 - `ACCESS_MEDIA_LOCATION`: 'android.permission.ACCESS_MEDIA_LOCATION'
+- `ACCEPT_HANDOVER`: 'android.permission.ACCEPT_HANDOVER'
+- `ACTIVITY_RECOGNITION`: 'android.permission.ACTIVITY_RECOGNITION'
+- `ANSWER_PHONE_CALLS`: 'android.permission.ANSWER_PHONE_CALLS'
+- `READ_PHONE_NUMBERS`: 'android.permission.READ_PHONE_NUMBERS'
+- `UWB_RANGING`: 'android.permission.UWB_RANGING'
 
 ### Result strings for requesting permissions
 


### PR DESCRIPTION
I did end up auditing the codebase and finding a few missing permissions. So I opened up a PR upstream in RN - https://github.com/facebook/react-native/commit/4b25a0aaa077caf9c437bcfeef8a226eda5a102e and it was merged today.

So this is pointed to the next documentation release. This adds:

https://developer.android.com/reference/android/Manifest.permission.html#ACCEPT_HANDOVER - 28
https://developer.android.com/reference/android/Manifest.permission.html#ACTIVITY_RECOGNITION - 29
https://developer.android.com/reference/android/Manifest.permission.html#ANSWER_PHONE_CALLS - 26
https://developer.android.com/reference/android/Manifest.permission.html#READ_PHONE_NUMBERS - 26
https://developer.android.com/reference/android/Manifest.permission.html#UWB_RANGING - 31

---

Would you accept a PR to organize all permissions alphabetically? I don't know what the pattern is now, but I think alphabetical would be easier to read.