### PR TITLE
Update docs for image.md

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -395,7 +395,9 @@ More details about `resize` and `scale` can be found at http://frescolib.org/doc
 
 Determines how to resize the image when the frame doesn't match the raw image dimensions. Defaults to `cover`.
 
-- `cover`: Scale the image uniformly (maintain the image's aspect ratio) so that both dimensions (width and height) of the image will be equal to or larger than the corresponding dimension of the view (minus padding).
+- `cover`: Scale the image uniformly (maintain the image's aspect ratio) so that
+  *  both dimensions (width and height) of the image will be equal to or larger than the corresponding dimension of the view (minus padding)
+  *  at least one dimension of the scaled image will be equal to the corresponding dimension of the view (minus padding)
 
 - `contain`: Scale the image uniformly (maintain the image's aspect ratio) so that both dimensions (width and height) of the image will be equal to or less than the corresponding dimension of the view (minus padding).
 


### PR DESCRIPTION
**Proposed documentation update**

This is missing, but this is an important information. Imagine a view sized 100x150 and an image sized 200x300. The old description could be interpreted in a way, that the image doesn't scale at all!
I agree, once you know it, this might be obvious, but I still feel like it's needed piece of info

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
