### PR TITLE
small custom CSS fixes and tweaks

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -277,6 +277,11 @@ hr {
     background-color: var(--light);
   }
 
+  div[class^="codeBlockContainer"] {
+    box-shadow: none;
+    margin-bottom: 1rem;
+  }
+
   div[class^="codeBlockContent"] {
     display: inline-grid;
     min-width: 100%;
@@ -1733,6 +1738,10 @@ html[data-theme="dark"] .docsRating {
       --ifm-col-width: calc(18 / 24 * 100%);
     }
   }
+
+  article.margin-bottom--xl {
+    margin-bottom: 2.5rem !important
+  }
 }
 
 html[data-theme="dark"] {
@@ -1767,6 +1776,7 @@ html[data-theme="light"] {
 
   .container.margin-vert--lg .row .col.col--7 {
     --ifm-col-width: 100% !important;
+    padding: 24px 16px !important;
   }
 
   .main-wrapper:not(.community-page) {


### PR DESCRIPTION
# Why & How

This PR fixes small display issues which emerges after latest Docusaurus upgrades. The list includes:
* removed broken and unnecessary shadow for the code block container (mostly visible in light theme)
  <img width="694" alt="Screenshot 2022-03-24 at 16 09 46" src="https://user-images.githubusercontent.com/719641/159947800-dcb1a3e9-223c-40b2-9985-5ac9111c3524.png">
* fixed uneven padding for the blog container on mobile
  <img width="472" alt="Screenshot 2022-03-24 at 16 11 05" src="https://user-images.githubusercontent.com/719641/159948045-d8691027-a6ab-4882-aa3d-89758237364f.png">
* reduced the spacing between blog post on the posts list (it was set to `5rem`, which is a bit too much, especially on mobile devices)
  <img width="846" alt="Screenshot 2022-03-24 at 16 13 50" src="https://user-images.githubusercontent.com/719641/159948674-04970599-b4ec-4121-a264-fb7c1d3c2429.png">

  
  
