### PR TITLE
adding android_errorMessage prop to TextInput

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -115,6 +115,16 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
+### `android_errorMessage` <div class="label android">Android</div>
+
+String to be read by screenreaders to indicate an error state. If this value is not null, an error will be announced. You can use onChangeText or onBlur to detect an error and set this prop. Once the error is gone, set this to null to clear the error.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `autoCapitalize`
 
 Tells `TextInput` to automatically capitalize certain characters. This property is not supported by some keyboard types such as `name-phone-pad`.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Adding Public API documentation for the TextInput android_errorMessage prop 

React Native Issue https://github.com/facebook/react-native/issues/30848
React Native PR https://github.com/facebook/react-native/compare/main...fabriziobertoglio1987:text-input-errors-build
More Information at https://github.com/fabriziobertoglio1987/react-native-notes/issues/12