### PR TITLE
Add "return" details for addEventListener()

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -160,7 +160,7 @@ Received when the user is not actively interacting with the app. Useful in situa
 addEventListener(type, handler);
 ```
 
-Add a handler to AppState changes by listening to the `change` event type and providing the handler
+Add a handler to AppState changes by listening to the `change` event type.  Returns the `EventSubscription`.
 
 ---
 
@@ -170,7 +170,7 @@ Add a handler to AppState changes by listening to the `change` event type and pr
 removeEventListener(type, handler);
 ```
 
-> **Deprecated.** Use the `remove()` method on the event subscription returned by [`addEventListener()`](#addeventlistener).
+> **Deprecated.** Use the `remove()` method on the `EventSubscription` returned by [`addEventListener()`](#addeventlistener).
 
 ## Properties
 

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -157,18 +157,18 @@ Received when the user is not actively interacting with the app. Useful in situa
 ### `addEventListener()`
 
 ```jsx
-addEventListener(type, listener);
+addEventListener(eventType, listener);
 ```
 
-Sets up a function that will be called whenever the specified event type on AppState occurs.  `type` can be one of `blur`, `change`, `focus` or `memoryWarning`.
-Returns the `EventSubscription`.
+Sets up a function that will be called whenever the specified event type on AppState occurs. Valid values for `eventType` are
+[listed above](https://reactnative.dev/docs/appstate#events).  Returns the `EventSubscription`.
 
 ---
 
 ### `removeEventListener()`
 
 ```jsx
-removeEventListener(type, listener);
+removeEventListener(eventType, listener);
 ```
 
 > **Deprecated.** Use the `remove()` method on the `EventSubscription` returned by [`addEventListener()`](#addeventlistener).

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -157,17 +157,18 @@ Received when the user is not actively interacting with the app. Useful in situa
 ### `addEventListener()`
 
 ```jsx
-addEventListener(type, handler);
+addEventListener(type, listener);
 ```
 
-Add a handler to AppState changes by listening to the `change` event type.  Returns the `EventSubscription`.
+Sets up a function that will be called whenever the specified event type on AppState occurs.  `type` can be one of `blur`, `change`, `focus` or `memoryWarning`.
+Returns the `EventSubscription`.
 
 ---
 
 ### `removeEventListener()`
 
 ```jsx
-removeEventListener(type, handler);
+removeEventListener(type, listener);
 ```
 
 > **Deprecated.** Use the `remove()` method on the `EventSubscription` returned by [`addEventListener()`](#addeventlistener).

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -161,7 +161,7 @@ addEventListener(eventType, listener);
 ```
 
 Sets up a function that will be called whenever the specified event type on AppState occurs. Valid values for `eventType` are
-[listed above](https://reactnative.dev/docs/appstate#events).  Returns the `EventSubscription`.
+[listed above](#events). Returns the `EventSubscription`.
 
 ---
 


### PR DESCRIPTION
There was no description of the return value from `addEventListener()`.

There currently does not seem to be documentation for [EventSubscription](https://github.com/facebook/react-native/blob/00bb2ba62d86477884484aad0cd72d3627d5f221/Libraries/vendor/emitter/EventSubscription.js#L17), which I would link to from this page if such a doc page existed.
