### PR TITLE
architecture section small tweaks

### DIFF
--- a/docs/architecture-glossary.md
+++ b/docs/architecture-glossary.md
@@ -1,5 +1,5 @@
 ---
-id: glossary
+id: architecture-glossary
 title: Glossary
 ---
 
@@ -9,7 +9,7 @@ React Native executes the same React framework code as React for the web. Howeve
 
 ## Host platform
 
-The platform embedding React Native (e.g., Android, iOS, Windows, macOS).
+The platform embedding React Native (e.g., Android, iOS, macOS, Windows).
 
 ## Host View Tree (and Host View)
 

--- a/docs/fabric-renderer.md
+++ b/docs/fabric-renderer.md
@@ -3,15 +3,15 @@ id: fabric-renderer
 title: Fabric
 ---
 
-Fabric is React Native's new rendering system, a conceptual evolution of the legacy render system. The core principles are to unify more render logic in C++, improve interoperability with [host platforms](glossary#host-platform), and to unlock new capabilities for React Native. Development began in 2018 and in 2021, React Native in the Facebook app is backed by the new renderer.
+Fabric is React Native's new rendering system, a conceptual evolution of the legacy render system. The core principles are to unify more render logic in C++, improve interoperability with [host platforms](architecture-glossary#host-platform), and to unlock new capabilities for React Native. Development began in 2018 and in 2021, React Native in the Facebook app is backed by the new renderer.
 
-This documentation provides an overview of the [new renderer](glossary#fabric-render) and its concepts. It avoids platform specifics and doesn’t contain any code snippets or pointers. This documentation covers key concepts, motivation, benefits, and an overview of the render pipeline in different scenarios.
+This documentation provides an overview of the [new renderer](architecture-glossary#fabric-render) and its concepts. It avoids platform specifics and doesn’t contain any code snippets or pointers. This documentation covers key concepts, motivation, benefits, and an overview of the render pipeline in different scenarios.
 
 ## Motivations and Benefits of the new renderer
 
 The render architecture was created to unlock better user experiences that weren’t possible with the legacy architecture. Some examples include:
 
-- With improved interoperablity between [host views](glossary#host-view-tree-and-host-view) and React views, the renderer is able to to measure and render React surfaces synchronously. In the legacy architecture, React Native layout was asynchronous which led to a layout “jump” issue when embedding a React Native rendered view in a _host view_.
+- With improved interoperablity between [host views](architecture-glossary#host-view-tree-and-host-view) and React views, the renderer is able to to measure and render React surfaces synchronously. In the legacy architecture, React Native layout was asynchronous which led to a layout “jump” issue when embedding a React Native rendered view in a _host view_.
 - With support of multi-priority and synchronous events, the renderer can prioritize certain user interactions to ensure they are handled in a timely manner.
 - [Integration with React Suspense](https://reactjs.org/blog/2019/11/06/building-great-user-experiences-with-concurrent-mode-and-suspense.html) which allows for more intuitive design of data fetching in React apps.
 - Enable React [Concurrent Features](https://github.com/reactwg/react-18/discussions/4) on React Native.
@@ -19,10 +19,10 @@ The render architecture was created to unlock better user experiences that weren
 
 The new architecture also provides benefits in code quality, performance, and extensibility:
 
-- **Type safety:** code generation to ensure type safety across the JS and [host platforms](glossary#host-platform). The code generation uses JavaScript component declarations as source of truth to generate C++ structs to hold the props. Mis-match between JavaScript and host component props triggers a build error.
+- **Type safety:** code generation to ensure type safety across the JS and [host platforms](architecture-glossary#host-platform). The code generation uses JavaScript component declarations as source of truth to generate C++ structs to hold the props. Mismatch between JavaScript and host component props triggers a build error.
 - **Shared C++ core**: the renderer is implemented in C++ and the core is shared among platforms. This increases consistency and makes it easier to adopt React Native on new platforms.
 - **Better Host Platform Interoperability**: Synchronous and thread-safe layout calculation improves user experiences when embedding host components into React Native, which means easier integration with host platform frameworks that require synchronous APIs.
 - **Improved Performance**: With the new cross-platform implementation of the renderer system, every platform benefits from performance improvements that may have been motivated by limitations of one platform. For example, view flattening was originally a performance solution for Android and is now provided by default on both Android and iOS.
 - **Consistency**: The new render system is cross-platform, it is easier to keep consistency among different platforms.
 - **Faster Startup**: Host components are lazily initialized by default.
-- **Less serialization of data between JS and host platform**: React used to transfer data between JavaScript and _host platform_ as serialized JSON. The new renderer improves the transfer of data by accessing JavaScript values directly using [JavaScript Interfaces (JSI)](glossary#javascript-interfaces-jsi).
+- **Less serialization of data between JS and host platform**: React used to transfer data between JavaScript and _host platform_ as serialized JSON. The new renderer improves the transfer of data by accessing JavaScript values directly using [JavaScript Interfaces (JSI)](architecture-glossary#javascript-interfaces-jsi).

--- a/docs/render-pipeline.md
+++ b/docs/render-pipeline.md
@@ -5,13 +5,13 @@ title: Render, Commit, and Mount
 
 > This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
 
-The React Native renderer goes through a sequence of work to render React logic to a [host platform](glossary#host-platform). This sequence of work is called the render pipeline and occurs for initial renders and updates to the UI state. This document goes over the render pipeline and how it differs in those scenarios.
+The React Native renderer goes through a sequence of work to render React logic to a [host platform](architecture-glossary#host-platform). This sequence of work is called the render pipeline and occurs for initial renders and updates to the UI state. This document goes over the render pipeline and how it differs in those scenarios.
 
 The render pipeline can be broken into three general phases:
 
-1. **Render:** React executes product logic which creates a [React Element Trees](glossary#react-element-tree-and-react-element) in JavaScript. From this tree, the renderer creates a [React Shadow Tree](glossary#react-shadow-tree-and-react-shadow-node) in C++.
+1. **Render:** React executes product logic which creates a [React Element Trees](architecture-glossary#react-element-tree-and-react-element) in JavaScript. From this tree, the renderer creates a [React Shadow Tree](architecture-glossary#react-shadow-tree-and-react-shadow-node) in C++.
 2. **Commit**: After a React Shadow Tree is fully created, the renderer triggers a commit. This **promotes** both the React Element Tree and the newly created React Shadow Tree as the “next tree” to be mounted. This also schedules calculation of its layout information.
-3. **Mount:** The React Shadow Tree, now with the results of layout calculation, is transformed into a [Host View Tree](glossary#host-view-tree-and-host-view).
+3. **Mount:** The React Shadow Tree, now with the results of layout calculation, is transformed into a [Host View Tree](architecture-glossary#host-view-tree-and-host-view).
 
 > The phases of the render pipeline may occur on different threads. Refer to the [Threading Model](threading-model) doc for more detail.
 
@@ -41,11 +41,11 @@ function MyComponent() {
 // <MyComponent />
 ```
 
-In the example above, `<MyComponent />` is a [React Element](glossary#react-element-tree-and-react-element). React recursively reduces this _React Element_ to a terminal [React Host Component](glossary#host-view-tree-and-host-view) by invoking it (or its `render` method if implemented with a JavaScript class) until every _React Element_ cannot be reduced any further. Now you have a _React Element Tree_ of [React Host Components](glossary#react-host-components-or-host-components).
+In the example above, `<MyComponent />` is a [React Element](architecture-glossary#react-element-tree-and-react-element). React recursively reduces this _React Element_ to a terminal [React Host Component](architecture-glossary#host-view-tree-and-host-view) by invoking it (or its `render` method if implemented with a JavaScript class) until every _React Element_ cannot be reduced any further. Now you have a _React Element Tree_ of [React Host Components](architecture-glossary#react-host-components-or-host-components).
 
 ![Phase one: render](/docs/assets/Architecture/renderer-pipeline/phase-one-render.png)
 
-During this process of element reduction, as each _React Element_ is invoked, the renderer also synchronously creates a [React Shadow Node](glossary#react-shadow-tree-and-react-shadow-node). This happens only for _React Host Components_, not for [React Composite Components](glossary#react-composite-components). In the example above, the `<View>` leads to the creation of a `ViewShadowNode` object, and the
+During this process of element reduction, as each _React Element_ is invoked, the renderer also synchronously creates a [React Shadow Node](architecture-glossary#react-shadow-tree-and-react-shadow-node). This happens only for _React Host Components_, not for [React Composite Components](architecture-glossary#react-composite-components). In the example above, the `<View>` leads to the creation of a `ViewShadowNode` object, and the
 `<Text>` leads to the creation of a `TextShadowNode` object. Notably, there is never a _React Shadow Node_ that directly represents `<MyComponent>`.
 
 Whenever React creates a parent-child relationship between two _React Element Nodes_, the renderer creates the same relationship between the corresponding _React Shadow Nodes_. This is how the _React Shadow Tree_ is assembled.
@@ -87,7 +87,7 @@ The mount phase transforms the _React Shadow Tree_ (which now contains data from
 </View>
 ```
 
-At a high level, React Native renderer creates a corresponding [Host View](glossary#host-view-tree-and-host-view) for each _React Shadow Node_ and mounts it on screen. In the example above, the renderer creates an instance of `android.view.ViewGroup` for the `<View>` and `android.widget.TextView` for `<Text>` and populates it with “Hello World”. Similarly for iOS a `UIView` is created with and text is populated with a call to `NSLayoutManager`. Each host view is then configured to use props from its React Shadow Node, and its size and position is configured using the calculated layout information.
+At a high level, React Native renderer creates a corresponding [Host View](architecture-glossary#host-view-tree-and-host-view) for each _React Shadow Node_ and mounts it on screen. In the example above, the renderer creates an instance of `android.view.ViewGroup` for the `<View>` and `android.widget.TextView` for `<Text>` and populates it with “Hello World”. Similarly for iOS a `UIView` is created with and text is populated with a call to `NSLayoutManager`. Each host view is then configured to use props from its React Shadow Node, and its size and position is configured using the calculated layout information.
 
 ![Step two](/docs/assets/Architecture/renderer-pipeline/render-pipeline-3.png)
 

--- a/docs/view-flattening.md
+++ b/docs/view-flattening.md
@@ -7,7 +7,7 @@ title: View Flattening
 
 #### View Flattening is an optimization by the React Native renderer to avoid deep layout trees.
 
-The React API is designed to be declarative and reusable through composition. This provides a great model for intuitive development. However, in implementation, these qualities of the API lead to the creation of deep [React Element Trees](glossary#react-element-tree-and-react-element), where a large majority of React Element Nodes only affect the layout of a View and don’t render anything on the screen. We call these types of nodes **“Layout-Only”** Nodes.
+The React API is designed to be declarative and reusable through composition. This provides a great model for intuitive development. However, in implementation, these qualities of the API lead to the creation of deep [React Element Trees](architecture-glossary#react-element-tree-and-react-element), where a large majority of React Element Nodes only affect the layout of a View and don’t render anything on the screen. We call these types of nodes **“Layout-Only”** Nodes.
 
 Conceptually, each of the Nodes of the React Element Tree have a 1:1 relationship with a view on the screen, therefore rendering a deep React Element Tree that is composed by a large amount of “Layout-Only” Node leads to poor performance during rendering.
 
@@ -36,7 +36,7 @@ As part of the render process, React Native will produce the following trees:
 
 Note that the Views (2) and (3) are “Layout Only” views, because they are rendered on the screen but they only render a `margin` of `10 px` on top of their children.
 
-To improve the performance of these types of React Element Trees, the renderer implements a View Flattening mechanism that merges or flattens these types of Nodes, reducing the depth of the [host view](glossary#host-view-tree-and-host-view) hierarchy that is rendered on the screen. This algorithm takes into consideration props like: `margin`, `padding`, `backgroundColor`, `opacity`, etc.
+To improve the performance of these types of React Element Trees, the renderer implements a View Flattening mechanism that merges or flattens these types of Nodes, reducing the depth of the [host view](architecture-glossary#host-view-tree-and-host-view) hierarchy that is rendered on the screen. This algorithm takes into consideration props like: `margin`, `padding`, `backgroundColor`, `opacity`, etc.
 
 The View Flattening algorithm is integrated by design as part of the diffing stage of the renderer, which means that we don’t use extra CPU cycles to optimize the React Element Tree flattening these types of views. As the rest of the core, the View flattening algorithm is implemented in C++ and its benefits are shared by default on all supported platforms.
 

--- a/docs/xplat-implementation.md
+++ b/docs/xplat-implementation.md
@@ -11,7 +11,7 @@ In the previous render system of React Native, the **[React Shadow Tree](glossar
 
 <!--TODO: Does the below paragraph makes sense to keep?-->
 
-The React Native team intends to incorporate an animation system into the render system and also extend the React Native render system to new platforms such as Windows, PlayStation, and more.
+The React Native team intends to incorporate an animation system into the render system and also extend the React Native render system to new platforms such as Windows, and operating systems in game consoles, televisions, and more.
 
 Leveraging C++ for the core render system introduces several advantages. A single implementation reduces the cost of development and maintenance. It improves the performance of creating React Shadow Trees and layout calculation because the overhead of integrating [Yoga](glossary#yoga-tree-and-yoga-node) with the renderer is minimized on Android (i.e. no more [JNI](glossary#java-native-interface-jni) for Yoga). Finally, the memory footprint of each React Shadow Node is smaller in C++ than it would be if allocated from Kotlin or Swift.
 

--- a/docs/xplat-implementation.md
+++ b/docs/xplat-implementation.md
@@ -7,17 +7,17 @@ title: Cross Platform Implementation
 
 #### The React Native renderer utilizes a core render implementation to be shared across platforms
 
-In the previous render system of React Native, the **[React Shadow Tree](glossary#react-shadow-tree-and-react-shadow-node)**, layout logic, and **[View Flattening](view-flattening.md)** algorithm were implemented once for each platform. The current renderer was designed to be a cross-platform solution by sharing a core C++ implementation.
+In the previous render system of React Native, the **[React Shadow Tree](architecture-glossary#react-shadow-tree-and-react-shadow-node)**, layout logic, and **[View Flattening](view-flattening.md)** algorithm were implemented once for each platform. The current renderer was designed to be a cross-platform solution by sharing a core C++ implementation.
 
 <!--TODO: Does the below paragraph makes sense to keep?-->
 
 The React Native team intends to incorporate an animation system into the render system and also extend the React Native render system to new platforms such as Windows, and operating systems in game consoles, televisions, and more.
 
-Leveraging C++ for the core render system introduces several advantages. A single implementation reduces the cost of development and maintenance. It improves the performance of creating React Shadow Trees and layout calculation because the overhead of integrating [Yoga](glossary#yoga-tree-and-yoga-node) with the renderer is minimized on Android (i.e. no more [JNI](glossary#java-native-interface-jni) for Yoga). Finally, the memory footprint of each React Shadow Node is smaller in C++ than it would be if allocated from Kotlin or Swift.
+Leveraging C++ for the core render system introduces several advantages. A single implementation reduces the cost of development and maintenance. It improves the performance of creating React Shadow Trees and layout calculation because the overhead of integrating [Yoga](architecture-glossary#yoga-tree-and-yoga-node) with the renderer is minimized on Android (i.e. no more [JNI](architecture-glossary#java-native-interface-jni) for Yoga). Finally, the memory footprint of each React Shadow Node is smaller in C++ than it would be if allocated from Kotlin or Swift.
 
 The team is also leveraging C++ features that enforce immutability to ensure there are no issues related to concurrent access to shared but not protected resources.
 
-It is important to recognize that the renderer use case for Android still incurs the cost of [JNI](glossary#java-native-interface-jni) for two primary use cases:
+It is important to recognize that the renderer use case for Android still incurs the cost of [JNI](architecture-glossary#java-native-interface-jni) for two primary use cases:
 
 - Layout calculation of complex views (e.g. `Text`, `TextInput`, etc.) requires sending props over JNI.
 - The mount phase requires sending mutation operations over JNI.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -168,12 +168,12 @@
       "type": "category",
       "label": "Architecture",
       "collapsed": false,
-      "collapsible": false,
       "items": [
         "architecture-overview",
         {
           "type": "category",
           "label": "Rendering",
+          "collapsible": false,
           "collapsed": false,
           "items": [
             "fabric-renderer",
@@ -183,7 +183,7 @@
             "threading-model"
           ]
         },
-        "glossary"
+        "architecture-glossary"
       ]
     }
   ]

--- a/website/versioned_docs/version-0.66/architecture-glossary.md
+++ b/website/versioned_docs/version-0.66/architecture-glossary.md
@@ -1,5 +1,5 @@
 ---
-id: glossary
+id: architecture-glossary
 title: Glossary
 ---
 
@@ -9,7 +9,7 @@ React Native executes the same React framework code as React for the web. Howeve
 
 ## Host platform
 
-The platform embedding React Native (e.g., Android, iOS, Windows, macOS).
+The platform embedding React Native (e.g., Android, iOS, macOS, Windows).
 
 ## Host View Tree (and Host View)
 

--- a/website/versioned_docs/version-0.66/fabric-renderer.md
+++ b/website/versioned_docs/version-0.66/fabric-renderer.md
@@ -3,15 +3,15 @@ id: fabric-renderer
 title: Fabric
 ---
 
-Fabric is React Native's new rendering system, a conceptual evolution of the legacy render system. The core principles are to unify more render logic in C++, improve interoperability with [host platforms](glossary#host-platform), and to unlock new capabilities for React Native. Development began in 2018 and in 2021, React Native in the Facebook app is backed by the new renderer.
+Fabric is React Native's new rendering system, a conceptual evolution of the legacy render system. The core principles are to unify more render logic in C++, improve interoperability with [host platforms](architecture-glossary#host-platform), and to unlock new capabilities for React Native. Development began in 2018 and in 2021, React Native in the Facebook app is backed by the new renderer.
 
-This documentation provides an overview of the [new renderer](glossary#fabric-render) and its concepts. It avoids platform specifics and doesn’t contain any code snippets or pointers. This documentation covers key concepts, motivation, benefits, and an overview of the render pipeline in different scenarios.
+This documentation provides an overview of the [new renderer](architecture-glossary#fabric-render) and its concepts. It avoids platform specifics and doesn’t contain any code snippets or pointers. This documentation covers key concepts, motivation, benefits, and an overview of the render pipeline in different scenarios.
 
 ## Motivations and Benefits of the new renderer
 
 The render architecture was created to unlock better user experiences that weren’t possible with the legacy architecture. Some examples include:
 
-- With improved interoperablity between [host views](glossary#host-view-tree-and-host-view) and React views, the renderer is able to to measure and render React surfaces synchronously. In the legacy architecture, React Native layout was asynchronous which led to a layout “jump” issue when embedding a React Native rendered view in a _host view_.
+- With improved interoperablity between [host views](architecture-glossary#host-view-tree-and-host-view) and React views, the renderer is able to to measure and render React surfaces synchronously. In the legacy architecture, React Native layout was asynchronous which led to a layout “jump” issue when embedding a React Native rendered view in a _host view_.
 - With support of multi-priority and synchronous events, the renderer can prioritize certain user interactions to ensure they are handled in a timely manner.
 - [Integration with React Suspense](https://reactjs.org/blog/2019/11/06/building-great-user-experiences-with-concurrent-mode-and-suspense.html) which allows for more intuitive design of data fetching in React apps.
 - Enable React [Concurrent Features](https://github.com/reactwg/react-18/discussions/4) on React Native.
@@ -19,10 +19,10 @@ The render architecture was created to unlock better user experiences that weren
 
 The new architecture also provides benefits in code quality, performance, and extensibility:
 
-- **Type safety:** code generation to ensure type safety across the JS and [host platforms](glossary#host-platform). The code generation uses JavaScript component declarations as source of truth to generate C++ structs to hold the props. Mis-match between JavaScript and host component props triggers a build error.
+- **Type safety:** code generation to ensure type safety across the JS and [host platforms](architecture-glossary#host-platform). The code generation uses JavaScript component declarations as source of truth to generate C++ structs to hold the props. Mis-match between JavaScript and host component props triggers a build error.
 - **Shared C++ core**: the renderer is implemented in C++ and the core is shared among platforms. This increases consistency and makes it easier to adopt React Native on new platforms.
 - **Better Host Platform Interoperability**: Synchronous and thread-safe layout calculation improves user experiences when embedding host components into React Native, which means easier integration with host platform frameworks that require synchronous APIs.
 - **Improved Performance**: With the new cross-platform implementation of the renderer system, every platform benefits from performance improvements that may have been motivated by limitations of one platform. For example, view flattening was originally a performance solution for Android and is now provided by default on both Android and iOS.
 - **Consistency**: The new render system is cross-platform, it is easier to keep consistency among different platforms.
 - **Faster Startup**: Host components are lazily initialized by default.
-- **Less serialization of data between JS and host platform**: React used to transfer data between JavaScript and _host platform_ as serialized JSON. The new renderer improves the transfer of data by accessing JavaScript values directly using [JavaScript Interfaces (JSI)](glossary#javascript-interfaces-jsi).
+- **Less serialization of data between JS and host platform**: React used to transfer data between JavaScript and _host platform_ as serialized JSON. The new renderer improves the transfer of data by accessing JavaScript values directly using [JavaScript Interfaces (JSI)](architecture-glossary#javascript-interfaces-jsi).

--- a/website/versioned_docs/version-0.66/render-pipeline.md
+++ b/website/versioned_docs/version-0.66/render-pipeline.md
@@ -5,13 +5,13 @@ title: Render, Commit, and Mount
 
 > This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
 
-The React Native renderer goes through a sequence of work to render React logic to a [host platform](glossary#host-platform). This sequence of work is called the render pipeline and occurs for initial renders and updates to the UI state. This document goes over the render pipeline and how it differs in those scenarios.
+The React Native renderer goes through a sequence of work to render React logic to a [host platform](architecture-glossary#host-platform). This sequence of work is called the render pipeline and occurs for initial renders and updates to the UI state. This document goes over the render pipeline and how it differs in those scenarios.
 
 The render pipeline can be broken into three general phases:
 
-1. **Render:** React executes product logic which creates a [React Element Trees](glossary#react-element-tree-and-react-element) in JavaScript. From this tree, the renderer creates a [React Shadow Tree](glossary#react-shadow-tree-and-react-shadow-node) in C++.
+1. **Render:** React executes product logic which creates a [React Element Trees](architecture-glossary#react-element-tree-and-react-element) in JavaScript. From this tree, the renderer creates a [React Shadow Tree](architecture-glossary#react-shadow-tree-and-react-shadow-node) in C++.
 2. **Commit**: After a React Shadow Tree is fully created, the renderer triggers a commit. This **promotes** both the React Element Tree and the newly created React Shadow Tree as the “next tree” to be mounted. This also schedules calculation of its layout information.
-3. **Mount:** The React Shadow Tree, now with the results of layout calculation, is transformed into a [Host View Tree](glossary#host-view-tree-and-host-view).
+3. **Mount:** The React Shadow Tree, now with the results of layout calculation, is transformed into a [Host View Tree](architecture-glossary#host-view-tree-and-host-view).
 
 > The phases of the render pipeline may occur on different threads. Refer to the [Threading Model](threading-model) doc for more detail.
 
@@ -41,11 +41,11 @@ function MyComponent() {
 // <MyComponent />
 ```
 
-In the example above, `<MyComponent />` is a [React Element](glossary#react-element-tree-and-react-element). React recursively reduces this _React Element_ to a terminal [React Host Component](glossary#host-view-tree-and-host-view) by invoking it (or its `render` method if implemented with a JavaScript class) until every _React Element_ cannot be reduced any further. Now you have a _React Element Tree_ of [React Host Components](glossary#react-host-components-or-host-components).
+In the example above, `<MyComponent />` is a [React Element](architecture-glossary#react-element-tree-and-react-element). React recursively reduces this _React Element_ to a terminal [React Host Component](architecture-glossary#host-view-tree-and-host-view) by invoking it (or its `render` method if implemented with a JavaScript class) until every _React Element_ cannot be reduced any further. Now you have a _React Element Tree_ of [React Host Components](architecture-glossary#react-host-components-or-host-components).
 
 ![Phase one: render](/docs/assets/Architecture/renderer-pipeline/phase-one-render.png)
 
-During this process of element reduction, as each _React Element_ is invoked, the renderer also synchronously creates a [React Shadow Node](glossary#react-shadow-tree-and-react-shadow-node). This happens only for _React Host Components_, not for [React Composite Components](glossary#react-composite-components). In the example above, the `<View>` leads to the creation of a `ViewShadowNode` object, and the
+During this process of element reduction, as each _React Element_ is invoked, the renderer also synchronously creates a [React Shadow Node](architecture-glossary#react-shadow-tree-and-react-shadow-node). This happens only for _React Host Components_, not for [React Composite Components](architecture-glossary#react-composite-components). In the example above, the `<View>` leads to the creation of a `ViewShadowNode` object, and the
 `<Text>` leads to the creation of a `TextShadowNode` object. Notably, there is never a _React Shadow Node_ that directly represents `<MyComponent>`.
 
 Whenever React creates a parent-child relationship between two _React Element Nodes_, the renderer creates the same relationship between the corresponding _React Shadow Nodes_. This is how the _React Shadow Tree_ is assembled.
@@ -87,7 +87,7 @@ The mount phase transforms the _React Shadow Tree_ (which now contains data from
 </View>
 ```
 
-At a high level, React Native renderer creates a corresponding [Host View](glossary#host-view-tree-and-host-view) for each _React Shadow Node_ and mounts it on screen. In the example above, the renderer creates an instance of `android.view.ViewGroup` for the `<View>` and `android.widget.TextView` for `<Text>` and populates it with “Hello World”. Similarly for iOS a `UIView` is created with and text is populated with a call to `NSLayoutManager`. Each host view is then configured to use props from its React Shadow Node, and its size and position is configured using the calculated layout information.
+At a high level, React Native renderer creates a corresponding [Host View](architecture-glossary#host-view-tree-and-host-view) for each _React Shadow Node_ and mounts it on screen. In the example above, the renderer creates an instance of `android.view.ViewGroup` for the `<View>` and `android.widget.TextView` for `<Text>` and populates it with “Hello World”. Similarly for iOS a `UIView` is created with and text is populated with a call to `NSLayoutManager`. Each host view is then configured to use props from its React Shadow Node, and its size and position is configured using the calculated layout information.
 
 ![Step two](/docs/assets/Architecture/renderer-pipeline/render-pipeline-3.png)
 

--- a/website/versioned_docs/version-0.66/view-flattening.md
+++ b/website/versioned_docs/version-0.66/view-flattening.md
@@ -7,7 +7,7 @@ title: View Flattening
 
 #### View Flattening is an optimization by the React Native renderer to avoid deep layout trees.
 
-The React API is designed to be declarative and reusable through composition. This provides a great model for intuitive development. However, in implementation, these qualities of the API lead to the creation of deep [React Element Trees](glossary#react-element-tree-and-react-element), where a large majority of React Element Nodes only affect the layout of a View and don’t render anything on the screen. We call these types of nodes **“Layout-Only”** Nodes.
+The React API is designed to be declarative and reusable through composition. This provides a great model for intuitive development. However, in implementation, these qualities of the API lead to the creation of deep [React Element Trees](architecture-glossary#react-element-tree-and-react-element), where a large majority of React Element Nodes only affect the layout of a View and don’t render anything on the screen. We call these types of nodes **“Layout-Only”** Nodes.
 
 Conceptually, each of the Nodes of the React Element Tree have a 1:1 relationship with a view on the screen, therefore rendering a deep React Element Tree that is composed by a large amount of “Layout-Only” Node leads to poor performance during rendering.
 
@@ -36,7 +36,7 @@ As part of the render process, React Native will produce the following trees:
 
 Note that the Views (2) and (3) are “Layout Only” views, because they are rendered on the screen but they only render a `margin` of `10 px` on top of their children.
 
-To improve the performance of these types of React Element Trees, the renderer implements a View Flattening mechanism that merges or flattens these types of Nodes, reducing the depth of the [host view](glossary#host-view-tree-and-host-view) hierarchy that is rendered on the screen. This algorithm takes into consideration props like: `margin`, `padding`, `backgroundColor`, `opacity`, etc.
+To improve the performance of these types of React Element Trees, the renderer implements a View Flattening mechanism that merges or flattens these types of Nodes, reducing the depth of the [host view](architecture-glossary#host-view-tree-and-host-view) hierarchy that is rendered on the screen. This algorithm takes into consideration props like: `margin`, `padding`, `backgroundColor`, `opacity`, etc.
 
 The View Flattening algorithm is integrated by design as part of the diffing stage of the renderer, which means that we don’t use extra CPU cycles to optimize the React Element Tree flattening these types of views. As the rest of the core, the View flattening algorithm is implemented in C++ and its benefits are shared by default on all supported platforms.
 

--- a/website/versioned_docs/version-0.66/xplat-implementation.md
+++ b/website/versioned_docs/version-0.66/xplat-implementation.md
@@ -7,17 +7,17 @@ title: Cross Platform Implementation
 
 #### The React Native renderer utilizes a core render implementation to be shared across platforms
 
-In the previous render system of React Native, the **[React Shadow Tree](glossary#react-shadow-tree-and-react-shadow-node)**, layout logic, and **[View Flattening](view-flattening.md)** algorithm were implemented once for each platform. The current renderer was designed to be a cross-platform solution by sharing a core C++ implementation.
+In the previous render system of React Native, the **[React Shadow Tree](architecture-glossary#react-shadow-tree-and-react-shadow-node)**, layout logic, and **[View Flattening](view-flattening.md)** algorithm were implemented once for each platform. The current renderer was designed to be a cross-platform solution by sharing a core C++ implementation.
 
 <!--TODO: Does the below paragraph makes sense to keep?-->
 
 The React Native team intends to incorporate an animation system into the render system and also extend the React Native render system to new platforms such as Windows, PlayStation, and more.
 
-Leveraging C++ for the core render system introduces several advantages. A single implementation reduces the cost of development and maintenance. It improves the performance of creating React Shadow Trees and layout calculation because the overhead of integrating [Yoga](glossary#yoga-tree-and-yoga-node) with the renderer is minimized on Android (i.e. no more [JNI](glossary#java-native-interface-jni) for Yoga). Finally, the memory footprint of each React Shadow Node is smaller in C++ than it would be if allocated from Kotlin or Swift.
+Leveraging C++ for the core render system introduces several advantages. A single implementation reduces the cost of development and maintenance. It improves the performance of creating React Shadow Trees and layout calculation because the overhead of integrating [Yoga](architecture-glossary#yoga-tree-and-yoga-node) with the renderer is minimized on Android (i.e. no more [JNI](architecture-glossary#java-native-interface-jni) for Yoga). Finally, the memory footprint of each React Shadow Node is smaller in C++ than it would be if allocated from Kotlin or Swift.
 
 The team is also leveraging C++ features that enforce immutability to ensure there are no issues related to concurrent access to shared but not protected resources.
 
-It is important to recognize that the renderer use case for Android still incurs the cost of [JNI](glossary#java-native-interface-jni) for two primary use cases:
+It is important to recognize that the renderer use case for Android still incurs the cost of [JNI](architecture-glossary#java-native-interface-jni) for two primary use cases:
 
 - Layout calculation of complex views (e.g. `Text`, `TextInput`, etc.) requires sending props over JNI.
 - The mount phase requires sending mutation operations over JNI.

--- a/website/versioned_sidebars/version-0.66-sidebars.json
+++ b/website/versioned_sidebars/version-0.66-sidebars.json
@@ -681,7 +681,6 @@
     {
       "type": "category",
       "collapsed": false,
-      "collapsible": false,
       "label": "Architecture",
       "items": [
         {
@@ -691,7 +690,7 @@
         {
           "type": "category",
           "collapsed": false,
-          "collapsible": true,
+          "collapsible": false,
           "label": "Rendering",
           "items": [
             {
@@ -718,7 +717,7 @@
         },
         {
           "type": "doc",
-          "id": "version-0.66/glossary"
+          "id": "version-0.66/architecture-glossary"
         }
       ]
     }


### PR DESCRIPTION
The following PR introduces the following changes to the Architecture:
* rename of Architecture Glossary page to `architecture-glossary` instead of just `glossary` (this matches the convection introduced by `architecutre-overview` and there might be a second "glossary"/"appendix" when the new architecture Playbook will land). Ideally we should start to group the docs files into subfolders (v1 doesn't support this afaik, but it should not be a problem in v2.
* update the Architecture sidebar, so it structure matches the other top-level pages on the website (flipped `collapsible`)
* reorder platforms in one of the sentence to alphabetical order.

### Sidebar preview
<img width="279" alt="Screenshot 2021-12-24 at 12 04 43" src="https://user-images.githubusercontent.com/719641/147347564-6cb6ed0d-ff1f-4bbd-8f99-cd2f8d93f8a9.png">
