### PR TITLE
Update migration guide feedback link to the working group

### DIFF
--- a/docs/_markdown-new-architecture-warning.mdx
+++ b/docs/_markdown-new-architecture-warning.mdx
@@ -1,0 +1,7 @@
+:::caution
+
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
+
+Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
+
+:::

--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -3,13 +3,9 @@ id: new-architecture-app-intro
 title: Prerequisites for Applications
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 There’s a few prerequisites that should be addressed before the new architecture is enabled in your application.
 

--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -5,7 +5,7 @@ title: Prerequisites for Applications
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-app-modules-android.md
+++ b/docs/new-architecture-app-modules-android.md
@@ -5,7 +5,7 @@ title: Enabling TurboModule on Android
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-app-modules-android.md
+++ b/docs/new-architecture-app-modules-android.md
@@ -3,13 +3,9 @@ id: new-architecture-app-modules-android
 title: Enabling TurboModule on Android
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 Make sure your application meets all the [prerequisites](new-architecture-app-intro).
 

--- a/docs/new-architecture-app-modules-ios.md
+++ b/docs/new-architecture-app-modules-ios.md
@@ -5,7 +5,7 @@ title: Enabling TurboModule on iOS
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-app-modules-ios.md
+++ b/docs/new-architecture-app-modules-ios.md
@@ -3,13 +3,9 @@ id: new-architecture-app-modules-ios
 title: Enabling TurboModule on iOS
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 Make sure your application meets all the [prerequisites](new-architecture-app-intro).
 

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -5,7 +5,7 @@ title: Enabling Fabric on Android
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -3,13 +3,9 @@ id: new-architecture-app-renderer-android
 title: Enabling Fabric on Android
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 Make sure your application meets all the [prerequisites](new-architecture-app-intro).
 

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -7,7 +7,7 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -4,14 +4,9 @@ title: Enabling Fabric on iOS
 ---
 
 import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-:::caution
-
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 This section will go over how to enable the new renderer in your app. Make sure your application meets all the [prerequisites](new-architecture-app-intro).
 

--- a/docs/new-architecture-appendix.md
+++ b/docs/new-architecture-appendix.md
@@ -5,7 +5,7 @@ title: Appendix
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-appendix.md
+++ b/docs/new-architecture-appendix.md
@@ -3,13 +3,9 @@ id: new-architecture-appendix
 title: Appendix
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 ## I. Flow Type to Native Type Mapping
 

--- a/docs/new-architecture-intro.md
+++ b/docs/new-architecture-intro.md
@@ -3,13 +3,9 @@ id: new-architecture-intro
 title: Adopting the New Architecture
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 # Getting Started with the New Architecture
 

--- a/docs/new-architecture-intro.md
+++ b/docs/new-architecture-intro.md
@@ -5,7 +5,7 @@ title: Adopting the New Architecture
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -5,7 +5,7 @@ title: Enabling in Android Library
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -3,13 +3,9 @@ id: new-architecture-library-android
 title: Enabling in Android Library
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 Once you have defined the JavaScript specs for your native modules as part of the [prerequisites](new-architecture-library-intro) and followed the Android/Gradle setup, you are now ready to migrate your library to the new architecture. Here are the steps you can follow to accomplish this.
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -3,13 +3,9 @@ id: new-architecture-library-intro
 title: Prerequisites for Libraries
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 The following steps will help ensure your modules and components are ready for the New Architecture.
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -5,7 +5,7 @@ title: Prerequisites for Libraries
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -7,7 +7,7 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 

--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -4,14 +4,9 @@ title: Enabling in iOS Library
 ---
 
 import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-:::caution
-
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 You have defined the JavaScript specs for your native modules as part of the [prerequisites](new-architecture-library-intro) and you are now ready to migrate your library to the new architecture. Here are the steps you can follow to accomplish this.
 

--- a/docs/new-architecture-troubleshooting.md
+++ b/docs/new-architecture-troubleshooting.md
@@ -3,13 +3,9 @@ id: new-architecture-troubleshooting
 title: Troubleshooting
 ---
 
-:::caution
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
-
-Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
-
-:::
+<NewArchitectureWarning/>
 
 This page contains resolutions to common problem you might face when migrating to the New Architecture.
 

--- a/docs/new-architecture-troubleshooting.md
+++ b/docs/new-architecture-troubleshooting.md
@@ -5,7 +5,7 @@ title: Troubleshooting
 
 :::caution
 
-This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [react-native-website PR](https://github.com/facebook/react-native-website) for this page.
+This documentation is still **experimental** and details are subject to changes as we iterate. Feel free to share your feedback on the [discussion inside the working group](https://github.com/reactwg/react-native-new-architecture/discussions/8) for this page.
 
 Moreover, it contains several **manual steps**. Please note that this won't be representative of the final developer experience once the New Architecture is stable. We're working on tools, templates and libraries to help you get started fast on the New Architecture, without having to go through the whole setup.
 


### PR DESCRIPTION
I've update all the warning banners to point to this discussion in the working group:
 - https://github.com/reactwg/react-native-new-architecture/discussions/8