### PR TITLE
Clarify intended audience for architecture overview

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -3,4 +3,4 @@ id: architecture-overview
 title: Architecture Overview
 ---
 
-This section is a work in progress intended to share conceptual overviews of how React Native's architecture works. Its intended audience includes library authors, core contributors, and the exceptionally curious.
+This section is a work in progress intended to share conceptual overviews of how React Native's architecture works. Its intended audience includes library authors, core contributors, and the exceptionally curious. It is not a requirement to be familiar with this material to use React Native.

--- a/website/versioned_docs/version-0.67/architecture-overview.md
+++ b/website/versioned_docs/version-0.67/architecture-overview.md
@@ -3,4 +3,4 @@ id: architecture-overview
 title: Architecture Overview
 ---
 
-This section is a work in progress intended to share conceptual overviews of how React Native's architecture works. Its intended audience includes library authors, core contributors, and the exceptionally curious.
+This section is a work in progress intended to share conceptual overviews of how React Native's architecture works. Its intended audience includes library authors, core contributors, and the exceptionally curious. It is not a requirement to be familiar with this material to use React Native.


### PR DESCRIPTION
Adding a sentence to clarify that it is not needed to understand architecture overview to use React Native.

Based on feedback: https://github.com/reactwg/react-native-new-architecture/discussions/1#discussioncomment-2265361