### PR TITLE
📚 Use more specific dependency React-Core

### DIFF
--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\""
   }
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "React-RCTFabric" # This is for fabric component
   s.dependency "React-Codegen"
   s.dependency "RCT-Folly", folly_version


### PR DESCRIPTION
This PR replaces the dependency from `React` with the one from `React-Core` in a code snippet.
