### PR TITLE
Updated link colors to meet WCAG color contrast guidelines.

### DIFF
--- a/website/src/css/_shared.scss
+++ b/website/src/css/_shared.scss
@@ -40,7 +40,7 @@
 
   &:hover {
     background: var(--ifm-menu-color-background-hover);
-    color: var(--ifm-color-primary);
+    color: var(--ifm-link-color);
   }
 }
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -47,6 +47,7 @@
 html[data-theme="light"] {
   --ifm-code-background: rgba(0, 0, 0, 0.06);
   --docsearch-container-background: rgba(32, 35, 42, 0.6);
+  --ifm-link-color: #357da1;
 }
 
 html[data-theme="dark"] {
@@ -913,6 +914,14 @@ div[class^="tableOfContents"] {
       padding: 0;
       border: 0;
     }
+
+    &:hover {
+      color: var(--ifm-link-color);
+
+      code {
+        color: var(--ifm-link-color);
+      }
+    }
   }
 
   .table-of-contents__link--active {
@@ -926,6 +935,14 @@ div[class^="tableOfContents"] {
       font-weight: 600;
       color: var(--ifm-font-color-base);
       white-space: nowrap;
+    }
+
+    &:hover {
+      color: var(--ifm-font-color-base);
+
+      code {
+        color: var(--ifm-font-color-base);
+      }
     }
   }
 }
@@ -1723,6 +1740,16 @@ html[data-theme="dark"] {
       a.margin-horiz--sm,
       a.padding-right--md {
         @extend %link-style-dark;
+      }
+    }
+  }
+}
+
+html[data-theme="light"] {
+  .main-wrapper.blog-wrapper {
+    .container.margin-vert--lg {
+      .col.text--right a:hover {
+        color: var(--ifm-link-color);
       }
     }
   }


### PR DESCRIPTION
This fixes a color contrast issue with a handful of links throughout the React Native website. These links were previously rendering as `--ifm-color-primary` (#06bcee) on white, which is a contrast ratio of only 2.22:1, failing all WCAG criteria. 

https://webaim.org/resources/contrastchecker/?fcolor=06BCEE&bcolor=FFFFFF

This PR changes the link color to be #357da1, which changes the color contrast to 4.56: 1, passing WCAG AA criteria.

https://webaim.org/resources/contrastchecker/?fcolor=357DA1&bcolor=FFFFFF

This change is only made when in light mode, since in dark mode, the original color against black has good contrast (9.43:1), and the new one is lower contrast (4.59:1).

Screenshots of all the affected UI in light mode, dark mode, and when hovered are below.

Dark Mode version menu (unchanged):
<img width="144" alt="Screen Shot 2022-02-24 at 4 59 08 PM" src="https://user-images.githubusercontent.com/1518064/155634489-05a047bd-465c-4390-811a-6770d39ba016.png">
Light mode version menu:
<img width="145" alt="Screen Shot 2022-02-24 at 4 58 37 PM" src="https://user-images.githubusercontent.com/1518064/155634494-e0c95cdf-421e-496a-8896-f861700dc905.png">

Dark mode hovered "Edit this page" button (unchanged):
<img width="705" alt="Screen Shot 2022-02-24 at 4 51 03 PM" src="https://user-images.githubusercontent.com/1518064/155634495-e0cd5c94-af73-43af-a133-7be4a86d9669.png">

Light mode hovered "Edit this page" button:
<img width="708" alt="Screen Shot 2022-02-24 at 4 50 57 PM" src="https://user-images.githubusercontent.com/1518064/155634498-4b677029-b5ab-4bac-877c-94dc87828a46.png">

Dark mode right-column table of contents (unchanged):
<img width="187" alt="Screen Shot 2022-02-24 at 4 49 52 PM" src="https://user-images.githubusercontent.com/1518064/155634500-f1c1190f-5244-4e18-9c9a-a25c628ae8aa.png">

Light mode right-column table of contents:
<img width="194" alt="Screen Shot 2022-02-24 at 4 49 47 PM" src="https://user-images.githubusercontent.com/1518064/155634503-ca6f2e4c-3d7c-4243-9c7c-862dc1c03a29.png">

Dark Mode tags page (unchanged):
<img width="858" alt="Screen Shot 2022-02-24 at 4 47 41 PM" src="https://user-images.githubusercontent.com/1518064/155634504-e596c8f9-3cb3-4ed6-b2df-71fba17226d7.png">

Light Mode tags page:
<img width="860" alt="Screen Shot 2022-02-24 at 4 47 33 PM" src="https://user-images.githubusercontent.com/1518064/155634506-1c9059fa-2263-4149-91b8-925d45fc1cae.png">

Dark Mode "View all tags" link (unchanged):
<img width="658" alt="Screen Shot 2022-02-24 at 4 41 57 PM" src="https://user-images.githubusercontent.com/1518064/155634507-fc0dbf9b-a45c-4108-8dc2-76b609c76167.png">

Light Mode "View all tags" link:
<img width="658" alt="Screen Shot 2022-02-24 at 4 41 51 PM" src="https://user-images.githubusercontent.com/1518064/155634509-40fa4044-b292-4f6a-bb47-4e5d0773ee28.png">

Dark mode tags, "Read More", and "Older entries" buttons, hovered (unchanged):
<img width="848" alt="Screen Shot 2022-02-24 at 4 34 59 PM" src="https://user-images.githubusercontent.com/1518064/155634513-20d5c364-ec33-4c99-bfe3-c399b3aebcbf.png">

Dark mode tags, "Read More", and "Older entries" buttons (unchanged):
<img width="836" alt="Screen Shot 2022-02-24 at 4 34 35 PM" src="https://user-images.githubusercontent.com/1518064/155634516-231855ba-fe52-4316-b66e-911dda509cbd.png">

Light mode tags, "Read More", and "Older entries" buttons, hovered:
<img width="851" alt="Screen Shot 2022-02-24 at 4 28 47 PM" src="https://user-images.githubusercontent.com/1518064/155634517-905d4b8a-cd76-4d32-9947-e121686a58a0.png">

Light mode tags, "Read More", and "Older entries" buttons:
<img width="846" alt="Screen Shot 2022-02-24 at 4 28 13 PM" src="https://user-images.githubusercontent.com/1518064/155634520-1b98cb9c-67b3-4cc1-8542-32ded38ef688.png">

