### PR TITLE
Remove unnecessary keyword

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -24,7 +24,7 @@ import { Animated, Text, View } from 'react-native';
 const FadeInView = (props) => {
   const fadeAnim = useRef(new Animated.Value(0)).current  // Initial value for opacity: 0
 
-  React.useEffect(() => {
+  useEffect(() => {
     Animated.timing(
       fadeAnim,
       {


### PR DESCRIPTION
useEffect is already imported as itself.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
