### PR TITLE
docs: adds `View props` to props section of Modal

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -206,6 +206,12 @@ export default App;
 
 ## Props
 
+### [View Props](view.md#props)
+
+Inherits [View Props](view.md#props).
+
+---
+
 ### `animated`
 
 > **Deprecated.** Use the [`animationType`](modal.md#animationtype) prop instead.


### PR DESCRIPTION
[here](https://github.com/facebook/react-native/blob/main/Libraries/Modal/Modal.js#L61) we can see that Modal inherits view props, so I'm adding this information to docs

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
