### PR TITLE
solution for Error: spawnSync ./gradlew EACCES

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,6 +111,6 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 ### Error: spawnSync ./gradlew EACCES
 
-if you run into issue where running `npm run android` on mac throws the above error, try to run `sudo chmod 755 android/gradlew` command to make gradlew files into executable.
+If you run into issue where running `npm run android` on mac throws the above error, try to run `sudo chmod +x android/gradlew` command to make gradlew files into executable.
 
 [metro]: https://facebook.github.io/metro/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,6 +111,6 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 ### Error: spawnSync ./gradlew EACCES
 
-if you run into issue where running `npm run android` on mac throws the above error, try to run `sudo chmod 755 android/gradlew` command to make gradlew files into executable. Which help code to give a run. 
+if you run into issue where running `npm run android` on mac throws the above error, try to run `sudo chmod 755 android/gradlew` command to make gradlew files into executable.
 
 [metro]: https://facebook.github.io/metro/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,4 +109,8 @@ Issue caused by the number of directories [inotify](https://github.com/guard/lis
 echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
+### Error: spawnSync ./gradlew EACCES
+
+if you run into issue where running `npm run android` on mac throws the above error, try to run `sudo chmod 755 android/gradlew` command to make gradlew files into executable. Which help code to give a run. 
+
 [metro]: https://facebook.github.io/metro/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,6 +111,6 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 ### Error: spawnSync ./gradlew EACCES
 
-If you run into issue where running `npm run android` on mac throws the above error, try to run `sudo chmod +x android/gradlew` command to make gradlew files into executable.
+If you run into issue where executing `npm run android` on macOS throws the above error, try to run `sudo chmod +x android/gradlew` command to make `gradlew` files into executable.
 
 [metro]: https://facebook.github.io/metro/


### PR DESCRIPTION
This commit updates the troubleshoot.md file by writting the solution to the ./gradlew EACCES error for mac users. 

