### PR TITLE
Added a known issue

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -911,3 +911,4 @@ Returns `true` if the input is currently focused; `false` otherwise.
 - [react-native#19096](https://github.com/facebook/react-native/issues/19096): Doesn't support Android's `onKeyPreIme`.
 - [react-native#19366](https://github.com/facebook/react-native/issues/19366): Calling .focus() after closing Android's keyboard via back button doesn't bring keyboard up again.
 - [react-native#26799](https://github.com/facebook/react-native/issues/26799): Doesn't support Android's `secureTextEntry` when `keyboardType="email-address"` or `keyboardType="phone-pad"`.
+- [react-native#19096](https://github.com/facebook/react-native/issues/24585): It renders a newly inputed letter, even if the the value remains unchanged. Afterwards it renders again and changes back to the fixed value.

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -911,4 +911,4 @@ Returns `true` if the input is currently focused; `false` otherwise.
 - [react-native#19096](https://github.com/facebook/react-native/issues/19096): Doesn't support Android's `onKeyPreIme`.
 - [react-native#19366](https://github.com/facebook/react-native/issues/19366): Calling .focus() after closing Android's keyboard via back button doesn't bring keyboard up again.
 - [react-native#26799](https://github.com/facebook/react-native/issues/26799): Doesn't support Android's `secureTextEntry` when `keyboardType="email-address"` or `keyboardType="phone-pad"`.
-- [react-native#19096](https://github.com/facebook/react-native/issues/24585): It renders a newly inputed letter, even if the the value remains unchanged. Afterwards it renders again and changes back to the fixed value.
+- [react-native#24585](https://github.com/facebook/react-native/issues/24585): It renders a newly inputed letter, even if the the value remains unchanged. Afterwards it renders again and changes back to the fixed value.


### PR DESCRIPTION
This bug is really annoying. It makes masking a textinput virtually impossible. All other established Frameworks dont have this problem.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#24585
-->
