### PR TITLE
📚 Rename JSCExecutorFactory into HermesExecutorFactory

### DIFF
--- a/docs/new-architecture-app-modules-ios.md
+++ b/docs/new-architecture-app-modules-ios.md
@@ -128,7 +128,9 @@ Next, you will create a `RCTTurboModuleManager` in your bridge delegate’s `jsE
   // Add this line...
   __weak __typeof(self) weakSelf = self;
 
-  return std::make_unique<facebook::react::JSCExecutorFactory>(
+  // If you want to use the `JSCExecutorFactory`, remember to add the `#import <React/JSCExecutorFactory.h>`
+  // import statement on top.
+  return std::make_unique<facebook::react::HermesExecutorFactory>(
     facebook::react::RCTJSIExecutorRuntimeInstaller([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
       if (!bridge) {
         return;


### PR DESCRIPTION
This PR fixes a concrete type in a code snippet.

The snippet as it was written does not compile because, in order to use the  `JSCExecutorFactory`, we need to also import the related header. We added this detail in a comment in the code.

The snippet has been updated with the `HermesExecutorFactory`: the related header is already imported in the guide and this makes Hermes the default executor.
