### PR TITLE
fix layout resizing when page includes wide code block

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -279,6 +279,7 @@ hr {
 
   div[class^="codeBlockContent"] {
     display: inline-grid;
+    min-width: 100%;
   }
 
   div[class^="codeBlockLines"] {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -277,6 +277,10 @@ hr {
     background-color: var(--light);
   }
 
+  div[class^="codeBlockContent"] {
+    display: inline-grid;
+  }
+
   div[class^="codeBlockLines"] {
     font-size: 80%;
   }


### PR DESCRIPTION
# Why

Currently, when viewing some of the pages, the website main container is resized a bit, which result in unnecessary layout shift when changing pages.

After the investigation it looks like the wide code blocks (with horizontal scrollbar) are the culprit in there. Unfortunately I was not able to fix an easy solution, padding and width seems to be set to the correct values, so I had to change the code block content display property, which do not affect to actual display of code blocks, but prevent the block from resizing the container. :man_shrugging:

# Preview

### Before
![Kapture 2022-02-26 at 20 44 11](https://user-images.githubusercontent.com/719641/155857407-e433da41-26d0-4462-8fc5-f9e84f0f4d38.gif)

### After
![Kapture 2022-02-26 at 21 03 26](https://user-images.githubusercontent.com/719641/155857547-8df9573e-794d-4aed-9c73-fa5e7224097c.gif)
