### PR TITLE
fix(ios): update Fabric in Podfile instructions

### DIFF
--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -34,11 +34,11 @@ def pods()
   # Use env variables to turn it on/off.
   fabric_enabled = ENV['USE_FABRIC']
 
-  # Pass the flag to enable fabric to use_react_native!.
   use_react_native!(
     ...
     # Modify here if your app root path isn't the same as this one.
     :app_path => "#{Dir.pwd}/..",
+    # Pass the flag to enable fabric to use_react_native!.
     :fabric_enabled => fabric_enabled
   )
 end

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -28,32 +28,20 @@ target 'Some App' do
 end
 
 def pods()
-# Get config
-config = use_native_modules!
+  # Get config
+  config = use_native_modules!
 
-# Use env variables to turn it on/off.
-fabric_enabled = ENV['USE_FABRIC']
-use_codegen_discovery= ENV['USE_CODEGEN_DISCOVERY']
+  # Use env variables to turn it on/off.
+  fabric_enabled = ENV['USE_FABRIC']
 
-# Enabled codegen discovery. This will run the codegen at preinstall time.
-# Files are generated at {pod installation root}/build/generated/ios/
-if use_codegen_discovery
-  Pod::UI.puts "[Codegen] Building target with codegen library discovery enabled."
-  pre_install do |installer|
-    use_react_native_codegen_discovery!({
-        react_native_path: config[:reactNativePath],
-        # Modify here if your app root path isn't the same as this one.
-        app_path: "#{Dir.pwd}/..",
-        fabric_enabled: fabric_enabled,
-    })
-  end
+  # Pass the flag to enable fabric to use_react_native!.
+  use_react_native!(
+    ...
+    # Modify here if your app root path isn't the same as this one.
+    :app_path => "#{Dir.pwd}/..",
+    :fabric_enabled => fabric_enabled
+  )
 end
-
-# Pass the flag to enable fabric to use_react_native!.
-use_react_native!(
-  ...
-  :fabric_enabled => fabric_enabled
-)
 ```
 
 ## 2. Update your root view


### PR DESCRIPTION
Following the current instructions verbatim, I'm getting the following errors:

```
[!] [Codegen] Error: app_path is required for use_react_native_codegen_discovery.

[!] [Codegen] If you are calling use_react_native_codegen_discovery! in your Podfile, please remove the call and pass `app_path` and/or `config_file_dir` to `use_react_native!`.
```

Reading through `react_native_pods.rb`, I think it should be enough to set `RCT_NEW_ARCH_ENABLED=1`, and pass `app_path` to `use_react_native`. The entire `if use_codegen_discovery` block is unnecessary. `use_react_native_codegen_discovery` gets called by `use_react_native!`.

Further, it would be great if we can drop `RCT_NEW_ARCH_ENABLED` and instead use the value of `fabric_enabled` to determine whether to enable codegen etc. But I suppose that's a PR against core first.