### PR TITLE
fix codegenNativeCommands section example

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -444,14 +444,14 @@ class MyComponent extends React.Component<Props> {
 
 **Creating the NativeCommands with `codegenNativeCommands`**
 
-```js title="MyCustomMapNativeComponent.js"
+```ts title="MyCustomMapNativeComponent.js"
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { HostComponent } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
 type MyCustomMapNativeComponentType = HostComponent<NativeProps>;
 
- interface NativeCommands {
-   +moveToRegion: (
+interface NativeCommands {
+  +moveToRegion: (
      viewRef: React.ElementRef<MyCustomMapNativeComponentType>,
       region: MapRegion,
       duration: number,

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -444,21 +444,19 @@ class MyComponent extends React.Component<Props> {
 
 **Creating the NativeCommands with `codegenNativeCommands`**
 
-```ts title="MyCustomMapNativeComponent.js"
-import codegeNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
-...
-type Props = {...};
+```js title="MyCustomMapNativeComponent.js"
+import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
+import type { HostComponent } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
-const MyCustomMapNativeComponent: HostComponent<Props> =
-   requireNativeComponent<Props>('MyCustomMapNativeComponent');
+type MyCustomMapNativeComponentType = HostComponent<NativeProps>;
 
-interface NativeCommands {
-  moveToRegion: (
-    ref: React.ElementRef<typeof MyCustomMapNativeComponent>,
-    region: MapRegion,
-    duration: number,
-  ) => void;
-}
+ interface NativeCommands {
+   +moveToRegion: (
+     viewRef: React.ElementRef<MyCustomMapNativeComponentType>,
+      region: MapRegion,
+      duration: number,
+   ) => void;
+ }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['moveToRegion'],


### PR DESCRIPTION
The codegenNativeCommands section has incorrect example

![image](https://user-images.githubusercontent.com/12766071/159280912-abce4294-10f9-4703-9d81-bc50879e4bf3.png)

Here you can find a working example:
https://github.com/callstack/react-native-pager-view/pull/534/commits/9f46b8fddb300a28e73e2a5eee6dbb6ef946bab0