### PR TITLE
index should not be used for react list keys

### DIFF
--- a/docs/using-a-listview.md
+++ b/docs/using-a-listview.md
@@ -89,7 +89,7 @@ const SectionListBasics = () => {
           ]}
           renderItem={({item}) => <Text style={styles.item}>{item}</Text>}
           renderSectionHeader={({section}) => <Text style={styles.sectionHeader}>{section.title}</Text>}
-          keyExtractor={(item, index) => index}
+          keyExtractor={(item, index) => `${item}-${index}`}
         />
       </View>
     );


### PR DESCRIPTION
Using index as keys can create potential bugs where the item is changed but react would not rerender it since the index is same in that list.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
