### PR TITLE
📚Use placeholders instead of hardcoded strings

### DIFF
--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -73,12 +73,12 @@ The way to render your app with Fabric depends on your setup. Here is an example
 
   UIView *rootView =
       [[RCTFabricSurfaceHostingProxyRootView alloc] initWithBridge:_bridge
-                                                        moduleName:@"MyTestApp"
+                                                        moduleName:<#moduleName#>
                                                  initialProperties:nil];
 #else
   // Current implementation to define rootview.
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                                   moduleName:@"MyTestApp"
+                                                   moduleName:<#moduleName#>
                                             initialProperties:nil];
 #endif
 ```


### PR DESCRIPTION
This pr replaces a couple of hardcoded strings with a placeholder that the user must fill in Xcode.
 
Before that, the user must remember to update those strings manually. By using Xcode placeholders, the compiler will ask the user to change them.
