### PR TITLE
Update handling-text-input.md to emphasize that setText(t) does not t…

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -18,7 +18,7 @@ const PizzaTranslator = () => {
       <TextInput
         style={{height: 40}}
         placeholder="Type here to translate!"
-        onChangeText={text => setText(text)}
+        onChangeText={newText => setText(newText)}
         defaultValue={text}
       />
       <Text style={{padding: 10, fontSize: 42}}>


### PR DESCRIPTION
…ake component state for input

Very minor: Since `PizzaTranslator` has `text` as a variable in its state, I propose that the `onChangeText` callback use a different variable name to emphasize that this value is *not* derived from component state but instead is used to set it. I use `t` to avoid verbosity, but `newText` might also be appropriate.

Note: I am a React Native neophyte; if the above goes against stylistic conventions with this framework, then perhaps an explanatory note below this page's code example would suffice.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
