### PR TITLE
move Fabric warning to partial, use admonition

### DIFF
--- a/docs/_fabric-warning.mdx
+++ b/docs/_fabric-warning.mdx
@@ -1,0 +1,5 @@
+:::caution
+
+This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
+
+:::

--- a/docs/render-pipeline.md
+++ b/docs/render-pipeline.md
@@ -3,7 +3,9 @@ id: render-pipeline
 title: Render, Commit, and Mount
 ---
 
-> This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
+import FabricWarning from './\_fabric-warning.mdx';
+
+<FabricWarning />
 
 The React Native renderer goes through a sequence of work to render React logic to a [host platform](architecture-glossary#host-platform). This sequence of work is called the render pipeline and occurs for initial renders and updates to the UI state. This document goes over the render pipeline and how it differs in those scenarios.
 

--- a/docs/threading-model.md
+++ b/docs/threading-model.md
@@ -3,7 +3,9 @@ id: threading-model
 title: Threading Model
 ---
 
-> This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
+import FabricWarning from './\_fabric-warning.mdx';
+
+<FabricWarning />
 
 #### The React Native renderer distributes the work of the [render pipeline](render-pipeline) across multiple threads.
 

--- a/docs/view-flattening.md
+++ b/docs/view-flattening.md
@@ -3,7 +3,9 @@ id: view-flattening
 title: View Flattening
 ---
 
-> This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
+import FabricWarning from './\_fabric-warning.mdx';
+
+<FabricWarning />
 
 #### View Flattening is an optimization by the React Native renderer to avoid deep layout trees.
 

--- a/docs/xplat-implementation.md
+++ b/docs/xplat-implementation.md
@@ -3,7 +3,9 @@ id: xplat-implementation
 title: Cross Platform Implementation
 ---
 
-> This document refers to the architecture of the new renderer, [Fabric](fabric-renderer), that is in active roll-out.
+import FabricWarning from './\_fabric-warning.mdx';
+
+<FabricWarning />
 
 #### The React Native renderer utilizes a core render implementation to be shared across platforms
 


### PR DESCRIPTION
This PR moves the Fabric warning used on the few New Arch pages to the partial (just for the ease of maintenance) and converts the "note" styling to the Docusaurus admonition.

# Preview
<img width="1392" alt="Screenshot 2022-03-08 at 16 57 39" src="https://user-images.githubusercontent.com/719641/157275772-10ed1bde-534e-44bf-a2f3-4af1c5ea4bdc.png">

