### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/sync-api-docs/generateMarkdown.js
+++ b/sync-api-docs/generateMarkdown.js
@@ -281,29 +281,29 @@ function preprocessDescription(desc) {
   });
 
   if (tabs === 2) {
-    const firstExample = desc.substr(desc.search('```SnackPlayer') + 1);
-    const secondExample = firstExample.substr(
+    const firstExample = desc.slice(desc.search('```SnackPlayer') + 1);
+    const secondExample = firstExample.slice(
       firstExample.search('```SnackPlayer') + 1
     );
 
     return (
-      desc.substr(0, desc.search('```SnackPlayer')) +
+      desc.substring(0, desc.search('```SnackPlayer')) +
       `\n## Example\n` +
       `${playgroundTab}\n\n${functionalBlock}\n\n${
-        '`' + firstExample.substr(0, firstExample.search('```') + 3)
+        '`' + firstExample.slice(0, firstExample.search('```') + 3)
       }\n\n${classBlock}\n\n${
-        '`' + secondExample.substr(0, secondExample.search('```') + 3)
+        '`' + secondExample.slice(0, secondExample.search('```') + 3)
       }\n\n${endBlock}` +
-      secondExample.substr(secondExample.search('```') + 3)
+      secondExample.slice(secondExample.search('```') + 3)
     );
   } else {
     if (desc.search('```SnackPlayer') !== -1) {
       return (
-        desc.substr(0, desc.search('```SnackPlayer')) +
+        desc.slice(0, desc.search('```SnackPlayer')) +
         '\n' +
         '\n## Example\n' +
         '\n' +
-        desc.substr(desc.search('```SnackPlayer'))
+        desc.slice(desc.search('```SnackPlayer'))
       );
     } else return desc;
   }

--- a/sync-api-docs/propFormatter.js
+++ b/sync-api-docs/propFormatter.js
@@ -77,7 +77,7 @@ function formatTypeColumn(prop) {
         const isMatch = prop.flowType.raw.match(/: [a-zA-Z]*/);
         if (isMatch) {
           // Formats EventType
-          const eventType = isMatch[0].substr(2);
+          const eventType = isMatch[0].slice(2);
           // Checks for aliases in magic and generates md url
           if (
             Object.hasOwnProperty.call(magic.linkableTypeAliases, eventType)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.