### PR TITLE
📚 Add instruction for M1 users to work with Cocoapods

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -45,6 +45,17 @@ sudo gem install cocoapods
 
 For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 ### React Native Command Line Interface
 
 React Native has a built-in command line interface. Rather than install and manage a specific version of the CLI globally, we recommend you access the current version at runtime using `npx`, which ships with Node.js. With `npx react-native <command>`, the current stable version of the CLI will be downloaded and executed at the time the command is run.

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -1,5 +1,3 @@
-import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
-
 ## Installing dependencies
 
 You will need Node, Watchman, the React Native command line interface, Xcode and CocoaPods.
@@ -47,7 +45,18 @@ sudo gem install cocoapods
 
 For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
-<M1Cocoapods />
+:::info
+
+**Note for Mac M1 users**
+
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+:::
 
 ### React Native Command Line Interface
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -1,3 +1,5 @@
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
 ## Installing dependencies
 
 You will need Node, Watchman, the React Native command line interface, Xcode and CocoaPods.
@@ -45,16 +47,7 @@ sudo gem install cocoapods
 
 For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 ### React Native Command Line Interface
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -1,4 +1,4 @@
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 ## Installing dependencies
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -1,3 +1,5 @@
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
+
 ## Installing dependencies
 
 You will need Node, Watchman, the React Native command line interface, Xcode and CocoaPods.
@@ -45,18 +47,7 @@ sudo gem install cocoapods
 
 For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
 
-:::info
-
-**Note for Mac M1 users**
-
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-:::
+<M1Cocoapods />
 
 ### React Native Command Line Interface
 

--- a/docs/_integration-with-exisiting-apps-objc.md
+++ b/docs/_integration-with-exisiting-apps-objc.md
@@ -186,6 +186,17 @@ Pod installation complete! There are 3 dependencies from the Podfile and 1 total
 
 > If this fails with errors mentioning `xcrun`, make sure that in Xcode in **Preferences > Locations** the Command Line Tools are assigned.
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 ### Code integration
 
 Now we will actually modify the native iOS application to integrate React Native. For our 2048 sample app, we will add a "High Score" screen in React Native.

--- a/docs/_integration-with-exisiting-apps-objc.md
+++ b/docs/_integration-with-exisiting-apps-objc.md
@@ -1,4 +1,4 @@
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants'; import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants'; import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 ## Key Concepts
 

--- a/docs/_integration-with-exisiting-apps-objc.md
+++ b/docs/_integration-with-exisiting-apps-objc.md
@@ -1,4 +1,4 @@
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants'; import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
 
 ## Key Concepts
 
@@ -186,16 +186,7 @@ Pod installation complete! There are 3 dependencies from the Podfile and 1 total
 
 > If this fails with errors mentioning `xcrun`, make sure that in Xcode in **Preferences > Locations** the Command Line Tools are assigned.
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 ### Code integration
 

--- a/docs/_integration-with-exisiting-apps-swift.md
+++ b/docs/_integration-with-exisiting-apps-swift.md
@@ -1,4 +1,4 @@
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 ## Key Concepts
 

--- a/docs/_integration-with-exisiting-apps-swift.md
+++ b/docs/_integration-with-exisiting-apps-swift.md
@@ -152,6 +152,17 @@ Pod installation complete! There are 3 dependencies from the Podfile and 1 total
 
 > If you get a warning such as "_The `swift-2048 [Debug]` target overrides the `FRAMEWORK_SEARCH_PATHS` build setting defined in `Pods/Target Support Files/Pods-swift-2048/Pods-swift-2048.debug.xcconfig`. This can lead to problems with the CocoaPods installation_", then make sure the `Framework Search Paths` in `Build Settings` for both `Debug` and `Release` only contain `$(inherited)`.
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 ### Code integration
 
 Now we will actually modify the native iOS application to integrate React Native. For our 2048 sample app, we will add a "High Score" screen in React Native.

--- a/docs/_integration-with-exisiting-apps-swift.md
+++ b/docs/_integration-with-exisiting-apps-swift.md
@@ -1,3 +1,5 @@
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
 ## Key Concepts
 
 The keys to integrating React Native components into your iOS application are to:
@@ -152,16 +154,7 @@ Pod installation complete! There are 3 dependencies from the Podfile and 1 total
 
 > If you get a warning such as "_The `swift-2048 [Debug]` target overrides the `FRAMEWORK_SEARCH_PATHS` build setting defined in `Pods/Target Support Files/Pods-swift-2048/Pods-swift-2048.debug.xcconfig`. This can lead to problems with the CocoaPods installation_", then make sure the `Framework Search Paths` in `Build Settings` for both `Debug` and `Release` only contain `$(inherited)`.
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 ### Code integration
 

--- a/docs/_markdown-m1-cocoapods.mdx
+++ b/docs/_markdown-m1-cocoapods.mdx
@@ -1,0 +1,10 @@
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>

--- a/docs/_markdown-m1-cocoapods.mdx
+++ b/docs/_markdown-m1-cocoapods.mdx
@@ -1,12 +1,3 @@
 :::info
-
-**Note for Mac M1 users**
-
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
+In case of issue with Cocoapods on a Mac M1, look at [how to set them up properly](https://reactnative.dev/docs/environment-setup#cocoapods).
 :::

--- a/docs/_markdown-m1-cocoapods.mdx
+++ b/docs/_markdown-m1-cocoapods.mdx
@@ -1,5 +1,7 @@
-<details>
-  <summary>Note for Mac M1 users</summary>
+:::info
+
+**Note for Mac M1 users**
+
 Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
 
 - `sudo arch -x86_64 gem install ffi`
@@ -7,4 +9,4 @@ Mac M1 architecture is not directly compatible with Cocoapods. If you encounter 
 
 These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
 
-</details>
+:::

--- a/docs/_markdown-m1-cocoapods.mdx
+++ b/docs/_markdown-m1-cocoapods.mdx
@@ -1,3 +1,11 @@
-:::info
-In case of issue with Cocoapods on a Mac M1, look at [how to set them up properly](https://reactnative.dev/docs/environment-setup#cocoapods).
-:::
+<details>
+    <summary>Note for Mac M1 users</summary>
+
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -2,7 +2,8 @@
 id: hermes
 title: Using Hermes
 ---
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 <a href="https://hermesengine.dev">
 <img width={300} height={300} style={{float: 'right', margin: '-30px 4px 0'}} src="/docs/assets/HermesLogo.svg" />

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -77,6 +77,17 @@ Next, install the Hermes pods:
 $ cd ios && pod install
 ```
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 That's it! You should now be able to develop and deploy your app as usual:
 
 ```shell

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -2,6 +2,7 @@
 id: hermes
 title: Using Hermes
 ---
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
 
 <a href="https://hermesengine.dev">
 <img width={300} height={300} style={{float: 'right', margin: '-30px 4px 0'}} src="/docs/assets/HermesLogo.svg" />
@@ -77,16 +78,7 @@ Next, install the Hermes pods:
 $ cd ios && pod install
 ```
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 That's it! You should now be able to develop and deploy your app as usual:
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -51,6 +51,17 @@ Run `pod install` in our `ios` directory in order to link it to our native iOS p
 npx pod-install
 ```
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the pod install properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 Once this is complete, re-build the app binary to start using your new library:
 
 ```bash

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -6,7 +6,8 @@ authorURL: 'https://twitter.com/notbrent'
 description: This guide introduces React Native developers to finding, installing, and using third-party libraries in their apps.
 ---
 
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants'; import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
 
 React Native provides a set of built-in [Core Components and APIs](./components-and-apis) ready to use in your app. You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If the Core Components and APIs don't have what you are looking for, you may be able to find and install a library from the community to add the functionality to your app.
 
@@ -51,16 +52,7 @@ Run `pod install` in our `ios` directory in order to link it to our native iOS p
 npx pod-install
 ```
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the pod install properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 Once this is complete, re-build the app binary to start using your new library:
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -6,8 +6,7 @@ authorURL: 'https://twitter.com/notbrent'
 description: This guide introduces React Native developers to finding, installing, and using third-party libraries in their apps.
 ---
 
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants'; import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
-
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants'; import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 React Native provides a set of built-in [Core Components and APIs](./components-and-apis) ready to use in your app. You're not limited to the components and APIs bundled with React Native. React Native has a community of thousands of developers. If the Core Components and APIs don't have what you are looking for, you may be able to find and install a library from the community to add the functionality to your app.
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -2,6 +2,7 @@
 id: navigation
 title: Navigating Between Screens
 ---
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
 
 Mobile apps are rarely made up of a single screen. Managing the presentation of, and transition between, multiple screens is typically handled by what is known as a navigator.
 
@@ -45,16 +46,7 @@ Next, install the required peer dependencies. You need to run different commands
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the pod install properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 Now, you need to wrap the whole app in `NavigationContainer`. Usually you'd do this in your entry file, such as `index.js` or `App.js`:
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -2,7 +2,8 @@
 id: navigation
 title: Navigating Between Screens
 ---
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 Mobile apps are rarely made up of a single screen. Managing the presentation of, and transition between, multiple screens is typically handled by what is known as a navigator.
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -45,6 +45,17 @@ Next, install the required peer dependencies. You need to run different commands
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the pod install properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 Now, you need to wrap the whole app in `NavigationContainer`. Usually you'd do this in your entry file, such as `index.js` or `App.js`:
 
 ```jsx

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -2,7 +2,8 @@
 id: new-architecture-app-renderer-ios
 title: Enabling Fabric on iOS
 ---
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 :::caution
 

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -2,6 +2,7 @@
 id: new-architecture-app-renderer-ios
 title: Enabling Fabric on iOS
 ---
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
 
 :::caution
 
@@ -123,13 +124,4 @@ module.exports = {
 USE_FABRIC=1 RCT_NEW_ARCH_ENABLED=1 pod install
 ```
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -23,38 +23,22 @@ Add changes to your Podfile. You can see some examples in [RNTester](https://git
 # Codegen produces files/classes that share names, and it will show the warning.
 # deterministic_uuids option surpresses the warning.
 install! 'cocoapods', :deterministic_uuids => false
-
 target 'Some App' do
   pods()
 end
-
 def pods()
-# Get config
-config = use_native_modules!
-
-# Use env variables to turn it on/off.
-fabric_enabled = ENV['USE_FABRIC']
-use_codegen_discovery= ENV['USE_CODEGEN_DISCOVERY']
-
-# Enabled codegen discovery. This will run the codegen at preinstall time.
-# Files are generated at {pod installation root}/build/generated/ios/
-if use_codegen_discovery
-  Pod::UI.puts "[Codegen] Building target with codegen library discovery enabled."
-  pre_install do |installer|
-    use_react_native_codegen_discovery!({
-        react_native_path: config[:reactNativePath],
-        # Modify here if your app root path isn't the same as this one.
-        app_path: "#{Dir.pwd}/..",
-        fabric_enabled: fabric_enabled,
-    })
-  end
+  # Get config
+  config = use_native_modules!
+  # Use env variables to turn it on/off.
+  fabric_enabled = ENV['USE_FABRIC']
+  use_react_native!(
+    ...
+    # Modify here if your app root path isn't the same as this one.
+    :app_path => "#{Dir.pwd}/..",
+    # Pass the flag to enable fabric to use_react_native!.
+    :fabric_enabled => fabric_enabled
+  )
 end
-
-# Pass the flag to enable fabric to use_react_native!.
-use_react_native!(
-  ...
-  :fabric_enabled => fabric_enabled
-)
 ```
 
 ## 2. Update your root view

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -28,20 +28,32 @@ target 'Some App' do
 end
 
 def pods()
-  # Get config
-  config = use_native_modules!
+# Get config
+config = use_native_modules!
 
-  # Use env variables to turn it on/off.
-  fabric_enabled = ENV['USE_FABRIC']
+# Use env variables to turn it on/off.
+fabric_enabled = ENV['USE_FABRIC']
+use_codegen_discovery= ENV['USE_CODEGEN_DISCOVERY']
 
-  use_react_native!(
-    ...
-    # Modify here if your app root path isn't the same as this one.
-    :app_path => "#{Dir.pwd}/..",
-    # Pass the flag to enable fabric to use_react_native!.
-    :fabric_enabled => fabric_enabled
-  )
+# Enabled codegen discovery. This will run the codegen at preinstall time.
+# Files are generated at {pod installation root}/build/generated/ios/
+if use_codegen_discovery
+  Pod::UI.puts "[Codegen] Building target with codegen library discovery enabled."
+  pre_install do |installer|
+    use_react_native_codegen_discovery!({
+        react_native_path: config[:reactNativePath],
+        # Modify here if your app root path isn't the same as this one.
+        app_path: "#{Dir.pwd}/..",
+        fabric_enabled: fabric_enabled,
+    })
+  end
 end
+
+# Pass the flag to enable fabric to use_react_native!.
+use_react_native!(
+  ...
+  :fabric_enabled => fabric_enabled
+)
 ```
 
 ## 2. Update your root view
@@ -110,3 +122,14 @@ module.exports = {
 // Run pod install with the flags
 USE_FABRIC=1 RCT_NEW_ARCH_ENABLED=1 pod install
 ```
+
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -94,7 +94,7 @@ On iOS, this generally requires your library to provide a Podspec (see [`react-n
 
 :::info
 
-To determine if your library is set up for autolinking, check the CocoaPods output after running `pod install` on an iOS project. If you see "auto linking library name", you are all set to go.
+To determine if your library is set up for autolinking, check the CocoaPods output after running `pod install` (or `arch -x86_64 pod install` in case of a Mac M1) on an iOS project. If you see "auto linking library name", you are all set to go.
 
 :::
 

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -52,6 +52,17 @@ end
 
 Currently, the Folly version used here must match the Folly version used by React Native. A version mismatch here may lead to errors when running `pod install`. If CocoaPods flags an issue with your Folly version, then you may have a version mismatch. Check which version is used by the core modules Podspecs (e.g. FBReactNativeSpec.podspec), and try running `pod install` again after editing your podspec with the correct Folly version.
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 :::
 
 ### Enable codegen in your `package.json`

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -2,6 +2,7 @@
 id: new-architecture-library-ios
 title: Enabling in iOS Library
 ---
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
 
 :::caution
 
@@ -52,16 +53,7 @@ end
 
 Currently, the Folly version used here must match the Folly version used by React Native. A version mismatch here may lead to errors when running `pod install`. If CocoaPods flags an issue with your Folly version, then you may have a version mismatch. Check which version is used by the core modules Podspecs (e.g. FBReactNativeSpec.podspec), and try running `pod install` again after editing your podspec with the correct Folly version.
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 :::
 

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -2,7 +2,8 @@
 id: new-architecture-library-ios
 title: Enabling in iOS Library
 ---
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 :::caution
 

--- a/docs/new-architecture-troubleshooting.md
+++ b/docs/new-architecture-troubleshooting.md
@@ -27,10 +27,10 @@ Open `~/Library/Developer/Xcode/DerivedData`. and look for a folder named after 
 
 The CocoaPods integration will see frequent updates as we rollout the New Architecture, and it is possible to end up with your workspace in a broken state after one of these changes. You may clean up any changes related to the codegen by performing some of these steps:
 
-1. Run `pod deintegrate` in your ios directory (or wherever your Podfile is located) and re-run `pod install`.
-2. Delete `Podfile.lock` and re-run `pod install`.
+1. Run `pod deintegrate` in your ios directory (or wherever your Podfile is located) and re-run `pod install` (or `arch -x86_64 pod install`, in case of a Mac M1).
+2. Delete `Podfile.lock` and re-run `pod install` (or `arch -x86_64 pod install`, in case of a Mac M1).
 3. Delete `node_modules` and re-run `yarn install`.
-4. Delete your codegen artifacts and re-run `pod install`, then clean and build your Xcode project.
+4. Delete your codegen artifacts and re-run `pod install` (or `arch -x86_64 pod install`, in case of a Mac M1), then clean and build your Xcode project.
 
 ## Folly Version
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,7 @@
 id: troubleshooting
 title: Troubleshooting
 ---
+import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
 
 These are some common issues you may run into while setting up React Native. If you encounter something that is not listed here, try [searching for the issue in GitHub](https://github.com/facebook/react-native/issues/).
 
@@ -61,16 +62,7 @@ pod 'React', :path => '../node_modules/react-native', :subspecs => [
 
 Next, make sure you have run `pod install` and that a `Pods/` directory has been created in your project with React installed. CocoaPods will instruct you to use the generated `.xcworkspace` file henceforth to be able to use these installed dependencies.
 
-<details>
-  <summary>Note for Mac M1 users</summary>
-Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
-
-- `sudo arch -x86_64 gem install ffi`
-- `arch -x86_64 pod install`
-
-These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
-
-</details>
+<M1Cocoapods />
 
 #### React Native does not compile when being used as a CocoaPod
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,6 +61,17 @@ pod 'React', :path => '../node_modules/react-native', :subspecs => [
 
 Next, make sure you have run `pod install` and that a `Pods/` directory has been created in your project with React installed. CocoaPods will instruct you to use the generated `.xcworkspace` file henceforth to be able to use these installed dependencies.
 
+<details>
+  <summary>Note for Mac M1 users</summary>
+Mac M1 architecture is not directly compatible with Cocoapods. If you encounter issues when installing pods, you can solve it by running:
+
+- `sudo arch -x86_64 gem install ffi`
+- `arch -x86_64 pod install`
+
+These commands install the `ffi` package, to load dynamically-linked libraries and let you run the `pod install` properly, and runs `pod install` with the proper architecture.
+
+</details>
+
 #### React Native does not compile when being used as a CocoaPod
 
 There is a CocoaPods plugin called [cocoapods-fix-react-native](https://github.com/orta/cocoapods-fix-react-native) which handles any potential post-fixing of the source code due to differences when using a dependency manager.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,8 @@
 id: troubleshooting
 title: Troubleshooting
 ---
-import M1Cocoapods from './_markdown-m1-cocoapods.mdx';
+
+import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 These are some common issues you may run into while setting up React Native. If you encounter something that is not listed here, try [searching for the issue in GitHub](https://github.com/facebook/react-native/issues/).
 


### PR DESCRIPTION
Add notes to help Mac M1 users troubleshoot common problems with Cocoapods.