### PR TITLE
Hyphenation normal enum

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                     | Default  |
+| ------------------------ | -------- |
+| enum(`'none'`, `'full'`) | `'none'` |
 
 ---
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                     | Default  |
-| ------------------------ | -------- |
-| enum(`'none'`, `'full'`) | `'none'` |
+| Type                                | Default  |
+| ----------------------------------- | -------- |
+| enum(`'none'`, `'normal'`,`'full'`) | `'none'` |
 
 ---
 

--- a/website/versioned_docs/version-0.64/text.md
+++ b/website/versioned_docs/version-0.64/text.md
@@ -334,9 +334,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                                                         | Default  |
+| ------------------------------------------------------------ | -------- |
+| enum(`'none'`, `'normal'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
 
 ---
 

--- a/website/versioned_docs/version-0.65/text.md
+++ b/website/versioned_docs/version-0.65/text.md
@@ -334,9 +334,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                                                         | Default  |
+| ------------------------------------------------------------ | -------- |
+| enum(`'none'`, `'normal'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
 
 ---
 

--- a/website/versioned_docs/version-0.66/text.md
+++ b/website/versioned_docs/version-0.66/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                                                         | Default  |
+| ------------------------------------------------------------ | -------- |
+| enum(`'none'`, `'normal'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
 
 ---
 

--- a/website/versioned_docs/version-0.67/text.md
+++ b/website/versioned_docs/version-0.67/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                                             | Default  |
-| ------------------------------------------------ | -------- |
-| enum(`'none'`, `'full'`, `'balanced'`, `'high'`) | `'none'` |
+| Type                     | Default  |
+| ------------------------ | -------- |
+| enum(`'none'`, `'full'`) | `'none'` |
 
 ---
 

--- a/website/versioned_docs/version-0.67/text.md
+++ b/website/versioned_docs/version-0.67/text.md
@@ -358,9 +358,9 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
-| Type                     | Default  |
-| ------------------------ | -------- |
-| enum(`'none'`, `'full'`) | `'none'` |
+| Type                                 | Default  |
+| ------------------------------------ | -------- |
+| enum(`'none'`, `'normal'`, `'full'`) | `'none'` |
 
 ---
 


### PR DESCRIPTION
Added the normal enum to all docs where android_hyphenationFrequency was used. 
As asked in [2982](../2982)