### PR TITLE
(Image) Fix documentation for onLoad event.

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -315,9 +315,11 @@ Invoked on mount and on layout changes.
 
 Invoked when load completes successfully.
 
+**Example:** `onLoad={({nativeEvent: {source: {width, height}}}) => setImageRealSize({width, height})}`
+
 | Type                                             |
 | ------------------------------------------------ |
-| ([ImageLoadEvent](image#imageloadevent)) => void |
+| ({ nativeEvent: [ImageLoadEvent](image#imageloadevent) }) => void |
 
 ---
 
@@ -574,9 +576,16 @@ Object returned in the `onLoad` callback.
 
 | Name   | Type   | Description                                                  |
 | ------ | ------ | ------------------------------------------------------------ |
+| source | object | The [source object](#source-object)                                            |
+
+#### Source Object
+**Properties:**
+
+| Name   | Type   | Description                                                  |
+| ------ | ------ | ------------------------------------------------------------ |
 | width  | number | The width of loaded image.                                   |
 | height | number | The height of loaded image.                                  |
-| uri    | string | A string representing the resource identifier for the image. |
+| uri    | string | A string representing the resource identifier for the image.  |
 
 ### ImageSource
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -317,8 +317,8 @@ Invoked when load completes successfully.
 
 **Example:** `onLoad={({nativeEvent: {source: {width, height}}}) => setImageRealSize({width, height})}`
 
-| Type                                             |
-| ------------------------------------------------ |
+| Type                                                              |
+| ----------------------------------------------------------------- |
 | ({ nativeEvent: [ImageLoadEvent](image#imageloadevent) }) => void |
 
 ---
@@ -574,18 +574,19 @@ Object returned in the `onLoad` callback.
 
 **Properties:**
 
-| Name   | Type   | Description                                                  |
-| ------ | ------ | ------------------------------------------------------------ |
-| source | object | The [source object](#source-object)                                            |
+| Name   | Type   | Description                         |
+| ------ | ------ | ----------------------------------- |
+| source | object | The [source object](#source-object) |
 
 #### Source Object
+
 **Properties:**
 
 | Name   | Type   | Description                                                  |
 | ------ | ------ | ------------------------------------------------------------ |
 | width  | number | The width of loaded image.                                   |
 | height | number | The height of loaded image.                                  |
-| uri    | string | A string representing the resource identifier for the image.  |
+| uri    | string | A string representing the resource identifier for the image. |
 
 ### ImageSource
 


### PR DESCRIPTION
### Problem
The [onLoad](https://reactnative.dev/docs/next/image#onload) event documentation is not correct, here is the sample:

#### Current with bug
```js
const onLoad = ({width, height, uri}) = {}
```

#### Fixed version
```js
const onLoad = ({nativeEvent: {source: {width, height, uri}}}) = {}
```

It was missing `nativeEvent` and `source` property. If you look at [onLayout](https://reactnative.dev/docs/next/image#onlayout) it has the `nativeEvent` property as well.