### PR TITLE
Add kotlin sample code in "Integration with an Android Fragment" documentation

### DIFF
--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -3,6 +3,8 @@ id: integration-with-android-fragment
 title: Integration with an Android Fragment
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 The guide for [Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps) details how to integrate a full-screen React Native app into an existing Android app as an Activity. To use React Native components within Fragments in an existing app requires some additional setup. The benefit of this is that it allows for a native app to integrate React Native components alongside native fragments in an Activity.
 
 ### 1. Add React Native to your app
@@ -17,11 +19,53 @@ You will need to implement the ReactApplication interface in your main Applicati
 
 Ensure your main Application Java class implements ReactApplication:
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+class MyReactApplication: Application(), ReactApplication {...}
+```
+
+</TabItem>
+<TabItem value="java">
+
 ```java
 public class MyReactApplication extends Application implements ReactApplication {...}
 ```
 
+</TabItem>
+</Tabs>
+
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+class MyReactApplication: Application(), ReactApplication {
+
+    override fun onCreate() {
+        super.onCreate()
+        SoLoader.init(this, false)
+    }
+
+    private val reactNativeHost = object : ReactNativeHost(this) {
+
+        override fun getUseDeveloperSupport() = BuildConfig.DEBUG
+
+        override fun getPackages(): List<ReactPackage> {
+            val packages = PackageList(this).getPackages()
+            // Packages that cannot be autolinked yet can be added manually here
+            return packages
+        }
+    }
+
+    override fun getReactNativeHost(): ReactNativeHost = reactNativeHost
+}
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 public class MyReactApplication extends Application implements ReactApplication {
@@ -51,7 +95,26 @@ public class MyReactApplication extends Application implements ReactApplication 
 }
 ```
 
+</TabItem>
+</Tabs>
+
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+import android.app.Application
+
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.soloader.SoLoader
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 import android.app.Application;
@@ -64,6 +127,9 @@ import com.facebook.soloader.SoLoader;
 
 import java.util.List;
 ```
+
+</TabItem>
+</Tabs>
 
 Perform a "Sync Project files with Gradle" operation.
 
@@ -101,11 +167,50 @@ Now in your Activity class e.g. `MainActivity.java` you need to add an OnClickLi
 
 Add the button field to the top of your Activity:
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+private lateinit var button: Button
+```
+
+</TabItem>
+<TabItem value="java">
+
 ```java
 private Button mButton;
 ```
 
+</TabItem>
+</Tabs>
+
 Update your Activity's onCreate method as follows:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.main_activity)
+
+    button = findViewById<Button>(R.id.button)
+    button.setOnClickListener {
+        val reactNativeFragment = ReactFragment.Builder()
+                .setComponentName("HelloWorld")
+                .setLaunchOptions(getLaunchOptions("test message"))
+                .build()
+
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.reactNativeFragment, reactNativeFragment)
+                .commit()
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 @Override
@@ -131,11 +236,27 @@ protected void onCreate(Bundle savedInstanceState) {
 }
 ```
 
+</TabItem>
+</Tabs>
+
 In the code above `Fragment reactNativeFragment = new ReactFragment.Builder()` creates the ReactFragment and `getSupportFragmentManager().beginTransaction().add()` adds the Fragment to the Frame Layout.
 
 If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your `index.js` or `index.android.js` file (it’s the first argument to the AppRegistry.registerComponent() method).
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+private fun getLaunchOptions(message: String) = Bundle().apply {
+    putString("message", message)
+}
+
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 private Bundle getLaunchOptions(String message) {
@@ -145,7 +266,27 @@ private Bundle getLaunchOptions(String message) {
 }
 ```
 
+</TabItem>
+</Tabs>
+
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+import android.app.Application
+
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.shell.MainReactPackage
+import com.facebook.soloader.SoLoader
+
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 import android.app.Application;
@@ -156,6 +297,9 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 ```
+
+</TabItem>
+</Tabs>
 
 Perform a "Sync Project files with Gradle" operation.
 

--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -54,7 +54,7 @@ class MyReactApplication: Application(), ReactApplication {
         override fun getUseDeveloperSupport() = BuildConfig.DEBUG
 
         override fun getPackages(): List<ReactPackage> {
-            val packages = PackageList(this).getPackages()
+            val packages = PackageList(this).getPackages().toMutableList()
             // Packages that cannot be autolinked yet can be added manually here
             return packages
         }

--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -42,24 +42,20 @@ Override the required methods `getUseDeveloperSupport`, `getPackages` and `getRe
 <TabItem value="kotlin">
 
 ```kotlin
-class MyReactApplication: Application(), ReactApplication {
-
+class MyReactApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
         SoLoader.init(this, false)
     }
-
-    private val reactNativeHost = object : ReactNativeHost(this) {
-
-        override fun getUseDeveloperSupport() = BuildConfig.DEBUG
-
-        override fun getPackages(): List<ReactPackage> {
-            val packages = PackageList(this).getPackages().toMutableList()
-            // Packages that cannot be autolinked yet can be added manually here
-            return packages
+    private val reactNativeHost =
+        object : ReactNativeHost(this) {
+            override fun getUseDeveloperSupport() = BuildConfig.DEBUG
+            override fun getPackages(): List<ReactPackage> {
+                val packages = PackageList(this).getPackages().toMutableList()
+                // Packages that cannot be autolinked yet can be added manually here
+                return packages
+            }
         }
-    }
-
     override fun getReactNativeHost(): ReactNativeHost = reactNativeHost
 }
 ```

--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -189,14 +189,12 @@ Update your Activity's onCreate method as follows:
 override fun onCreate(savedInstanceState: Bundle) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.main_activity)
-
     button = findViewById<Button>(R.id.button)
     button.setOnClickListener {
         val reactNativeFragment = ReactFragment.Builder()
                 .setComponentName("HelloWorld")
                 .setLaunchOptions(getLaunchOptions("test message"))
                 .build()
-
         getSupportFragmentManager()
                 .beginTransaction()
                 .add(R.id.reactNativeFragment, reactNativeFragment)

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -19,13 +19,6 @@ const packageManagers = [
 ];
 const defaultPackageManager = 'npm';
 
-const androidLanguages = [
-  {label: 'Java', value: 'java'},
-  {label: 'Kotlin', value: 'kotlin'},
-];
-
-const defaultAndroidLanguage = 'kotlin';
-
 const guides = [
   {label: 'Expo CLI Quickstart', value: 'quickstart'},
   {label: 'React Native CLI Quickstart', value: 'native'},

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -59,10 +59,12 @@ export default {
   defaultPackageManager,
   defaultPlatform,
   defaultSyntax,
+  defaultAndroidLanguage,
   getDevNotesTabs,
   guides,
   oses,
   packageManagers,
   platforms,
   syntax,
+  androidLanguages,
 };

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -24,7 +24,7 @@ const androidLanguages = [
   {label: 'Kotlin', value: 'kotlin'},
 ];
 
-const defaultAndroidLanguage = 'kotlin';
+const defaultAndroidLanguage = 'java';
 
 const guides = [
   {label: 'Expo CLI Quickstart', value: 'quickstart'},

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -19,6 +19,13 @@ const packageManagers = [
 ];
 const defaultPackageManager = 'npm';
 
+const androidLanguages = [
+  {label: 'Java', value: 'java'},
+  {label: 'Kotlin', value: 'kotlin'},
+];
+
+const defaultAndroidLanguage = 'kotlin';
+
 const guides = [
   {label: 'Expo CLI Quickstart', value: 'quickstart'},
   {label: 'React Native CLI Quickstart', value: 'native'},

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -3,8 +3,6 @@ id: integration-with-android-fragment
 title: Integration with an Android Fragment
 ---
 
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
-
 The guide for [Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps) details how to integrate a full-screen React Native app into an existing Android app as an Activity. To use React Native components within Fragments in an existing app requires some additional setup. The benefit of this is that it allows for a native app to integrate React Native components alongside native fragments in an Activity.
 
 ### 1. Add React Native to your app
@@ -19,57 +17,11 @@ You will need to implement the ReactApplication interface in your main Applicati
 
 Ensure your main Application Java class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-class MyReactApplication: Application(), ReactApplication {...}
-```
-
-</TabItem>
-<TabItem value="java">
-
 ```java
 public class MyReactApplication extends Application implements ReactApplication {...}
 ```
 
-</TabItem>
-</Tabs>
-
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
-
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-class MyReactApplication: Application(), ReactApplication {
-
-    override fun onCreate(): Unit {
-        super.onCreate()
-        SoLoader.init(this, false)
-    }
-
-    private val reactNativeHost = object: ReactNativeHost(this) {
-
-        override fun getUseDeveloperSupport(): Boolean {
-            return BuildConfig.DEBUG
-        }
-
-        override fun getPackages(): List<ReactPackage> {
-            val packages = PackageList(this).getPackages()
-            // Packages that cannot be autolinked yet can be added manually here
-            return packages
-        }
-    }
-
-    override fun getReactNativeHost(): ReactNativeHost {
-        return reactNativeHost
-    }
-}
-```
-
-</TabItem>
-<TabItem value="java">
 
 ```java
 public class MyReactApplication extends Application implements ReactApplication {
@@ -99,28 +51,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 }
 ```
 
-</TabItem>
-</Tabs>
-
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
-
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-import android.app.Application
-
-import com.facebook.react.PackageList
-import com.facebook.react.ReactApplication
-import com.facebook.react.ReactNativeHost
-import com.facebook.react.ReactPackage
-import com.facebook.soloader.SoLoader
-
-import java.util.List
-```
-
-</TabItem>
-<TabItem value="java">
 
 ```java
 import android.app.Application;
@@ -133,9 +64,6 @@ import com.facebook.soloader.SoLoader;
 
 import java.util.List;
 ```
-
-</TabItem>
-</Tabs>
 
 Perform a "Sync Project files with Gradle" operation.
 
@@ -173,50 +101,11 @@ Now in your Activity class e.g. `MainActivity.java` you need to add an OnClickLi
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-private lateinit var button: Button
-```
-
-</TabItem>
-<TabItem value="java">
-
 ```java
 private Button mButton;
 ```
 
-</TabItem>
-</Tabs>
-
 Update your Activity's onCreate method as follows:
-
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-override fun onCreate(savedInstanceState: Bundle): Unit {
-    super.onCreate(savedInstanceState)
-    setContentView(R.layout.main_activity)
-
-    button = findViewById(R.id.button) as Button
-    button.setOnClickListener {
-        val reactNativeFragment = ReactFragment.Builder()
-                .setComponentName("HelloWorld")
-                .setLaunchOptions(getLaunchOptions("test message"))
-                .build()
-
-        getSupportFragmentManager()
-                .beginTransaction()
-                .add(R.id.reactNativeFragment, reactNativeFragment)
-                .commit()
-    }
-}
-```
-
-</TabItem>
-<TabItem value="java">
 
 ```java
 @Override
@@ -242,29 +131,11 @@ protected void onCreate(Bundle savedInstanceState) {
 }
 ```
 
-</TabItem>
-</Tabs>
-
 In the code above `Fragment reactNativeFragment = new ReactFragment.Builder()` creates the ReactFragment and `getSupportFragmentManager().beginTransaction().add()` adds the Fragment to the Frame Layout.
 
 If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your `index.js` or `index.android.js` file (it’s the first argument to the AppRegistry.registerComponent() method).
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
-
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-private fun getLaunchOptions(String message): Bundle {
-    val initialProperties = Bundle()
-    initialProperties.putString("message", message)
-    return initialProperties
-}
-
-```
-
-</TabItem>
-<TabItem value="java">
 
 ```java
 private Bundle getLaunchOptions(String message) {
@@ -274,27 +145,7 @@ private Bundle getLaunchOptions(String message) {
 }
 ```
 
-</TabItem>
-</Tabs>
-
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
-
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
-<TabItem value="kotlin">
-
-```kotlin
-import android.app.Application
-
-import com.facebook.react.ReactApplication
-import com.facebook.react.ReactNativeHost
-import com.facebook.react.ReactPackage
-import com.facebook.react.shell.MainReactPackage
-import com.facebook.soloader.SoLoader
-
-```
-
-</TabItem>
-<TabItem value="java">
 
 ```java
 import android.app.Application;
@@ -305,9 +156,6 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 ```
-
-</TabItem>
-</Tabs>
 
 Perform a "Sync Project files with Gradle" operation.
 

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -51,9 +51,7 @@ class MyReactApplication: Application(), ReactApplication {
 
     private val reactNativeHost = object : ReactNativeHost(this) {
 
-        override fun getUseDeveloperSupport(): Boolean {
-            return BuildConfig.DEBUG
-        }
+        override fun getUseDeveloperSupport() = BuildConfig.DEBUG
 
         override fun getPackages(): List<ReactPackage> {
             val packages = PackageList(this).getPackages()

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -49,7 +49,7 @@ class MyReactApplication: Application(), ReactApplication {
         SoLoader.init(this, false)
     }
 
-    private val reactNativeHost = object: ReactNativeHost(this) {
+    private val reactNativeHost = object : ReactNativeHost(this) {
 
         override fun getUseDeveloperSupport(): Boolean {
             return BuildConfig.DEBUG

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -3,6 +3,8 @@ id: integration-with-android-fragment
 title: Integration with an Android Fragment
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 The guide for [Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps) details how to integrate a full-screen React Native app into an existing Android app as an Activity. To use React Native components within Fragments in an existing app requires some additional setup. The benefit of this is that it allows for a native app to integrate React Native components alongside native fragments in an Activity.
 
 ### 1. Add React Native to your app
@@ -17,11 +19,57 @@ You will need to implement the ReactApplication interface in your main Applicati
 
 Ensure your main Application Java class implements ReactApplication:
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+class MyReactApplication: Application(), ReactApplication {...}
+```
+
+</TabItem>
+<TabItem value="java">
+
 ```java
 public class MyReactApplication extends Application implements ReactApplication {...}
 ```
 
+</TabItem>
+</Tabs>
+
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+class MyReactApplication: Application(), ReactApplication {
+
+    override fun onCreate(): Unit {
+        super.onCreate()
+        SoLoader.init(this, false)
+    }
+
+    private val reactNativeHost = object: ReactNativeHost(this) {
+
+        override fun getUseDeveloperSupport(): Boolean {
+            return BuildConfig.DEBUG
+        }
+
+        override fun getPackages(): List<ReactPackage> {
+            val packages = PackageList(this).getPackages()
+            // Packages that cannot be autolinked yet can be added manually here
+            return packages
+        }
+    }
+
+    override fun getReactNativeHost(): ReactNativeHost {
+        return reactNativeHost
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 public class MyReactApplication extends Application implements ReactApplication {
@@ -51,7 +99,28 @@ public class MyReactApplication extends Application implements ReactApplication 
 }
 ```
 
+</TabItem>
+</Tabs>
+
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+import android.app.Application
+
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.soloader.SoLoader
+
+import java.util.List
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 import android.app.Application;
@@ -64,6 +133,9 @@ import com.facebook.soloader.SoLoader;
 
 import java.util.List;
 ```
+
+</TabItem>
+</Tabs>
 
 Perform a "Sync Project files with Gradle" operation.
 
@@ -101,11 +173,50 @@ Now in your Activity class e.g. `MainActivity.java` you need to add an OnClickLi
 
 Add the button field to the top of your Activity:
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+private lateinit var button: Button
+```
+
+</TabItem>
+<TabItem value="java">
+
 ```java
 private Button mButton;
 ```
 
+</TabItem>
+</Tabs>
+
 Update your Activity's onCreate method as follows:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle): Unit {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.main_activity)
+
+    button = findViewById(R.id.button) as Button
+    button.setOnClickListener {
+        val reactNativeFragment = ReactFragment.Builder()
+                .setComponentName("HelloWorld")
+                .setLaunchOptions(getLaunchOptions("test message"))
+                .build()
+
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.reactNativeFragment, reactNativeFragment)
+                .commit()
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 @Override
@@ -131,11 +242,29 @@ protected void onCreate(Bundle savedInstanceState) {
 }
 ```
 
+</TabItem>
+</Tabs>
+
 In the code above `Fragment reactNativeFragment = new ReactFragment.Builder()` creates the ReactFragment and `getSupportFragmentManager().beginTransaction().add()` adds the Fragment to the Frame Layout.
 
 If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your `index.js` or `index.android.js` file (it’s the first argument to the AppRegistry.registerComponent() method).
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+private fun getLaunchOptions(String message): Bundle {
+    val initialProperties = Bundle()
+    initialProperties.putString("message", message)
+    return initialProperties
+}
+
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 private Bundle getLaunchOptions(String message) {
@@ -145,7 +274,27 @@ private Bundle getLaunchOptions(String message) {
 }
 ```
 
+</TabItem>
+</Tabs>
+
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
+
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+import android.app.Application
+
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.shell.MainReactPackage
+import com.facebook.soloader.SoLoader
+
+```
+
+</TabItem>
+<TabItem value="java">
 
 ```java
 import android.app.Application;
@@ -156,6 +305,9 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 ```
+
+</TabItem>
+</Tabs>
 
 Perform a "Sync Project files with Gradle" operation.
 

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -251,10 +251,8 @@ Add the `getLaunchOptions` method which will allow you to pass props through to 
 <TabItem value="kotlin">
 
 ```kotlin
-private fun getLaunchOptions(String message): Bundle {
-    val initialProperties = Bundle()
-    initialProperties.putString("message", message)
-    return initialProperties
+private fun getLaunchOptions(message: String) = Bundle().apply {
+    putString("message", message)
 }
 
 ```

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -112,7 +112,6 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.soloader.SoLoader
 
-import java.util.List
 ```
 
 </TabItem>

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -111,7 +111,6 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.soloader.SoLoader
-
 ```
 
 </TabItem>

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -60,9 +60,7 @@ class MyReactApplication: Application(), ReactApplication {
         }
     }
 
-    override fun getReactNativeHost(): ReactNativeHost {
-        return reactNativeHost
-    }
+    override fun getReactNativeHost(): ReactNativeHost = reactNativeHost
 }
 ```
 

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -54,7 +54,7 @@ class MyReactApplication: Application(), ReactApplication {
         override fun getUseDeveloperSupport() = BuildConfig.DEBUG
 
         override fun getPackages(): List<ReactPackage> {
-            val packages = PackageList(this).getPackages()
+            val packages = PackageList(this).getPackages().toMutableList()
             // Packages that cannot be autolinked yet can be added manually here
             return packages
         }

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -42,24 +42,20 @@ Override the required methods `getUseDeveloperSupport`, `getPackages` and `getRe
 <TabItem value="kotlin">
 
 ```kotlin
-class MyReactApplication: Application(), ReactApplication {
-
+class MyReactApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
         SoLoader.init(this, false)
     }
-
-    private val reactNativeHost = object : ReactNativeHost(this) {
-
-        override fun getUseDeveloperSupport() = BuildConfig.DEBUG
-
-        override fun getPackages(): List<ReactPackage> {
-            val packages = PackageList(this).getPackages().toMutableList()
-            // Packages that cannot be autolinked yet can be added manually here
-            return packages
+    private val reactNativeHost =
+        object : ReactNativeHost(this) {
+            override fun getUseDeveloperSupport() = BuildConfig.DEBUG
+            override fun getPackages(): List<ReactPackage> {
+                val packages = PackageList(this).getPackages().toMutableList()
+                // Packages that cannot be autolinked yet can be added manually here
+                return packages
+            }
         }
-    }
-
     override fun getReactNativeHost(): ReactNativeHost = reactNativeHost
 }
 ```

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -200,7 +200,7 @@ override fun onCreate(savedInstanceState: Bundle): Unit {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.main_activity)
 
-    button = findViewById(R.id.button) as Button
+    button = findViewById<Button>(R.id.button)
     button.setOnClickListener {
         val reactNativeFragment = ReactFragment.Builder()
                 .setComponentName("HelloWorld")

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -192,7 +192,7 @@ Update your Activity's onCreate method as follows:
 <TabItem value="kotlin">
 
 ```kotlin
-override fun onCreate(savedInstanceState: Bundle): Unit {
+override fun onCreate(savedInstanceState: Bundle) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.main_activity)
 

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -189,7 +189,7 @@ Update your Activity's onCreate method as follows:
 override fun onCreate(savedInstanceState: Bundle) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.main_activity)
-    
+
     button = findViewById<Button>(R.id.button)
     button.setOnClickListener {
         val reactNativeFragment =

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -189,18 +189,18 @@ Update your Activity's onCreate method as follows:
 override fun onCreate(savedInstanceState: Bundle) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.main_activity)
-
+    
     button = findViewById<Button>(R.id.button)
     button.setOnClickListener {
-        val reactNativeFragment = ReactFragment.Builder()
+        val reactNativeFragment =
+            ReactFragment.Builder()
                 .setComponentName("HelloWorld")
                 .setLaunchOptions(getLaunchOptions("test message"))
                 .build()
-
         getSupportFragmentManager()
-                .beginTransaction()
-                .add(R.id.reactNativeFragment, reactNativeFragment)
-                .commit()
+            .beginTransaction()
+            .add(R.id.reactNativeFragment, reactNativeFragment)
+            .commit()
     }
 }
 ```

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -44,7 +44,7 @@ Override the required methods `getUseDeveloperSupport`, `getPackages` and `getRe
 ```kotlin
 class MyReactApplication: Application(), ReactApplication {
 
-    override fun onCreate(): Unit {
+    override fun onCreate() {
         super.onCreate()
         SoLoader.init(this, false)
     }


### PR DESCRIPTION
This PR updates the "[https://reactnative.dev/docs/integration-with-android-fragment](Integration with an Android Fragment)" documentation to display Kotlin and java code samples

This is the first step on the effort to display Kotlin code in RN OSS documentation

![integration-with-android-fragment-kotlin](https://user-images.githubusercontent.com/515103/155773754-7d3e786c-559e-4c59-8198-d5807a998fb6.png)

