### PR TITLE
Added the `accessibilityLanguage` prop documentation

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -68,7 +68,7 @@ Android In the above example, TalkBack will read the hint after the label. At th
 
 ### `accessibilityLanguage` <div class="label ios">iOS</div>
 
-Using the `accessibilityLanguage` property the screen reader will understand which language to use while reading the element's **label**, **value** and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
+By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value** and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
 ```jsx
 <View

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -66,6 +66,19 @@ iOS In the above example, VoiceOver will read the hint after the label, if the u
 
 Android In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
+### `accessibilityLanguage` <div class="label ios">iOS</div>
+
+Using the `accessibilityLanguage` property the screen reader will understand which language to use while reading the element's **label**, **value** and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
+
+```jsx
+<View
+  accessible={true}
+  accessibilityLabel="Pizza"
+  accessibilityLanguage="it-IT">
+  <Text>🍕</Text>
+</View>
+```
+
 ### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
 
 Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be false so that these specific views won't have their colors inverted.

--- a/docs/button.md
+++ b/docs/button.md
@@ -138,6 +138,18 @@ Text to display for blindness accessibility features.
 
 ---
 
+### `accessibilityLanguage` <div class="label ios">iOS</div>
+
+A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
+
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `accessibilityActions`
 
 Accessibility actions allow an assistive technology to programmatically invoke the actions of a component. The `accessibilityActions` property should contain a list of action objects. Each action object should contain the field name and label.

--- a/docs/button.md
+++ b/docs/button.md
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
-See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more information.
 
 | Type   |
 | ------ |

--- a/docs/text.md
+++ b/docs/text.md
@@ -262,6 +262,18 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
+### `accessibilityLanguage` <div class="label ios">iOS</div>
+
+A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
+
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `accessibilityLabel`
 
 Overrides the text that's read by the screen reader when the user interacts with the element. By default, the label is constructed by traversing all the children and accumulating all the `Text` nodes separated by space.

--- a/docs/text.md
+++ b/docs/text.md
@@ -266,7 +266,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
-See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more information.
 
 | Type   |
 | ------ |

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -109,6 +109,18 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
+### `accessibilityLanguage` <div class="label ios">iOS</div>
+
+A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
+
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `accessibilityHint`
 
 An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not clear from the accessibility label.

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -113,7 +113,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
-See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more information.
 
 | Type   |
 | ------ |

--- a/docs/view.md
+++ b/docs/view.md
@@ -120,7 +120,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
-See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more information.
 
 | Type   |
 | ------ |

--- a/docs/view.md
+++ b/docs/view.md
@@ -116,6 +116,18 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
+### `accessibilityLanguage` <div class="label ios">iOS</div>
+
+A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
+
+See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentation/objectivec/nsobject/1615192-accessibilitylanguage) for more informations.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.


### PR DESCRIPTION
This PR is going to add the `accessibilityLanguage` prop documentation to all the components targeted by the changes of https://github.com/facebook/react-native/pull/33090.

I'm not a native english speaker so I'm open to improvements / changes 🙂

