### PR TITLE
add styles for non-linkable sidebar entries

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -97,7 +97,7 @@ main[class^="docMainContainer"] > .container {
 
 @media (min-width: 1440px) {
   .container {
-    max-width: auto !important;
+    max-width: inherit !important;
   }
 }
 
@@ -105,6 +105,10 @@ main[class^="docMainContainer"] > .container {
   main[class^="docMainContainer"] {
     width: calc(100% - var(--doc-sidebar-width));
     display: contents;
+  }
+
+  div[class*="docItemCol"] {
+    max-width: inherit !important;
   }
 }
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -660,8 +660,8 @@ aside[class^="docSidebarContainer"] {
     @extend %scrollbar-style;
   }
 
-  .menu__list .menu__link--sublist {
-    font-size: 15px !important;
+  .menu__list .menu__link--sublist, a[class*="menuLinkText"] {
+    font-size: 16px !important;
     font-weight: 700 !important;
     padding: 5px 12px !important;
     color: var(--subtle) !important;
@@ -671,6 +671,15 @@ aside[class^="docSidebarContainer"] {
       margin-right: -6px;
       margin-top: -1px;
     }
+  }
+
+  .menu__list .menu__list .menu__link--sublist, a[class*="menuLinkText"] {
+    font-weight: 600 !important;
+    font-size: 15px !important;
+  }
+
+  .menu__list-item .menu__list-item .menu__list-item {
+    padding-left: 8px;
   }
 
   @media only screen and (max-width: 1120px) {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1542,6 +1542,9 @@ html[data-theme="dark"] .docsRating {
     }
 
     div[class^="sidebar"] {
+      margin-left: 0;
+      margin-right: -16px;
+
       h3 {
         font-size: 16px;
         margin-bottom: 0;
@@ -1568,7 +1571,7 @@ html[data-theme="dark"] .docsRating {
 
   .container .row .col.col--7 {
     --ifm-col-width: calc(15 / 24 * 100%);
-    padding: 24px 16px 24px 20px;
+    padding: 24px 16px 24px 32px;
 
     &:last-child {
       --ifm-col-width: calc(18 / 24 * 100%);


### PR DESCRIPTION
Refs: #2882

So far we were not using non-linkable grouping in the sidebar (`collapsible: false`), but this feature could be leverage for the The New Architecture guide and future website content. This also enables us to rethink the current sidebar organization, which also can benefit for those non-linkable sections.

At this moment titles of the groups looks like the regular entry, which might confuse the users, This PR adds the proper styling for those sidebar headers and also fixes the missing indentation and unintended font size overwrite at the sidebar top-level after one of the latest Docusaurs updates.

### Preview

> You can only see the indent and font size changes in here. If you want to see the non-linkable check out the preview in #2882.

<img width="279" alt="Screenshot 2021-12-16 at 13 53 56" src="https://user-images.githubusercontent.com/719641/146375755-5a6675e4-097f-4996-834a-5e847d103cb2.png">
