### PR TITLE
feat: add cancelButtonTintColor props in ActionSheetIOS for change cancel tint color

### DIFF
--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -69,6 +69,7 @@ Display an iOS action sheet. The `options` object must contain one or more of:
 
 - `options` (array of strings) - a list of button titles (required)
 - `cancelButtonIndex` (int) - index of cancel button in `options`
+- `cancelButtonTintColor` (string) - the [color](colors) used for the change the text color of the cancel button
 - `destructiveButtonIndex` (int or array of ints) - indices of destructive buttons in `options`
 - `title` (string) - a title to show above the action sheet
 - `message` (string) - a message to show below the title


### PR DESCRIPTION
Reference https://github.com/facebook/react-native/pull/31972
This prop was missing in docs
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
