### PR TITLE
Linking.canOpenURL returing false for https URLs

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -328,7 +328,7 @@ The `Promise` will reject on Android if it was impossible to check if the URL ca
 >     <queries>
 >         <intent>
 >             <action android:name="android.intent.action.VIEW" />
->             <data android:scheme="https"/>
+>             <data android:scheme="https" android:host="*" />
 >         </intent>
 >     </queries>
 > </manifest>


### PR DESCRIPTION
`Linking.canOpenURL(url)` was returning `false` with Android 11 (SDK 30) even with the above queries section in AndrpidManifest.xml. To fix it I had to add android:host="*" to the `data` tag.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
