### PR TITLE
Use diff syntax for codeblocks

### DIFF
--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -72,53 +72,51 @@ ls -la node_modules/react-native-gradle-plugin
 
 Now, you can edit your **top level** `settings.gradle` file to include the following line at the end of the file:
 
-```groovy
-includeBuild('../node_modules/react-native-gradle-plugin')
+```diff title='android/settings.gradle'
+ include ':app'
++includeBuild('../node_modules/react-native-gradle-plugin')
 
-include(":ReactAndroid")
-project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
++include(":ReactAndroid")
++project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
 ```
 
 Then, edit your **top-level Gradle file** to include the highlighted lines:
 
-```groovy
+```diff title='android/build.gradle'
 buildscript {
     // ...
     dependencies {
         // Make sure that AGP is at least at version 7.x
-        classpath("com.android.tools.build:gradle:7.0.4")
+-       classpath("com.android.tools.build:gradle:4.2.2")
++       classpath("com.android.tools.build:gradle:7.0.4")
 
-        // Add those lines
-        classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("de.undercouch:gradle-download-task:4.1.2")
++       classpath("com.facebook.react:react-native-gradle-plugin")
++       classpath("de.undercouch:gradle-download-task:4.1.2")
     }
 }
 ```
 
 Edit your **module-level** **Gradle file** (usually `app/build.gradle[.kts]`) to include the following:
 
-```groovy
-apply plugin: "com.android.application"
+```diff title='android/app/settings.gradle'
+ apply plugin: "com.android.application"
 
-// Add those lines
-apply plugin: "com.facebook.react"
-// Add those lines as well
-react {
-    reactRoot = rootProject.file("../node_modules/react-native/")
-    codegenDir = rootProject.file("../node_modules/react-native-codegen/")
-}
++apply plugin: "com.facebook.react"
+
++react {
++    reactRoot = rootProject.file("../node_modules/react-native/")
++    codegenDir = rootProject.file("../node_modules/react-native-codegen/")
++}
 ```
 
 Finally, it’s time to update your project to use the `react-native` dependency from source, rather than using a precompiled artifact from the NPM package. This is needed as the later setup will rely on building the native code from source.
 
 Let’s edit your **module level** `build.gradle` (the one inside `app/` folder) and change the following line:
 
-```groovy
+```diff title='android/app/build.gradle'
 dependencies {
-  // Replace this:
-  implementation "com.facebook.react:react-native:+"  // From node_modules
-  // With this:
-  implementation project(":ReactAndroid")  // From node_modules
+-  implementation "com.facebook.react:react-native:+"  // From node_modules
++  implementation project(":ReactAndroid")  // From node_modules
 ```
 
 ## Use Hermes
@@ -173,7 +171,7 @@ In order to set up the TurboModule system, you will add some code to interact wi
 
 Now you will have your AppDelegate conform to `RCTCxxBridgeDelegate`. Start by adding the following imports at the top of your AppDelegate file:
 
-```objc
+```objc title='AppDelegate.mm'
 #import <reacthermes/HermesExecutorFactory.h>
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/RCTJSIExecutorRuntimeInstaller.h>
@@ -181,7 +179,7 @@ Now you will have your AppDelegate conform to `RCTCxxBridgeDelegate`. Start by a
 
 Then, declare your app delegate as a `RCTCxxBridgeDelegate` provider:
 
-```objc
+```objc title='AppDelegate.mm'
 @interface AppDelegate () <RCTCxxBridgeDelegate> {
   // ...
 }
@@ -192,7 +190,7 @@ To conform to the `RCTCxxBridgeDelegate` protocol, you will need to implement th
 
 You can implement the `jsExecutorFactoryForBridge:` method like this:
 
-```objc
+```objc title='AppDelegate.mm'
 #pragma mark - RCTCxxBridgeDelegate
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge

--- a/docs/new-architecture-app-modules-ios.md
+++ b/docs/new-architecture-app-modules-ios.md
@@ -17,14 +17,14 @@ Make sure your application meets all the [prerequisites](new-architecture-app-in
 
 Add the following imports at the top of your bridge delegate (e.g. `AppDelegate.mm`):
 
-```objc
+```objc title='AppDelegate.mm'
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <React/CoreModulesPlugins.h>
 ```
 
 You will also need to declare that your AppDelegate conforms to the `RCTTurboModuleManagerDelegate` protocol, as well as create an instance variable for our Turbo Module manager:
 
-```objc
+```objc title='AppDelegate.mm'
 @interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
   // ...
   RCTTurboModuleManager *_turboModuleManager;
@@ -103,7 +103,7 @@ Take note of `getModuleInstanceFromClass:` in the following example, as it inclu
 
 Next, you will create a `RCTTurboModuleManager` in your bridge delegate’s `jsExecutorFactoryForBridge:` method, and install the JavaScript bindings:
 
-```objc
+```objc title='AppDelegate.mm'
 #pragma mark - RCTCxxBridgeDelegate
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
@@ -159,7 +159,7 @@ RCTEnableTurboModule(YES);
 
 #### Example
 
-```objc
+```objc title='AppDelegate.mm'
 @implementation AppDelegate
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -19,50 +19,49 @@ In order to enable Fabric in your app, you would need to add a `JSIModulePackage
 
 Once you located it, you need to add the `getJSIModulePackage` method as from the snippet below:
 
-```java title='MyApplication.java'
+```diff title='MyApplication.java'
 public class MyApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost =
     new ReactNativeHost(this) {
 
-      // Add those lines:
-      @Nullable
-      @Override
-      protected JSIModulePackage getJSIModulePackage() {
-        return new JSIModulePackage() {
-          @Override
-          public List<JSIModuleSpec> getJSIModules(
-              final ReactApplicationContext reactApplicationContext,
-              final JavaScriptContextHolder jsContext) {
-            final List<JSIModuleSpec> specs = new ArrayList<>();
-            specs.add(new JSIModuleSpec() {
-              @Override
-              public JSIModuleType getJSIModuleType() {
-                return JSIModuleType.UIManager;
-              }
-
-              @Override
-              public JSIModuleProvider<UIManager> getJSIModuleProvider() {
-                final ComponentFactory componentFactory = new ComponentFactory();
-                CoreComponentsRegistry.register(componentFactory);
-                final ReactInstanceManager reactInstanceManager = getReactInstanceManager();
-
-                ViewManagerRegistry viewManagerRegistry =
-                    new ViewManagerRegistry(
-                        reactInstanceManager.getOrCreateViewManagers(
-                            reactApplicationContext));
-
-                return new FabricJSIModuleProvider(
-                    reactApplicationContext,
-                    componentFactory,
-                    new EmptyReactNativeConfig(),
-                    viewManagerRegistry);
-              }
-            });
-            return specs;
-          }
-        };
-      }
++     @Nullable
++     @Override
++     protected JSIModulePackage getJSIModulePackage() {
++       return new JSIModulePackage() {
++         @Override
++         public List<JSIModuleSpec> getJSIModules(
++             final ReactApplicationContext reactApplicationContext,
++             final JavaScriptContextHolder jsContext) {
++           final List<JSIModuleSpec> specs = new ArrayList<>();
++           specs.add(new JSIModuleSpec() {
++             @Override
++             public JSIModuleType getJSIModuleType() {
++               return JSIModuleType.UIManager;
++             }
++
++             @Override
++             public JSIModuleProvider<UIManager> getJSIModuleProvider() {
++               final ComponentFactory componentFactory = new ComponentFactory();
++               CoreComponentsRegistry.register(componentFactory);
++               final ReactInstanceManager reactInstanceManager = getReactInstanceManager();
++
++               ViewManagerRegistry viewManagerRegistry =
++                   new ViewManagerRegistry(
++                       reactInstanceManager.getOrCreateViewManagers(
++                           reactApplicationContext));
++
++               return new FabricJSIModuleProvider(
++                   reactApplicationContext,
++                   componentFactory,
++                   new EmptyReactNativeConfig(),
++                   viewManagerRegistry);
++             }
++           });
++           return specs;
++         }
++       };
++     }
     };
 }
 ```
@@ -72,31 +71,31 @@ public class MyApplication extends Application implements ReactApplication {
 Inside your `Activity` class, you need to make sure you’re calling `setIsFabric` on the `ReactRootView`.
 If you don’t have a `ReactActivityDelegate` you might need to create one.
 
-```java
+```diff title='MainActivity.java'
 public class MainActivity extends ReactActivity {
 
   // Add the Activity Delegate, if you don't have one already.
-  public static class MainActivityDelegate extends ReactActivityDelegate {
-
-    public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
-      super(activity, mainComponentName);
-    }
-
-    @Override
-    protected ReactRootView createRootView() {
-      ReactRootView reactRootView = new ReactRootView(getContext());
-
-      // Make sure to call setIsFabric(true) on your ReactRootView
-      reactRootView.setIsFabric(true);
-      return reactRootView;
-    }
-  }
++ public static class MainActivityDelegate extends ReactActivityDelegate {
++
++   public MainActivityDelegate(ReactActivity activity, String mainComponentName) {
++     super(activity, mainComponentName);
++   }
++
++   @Override
++   protected ReactRootView createRootView() {
++     ReactRootView reactRootView = new ReactRootView(getContext());
++
++     // Make sure to call setIsFabric(true) on your ReactRootView
++     reactRootView.setIsFabric(true);
++     return reactRootView;
++   }
++ }
 
   // Make sure to override the `createReactActivityDelegate()` method.
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new MainActivityDelegate(this, getMainComponentName());
-  }
++ @Override
++ protected ReactActivityDelegate createReactActivityDelegate() {
++   return new MainActivityDelegate(this, getMainComponentName());
++ }
 }
 ```
 
@@ -202,7 +201,7 @@ public class MyNativeViewManager extends SimpleViewManager<MyNativeView>
 
 Specifically inside the `ReactNativeHost` , update `getPackages` method to include the following:
 
-```java
+```diff title='MyApplication.java'
 public class MyApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
@@ -216,22 +215,22 @@ public class MyApplication extends Application implements ReactApplication {
       // ... other packages or `TurboReactPackage added` here...
 
       // Add those lines.
-      packages.add(new ReactPackage() {
-        @NonNull
-        @Override
-        public List<NativeModule> createNativeModules(
-            @NonNull ReactApplicationContext reactContext) {
-          return Collections.emptyList();
-        }
-
-        @NonNull
-        @Override
-        public List<ViewManager> createViewManagers(
-            @NonNull ReactApplicationContext reactContext) {
-          // Your ViewManager is returned here.
-          return Collections.singletonList(new MyNativeViewManager());
-        }
-      });
++     packages.add(new ReactPackage() {
++       @NonNull
++       @Override
++       public List<NativeModule> createNativeModules(
++           @NonNull ReactApplicationContext reactContext) {
++         return Collections.emptyList();
++       }
++
++       @NonNull
++       @Override
++       public List<ViewManager> createViewManagers(
++           @NonNull ReactApplicationContext reactContext) {
++         // Your ViewManager is returned here.
++         return Collections.singletonList(new MyNativeViewManager());
++       }
++     });
       return packages;
     }
   };
@@ -244,7 +243,7 @@ You need to create a new component Registry that will allow you to **register** 
 
 As you can see, some methods are `native()` which we will implement in C++ in the following paragraph.
 
-```java
+```java title='MyComponentsRegistry.java'
 package com.awesomeproject;
 
 import com.facebook.jni.HybridData;
@@ -279,7 +278,7 @@ public class MyComponentsRegistry {
 
 Finally, let’s edit the `getJSIModulePackage` from the `ReactNativeHost` to also register your Component Registry alongside the Core one:
 
-```java
+```diff title='MyApplication.java'
 public class MyApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
@@ -293,17 +292,14 @@ public class MyApplication extends Application implements ReactApplication {
                 final JavaScriptContextHolder jsContext) {
           final List<JSIModuleSpec> specs = new ArrayList<>();
           specs.add(new JSIModuleSpec() {
-            // ...
 
             @Override
             public JSIModuleProvider<UIManager> getJSIModuleProvider() {
               final ComponentFactory componentFactory = new ComponentFactory();
               CoreComponentsRegistry.register(componentFactory);
 
-              // Add this line just below CoreComponentsRegistry.register
-              MyComponentsRegistry.register(componentFactory);
-
-              // ...
++             // Add this line just below CoreComponentsRegistry.register
++             MyComponentsRegistry.register(componentFactory);
             }
           });
           return specs;
@@ -434,20 +430,18 @@ void MyComponentsRegistry::registerNatives() {
 
 If you followed the TurboModule instructions, you should have a `OnLoad.cpp` file inside the `src/main/jni` folder. There you should add a line to load the `MyComponentsRegistry` class:
 
-```cpp title="OnLoad.cpp"
-#include <fbjni/fbjni.h>
-#include "MyApplicationTurboModuleManagerDelegate.h"
-// Add this import
-#include "MyComponentsRegistry.h"
-
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
-  return facebook::jni::initialize(vm, [] {
-    facebook::react::MyApplicationTurboModuleManagerDelegate::registerNatives();
-
-    // Add this line
-    facebook::react::MyComponentsRegistry::registerNatives();
-  });
-}
+```diff title="OnLoad.cpp"
+ #include <fbjni/fbjni.h>
+ #include "MyApplicationTurboModuleManagerDelegate.h"
++#include "MyComponentsRegistry.h"
+ 
+ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+   return facebook::jni::initialize(vm, [] {
+     facebook::react::MyApplicationTurboModuleManagerDelegate::registerNatives();
+ 
++    facebook::react::MyComponentsRegistry::registerNatives();
+   });
+ }
 ```
 
 You can now verify that everything works correctly by running your android app:

--- a/docs/new-architecture-app-renderer-android.md
+++ b/docs/new-architecture-app-renderer-android.md
@@ -434,11 +434,11 @@ If you followed the TurboModule instructions, you should have a `OnLoad.cpp` fil
  #include <fbjni/fbjni.h>
  #include "MyApplicationTurboModuleManagerDelegate.h"
 +#include "MyComponentsRegistry.h"
- 
+
  JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
    return facebook::jni::initialize(vm, [] {
      facebook::react::MyApplicationTurboModuleManagerDelegate::registerNatives();
- 
+
 +    facebook::react::MyComponentsRegistry::registerNatives();
    });
  }

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -17,7 +17,7 @@ Once you have defined the JavaScript specs for your native modules as part of th
 
 You can now configure Codegen by specifying the following in the module-level `build.gradle` file:
 
-```groovy
+```groovy title='android/app/build.gradle'
 react {
     reactRoot = rootProject.file("../node_modules/react-native/")
     jsRootDir = rootProject.file("../js/")
@@ -93,7 +93,7 @@ Update your native module or component to ensure it **extends the abstract class
 
 Following the example set forth in the previous section, your library might import `NativeAwesomeManagerSpec`, implement the relevant native interface and the necessary methods for it:
 
-```java
+```java title='NativeAwesomeManager.java'
 import androidx.annotation.NonNull;
 
 import com.example.samplelibrary.NativeAwesomeManagerSpec;


### PR DESCRIPTION
I've updated several codeblocks in the migration guide to use the `diff` syntax + I've added several missing `title='...'` so it's cleared of which file we're talking about.