### PR TITLE
changed android_hyphenation to version 0.67.3

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                     | Default  |
+| ------------------------ | -------- |
+| enum(`'none'`, `'full'`) | `'none'` |
 
 ---
 

--- a/website/versioned_docs/version-0.67/text.md
+++ b/website/versioned_docs/version-0.67/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                     | Default  |
+| ------------------------ | -------- |
+| enum(`'none'`, `'full'`) | `'none'` |
 
 ---
 


### PR DESCRIPTION
This PR changes the documentation of the android_hyphenation property to the new changes of version 0.67.3 as stated in this changelog: 
https://github.com/facebook/react-native/blob/main/CHANGELOG.md#android-specific-3
This PR corresponds to the following issue:
https://github.com/facebook/react-native/issues/33104
