### PR TITLE
Update props of SectionList to declare inheritance from VirtualizedList explicitly

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -178,9 +178,9 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
-### [ScrollView Props](scrollview.md#props)
+### [VirtualizedList Props](virtualizedlist.md#props)
 
-Inherits [ScrollView Props](scrollview.md#props).
+Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 


### PR DESCRIPTION
Update props inheritance

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Props of SectionList are inherits from VirtualizedSectionList -> VirtualizedList -> ScrollView.

Since VirtualizedSectionList isn't documented on website, IMO, SectionList should declare its props is inherited from VirtualizedList at least.