### PR TITLE
update changelog links after RNC deprecation

### DIFF
--- a/website/blog/2019-09-18-version-0.61.md
+++ b/website/blog/2019-09-18-version-0.61.md
@@ -54,4 +54,4 @@ Please report any issues with Fast Refresh on GitHub, and we’ll look into them
 
 Thanks to all of the contributors that helped make 0.61 possible!
 
-To see all the updates, take a look at the [0.61 changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md).
+To see all the updates, take a look at the [0.61 changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0610).

--- a/website/blog/2020-03-26-version-0.62.md
+++ b/website/blog/2020-03-26-version-0.62.md
@@ -96,4 +96,4 @@ We're always working to improve the upgrade experience, and we hope that these t
 
 Thank you to the hundreds of contributors that helped make 0.62 possible!
 
-To see all the updates, take a look at the [0.62 changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#0620).
+To see all the updates, take a look at the [0.62 changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0620).

--- a/website/blog/2020-07-06-version-0.63.md
+++ b/website/blog/2020-07-06-version-0.63.md
@@ -154,4 +154,4 @@ Thank you to the hundreds of contributors that helped make 0.63 possible!
 
 > Special thanks to [Rick Hanlon](https://twitter.com/rickhanlonii) for authoring the section on `LogBox` and [Eli White](https://twitter.com/Eli_White) for authoring the `Pressable` part of this article.
 
-To see all the updates, take a look at the [0.63 changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#0630).
+To see all the updates, take a look at the [0.63 changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0630).

--- a/website/blog/2021-03-12-version-0.64.md
+++ b/website/blog/2021-03-12-version-0.64.md
@@ -87,4 +87,4 @@ More information about React 17 is available [on the React blog](https://reactjs
 
 ## Thanks
 
-Thank you to the hundreds of contributors that helped make 0.64 possible! The [0.64 changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0640) includes all of the changes included in this release.
+Thank you to the hundreds of contributors that helped make 0.64 possible! The [0.64 changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0640) includes all of the changes included in this release.

--- a/website/blog/2021-08-17-version-065.md
+++ b/website/blog/2021-08-17-version-065.md
@@ -41,4 +41,4 @@ You can follow along or contribute to our [outstanding accessibility issues](htt
 
 ## Thank You!
 
-This release includes over **1100 commits** from **61 contributors**. Thank you to everyone who has contributed and supported this release! You can find the [full changelog here](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0650).
+This release includes over **1100 commits** from **61 contributors**. Thank you to everyone who has contributed and supported this release! You can find the [full changelog here](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0650).

--- a/website/blog/2021-10-01-version-066.md
+++ b/website/blog/2021-10-01-version-066.md
@@ -81,7 +81,7 @@ $ npm add <path to tarball>
 
 ### Acknowledgements
 
-This release includes **621 commits** with **92 contributors**! Thank you to all our contributors new and old! You can find the [full changelog here](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0660).
+This release includes **621 commits** with **92 contributors**! Thank you to all our contributors new and old! You can find the [full changelog here](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0660).
 
 As well, thank you to the following contributors for their support in preparing, testing and unblocking this release!
 

--- a/website/versioned_docs/version-0.65/roottag.md
+++ b/website/versioned_docs/version-0.65/roottag.md
@@ -71,4 +71,4 @@ The legacy context access to `RootTag` will be removed and replaced by `RootTagC
 
 ## Future Plans
 
-With the new React Native architecture progressing, there will be future iterations to `RootTag`, with the intention to keep the `RootTag` type opaque and prevent thrash in React Native codebases. Please do not rely on the fact that RootTag currently aliases to a number! If your app relies on RootTags, keep an eye on our version change logs, which you can find [here](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md).
+With the new React Native architecture progressing, there will be future iterations to `RootTag`, with the intention to keep the `RootTag` type opaque and prevent thrash in React Native codebases. Please do not rely on the fact that RootTag currently aliases to a number! If your app relies on RootTags, keep an eye on our version change logs, which you can find [here](https://github.com/facebook/react-native/blob/main/CHANGELOG.md).

--- a/website/versioned_docs/version-0.66/roottag.md
+++ b/website/versioned_docs/version-0.66/roottag.md
@@ -71,4 +71,4 @@ The legacy context access to `RootTag` will be removed and replaced by `RootTagC
 
 ## Future Plans
 
-With the new React Native architecture progressing, there will be future iterations to `RootTag`, with the intention to keep the `RootTag` type opaque and prevent thrash in React Native codebases. Please do not rely on the fact that RootTag currently aliases to a number! If your app relies on RootTags, keep an eye on our version change logs, which you can find [here](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md).
+With the new React Native architecture progressing, there will be future iterations to `RootTag`, with the intention to keep the `RootTag` type opaque and prevent thrash in React Native codebases. Please do not rely on the fact that RootTag currently aliases to a number! If your app relies on RootTags, keep an eye on our version change logs, which you can find [here](https://github.com/facebook/react-native/blob/main/CHANGELOG.md).


### PR DESCRIPTION
This PR updates all the remaining Changelog file links on the website (mostly in blog posts), so now they leads to the core repository instead of deprecated/archived RNC repository.