### PR TITLE
Corrected outdated command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ Then run the following commands to create a new React Native project called "Awe
 <TabItem value="npm">
 
 ```shell
-expo init AwesomeProject
+npx expo init AwesomeProject
 
 cd AwesomeProject
 npm start # you can also use: expo start


### PR DESCRIPTION
I tried to use the "expo init" command after installng expo globally and I was simply greeted with an error that stated : "bash: expo: command not found".
After reading more about the problem on the internet, I concluded that the correct command is "npx expo".
You may want to search more about the problem but the issue is old and is more common on MacOS.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
