### PR TITLE
📚 Use empty dicts instead of nil

### DIFF
--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -74,12 +74,12 @@ The way to render your app with Fabric depends on your setup. Here is an example
   UIView *rootView =
       [[RCTFabricSurfaceHostingProxyRootView alloc] initWithBridge:_bridge
                                                         moduleName:<#moduleName#>
-                                                 initialProperties:nil];
+                                                 initialProperties:@{}];
 #else
   // Current implementation to define rootview.
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:<#moduleName#>
-                                            initialProperties:nil];
+                                            initialProperties:@{}];
 #endif
 ```
 


### PR DESCRIPTION
This PR updates a code snippet to use empty dictionaries instead of `nil` values.  Despite the code work in both ways, an empty dictionary is a safer and more future-proof approach.
