### PR TITLE
fix: can not run npx react-native init MyApp --template react-native-template-typescript

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -14,7 +14,7 @@ If you're starting a new project, there are a few different ways to get started.
 You can use the [TypeScript template][ts-template]:
 
 ```shell
-npx react-native init MyApp --template react-native-template-typescript
+npx react-native --ignore-existing init MyApp --template react-native-template-typescript
 ```
 
 > **Note:** If the above command is failing, you may have an old version of `react-native` or `react-native-cli` installed globally on your system. To fix the issue try uninstalling the CLI:


### PR DESCRIPTION
…t-native-template-typescript).

Getting this error while using npx react-native init MyApp --template react-native-template-typescript. The project installation fails in most cases and lands into unexpected bugs. More details of this issue can be found here:

https://github.com/react-native-community/react-native-template-typescript/issues/80

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
