### PR TITLE
fix: spelling error mudule -> module

### DIFF
--- a/docs/new-architecture-app-modules-android.md
+++ b/docs/new-architecture-app-modules-android.md
@@ -1,6 +1,6 @@
 ---
 id: new-architecture-app-modules-android
-title: Enabling TurboMudule on Android
+title: Enabling TurboModule on Android
 ---
 
 :::caution


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
- This PR fixes the spelling of TurboMudule to TurboModule.
