### PR TITLE
Mark Text selectable prop as android only

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -571,7 +571,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 ---
 
-### `selectable`
+### `selectable` <div class="label android">Android</div>
 
 Lets the user select text, to use the native copy and paste functionality.
 


### PR DESCRIPTION
`selectable` is also android only: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1349b640d4d07f40aa7c1c6931f18e3fbf667f3a/types/react-native/index.d.ts#L830

Also there seems to be a long feature request to support this on iOS? https://react-native.canny.io/feature-requests/p/support-selecting-text-within-text-elements-for-copypaste-etc

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
