### PR TITLE
Remove doc reference to duration in scrollToEnd

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -752,9 +752,9 @@ Scrolls to a given x, y offset, either immediately, with a smooth animation.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({ duration: 500 })` for a controlled duration scroll. If no options are passed, `animated` defaults to `true`.
+Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. If no options are passed, `animated` defaults to `true`.


### PR DESCRIPTION
Looks like duration prop isn't available anymore for ScrollView.scrollToEnd.

https://github.com/facebook/react-native/blob/1465c8f3874cdee8c325ab4a4916fda0b3e43bdb/Libraries/Components/ScrollView/ScrollViewCommands.js#L28-L31

According to this comment it was deleted at some point.

https://github.com/facebook/react-native/issues/25589#issuecomment-510488031

