### PR TITLE
Migrate Algolia DocSearch account

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -58,7 +58,9 @@ const siteConfig = {
   },
   blogSidebarCount: 'ALL',
   algolia: {
-    apiKey: '2c98749b4a1e588efec53b2acec13025',
+    // apiKey: '2c98749b4a1e588efec53b2acec13025',
+    appId: '2W9DUHXF3I',
+    apiKey: 'f3a42b24f7c22d56073f9d1b024799f0',
     indexName: 'react-native-archive',
     algoliaOptions: {
       facetFilters: ['tags:VERSION'],

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -63,7 +63,7 @@ const siteConfig = {
     apiKey: 'f3a42b24f7c22d56073f9d1b024799f0',
     indexName: 'react-native-archive',
     algoliaOptions: {
-      facetFilters: ['tags:VERSION'],
+      facetFilters: ['version:VERSION'],
       hitsPerPage: 5,
     },
   },


### PR DESCRIPTION
Migrate Algolia account on archived Docusaurus v1 site: https://archive.reactnative.dev

See also https://v1.docusaurus.io/blog/2021/11/05/algolia-migration

---

@Simek I invited you to a react-native-archive project on the DocSearch dashboard. Let me know if I should invite anyone else at Meta.

v1 site search is still working (readonly), but @shortcuts still recommend to migrate because some day that readonly index might be deleted

---

Preview: https://deploy-preview-2990--react-native-archive.netlify.app/