### PR TITLE
[DOCS] Update flatlist.md

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -249,7 +249,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 | Type      |
 | --------- |
-| component |
+| function  |
 
 ---
 


### PR DESCRIPTION
changed the type of `ItemSeparatorComponent` from component to function, since in the given example a function was passed rather than a component, also, in my personal experience when I tried passing a component directly it broke saying it was expecting a string/class/function.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
