### PR TITLE
win/android docs: update node install to use nodejs-lts

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -8,7 +8,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 
-It is recommended to use a LTS version of Node. If you want to be able to switch between different versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
+It is recommended to use an LTS version of Node. If you want to be able to switch between different versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 
 React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using Chocolatey as well.
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -8,17 +8,17 @@ While you can use any editor of your choice to develop your app, you will need t
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 
-If you want to be able to switch between different Node versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
+It is recommended to use a LTS version of Node. If you want to be able to switch between different versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 
 React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk8/), which can be installed using Chocolatey as well.
 
 Open an Administrator Command Prompt (right click Command Prompt and select "Run as Administrator"), then run the following command:
 
 ```powershell
-choco install -y nodejs.install openjdk8
+choco install -y nodejs-lts openjdk8
 ```
 
-If you have already installed Node on your system, make sure it is Node 12 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
+If you have already installed Node on your system, make sure it is Node LTS 12 or newer. If you already have a JDK on your system, make sure it is version 8 or newer.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 


### PR DESCRIPTION
What:
Updated React Native CLI Quickstart/Windows-Android docs to use the LTS version of node during choco install, and recommended use of LTS in general, similarly to how React docs do the same.

Why:
_getting-started-windows-android.md currently lists the choco install command as:
```choco install -y nodejs.install openjdk8```
...which will install node.js version 17 (current)

While you will still be able to init an app with the react-native CLI and node.js 17, the command ```npx react-native run-android``` **_will fail_** due to the same bug affecting [facebook/create-react-app#11562](https://github.com/facebook/create-react-app/issues/11562)