### PR TITLE
improve ToC and readability of Android Native Components

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -23,13 +23,11 @@ To send a view:
 4. Register the manager in `createViewManagers` of the applications package.
 5. Implement the JavaScript module
 
-## 1. Create the `ViewManager` subclass
+### 1. Create the `ViewManager` subclass
 
 In this example we create view manager class `ReactImageManager` that extends `SimpleViewManager` of type `ReactImageView`. `ReactImageView` is the type of object managed by the manager, this will be the custom native view. Name returned by `getName` is used to reference the native view type from JavaScript.
 
 ```java
-...
-
 public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
   public static final String REACT_CLASS = "RCTImageView";
@@ -43,9 +41,10 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
   public String getName() {
     return REACT_CLASS;
   }
+}
 ```
 
-## 2. Implement method `createViewInstance`
+### 2. Implement method `createViewInstance`
 
 Views are created in the `createViewInstance` method, the view should initialize itself in its default state, any properties will be set via a follow up call to `updateView.`
 
@@ -56,7 +55,7 @@ Views are created in the `createViewInstance` method, the view should initialize
   }
 ```
 
-## 3. Expose view property setters using `@ReactProp` (or `@ReactPropGroup`) annotation
+### 3. Expose view property setters using `@ReactProp` (or `@ReactPropGroup`) annotation
 
 Properties that are to be reflected in JavaScript needs to be exposed as setter method annotated with `@ReactProp` (or `@ReactPropGroup`). Setter method should take view to be updated (of the current view type) as a first argument and property value as a second argument. Setter should be declared as a `void` method and should be `public`. Property type sent to JS is determined automatically based on the type of value argument of the setter. The following type of values are currently supported: `boolean`, `int`, `float`, `double`, `String`, `Boolean`, `Integer`, `ReadableArray`, `ReadableMap`.
 
@@ -87,7 +86,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
   }
 ```
 
-## 4. Register the `ViewManager`
+### 4. Register the `ViewManager`
 
 The final Java step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.md), via the applications package member function `createViewManagers.`
 
@@ -101,13 +100,11 @@ The final Java step is to register the ViewManager to the application, this happ
   }
 ```
 
-## 5. Implement the JavaScript module
+### 5. Implement the JavaScript module
 
 The very final step is to create the JavaScript module that defines the interface layer between Java and JavaScript for the users of your new view. It is recommended for you to document the component interface in this module (e.g. using Flow, TypeScript, or plain old comments).
 
-```jsx
-// ImageView.js
-
+```jsx title="ImageView.js"
 import { requireNativeComponent } from 'react-native';
 
 /**
@@ -122,7 +119,7 @@ module.exports = requireNativeComponent('RCTImageView');
 
 The `requireNativeComponent` function takes the name of the native view. Note that if your component needs to do anything more sophisticated (e.g. custom event handling), you should wrap the native component in another React component. This is illustrated in the `MyCustomView` example below.
 
-# Events
+## Events
 
 So now we know how to expose native view components that we can control freely from JS, but how do we deal with events from the user, like pinch-zooms or panning? When a native event occurs the native code should issue an event to the JavaScript representation of the View, and the two views are linked with the value returned from the `getId()` method.
 
@@ -133,10 +130,9 @@ class MyCustomView extends View {
       WritableMap event = Arguments.createMap();
       event.putString("message", "MyMessage");
       ReactContext reactContext = (ReactContext)getContext();
-      reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-          getId(),
-          "topChange",
-          event);
+      reactContext
+          .getJSModule(RCTEventEmitter.class)
+          .receiveEvent(getId(), "topChange", event);
     }
 }
 ```
@@ -147,28 +143,26 @@ To map the `topChange` event name to the `onChange` callback prop in JavaScript,
 public class ReactImageManager extends SimpleViewManager<MyCustomView> {
     ...
     public Map getExportedCustomBubblingEventTypeConstants() {
-        return MapBuilder.builder()
-            .put(
-                "topChange",
-                MapBuilder.of(
-                    "phasedRegistrationNames",
-                    MapBuilder.of("bubbled", "onChange")))
-                    .build();
+        return MapBuilder.builder().put(
+            "topChange",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onChange")
+            )
+        ).build();
     }
 }
 ```
 
 This callback is invoked with the raw event, which we typically process in the wrapper component to make a simpler API:
 
-```jsx
-// MyCustomView.js
-
+```jsx title="MyCustomView.js"
 class MyCustomView extends React.Component {
   constructor(props) {
     super(props);
     this._onChange = this._onChange.bind(this);
   }
-  _onChange(event: Event) {
+  _onChange(event) {
     if (!this.props.onChangeMessage) {
       return;
     }
@@ -186,20 +180,19 @@ MyCustomView.propTypes = {
   ...
 };
 
-var RCTMyCustomView = requireNativeComponent(`RCTMyCustomView`);
+const RCTMyCustomView = requireNativeComponent(`RCTMyCustomView`);
 ```
 
-# Integration with an Android Fragment Example
+## Integration with an Android Fragment example
 
 In order to integrate existing Native UI elements to your React Native app, you might need to use Android Fragments to give you a more granular control over your native component than returning a `View` from your `ViewManager`. You will need this if you want to add custom logic that is tied to your view with the help of [lifecycle methods](https://developer.android.com/guide/fragments/lifecycle), such as `onViewCreated`, `onPause`, `onResume`. The following steps will show you how to do it:
 
-## 1. Create an example custom view
+### 1. Create an example custom view
 
 First, let's create a `CustomView` class which extends `FrameLayout` (the content of this view can be any view that you'd like to render)
 
-`CustomView.java`
-
-```java
+```java title="CustomView.java"
+// replace with your package
 package com.mypackage;
 
 import android.content.Context;
@@ -225,11 +218,9 @@ public class CustomView extends FrameLayout {
 }
 ```
 
-## 2. Create a `Fragment`
+### 2. Create a `Fragment`
 
-`MyFragment.java`
-
-```java
+```java title="MyFragment.java"
 // replace with your package
 package com.mypackage;
 
@@ -282,11 +273,9 @@ public class MyFragment extends Fragment {
 }
 ```
 
-## 3. Create the `ViewManager` subclass
+### 3. Create the `ViewManager` subclass
 
-`MyViewManager.java`
-
-```java
+```java title="MyViewManager.java"
 // replace with your package
 package com.mypackage;
 
@@ -347,7 +336,11 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
    * Handle "create" command (called from JS) and call createFragment method
    */
   @Override
-  public void receiveCommand(@NonNull FrameLayout root, String commandId, @Nullable ReadableArray args) {
+  public void receiveCommand(
+    @NonNull FrameLayout root,
+    String commandId,
+    @Nullable ReadableArray args
+  ) {
     super.receiveCommand(root, commandId, args);
     int reactNativeViewId = args.getInt(0);
     int commandIdInt = Integer.parseInt(commandId);
@@ -411,13 +404,12 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
       view.layout(0, 0, width, height);
   }
+}
 ```
 
-## 4. Register the `ViewManager`
+### 4. Register the `ViewManager`
 
-`MyPackage.java`
-
-```java
+```java title="MyPackage.java"
 // replace with your package
 package com.mypackage;
 
@@ -440,11 +432,9 @@ public class MyPackage implements ReactPackage {
 }
 ```
 
-## 5. Register the `Package`
+### 5. Register the `Package`
 
-`MainApplication.java`
-
-```java
+```java title="MainApplication.java"
     @Override
     protected List<ReactPackage> getPackages() {
       List<ReactPackage> packages = new PackageList(this).getPackages();
@@ -454,11 +444,11 @@ public class MyPackage implements ReactPackage {
     }
 ```
 
-## 6. Implement the JavaScript module
+### 6. Implement the JavaScript module
 
-I. `MyViewManager.jsx`
+I. Start with custom View manager:
 
-```jsx
+```jsx title="MyViewManager.jsx"
 import { requireNativeComponent } from 'react-native';
 
 export const MyViewManager = requireNativeComponent(
@@ -466,9 +456,9 @@ export const MyViewManager = requireNativeComponent(
 );
 ```
 
-II. ` MyView.jsx` calling the `create` method
+II. Then implement custom View calling the `create` method:
 
-```jsx
+```jsx title="MyView.jsx"
 import React, { useEffect, useRef } from 'react';
 import { UIManager, findNodeHandle } from 'react-native';
 
@@ -477,7 +467,8 @@ import { MyViewManager } from './my-view-manager';
 const createFragment = (viewId) =>
   UIManager.dispatchViewManagerCommand(
     viewId,
-    UIManager.MyViewManager.Commands.create.toString(), // we are calling the 'create' command
+    // we are calling the 'create' command
+    UIManager.MyViewManager.Commands.create.toString(),
     [viewId]
   );
 
@@ -486,7 +477,7 @@ export const MyView = () => {
 
   useEffect(() => {
     const viewId = findNodeHandle(ref.current);
-    createFragment(viewId!);
+    createFragment(viewId);
   }, []);
 
   return (
@@ -501,7 +492,6 @@ export const MyView = () => {
     />
   );
 };
-
 ```
 
-If you want to expose property setters using `@ReactProp` (or `@ReactPropGroup`) annotation: _see ImageView example above_
+If you want to expose property setters using `@ReactProp` (or `@ReactPropGroup`) annotation see the [ImageView example](#imageview-example) above.

--- a/website/versioned_docs/version-0.66/native-components-android.md
+++ b/website/versioned_docs/version-0.66/native-components-android.md
@@ -23,13 +23,11 @@ To send a view:
 4. Register the manager in `createViewManagers` of the applications package.
 5. Implement the JavaScript module
 
-## 1. Create the `ViewManager` subclass
+### 1. Create the `ViewManager` subclass
 
 In this example we create view manager class `ReactImageManager` that extends `SimpleViewManager` of type `ReactImageView`. `ReactImageView` is the type of object managed by the manager, this will be the custom native view. Name returned by `getName` is used to reference the native view type from JavaScript.
 
 ```java
-...
-
 public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
   public static final String REACT_CLASS = "RCTImageView";
@@ -43,9 +41,10 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
   public String getName() {
     return REACT_CLASS;
   }
+}
 ```
 
-## 2. Implement method `createViewInstance`
+### 2. Implement method `createViewInstance`
 
 Views are created in the `createViewInstance` method, the view should initialize itself in its default state, any properties will be set via a follow up call to `updateView.`
 
@@ -56,7 +55,7 @@ Views are created in the `createViewInstance` method, the view should initialize
   }
 ```
 
-## 3. Expose view property setters using `@ReactProp` (or `@ReactPropGroup`) annotation
+### 3. Expose view property setters using `@ReactProp` (or `@ReactPropGroup`) annotation
 
 Properties that are to be reflected in JavaScript needs to be exposed as setter method annotated with `@ReactProp` (or `@ReactPropGroup`). Setter method should take view to be updated (of the current view type) as a first argument and property value as a second argument. Setter should be declared as a `void` method and should be `public`. Property type sent to JS is determined automatically based on the type of value argument of the setter. The following type of values are currently supported: `boolean`, `int`, `float`, `double`, `String`, `Boolean`, `Integer`, `ReadableArray`, `ReadableMap`.
 
@@ -87,7 +86,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
   }
 ```
 
-## 4. Register the `ViewManager`
+### 4. Register the `ViewManager`
 
 The final Java step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.md), via the applications package member function `createViewManagers.`
 
@@ -101,13 +100,11 @@ The final Java step is to register the ViewManager to the application, this happ
   }
 ```
 
-## 5. Implement the JavaScript module
+### 5. Implement the JavaScript module
 
 The very final step is to create the JavaScript module that defines the interface layer between Java and JavaScript for the users of your new view. It is recommended for you to document the component interface in this module (e.g. using Flow, TypeScript, or plain old comments).
 
-```jsx
-// ImageView.js
-
+```jsx title="ImageView.js"
 import { requireNativeComponent } from 'react-native';
 
 /**
@@ -122,7 +119,7 @@ module.exports = requireNativeComponent('RCTImageView');
 
 The `requireNativeComponent` function takes the name of the native view. Note that if your component needs to do anything more sophisticated (e.g. custom event handling), you should wrap the native component in another React component. This is illustrated in the `MyCustomView` example below.
 
-# Events
+## Events
 
 So now we know how to expose native view components that we can control freely from JS, but how do we deal with events from the user, like pinch-zooms or panning? When a native event occurs the native code should issue an event to the JavaScript representation of the View, and the two views are linked with the value returned from the `getId()` method.
 
@@ -133,10 +130,9 @@ class MyCustomView extends View {
       WritableMap event = Arguments.createMap();
       event.putString("message", "MyMessage");
       ReactContext reactContext = (ReactContext)getContext();
-      reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
-          getId(),
-          "topChange",
-          event);
+      reactContext
+          .getJSModule(RCTEventEmitter.class)
+          .receiveEvent(getId(), "topChange", event);
     }
 }
 ```
@@ -147,28 +143,26 @@ To map the `topChange` event name to the `onChange` callback prop in JavaScript,
 public class ReactImageManager extends SimpleViewManager<MyCustomView> {
     ...
     public Map getExportedCustomBubblingEventTypeConstants() {
-        return MapBuilder.builder()
-            .put(
-                "topChange",
-                MapBuilder.of(
-                    "phasedRegistrationNames",
-                    MapBuilder.of("bubbled", "onChange")))
-                    .build();
+        return MapBuilder.builder().put(
+            "topChange",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onChange")
+            )
+        ).build();
     }
 }
 ```
 
 This callback is invoked with the raw event, which we typically process in the wrapper component to make a simpler API:
 
-```jsx
-// MyCustomView.js
-
+```jsx title="MyCustomView.js"
 class MyCustomView extends React.Component {
   constructor(props) {
     super(props);
     this._onChange = this._onChange.bind(this);
   }
-  _onChange(event: Event) {
+  _onChange(event) {
     if (!this.props.onChangeMessage) {
       return;
     }
@@ -186,18 +180,47 @@ MyCustomView.propTypes = {
   ...
 };
 
-var RCTMyCustomView = requireNativeComponent(`RCTMyCustomView`);
+const RCTMyCustomView = requireNativeComponent(`RCTMyCustomView`);
 ```
 
-# Integration with an Android Fragment Example
+## Integration with an Android Fragment example
 
 In order to integrate existing Native UI elements to your React Native app, you might need to use Android Fragments to give you a more granular control over your native component than returning a `View` from your `ViewManager`. You will need this if you want to add custom logic that is tied to your view with the help of [lifecycle methods](https://developer.android.com/guide/fragments/lifecycle), such as `onViewCreated`, `onPause`, `onResume`. The following steps will show you how to do it:
 
-## 1. Create a `Fragment`
+### 1. Create an example custom view
 
-`MyFragment.java`
+First, let's create a `CustomView` class which extends `FrameLayout` (the content of this view can be any view that you'd like to render)
 
-```java
+```java title="CustomView.java"
+// replace with your package
+package com.mypackage;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+public class CustomView extends FrameLayout {
+  public CustomView(@NonNull Context context) {
+    super(context);
+    // set padding and background color
+    this.setPadding(16,16,16,16);
+    this.setBackgroundColor(Color.parseColor("#5FD3F3"));
+
+    // add default text view
+    TextView text = new TextView(context);
+    text.setText("Welcome to Android Fragments with React Native.");
+    this.addView(text);
+  }
+}
+```
+
+### 2. Create a `Fragment`
+
+```java title="MyFragment.java"
 // replace with your package
 package com.mypackage;
 
@@ -216,7 +239,7 @@ public class MyFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         super.onCreateView(inflater, parent, savedInstanceState);
-        customView = new CustomView();
+        customView = new CustomView(this.getContext());
         return customView; // this CustomView could be any view that you want to render
     }
 
@@ -250,11 +273,9 @@ public class MyFragment extends Fragment {
 }
 ```
 
-## 2. Create the `ViewManager` subclass
+### 3. Create the `ViewManager` subclass
 
-`MyViewManager.java`
-
-```java
+```java title="MyViewManager.java"
 // replace with your package
 package com.mypackage;
 
@@ -280,6 +301,8 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
   public static final String REACT_CLASS = "MyViewManager";
   public final int COMMAND_CREATE = 1;
+  private int propWidth;
+  private int propHeight;
 
   ReactApplicationContext reactContext;
 
@@ -313,7 +336,11 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
    * Handle "create" command (called from JS) and call createFragment method
    */
   @Override
-  public void receiveCommand(@NonNull FrameLayout root, String commandId, @Nullable ReadableArray args) {
+  public void receiveCommand(
+    @NonNull FrameLayout root,
+    String commandId,
+    @Nullable ReadableArray args
+  ) {
     super.receiveCommand(root, commandId, args);
     int reactNativeViewId = args.getInt(0);
     int commandIdInt = Integer.parseInt(commandId);
@@ -326,11 +353,22 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
     }
   }
 
+  @ReactPropGroup(names = {"width", "height"}, customType = "Style")
+  public void setStyle(FrameLayout view, int index, Integer value) {
+    if (index == 0) {
+      propWidth = value;
+    }
+
+    if (index == 1) {
+      propHeight = value;
+    }
+  }
+
   /**
    * Replace your React Native view with a custom fragment
    */
   public void createFragment(FrameLayout root, int reactNativeViewId) {
-    ViewGroup parentView = (ViewGroup) root.findViewById(reactNativeViewId).getParent();
+    ViewGroup parentView = (ViewGroup) root.findViewById(reactNativeViewId);
     setupLayout(parentView);
 
     final MyFragment myFragment = new MyFragment();
@@ -366,13 +404,12 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
       view.layout(0, 0, width, height);
   }
+}
 ```
 
-## 3. Register the `ViewManager`
+### 4. Register the `ViewManager`
 
-`MyPackage.java`
-
-```java
+```java title="MyPackage.java"
 // replace with your package
 package com.mypackage;
 
@@ -395,11 +432,9 @@ public class MyPackage implements ReactPackage {
 }
 ```
 
-## 4. Register the `Package`
+### 5. Register the `Package`
 
-`MainApplication.java`
-
-```java
+```java title="MainApplication.java"
     @Override
     protected List<ReactPackage> getPackages() {
       List<ReactPackage> packages = new PackageList(this).getPackages();
@@ -409,11 +444,11 @@ public class MyPackage implements ReactPackage {
     }
 ```
 
-## 5. Implement the JavaScript module
+### 6. Implement the JavaScript module
 
-I. `MyViewManager.jsx`
+I. Start with custom View manager:
 
-```jsx
+```jsx title="MyViewManager.jsx"
 import { requireNativeComponent } from 'react-native';
 
 export const MyViewManager = requireNativeComponent(
@@ -421,9 +456,9 @@ export const MyViewManager = requireNativeComponent(
 );
 ```
 
-II. ` MyView.jsx` calling the `create` method
+II. Then implement custom View calling the `create` method:
 
-```jsx
+```jsx title="MyView.jsx"
 import React, { useEffect, useRef } from 'react';
 import { UIManager, findNodeHandle } from 'react-native';
 
@@ -432,30 +467,31 @@ import { MyViewManager } from './my-view-manager';
 const createFragment = (viewId) =>
   UIManager.dispatchViewManagerCommand(
     viewId,
-    UIManager.MyViewManager.Commands.create.toString(), // we are calling the 'create' command
+    // we are calling the 'create' command
+    UIManager.MyViewManager.Commands.create.toString(),
     [viewId]
   );
 
-export const MyView = ({ style }) => {
+export const MyView = () => {
   const ref = useRef(null);
 
   useEffect(() => {
     const viewId = findNodeHandle(ref.current);
-    createFragment(viewId!);
+    createFragment(viewId);
   }, []);
 
   return (
     <MyViewManager
       style={{
-        ...(style || {}),
-        height: style && style.height !== undefined ? style.height || '100%',
-        width: style && style.width !== undefined ? style.width || '100%'
+        // converts dpi to px, provide desired height
+        height: PixelRatio.getPixelSizeForLayoutSize(200),
+        // converts dpi to px, provide desired width
+        width: PixelRatio.getPixelSizeForLayoutSize(200)
       }}
       ref={ref}
     />
   );
 };
-
 ```
 
-If you want to expose property setters using `@ReactProp` (or `@ReactPropGroup`) annotation: _see ImageView example above_
+If you want to expose property setters using `@ReactProp` (or `@ReactPropGroup`) annotation see the [ImageView example](#imageview-example) above.


### PR DESCRIPTION
This PR aims to improve a bit the readability of [Android Native Components](https://reactnative.dev/docs/next/native-components-android) page.

There are basically two changes, the first improves the Table of Content by adjusting the used header sizes. 

The second one refactors comments with file names to the `title` parameter for the Docusaurus code block, which will appear above the code. It was used on the website in the past but very sparsely.

I have also reformatted example codes in few places, so they better fit the website default content width.

The changes have also been backported to the `0.66` docs, which was the only version (besides `next` where Fragments example was present).

## Preview

#### ToC

<img width="281" alt="Screenshot 2021-11-24 at 15 46 21" src="https://user-images.githubusercontent.com/719641/143260825-dc953648-0dce-4755-bc65-11c37369179a.png">

#### Code block with title

<img width="854" alt="Screenshot 2021-11-24 at 15 53 18" src="https://user-images.githubusercontent.com/719641/143260975-16399c1c-896f-49e5-8765-cea2c5bab801.png">
