### PR TITLE
refactor(getting-started): path to sdk binaries

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -47,23 +47,22 @@ Next, select the "SDK Tools" tab and check the box next to "Show Package Details
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
-<h4>3. Configure the ANDROID_HOME environment variable</h4>
+<h4>3. Configure the ANDROID_SDK_ROOT environment variable</h4>
 
 The React Native tools require some environment variables to be set up in order to build apps with native code.
 
 Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you are using `zsh` then `~/.zprofile` or `~/.zshrc`) config file:
 
 ```shell
-export ANDROID_HOME=$HOME/Android/Sdk
-export PATH=$PATH:$ANDROID_HOME/emulator
-export PATH=$PATH:$ANDROID_HOME/tools
-export PATH=$PATH:$ANDROID_HOME/tools/bin
-export PATH=$PATH:$ANDROID_HOME/platform-tools
+export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
+export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
+export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin
+export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```
 
 > `.bash_profile` is specific to `bash`. If you're using another shell, you will need to edit the appropriate shell-specific config file.
 
-Type `source $HOME/.bash_profile` for `bash` or `source $HOME/.zprofile` to load the config into your current shell. Verify that ANDROID_HOME has been set by running `echo $ANDROID_HOME` and the appropriate directories have been added to your path by running `echo $PATH`.
+Type `source $HOME/.bash_profile` for `bash` or `source $HOME/.zprofile` to load the config into your current shell. Verify that ANDROID_SDK_ROOT has been set by running `echo $ANDROID_SDK_ROOT` and the appropriate directories have been added to your path by running `echo $PATH`.
 
 > Please make sure you use the correct Android SDK path. You can find the actual location of the SDK in the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
 

--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -56,6 +56,7 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you
 ```shell
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
+# Commandline Path is determined by version "/cmdline-tools/[VERSION]/bin" latest is the default from Android studio but please check you setup within the SDK Manager
 export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```

--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -56,8 +56,6 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you
 ```shell
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
-# Commandline Path is determined by version "/cmdline-tools/[VERSION]/bin" latest is the default from Android studio but please check you setup within the SDK Manager
-export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -65,13 +65,6 @@ Next, select the "SDK Tools" tab and check the box next to "Show Package Details
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
-You can also run the following command after setting ANDROID_SDK_ROOT.
-
-```shell
-sdkmanager "platforms;android-30" "system-images;android-30;default;x86_64" "system-images;android-30;google_apis;x86"
-sdkmanager "cmdline-tools;latest" "build-tools;30.0.2"
-```
-
 <h4>3. Configure the ANDROID_SDK_ROOT environment variable</h4>
 
 The React Native tools require some environment variables to be set up in order to build apps with native code.
@@ -81,8 +74,6 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you
 ```shell
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
-# Commandline Path is determined by version "/cmdline-tools/[VERSION]/bin" latest is the default from Android studio but please check you setup within the SDK Manager
-export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -81,6 +81,7 @@ Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you
 ```shell
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
+# Commandline Path is determined by version "/cmdline-tools/[VERSION]/bin" latest is the default from Android studio but please check you setup within the SDK Manager
 export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -61,7 +61,7 @@ Select the "SDK Platforms" tab from within the SDK Manager, then check the box n
 - `Android SDK Platform 30`
 - `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `30.0.2` is selected and check the "Android SDK Command-line Tools (latest)".
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `30.0.2` is selected.
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -65,30 +65,29 @@ Next, select the "SDK Tools" tab and check the box next to "Show Package Details
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
-You can also run the following command after setting ANDROID_HOME.
+You can also run the following command after setting ANDROID_SDK_ROOT.
 
 ```shell
 sdkmanager "platforms;android-30" "system-images;android-30;default;x86_64" "system-images;android-30;google_apis;x86"
 sdkmanager "cmdline-tools;latest" "build-tools;30.0.2"
 ```
 
-<h4>3. Configure the ANDROID_HOME environment variable</h4>
+<h4>3. Configure the ANDROID_SDK_ROOT environment variable</h4>
 
 The React Native tools require some environment variables to be set up in order to build apps with native code.
 
 Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you are using `zsh` then `~/.zprofile` or `~/.zshrc`) config file:
 
 ```shell
-export ANDROID_HOME=$HOME/Library/Android/sdk
-export PATH=$PATH:$ANDROID_HOME/emulator
-export PATH=$PATH:$ANDROID_HOME/tools
-export PATH=$PATH:$ANDROID_HOME/tools/bin
-export PATH=$PATH:$ANDROID_HOME/platform-tools
+export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
+export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
+export PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin
+export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```
 
 > `.bash_profile` is specific to `bash`. If you're using another shell, you will need to edit the appropriate shell-specific config file.
 
-Type `source $HOME/.bash_profile` for `bash` or `source $HOME/.zprofile` to load the config into your current shell. Verify that ANDROID_HOME has been set by running `echo $ANDROID_HOME` and the appropriate directories have been added to your path by running `echo $PATH`.
+Type `source $HOME/.bash_profile` for `bash` or `source $HOME/.zprofile` to load the config into your current shell. Verify that ANDROID_SDK_ROOT has been set by running `echo $ANDROID_SDK_ROOT` and the appropriate directories have been added to your path by running `echo $PATH`.
 
 > Please make sure you use the correct Android SDK path. You can find the actual location of the SDK in the Android Studio "Preferences" dialog, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
 


### PR DESCRIPTION
## Description

Changes in two parts. For both Linux and MacOS getting started guides:

* From version 4 of command line tools the path to binaries was updated to `/cmdline-tools/latest/bin` with the previous being deprecated. 
* The name of the path environment variable has been updated to `ANDROID_SDK_ROOT` (https://developer.android.com/studio/command-line/variables#:~:text=ANDROID_HOME%2C%20which%20also%20points%20to%20the%20SDK%20installation%20directory%2C%20is%20deprecated.)

This PR updates the paths for both docs and replaces instances `ANDROID_HOME` with the updated `ANDROID_SDK_ROOT`.

NOTE: there are instances of ANDROID_HOME within the windows getting started guide but as they are backed up with images also utilising this name that I am unable to replace then have opted to leave that guide as it is. 

## Motivation and Context

The reason for the change is that the deprecated version of the SDK manager does not work with the java v11+ so making the getting started guide broken for new users as it recommended to install that version of the JDK. Equally the errors that get spun out are far from clear as to the problem making it hard to realise it requires a simple fix. 

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

