### PR TITLE
update and generalize all of the `scrollToEnd` prop descriptions

### DIFF
--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -571,12 +571,20 @@ hasMore () => boolean;
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd((params: object));
-
-Valid `params` consist of:
-
-- 'animated' (boolean). Optional default is true.
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- `'animated'` (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.60/flatlist.md
+++ b/website/versioned_docs/version-0.60/flatlist.md
@@ -578,7 +578,7 @@ List of `ViewabilityConfig`/`onViewableItemsChanged` pairs. A specific `onViewab
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd([params]);
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 Scrolls to the end of the content. May be janky without `getItemLayout` prop.

--- a/website/versioned_docs/version-0.60/listview.md
+++ b/website/versioned_docs/version-0.60/listview.md
@@ -40,37 +40,6 @@ There are a few performance operations designed to make ListView scroll smoothly
 
 - Rate-limited row rendering - By default, only one row is rendered per event-loop (customizable with the `pageSize` prop). This breaks up the work into smaller chunks to reduce the chance of dropping frames while rendering rows.
 
-### Props
-
-- [ScrollView props...](scrollview.md#props)
-
-* [`dataSource`](listview.md#datasource)
-* [`initialListSize`](listview.md#initiallistsize)
-* [`onEndReachedThreshold`](listview.md#onendreachedthreshold)
-* [`pageSize`](listview.md#pagesize)
-* [`renderRow`](listview.md#renderrow)
-* [`renderScrollComponent`](listview.md#renderscrollcomponent)
-* [`scrollRenderAheadDistance`](listview.md#scrollrenderaheaddistance)
-* [`stickyHeaderIndices`](listview.md#stickyheaderindices)
-* [`enableEmptySections`](listview.md#enableemptysections)
-* [`renderHeader`](listview.md#renderheader)
-* [`onEndReached`](listview.md#onendreached)
-* [`stickySectionHeadersEnabled`](listview.md#stickysectionheadersenabled)
-* [`renderSectionHeader`](listview.md#rendersectionheader)
-* [`renderSeparator`](listview.md#renderseparator)
-* [`onChangeVisibleRows`](listview.md#onchangevisiblerows)
-* [`removeClippedSubviews`](listview.md#removeclippedsubviews)
-* [`renderFooter`](listview.md#renderfooter)
-
-### Methods
-
-- [`getMetrics`](listview.md#getmetrics)
-- [`scrollTo`](listview.md#scrollto)
-- [`scrollToEnd`](listview.md#scrolltoend)
-- [`flashScrollIndicators`](listview.md#flashscrollindicators)
-
----
-
 # Reference
 
 ## Props
@@ -280,14 +249,12 @@ See `ScrollView#scrollTo`.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: object));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ListView scrolls to the bottom. If this is a horizontal ListView scrolls to the right.
 
 Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
-
-See `ScrollView#scrollToEnd`.
 
 ---
 

--- a/website/versioned_docs/version-0.60/scrollview.md
+++ b/website/versioned_docs/version-0.60/scrollview.md
@@ -699,12 +699,12 @@ Note: The weird function signature is due to the fact that, for historical reaso
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({duration: 500})` for a controlled duration scroll. If no options are passed, `animated` defaults to true.
+Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
 
 ---
 

--- a/website/versioned_docs/version-0.60/virtualizedlist.md
+++ b/website/versioned_docs/version-0.60/virtualizedlist.md
@@ -449,8 +449,20 @@ Set this when offset is needed for the loading indicator to show correctly.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([params]: object));
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.61/flatlist.md
+++ b/website/versioned_docs/version-0.61/flatlist.md
@@ -578,16 +578,16 @@ List of `ViewabilityConfig`/`onViewableItemsChanged` pairs. A specific `onViewab
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd([params]);
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 Scrolls to the end of the content. May be janky without `getItemLayout` prop.
 
 **Parameters:**
 
-| Name   | Type   | Required | Description |
-| ------ | ------ | -------- | ----------- |
-| params | object | No       | See below.  |
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
 
 Valid `params` keys are:
 

--- a/website/versioned_docs/version-0.61/listview.md
+++ b/website/versioned_docs/version-0.61/listview.md
@@ -40,37 +40,6 @@ There are a few performance operations designed to make ListView scroll smoothly
 
 - Rate-limited row rendering - By default, only one row is rendered per event-loop (customizable with the `pageSize` prop). This breaks up the work into smaller chunks to reduce the chance of dropping frames while rendering rows.
 
-### Props
-
-- [ScrollView props...](scrollview.md#props)
-
-* [`dataSource`](listview.md#datasource)
-* [`initialListSize`](listview.md#initiallistsize)
-* [`onEndReachedThreshold`](listview.md#onendreachedthreshold)
-* [`pageSize`](listview.md#pagesize)
-* [`renderRow`](listview.md#renderrow)
-* [`renderScrollComponent`](listview.md#renderscrollcomponent)
-* [`scrollRenderAheadDistance`](listview.md#scrollrenderaheaddistance)
-* [`stickyHeaderIndices`](listview.md#stickyheaderindices)
-* [`enableEmptySections`](listview.md#enableemptysections)
-* [`renderHeader`](listview.md#renderheader)
-* [`onEndReached`](listview.md#onendreached)
-* [`stickySectionHeadersEnabled`](listview.md#stickysectionheadersenabled)
-* [`renderSectionHeader`](listview.md#rendersectionheader)
-* [`renderSeparator`](listview.md#renderseparator)
-* [`onChangeVisibleRows`](listview.md#onchangevisiblerows)
-* [`removeClippedSubviews`](listview.md#removeclippedsubviews)
-* [`renderFooter`](listview.md#renderfooter)
-
-### Methods
-
-- [`getMetrics`](listview.md#getmetrics)
-- [`scrollTo`](listview.md#scrollto)
-- [`scrollToEnd`](listview.md#scrolltoend)
-- [`flashScrollIndicators`](listview.md#flashscrollindicators)
-
----
-
 # Reference
 
 ## Props
@@ -280,14 +249,12 @@ See `ScrollView#scrollTo`.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: object));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ListView scrolls to the bottom. If this is a horizontal ListView scrolls to the right.
 
 Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
-
-See `ScrollView#scrollToEnd`.
 
 ---
 

--- a/website/versioned_docs/version-0.61/scrollview.md
+++ b/website/versioned_docs/version-0.61/scrollview.md
@@ -699,12 +699,12 @@ Note: The weird function signature is due to the fact that, for historical reaso
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({duration: 500})` for a controlled duration scroll. If no options are passed, `animated` defaults to true.
+Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
 
 ---
 

--- a/website/versioned_docs/version-0.61/virtualizedlist.md
+++ b/website/versioned_docs/version-0.61/virtualizedlist.md
@@ -449,8 +449,20 @@ Set this when offset is needed for the loading indicator to show correctly.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([params]: object));
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.62/flatlist.md
+++ b/website/versioned_docs/version-0.62/flatlist.md
@@ -579,16 +579,16 @@ List of `ViewabilityConfig`/`onViewableItemsChanged` pairs. A specific `onViewab
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd([params]);
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 Scrolls to the end of the content. May be janky without `getItemLayout` prop.
 
 **Parameters:**
 
-| Name   | Type   | Required | Description |
-| ------ | ------ | -------- | ----------- |
-| params | object | No       | See below.  |
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
 
 Valid `params` keys are:
 

--- a/website/versioned_docs/version-0.62/listview.md
+++ b/website/versioned_docs/version-0.62/listview.md
@@ -40,37 +40,6 @@ There are a few performance operations designed to make ListView scroll smoothly
 
 - Rate-limited row rendering - By default, only one row is rendered per event-loop (customizable with the `pageSize` prop). This breaks up the work into smaller chunks to reduce the chance of dropping frames while rendering rows.
 
-### Props
-
-- [ScrollView props...](scrollview.md#props)
-
-* [`dataSource`](listview.md#datasource)
-* [`initialListSize`](listview.md#initiallistsize)
-* [`onEndReachedThreshold`](listview.md#onendreachedthreshold)
-* [`pageSize`](listview.md#pagesize)
-* [`renderRow`](listview.md#renderrow)
-* [`renderScrollComponent`](listview.md#renderscrollcomponent)
-* [`scrollRenderAheadDistance`](listview.md#scrollrenderaheaddistance)
-* [`stickyHeaderIndices`](listview.md#stickyheaderindices)
-* [`enableEmptySections`](listview.md#enableemptysections)
-* [`renderHeader`](listview.md#renderheader)
-* [`onEndReached`](listview.md#onendreached)
-* [`stickySectionHeadersEnabled`](listview.md#stickysectionheadersenabled)
-* [`renderSectionHeader`](listview.md#rendersectionheader)
-* [`renderSeparator`](listview.md#renderseparator)
-* [`onChangeVisibleRows`](listview.md#onchangevisiblerows)
-* [`removeClippedSubviews`](listview.md#removeclippedsubviews)
-* [`renderFooter`](listview.md#renderfooter)
-
-### Methods
-
-- [`getMetrics`](listview.md#getmetrics)
-- [`scrollTo`](listview.md#scrollto)
-- [`scrollToEnd`](listview.md#scrolltoend)
-- [`flashScrollIndicators`](listview.md#flashscrollindicators)
-
----
-
 # Reference
 
 ## Props
@@ -280,14 +249,12 @@ See `ScrollView#scrollTo`.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: object));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ListView scrolls to the bottom. If this is a horizontal ListView scrolls to the right.
 
 Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
-
-See `ScrollView#scrollToEnd`.
 
 ---
 

--- a/website/versioned_docs/version-0.62/scrollview.md
+++ b/website/versioned_docs/version-0.62/scrollview.md
@@ -723,12 +723,12 @@ Note: The weird function signature is due to the fact that, for historical reaso
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({duration: 500})` for a controlled duration scroll. If no options are passed, `animated` defaults to true.
+Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
 
 ---
 

--- a/website/versioned_docs/version-0.62/virtualizedlist.md
+++ b/website/versioned_docs/version-0.62/virtualizedlist.md
@@ -517,13 +517,20 @@ Set this when offset is needed for the loading indicator to show correctly.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd((params: object));
-
-Valid `params` consist of:
-
-- 'animated' (boolean). Optional default is true.
-
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.63/flatlist.md
+++ b/website/versioned_docs/version-0.63/flatlist.md
@@ -571,16 +571,16 @@ List of `ViewabilityConfig`/`onViewableItemsChanged` pairs. A specific `onViewab
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd([params]);
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 Scrolls to the end of the content. May be janky without `getItemLayout` prop.
 
 **Parameters:**
 
-| Name   | Type   | Required | Description |
-| ------ | ------ | -------- | ----------- |
-| params | object | No       | See below.  |
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
 
 Valid `params` keys are:
 

--- a/website/versioned_docs/version-0.63/listview.md
+++ b/website/versioned_docs/version-0.63/listview.md
@@ -40,37 +40,6 @@ There are a few performance operations designed to make ListView scroll smoothly
 
 - Rate-limited row rendering - By default, only one row is rendered per event-loop (customizable with the `pageSize` prop). This breaks up the work into smaller chunks to reduce the chance of dropping frames while rendering rows.
 
-### Props
-
-- [ScrollView props...](scrollview.md#props)
-
-* [`dataSource`](listview.md#datasource)
-* [`initialListSize`](listview.md#initiallistsize)
-* [`onEndReachedThreshold`](listview.md#onendreachedthreshold)
-* [`pageSize`](listview.md#pagesize)
-* [`renderRow`](listview.md#renderrow)
-* [`renderScrollComponent`](listview.md#renderscrollcomponent)
-* [`scrollRenderAheadDistance`](listview.md#scrollrenderaheaddistance)
-* [`stickyHeaderIndices`](listview.md#stickyheaderindices)
-* [`enableEmptySections`](listview.md#enableemptysections)
-* [`renderHeader`](listview.md#renderheader)
-* [`onEndReached`](listview.md#onendreached)
-* [`stickySectionHeadersEnabled`](listview.md#stickysectionheadersenabled)
-* [`renderSectionHeader`](listview.md#rendersectionheader)
-* [`renderSeparator`](listview.md#renderseparator)
-* [`onChangeVisibleRows`](listview.md#onchangevisiblerows)
-* [`removeClippedSubviews`](listview.md#removeclippedsubviews)
-* [`renderFooter`](listview.md#renderfooter)
-
-### Methods
-
-- [`getMetrics`](listview.md#getmetrics)
-- [`scrollTo`](listview.md#scrollto)
-- [`scrollToEnd`](listview.md#scrolltoend)
-- [`flashScrollIndicators`](listview.md#flashscrollindicators)
-
----
-
 # Reference
 
 ## Props
@@ -280,14 +249,12 @@ See `ScrollView#scrollTo`.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: object));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ListView scrolls to the bottom. If this is a horizontal ListView scrolls to the right.
 
 Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
-
-See `ScrollView#scrollToEnd`.
 
 ---
 

--- a/website/versioned_docs/version-0.63/scrollview.md
+++ b/website/versioned_docs/version-0.63/scrollview.md
@@ -736,12 +736,12 @@ Note: The weird function signature is due to the fact that, for historical reaso
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({duration: 500})` for a controlled duration scroll. If no options are passed, `animated` defaults to true.
+Use `scrollToEnd({animated: true})` for smooth animated scrolling, `scrollToEnd({animated: false})` for immediate scrolling. If no options are passed, `animated` defaults to true.
 
 ---
 

--- a/website/versioned_docs/version-0.63/virtualizedlist.md
+++ b/website/versioned_docs/version-0.63/virtualizedlist.md
@@ -510,13 +510,20 @@ Set this when offset is needed for the loading indicator to show correctly.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd((params: object));
-
-Valid `params` consist of:
-
-- 'animated' (boolean). Optional default is true.
-
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.64/flatlist.md
+++ b/website/versioned_docs/version-0.64/flatlist.md
@@ -610,7 +610,7 @@ Tells the list an interaction has occurred, which should trigger viewability cal
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(params);
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 Scrolls to the end of the content. May be janky without `getItemLayout` prop.

--- a/website/versioned_docs/version-0.64/scrollview.md
+++ b/website/versioned_docs/version-0.64/scrollview.md
@@ -732,12 +732,12 @@ Scrolls to a given x, y offset, either immediately, with a smooth animation.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({ duration: 500 })` for a controlled duration scroll. If no options are passed, `animated` defaults to `true`.
+Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. If no options are passed, `animated` defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.64/virtualizedlist.md
+++ b/website/versioned_docs/version-0.64/virtualizedlist.md
@@ -571,12 +571,20 @@ hasMore () => boolean;
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd((params: object));
-
-Valid `params` consist of:
-
-- 'animated' (boolean). Optional default is true.
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/website/versioned_docs/version-0.65/scrollview.md
+++ b/website/versioned_docs/version-0.65/scrollview.md
@@ -742,9 +742,9 @@ Scrolls to a given x, y offset, either immediately, with a smooth animation.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({ duration: 500 })` for a controlled duration scroll. If no options are passed, `animated` defaults to `true`.
+Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. If no options are passed, `animated` defaults to `true`.

--- a/website/versioned_docs/version-0.65/virtualizedlist.md
+++ b/website/versioned_docs/version-0.65/virtualizedlist.md
@@ -571,12 +571,21 @@ hasMore () => boolean;
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd((params: object));
-
-Valid `params` consist of:
-
-- 'animated' (boolean). Optional default is true.
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+
 
 ---
 

--- a/website/versioned_docs/version-0.65/virtualizedlist.md
+++ b/website/versioned_docs/version-0.65/virtualizedlist.md
@@ -586,7 +586,6 @@ Valid `params` keys are:
 
 - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
-
 ---
 
 ### `scrollToIndex()`

--- a/website/versioned_docs/version-0.66/flatlist.md
+++ b/website/versioned_docs/version-0.66/flatlist.md
@@ -610,7 +610,7 @@ Tells the list an interaction has occurred, which should trigger viewability cal
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(params);
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 Scrolls to the end of the content. May be janky without `getItemLayout` prop.

--- a/website/versioned_docs/version-0.66/scrollview.md
+++ b/website/versioned_docs/version-0.66/scrollview.md
@@ -752,9 +752,9 @@ Scrolls to a given x, y offset, either immediately, with a smooth animation.
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd(([options]: { animated: boolean, duration: number }));
+scrollToEnd(([options]: { animated: boolean }));
 ```
 
 If this is a vertical ScrollView scrolls to the bottom. If this is a horizontal ScrollView scrolls to the right.
 
-Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. For Android, you may specify a duration, e.g. `scrollToEnd({ duration: 500 })` for a controlled duration scroll. If no options are passed, `animated` defaults to `true`.
+Use `scrollToEnd({ animated: true })` for smooth animated scrolling, `scrollToEnd({ animated: false })` for immediate scrolling. If no options are passed, `animated` defaults to `true`.

--- a/website/versioned_docs/version-0.66/virtualizedlist.md
+++ b/website/versioned_docs/version-0.66/virtualizedlist.md
@@ -571,12 +571,20 @@ hasMore () => boolean;
 ### `scrollToEnd()`
 
 ```jsx
-scrollToEnd((params: object));
-
-Valid `params` consist of:
-
-- 'animated' (boolean). Optional default is true.
+scrollToEnd(([options]: { animated: boolean }));
 ```
+
+Scrolls to the end of the content. May be janky without `getItemLayout` prop.
+
+**Parameters:**
+
+| Name   | Type   |
+| ------ | ------ |
+| params | object |
+
+Valid `params` keys are:
+
+- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 


### PR DESCRIPTION
# Why & how

Follow up to #2857 

This PR fixes the invalid `duration` key description for the `ScrollList` and attempts to generalize the description and documentation of all `scrollToEnd` props available in the `*List` components.

In the future, we should also take a deeper look into the the exact exported types per component/list, since usually we do not duplicate the props description if that prop comes from parent/extended component. In case of `scrollToEnd`, it might be only a `VitualizedList` prop, but for now it was more important to remove invalid information to avoid users confusion. 🙂 

I have also removed few in-content ToC's on the deperecated `ListView` pages, since they are the relict of the past, when website do not use the build-in ToC (right sidebar). Somehow this list survived the migration efforts to the Docusuaurs V2. 🤷‍♂️ 