### PR TITLE
Update _getting-started-macos-ios.md

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -120,7 +120,7 @@ The above command will automatically run your app on the iOS Simulator by defaul
 Now that you have successfully run the app, let's modify it.
 
 - Open `App.js` in your text editor of choice and edit some lines.
-- Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
+- Hit `⌘D` in your iOS Simulator to reload the app and see your changes!
 
 ### That's it!
 


### PR DESCRIPTION
Changed the instruction to hit  `⌘R` to reload to `⌘D` since the former is now the iOS Simulator command to record your screen rather than refresh.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
