### PR TITLE
new-arch code formatting and small tweaks

### DIFF
--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -112,7 +112,11 @@ Hermes is an open-source JavaScript engine optimized for React Native. We highly
 
 Please [follow the instructions on the React Native website](hermes) in order to enable Hermes in your application.
 
-> iOS: If you opt out of using Hermes, you will need to replace `HermesExecutorFactory` with `JSCExecutorFactory` in any examples used throughout the rest of this playbook.
+:::caution
+
+**iOS:** If you opt out of using Hermes, you will need to replace `HermesExecutorFactory` with `JSCExecutorFactory` in any examples used throughout the rest of this playbook.
+
+:::
 
 ## iOS: Enable C++17 language feature support
 
@@ -132,13 +136,21 @@ If done correctly, your diff will show the following changes to your project fil
 CLANG_CXX_LANGUAGE_STANDARD = "c++17"
 ```
 
-> Your project should also be configured to support Folly. This should be done automatically once the library dependency is picked up, so no further changes to your project are necessary.
+:::info
+
+Your project should also be configured to support Folly. This should be done automatically once the library dependency is picked up, so no further changes to your project are necessary.
+
+:::
 
 ## iOS: Use Objective-C++ (`.mm` extension)
 
 TurboModules can be written using Objective-C or C++. In order to support both cases, any source files that include C++ code should use the `.mm` file extension. This extension corresponds to Objective-C++, a language variant that allows for the use of a combination of C++ and Objective-C in source files.
 
-> Use Xcode to rename existing files to ensure file references persist in your project. You might need to clean the build folder (_Project → Clean Build Folder_) before re-building the app. If the file is renamed outside of Xcode, you may need to click on the old `.m` file reference and Locate the new file.
+:::info
+
+Use Xcode to rename existing files to ensure file references persist in your project. You might need to clean the build folder (_Project → Clean Build Folder_) before re-building the app. If the file is renamed outside of Xcode, you may need to click on the old `.m` file reference and Locate the new file.
+
+:::
 
 ## iOS: TurboModules: Ensure your App Provides an `RCTCxxBridgeDelegate`
 

--- a/docs/new-architecture-app-modules-android.md
+++ b/docs/new-architecture-app-modules-android.md
@@ -7,7 +7,11 @@ Make sure your application meets all the [prerequisites](new-architecture-app-in
 
 ## 1. Enable NDK and the native build
 
-> NOTE: In this iteration of the playbook we’re setting up the project to let you build from source. You might notice an increase in your build time because of this. We’re looking into what would be the preferred approach here so please feel free to share your feedbacks.
+:::caution
+
+In this iteration of the playbook we’re setting up the project to let you build from source. You might notice an increase in your build time because of this. We’re looking into what would be the preferred approach here so please feel free to share your feedbacks.
+
+:::
 
 The code-gen will output some Java and some C++ code that now we need to build.
 

--- a/docs/new-architecture-app-modules-ios.md
+++ b/docs/new-architecture-app-modules-ios.md
@@ -10,8 +10,8 @@ Make sure your application meets all the [prerequisites](new-architecture-app-in
 Add the following imports at the top of your bridge delegate (e.g. `AppDelegate.mm`):
 
 ```objc
-#import<ReactCommon/RCTTurboModuleManager.h>
-#import<React/CoreModulesPlugins.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+#import <React/CoreModulesPlugins.h>
 ```
 
 You will also need to declare that your AppDelegate conforms to the `RCTTurboModuleManagerDelegate` protocol, as well as create an instance variable for our Turbo Module manager:
@@ -34,9 +34,7 @@ To conform to the `RCTTurboModuleManagerDelegate` protocol, you will implement t
 
 Take note of `getModuleInstanceFromClass:` in the following example, as it includes some necessary instantiation of several core modules that you will need to include in your application. Eventually, this may not be required.
 
-```objc
-// AppDelegate.mm
-
+```objc title='AppDelegate.mm'
 // ...
 
 #import <React/RCTDataRequestHandler.h>
@@ -60,9 +58,9 @@ Take note of `getModuleInstanceFromClass:` in the following example, as it inclu
   return RCTCoreModulesClassProvider(name);
 }
 
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
-                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
-{
+- (std::shared_ptr<facebook::react::TurboModule>)
+    getTurboModule:(const std::string &)name
+         jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker {
   return nullptr;
 }
 
@@ -78,13 +76,15 @@ Take note of `getModuleInstanceFromClass:` in the following example, as it inclu
           return @ [[RCTGIFImageDecoder new]];
         }];
   } else if (moduleClass == RCTNetworking.class) {
-    return [[moduleClass alloc] initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry * moduleRegistry) {
-      return @[
-        [RCTHTTPRequestHandler new],
-        [RCTDataRequestHandler new],
-        [RCTFileRequestHandler new],
-      ];
-    }];
+     return [[moduleClass alloc]
+        initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(
+            RCTModuleRegistry *moduleRegistry) {
+          return @[
+            [RCTHTTPRequestHandler new],
+            [RCTDataRequestHandler new],
+            [RCTFileRequestHandler new],
+          ];
+        }];
   }
   // No custom initializer here.
   return [moduleClass new];
@@ -102,9 +102,10 @@ Next, you will create a `RCTTurboModuleManager` in your bridge delegate’s `jsE
 {
   // Add these lines to create a TurboModuleManager
   if (RCTTurboModuleEnabled()) {
-    _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                                               delegate:self
-                                                              jsInvoker:bridge.jsCallInvoker];
+    _turboModuleManager =
+        [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                             delegate:self
+                                            jsInvoker:bridge.jsCallInvoker];
 
     // Necessary to allow NativeModules to lookup TurboModules
     [bridge setRCTTurboModuleRegistry:_turboModuleManager];

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -116,15 +116,15 @@ First, make sure you followed the instructions to [Enabling the New Renderer (Fa
 1. Make sure your other JS changes are ready to go by following Preparing your JavaScript codebase for the new React Native Renderer (Fabric)
 2. Replace the call to `requireNativeComponent` with `codegenNativeComponent`. This tells the JS codegen to start generating the native implementation of the component, consisting of C++ and Java classes. This is how it looks for the WebView component:
 
-```javascript
+```ts
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 // babel-plugin-codegen will replace the function call to use NativeComponentRegistry
 // 'RCTWebView' is interopped by RCTFabricComponentsPlugins
 
-export default (codegenNativeComponent <
-  NativeProps >
-  'RCTWebView': HostComponent<NativeProps>);
+export default (codegenNativeComponent<NativeProps>(
+  'RCTWebView',
+): HostComponent<NativeProps>);
 ```
 
 4. **[Flow users]** Make sure your native component has Flow types for its props, since the JS codegen uses these types to generate the type-safe native implementation of the component. The codegen generates C++ classes during the build time, which guarantees that the native implementation is always up-to-date with its JS interface. Use [these c++ compatible types](https://github.com/facebook/react-native/blob/main/Libraries/Types/CodegenTypes.js#L28-L30).

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -14,47 +14,49 @@ Once you located it, you need to add the `getJSIModulePackage` method as from th
 ```java
 public class MyApplication extends Application implements ReactApplication {
 
-    private final ReactNativeHost mReactNativeHost =
-            new ReactNativeHost(this) {
+  private final ReactNativeHost mReactNativeHost =
+    new ReactNativeHost(this) {
 
-                // Add those lines:
-                @Nullable
-                @Override
-                protected JSIModulePackage getJSIModulePackage() {
-                    return new JSIModulePackage() {
-                        @Override
-                        public List<JSIModuleSpec> getJSIModules(
-                                final ReactApplicationContext reactApplicationContext,
-                                final JavaScriptContextHolder jsContext) {
-                            final List<JSIModuleSpec> specs = new ArrayList<>();
-                            specs.add(new JSIModuleSpec() {
-                                @Override
-                                public JSIModuleType getJSIModuleType() {
-                                    return JSIModuleType.UIManager;
-                                }
+      // Add those lines:
+      @Nullable
+      @Override
+      protected JSIModulePackage getJSIModulePackage() {
+        return new JSIModulePackage() {
+          @Override
+          public List<JSIModuleSpec> getJSIModules(
+              final ReactApplicationContext reactApplicationContext,
+              final JavaScriptContextHolder jsContext) {
+            final List<JSIModuleSpec> specs = new ArrayList<>();
+            specs.add(new JSIModuleSpec() {
+              @Override
+              public JSIModuleType getJSIModuleType() {
+                return JSIModuleType.UIManager;
+              }
 
-                                @Override
-                                public JSIModuleProvider<UIManager> getJSIModuleProvider() {
-                                    final ComponentFactory componentFactory = new ComponentFactory();
-                                    CoreComponentsRegistry.register(componentFactory);
-                                    final ReactInstanceManager reactInstanceManager = getReactInstanceManager();
+              @Override
+              public JSIModuleProvider<UIManager> getJSIModuleProvider() {
+                final ComponentFactory componentFactory = new ComponentFactory();
+                CoreComponentsRegistry.register(componentFactory);
+                final ReactInstanceManager reactInstanceManager = getReactInstanceManager();
 
-                                    ViewManagerRegistry viewManagerRegistry =
-                                            new ViewManagerRegistry(
-                                                    reactInstanceManager.getOrCreateViewManagers(
-                                                            reactApplicationContext));
+                ViewManagerRegistry viewManagerRegistry =
+                    new ViewManagerRegistry(
+                        reactInstanceManager.getOrCreateViewManagers(
+                            reactApplicationContext));
 
-                                    return new FabricJSIModuleProvider(
-                                            reactApplicationContext,
-                                            componentFactory,
-                                            new EmptyReactNativeConfig(),
-                                            viewManagerRegistry);
-                                }
-                            });
-                            return specs;
-                        }
-                    };
-                }
+                return new FabricJSIModuleProvider(
+                    reactApplicationContext,
+                    componentFactory,
+                    new EmptyReactNativeConfig(),
+                    viewManagerRegistry);
+              }
+            });
+            return specs;
+          }
+        };
+      }
+    };
+}
 ```
 
 ## 2. Make sure your call `setIsFabric` on your Activity’s `ReactRootView`
@@ -116,16 +118,18 @@ First, make sure you followed the instructions to [Enabling the New Renderer (Fa
 
 ```javascript
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
 // babel-plugin-codegen will replace the function call to use NativeComponentRegistry
 // 'RCTWebView' is interopped by RCTFabricComponentsPlugins
+
 export default (codegenNativeComponent<NativeProps>(
-  'RCTWebView',
+  'RCTWebView'
 ): HostComponent<NativeProps>);
 ```
 
 4. **[Flow users]** Make sure your native component has Flow types for its props, since the JS codegen uses these types to generate the type-safe native implementation of the component. The codegen generates C++ classes during the build time, which guarantees that the native implementation is always up-to-date with its JS interface. Use [these c++ compatible types](https://github.com/facebook/react-native/blob/main/Libraries/Types/CodegenTypes.js#L28-L30).
 
-```javascript title="RNTMyNativeViewNativeComponent.js"
+```ts title="RNTMyNativeViewNativeComponent.js"
 import type {Int32} from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type {HostComponent} from 'react-native';
@@ -134,9 +138,9 @@ import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTyp
 type NativeProps = $ReadOnly<{|
   ...ViewProps, // This is required.
   someNumber: Int32,
-  |}>;
+|}>;
 
-...
+[...]
 
 export default (codegenNativeComponent<NativeProps>(
   'RNTMyNativeView',
@@ -153,7 +157,7 @@ Specifically you will have to implement the generated **ViewManagerInterface** a
 Your ViewManager could follow this structure. The MyNativeView class in this example is an Android View implementation (like a subclass of LinearLayout, Button, TextView, etc.)
 
 ```java
-/** View manager for MyNativeView components. */
+// View manager for MyNativeView components.
 @ReactModule(name = MyNativeViewManager.REACT_CLASS)
 public class MyNativeViewManager extends SimpleViewManager<MyNativeView>
         implements RNTMyNativeViewManagerInterface<MyNativeView> {
@@ -222,6 +226,8 @@ public class MyApplication extends Application implements ReactApplication {
       });
       return packages;
     }
+  };
+}
 ```
 
 3. **Add a Fabric Component Registry**
@@ -240,24 +246,24 @@ import com.facebook.soloader.SoLoader;
 
 @DoNotStrip
 public class MyComponentsRegistry {
-	static {
-		SoLoader.loadLibrary("fabricjni");
-	}
+  static {
+    SoLoader.loadLibrary("fabricjni");
+  }
 
-	@DoNotStrip private final HybridData mHybridData;
+  @DoNotStrip private final HybridData mHybridData;
 
-	@DoNotStrip
-	private native HybridData initHybrid(ComponentFactory componentFactory);
+  @DoNotStrip
+  private native HybridData initHybrid(ComponentFactory componentFactory);
 
-	@DoNotStrip
-	private MyComponentsRegistry(ComponentFactory componentFactory) {
-		mHybridData = initHybrid(componentFactory);
-	}
+  @DoNotStrip
+  private MyComponentsRegistry(ComponentFactory componentFactory) {
+    mHybridData = initHybrid(componentFactory);
+  }
 
-	@DoNotStrip
-	public static MyComponentsRegistry register(ComponentFactory componentFactory) {
-		return new MyComponentsRegistry(componentFactory);
-	}
+  @DoNotStrip
+  public static MyComponentsRegistry register(ComponentFactory componentFactory) {
+    return new MyComponentsRegistry(componentFactory);
+  }
 }
 ```
 
@@ -287,7 +293,7 @@ public class MyApplication extends Application implements ReactApplication {
               CoreComponentsRegistry.register(componentFactory);
 
               // Add this line just below CoreComponentsRegistry.register
-              MyComponentsRegistry.register(componentFactory)
+              MyComponentsRegistry.register(componentFactory);
 
               // ...
             }
@@ -296,6 +302,8 @@ public class MyApplication extends Application implements ReactApplication {
         }
       };
     }
+  };
+}
 ```
 
 ### Native/C++ Changes

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -156,7 +156,7 @@ export default (codegenNativeComponent<NativeProps>(
 Specifically you will have to implement the generated **ViewManagerInterface** and to pass events to the generated **ViewManagerDelegate.**
 Your ViewManager could follow this structure. The MyNativeView class in this example is an Android View implementation (like a subclass of LinearLayout, Button, TextView, etc.)
 
-```java
+```java title='MyNativeViewManager.java'
 // View manager for MyNativeView components.
 @ReactModule(name = MyNativeViewManager.REACT_CLASS)
 public class MyNativeViewManager extends SimpleViewManager<MyNativeView>

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -122,9 +122,9 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 // babel-plugin-codegen will replace the function call to use NativeComponentRegistry
 // 'RCTWebView' is interopped by RCTFabricComponentsPlugins
 
-export default (codegenNativeComponent<NativeProps>(
-  'RCTWebView'
-): HostComponent<NativeProps>);
+export default (codegenNativeComponent <
+  NativeProps >
+  'RCTWebView': HostComponent<NativeProps>);
 ```
 
 4. **[Flow users]** Make sure your native component has Flow types for its props, since the JS codegen uses these types to generate the type-safe native implementation of the component. The codegen generates C++ classes during the build time, which guarantees that the native implementation is always up-to-date with its JS interface. Use [these c++ compatible types](https://github.com/facebook/react-native/blob/main/Libraries/Types/CodegenTypes.js#L28-L30).

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -11,7 +11,7 @@ In order to enable Fabric in your app, you would need to add a `JSIModulePackage
 
 Once you located it, you need to add the `getJSIModulePackage` method as from the snippet below:
 
-```java
+```java title='MyApplication.java'
 public class MyApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost =

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -64,14 +64,15 @@ The way to render your app with Fabric depends on your setup. Here is an example
 #import <react/config/ReactNativeConfig.h>
 #endif
 
-@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+@interface AppDelegate () <RCTCxxBridgeDelegate,
+                           RCTTurboModuleManagerDelegate> {
 #ifdef RN_FABRIC_ENABLED
   RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
   std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
   facebook::react::ContextContainer::Shared _contextContainer;
 #endif
 
-// Find a line that define rootView and replace/edit with the following lines.
+  // Find a line that define rootView and replace/edit with the following lines.
 
 #ifdef RN_FABRIC_ENABLED
   _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
@@ -79,15 +80,18 @@ The way to render your app with Fabric depends on your setup. Here is an example
 
   _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
 
-  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:_bridge contextContainer:_contextContainer];
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc]
+        initWithBridge:_bridge
+      contextContainer:_contextContainer];
 
   _bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
 
-  UIView *rootView = [[RCTFabricSurfaceHostingProxyRootView alloc] initWithBridge:_bridge
-                                                                       moduleName:@"MyTestApp"
-                                                                initialProperties:nil];
+  UIView *rootView =
+      [[RCTFabricSurfaceHostingProxyRootView alloc] initWithBridge:_bridge
+                                                        moduleName:@"MyTestApp"
+                                                 initialProperties:nil];
 #else
-   // Current implementation to define rootview.
+  // Current implementation to define rootview.
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"MyTestApp"
                                             initialProperties:nil];

--- a/docs/new-architecture-appendix.md
+++ b/docs/new-architecture-appendix.md
@@ -44,7 +44,7 @@ You can trigger the code-gen by invoking the following task:
 
 The extra `--rerun-tasks` flag is added to make sure Gradle is ignoring the `UP-TO-DATE` checks for this task. You should not need it during normal development.
 
-The `generateCodegenArtifactsFromSchema` task normally runs before the `preBuild` task, so you should not need to invoke it manually but it will be triggered before your builds.
+The `generateCodegenArtifactsFromSchema` task normally runs before the `preBuild` task, so you should not need to invoke it manually, but it will be triggered before your builds.
 
 ### Invoking the script manually
 

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -19,7 +19,11 @@ react {
 }
 ```
 
-_(Please note that this setup requires you to have the React Gradle Plugin configured in the prerequisite step)._
+:::info
+
+Please note that this setup requires you to have the React Gradle Plugin configured in the prerequisite step).
+
+:::
 
 There are three arguments that are required:
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -84,7 +84,11 @@ android/settings.gradle:apply from: file("../node_modules/@react-native-communit
 
 On iOS, this generally requires your library to provide a Podspec (see [`react-native-webview`](https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec) for an example).
 
-> To determine if your library is set up for autolinking, check the CocoaPods output after running `pod install` on an iOS project. If you see "auto linking library name", you are all set to go.
+:::info
+
+To determine if your library is set up for autolinking, check the CocoaPods output after running `pod install` on an iOS project. If you see "auto linking library name", you are all set to go.
+
+:::
 
 ## Preparing your JavaScript codebase for the new React Native Renderer (Fabric)
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -379,9 +379,9 @@ return <RNTMyNativeViewNativeComponent />;
 ```
 
 ```js title="RNTMyNativeViewNativeComponent.js"
-import {requireNativeComponent} from 'react-native';
+import { requireNativeComponent } from 'react-native';
 const RNTMyNativeViewNativeComponent = requireNativeComponent(
-  'RNTMyNativeView',
+  'RNTMyNativeView'
 );
 export default RNTMyNativeViewNativeComponent;
 ```
@@ -394,7 +394,7 @@ If `requireNativeComponent` is not typed, you can temporarily use the `mixed` ty
 import type { HostComponent } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 // ...
 const RCTWebViewNativeComponent: HostComponent<mixed> =
-  requireNativeComponent <mixed> 'RNTMyNativeView';
+  requireNativeComponent < mixed > 'RNTMyNativeView';
 ```
 
 ### Migrating off `dispatchViewManagerCommand`

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -254,11 +254,11 @@ this._scrollView.measure((x, y, width, height) => {
 
 ### Migrating off `setNativeProps`
 
-setNativeProps will not be supported in the post-Fabric world. To migrate, move all `setNativeProp` values to component state.
+`setNativeProps` will not be supported in the post-Fabric world. To migrate, move all `setNativeProp` values to component state.
 
 **Example**
 
-```tsx
+```ts
 class MyComponent extends React.Component<Props> {
   _viewRef: ?React.ElementRef<typeof View>;
 
@@ -358,18 +358,27 @@ Be wary of your assumptions as uncaught subtleties can introduce differences in 
 
 This will prepare for the JS to be ready for the new codegen system for the new architecture. The new file should be named `<ComponentName>NativeComponent.js.`
 
-```javascript
-// 1. MyNativeView.js
-// Old way
-const RNTMyNativeView = requireNativeComponent('RNTMyNativeView');
-...
-  return <RNTMyNativeView />
-// New way
-import RNTMyNativeViewNativeComponent from './RNTMyNativeViewNativeComponent';
-...
-  return <RNTMyNativeViewNativeComponent />
+#### Old way
 
-// RNTMyNativeViewNativeComponent.js
+```js
+const RNTMyNativeView = requireNativeComponent('RNTMyNativeView');
+
+[...]
+
+return <RNTMyNativeView />;
+```
+
+#### New way
+
+```js title="RNTMyNativeNativeComponent.js"
+import RNTMyNativeViewNativeComponent from './RNTMyNativeViewNativeComponent';
+
+[...]
+
+return <RNTMyNativeViewNativeComponent />;
+```
+
+```js title="RNTMyNativeViewNativeComponent.js"
 import {requireNativeComponent} from 'react-native';
 const RNTMyNativeViewNativeComponent = requireNativeComponent(
   'RNTMyNativeView',
@@ -377,13 +386,15 @@ const RNTMyNativeViewNativeComponent = requireNativeComponent(
 export default RNTMyNativeViewNativeComponent;
 ```
 
-**[Flow users]** If `requireNativeComponent` is not typed, you can temporarily use the `mixed` type to fix the Flow warning, for example:
+#### Flow support
 
-```javascript
+If `requireNativeComponent` is not typed, you can temporarily use the `mixed` type to fix the Flow warning, for example:
+
+```js
 import type { HostComponent } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 // ...
 const RCTWebViewNativeComponent: HostComponent<mixed> =
-  requireNativeComponent < mixed > 'RNTMyNativeView';
+  requireNativeComponent <mixed> 'RNTMyNativeView';
 ```
 
 ### Migrating off `dispatchViewManagerCommand`
@@ -392,13 +403,13 @@ Similar to one above, in an effort to avoid calling methods on the UIManager, al
 
 **Before**
 
-```jsx
+```tsx
 class MyComponent extends React.Component<Props> {
   _moveToRegion: (region: Region, duration: number) => {
     UIManager.dispatchViewManagerCommand(
       ReactNative.findNodeHandle(this),
       'moveToRegion',
-      [region, duration],
+      [region, duration]
     );
   }
 
@@ -410,7 +421,7 @@ class MyComponent extends React.Component<Props> {
 
 **Creating the NativeCommands with `codegenNativeCommands`**
 
-```js title="MyCustomMapNativeComponent.js"
+```ts title="MyCustomMapNativeComponent.js"
 import codegeNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 ...
 type Props = {...};
@@ -419,7 +430,7 @@ const MyCustomMapNativeComponent: HostComponent<Props> =
    requireNativeComponent<Props>('MyCustomMapNativeComponent');
 
 interface NativeCommands {
-  +moveToRegion: (
+  moveToRegion: (
     ref: React.ElementRef<typeof MyCustomMapNativeComponent>,
     region: MapRegion,
     duration: number,
@@ -440,7 +451,7 @@ Note:
 
 ### Using Your Command
 
-```jsx
+```tsx
 import {Commands, ... } from './MyCustomMapNativeComponent';
 
 class MyComponent extends React.Component<Props> {
@@ -472,7 +483,7 @@ In the example the code-generated `Commands` will dispatch `moveToRegion` call t
 
 ```objc
 RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
-                        region:(`NSDictionary`` ``*`)region
+                        region:(NSDictionary *)region
                       duration:(double)duration
 {
    ...

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
 end
 ```
 
-> Note: Currently, the Folly version used here must match the Folly version used by React Native. A version mismatch here may lead to errors when running `pod install`. If CocoaPods flags an issue with your Folly version, then you may have a version mismatch. Check which version is used by the core modules Podspecs (e.g. FBReactNativeSpec.podspec), and try running `pod install` again after editing your podspec with the correct Folly version.
+> **Note:** Currently, the Folly version used here must match the Folly version used by React Native. A version mismatch here may lead to errors when running `pod install`. If CocoaPods flags an issue with your Folly version, then you may have a version mismatch. Check which version is used by the core modules Podspecs (e.g. FBReactNativeSpec.podspec), and try running `pod install` again after editing your podspec with the correct Folly version.
 
 ### Enable codegen in your `package.json`
 

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -40,14 +40,23 @@ Pod::Spec.new do |s|
 end
 ```
 
-> **Note:** Currently, the Folly version used here must match the Folly version used by React Native. A version mismatch here may lead to errors when running `pod install`. If CocoaPods flags an issue with your Folly version, then you may have a version mismatch. Check which version is used by the core modules Podspecs (e.g. FBReactNativeSpec.podspec), and try running `pod install` again after editing your podspec with the correct Folly version.
+:::caution
+
+Currently, the Folly version used here must match the Folly version used by React Native. A version mismatch here may lead to errors when running `pod install`. If CocoaPods flags an issue with your Folly version, then you may have a version mismatch. Check which version is used by the core modules Podspecs (e.g. FBReactNativeSpec.podspec), and try running `pod install` again after editing your podspec with the correct Folly version.
+
+:::
 
 ### Enable codegen in your `package.json`
 
 At this point, you are now ready to enable code-gen support in your library. In your library’s package.json add the following:
 
+:::info
+
+Please note that this format is subject to change.
+
+:::
+
 ```json title="package.json"
-// Please note that this format is subject to change.
 "codegenConfig": {
   "libraries": [
     {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -20,6 +20,7 @@
   --ifm-code-font-size: 90%;
   --ifm-code-border-radius: 3px;
   --ifm-blockquote-color: var(--ifm-font-color-base);
+  --ifm-blockquote-font-size: 16px;
   --ifm-table-head-color: var(--subtle);
   --ifm-link-hover-decoration: none;
   --ifm-navbar-background-color: var(--deepdark);
@@ -338,6 +339,16 @@ html[data-theme="dark"] article .badge {
 
   .margin-top--md {
     margin-top: 0.33rem !important;
+  }
+}
+
+.admonition {
+  text-align: left;
+  font-size: var(--ifm-blockquote-font-size);
+  line-height: var(--ifm-pre-line-height);
+
+  h5 {
+    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
This PR aims to improve the code block readability (code block on the website are quite narrow, so it bets to wrap the code around ~65-70 chars per line to avoid horizontal scrolling if possible) and correctness in the new Architecture playbook pages. 

Mainly whitespace and formatting has been changed, however there are few other changes, like sections rework in libraries intro.

I have also tried to add support for the Flow syntax highlight, but it might require some changes or update of Prism library in the Docusaurus to work as intended. Currently the Flow code is unhighlighted, and when flow is listed in additional supported languages in config the website fail to start (due to missing file for Flow highlight definition). 

It also looks like the TypeScript highlight works a bit better than JS one in the Flow files, so I have changed the code block language temporarily. However, I will try to resolved this problem soon. 🙂 