### PR TITLE
hide VersionDropdown on non-versioned pages, reduce the visible versions list

### DIFF
--- a/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -15,8 +15,8 @@ import {
 import {useDocsPreferredVersion} from '@docusaurus/theme-common';
 import {translate} from '@docusaurus/Translate';
 
-const getVersionMainDoc = (version) =>
-  version.docs.find((doc) => doc.id === version.mainDocId);
+const getVersionMainDoc = version =>
+  version.docs.find(doc => doc.id === version.mainDocId);
 
 export default function DocsVersionDropdownNavbarItem({
   mobile,
@@ -41,7 +41,7 @@ export default function DocsVersionDropdownNavbarItem({
   const reducedVersions = versions.slice(0, 6);
 
   function getItems() {
-    const versionLinks = reducedVersions.map((version) => {
+    const versionLinks = reducedVersions.map(version => {
       // We try to link to the same doc, in another version
       // When not possible, fallback to the "main doc" of the version
       const versionDoc =

--- a/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+import {
+  useVersions,
+  useLatestVersion,
+  useActiveDocContext,
+} from '@theme/hooks/useDocs';
+import {useDocsPreferredVersion} from '@docusaurus/theme-common';
+import {translate} from '@docusaurus/Translate';
+
+const getVersionMainDoc = (version) =>
+  version.docs.find((doc) => doc.id === version.mainDocId);
+
+export default function DocsVersionDropdownNavbarItem({
+  mobile,
+  docsPluginId,
+  dropdownActiveClassDisabled,
+  dropdownItemsBefore,
+  dropdownItemsAfter,
+  ...props
+}) {
+  const activeDocContext = useActiveDocContext(docsPluginId);
+  const versions = useVersions(docsPluginId);
+  const latestVersion = useLatestVersion(docsPluginId);
+  const {preferredVersion, savePreferredVersionName} =
+    useDocsPreferredVersion(docsPluginId);
+
+  // (CUSTOM) Hide version dropdown on non-versioned pages
+  if (!activeDocContext.activeDoc) {
+    return null;
+  }
+
+  // (CUSTOM) Show only `next` and last 5 versions in the dropdown
+  const reducedVersions = versions.slice(0, 6);
+
+  function getItems() {
+    const versionLinks = reducedVersions.map((version) => {
+      // We try to link to the same doc, in another version
+      // When not possible, fallback to the "main doc" of the version
+      const versionDoc =
+        activeDocContext?.alternateDocVersions[version.name] ||
+        getVersionMainDoc(version);
+      return {
+        isNavLink: true,
+        label: version.label,
+        to: versionDoc.path,
+        isActive: () => version === activeDocContext?.activeVersion,
+        onClick: () => {
+          savePreferredVersionName(version.name);
+        },
+      };
+    });
+    return [...dropdownItemsBefore, ...versionLinks, ...dropdownItemsAfter];
+  }
+
+  const items = getItems();
+  const dropdownVersion =
+    activeDocContext.activeVersion ?? preferredVersion ?? latestVersion; // Mobile dropdown is handled a bit differently
+
+  const dropdownLabel =
+    mobile && items
+      ? translate({
+          id: 'theme.navbar.mobileVersionsDropdown.label',
+          message: 'Versions',
+          description:
+            'The label for the navbar versions dropdown on mobile view',
+        })
+      : dropdownVersion.label;
+  const dropdownTo =
+    mobile && items ? undefined : getVersionMainDoc(dropdownVersion).path; // We don't want to render a version dropdown with 0 or 1 item
+  // If we build the site with a single docs version (onlyIncludeVersions: ['1.0.0'])
+  // We'd rather render a button instead of a dropdown
+
+  if (items.length <= 1) {
+    return (
+      <DefaultNavbarItem
+        {...props}
+        mobile={mobile}
+        label={dropdownLabel}
+        to={dropdownTo}
+        isActive={dropdownActiveClassDisabled ? () => false : undefined}
+      />
+    );
+  }
+
+  return (
+    <DropdownNavbarItem
+      {...props}
+      mobile={mobile}
+      label={dropdownLabel}
+      to={dropdownTo}
+      items={items}
+      isActive={dropdownActiveClassDisabled ? () => false : undefined}
+    />
+  );
+}


### PR DESCRIPTION
# Why & How

Since latest changes to the docs structure and introducing multiple docs instances part of the website is versioned, and part of the website is static.

Due to those changes I feel like the `VersionDropdown` adds a bit of unnecessary confusion, so I have decided to swizzle it and propose a change that hides the version selector from all of the non-versioned pages. The selector is only visible when viewing the pages from `Guides`, `APIs` and `Components`. This might not be in line with other Docususaurus sites, but I feel like it's a better UX in our case.

I have decided to swizzle because AFAIK Docusuaurs do not offer a configs for the changes I would like to achieve. 

The code I have added has been annotated with comment starting with `(CUSTOM)`, so we can identify the part we edited during Docusuaurs updates in the future.

In addition to that, I have reduced the number of visible versions in the dropdown to 5 latest releases + `next`.

## Preview
<img width="1417" alt="Screenshot 2022-03-25 at 14 12 06" src="https://user-images.githubusercontent.com/719641/160127100-e946c54f-d7af-4d2e-8844-880bef48e581.png">
<img width="343" alt="Screenshot 2022-03-25 at 14 11 41" src="https://user-images.githubusercontent.com/719641/160127109-312395d8-498b-46f1-8d2a-2b990f509fa5.png">

