### PR TITLE
New Arch Appendix types section refactor

### DIFF
--- a/docs/new-architecture-appendix.md
+++ b/docs/new-architecture-appendix.md
@@ -11,21 +11,79 @@ import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
 
 You may use the following table as a reference for which types are supported and what they map to in each platform:
 
-| Flow Type                                      | Nullable Support?                             | Android (Java)                       | iOS                                                            | Note                                                                           |
-| ---------------------------------------------- | --------------------------------------------- | ------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `string`                                       | `?string`                                     | `String`                             | `NSString`                                                     |                                                                                |
-| `boolean`                                      | `?boolean`                                    | `Boolean`                            | `NSNumber`                                                     |                                                                                |
-| `number`                                       | No                                            | `double`                             | `NSNumber`                                                     |                                                                                |
-| <code>{&#124; foo: string, ... &#124;}</code>  | <code>?{&#124; foo: string, ...&#124;}</code> |                                      |                                                                | Object literal. This is recommended over simply using Object, for type safety. |
-| `Object`                                       | `?Object`                                     | `ReadableMap`                        | `@{} (untyped dictionary)`                                     | Recommended to use object literal (see above).                                 |
-| `Array<*>`                                     | `?Array<*>`                                   | `ReadableArray`                      | `NSArray` (or `RCTConvertVecToArray` when used inside objects) |                                                                                |
-| `Function`                                     | `?Function`                                   |                                      |                                                                |                                                                                |
-| `Promise<*>`                                   | `?Promise<*>`                                 | `com.facebook.react.bridge.Promise`  | `RCTPromiseResolve` and `RCTPromiseRejectBlock`                |                                                                                |
-| Type aliases of the above                      | Yes                                           |                                      |                                                                |                                                                                |
-| Type Unions <code>'SUCCESS'&#124;'FAIL'</code> | Only as callbacks.                            |                                      |                                                                | Type unions only supported as callbacks.                                       |
-| Callbacks: `( ) =>`                            | Yes                                           | `com.facebook.react.bridge.Callback` | `RCTResponseSenderBlock`                                       | Callback functions are not type checked, and are generalized as Objects.       |
+### `string`
 
+| Nullable Support? | Android (Java) | iOS        |
+| ----------------- | -------------- | ---------- |
+| `?string`         | `String`       | `NSString` |
+
+### `boolean`
+
+| Nullable Support? | Android (Java) | iOS        |
+| ----------------- | -------------- | ---------- |
+| `?boolean`        | `Boolean`      | `NSNumber` |
+
+### Object literal
+
+This is recommended over simply using `Object`, for type safety.
+
+**Example:** `{| foo: string, ... |}`
+
+| Nullable Support?                             | Android (Java) | iOS |
+| --------------------------------------------- | -------------- | --- |
+| <code>?{&#124; foo: string, ...&#124;}</code> | -              | -   |
+
+### `Object`
+
+:::note
+Recommended to use [Object literal](#object-literal) instead.
+:::
+
+| Nullable Support? | Android (Java) | iOS                        |
+| ----------------- | -------------- | -------------------------- |
+| `?Object`         | `ReadableMap`  | `@{}` (untyped dictionary) |
+
+### `Array<*>`
+
+| Nullable Support? | Android (Java)  | iOS                                                            |
+| ----------------- | --------------- | -------------------------------------------------------------- |
+| `?Array<*>`       | `ReadableArray` | `NSArray` (or `RCTConvertVecToArray` when used inside objects) |
+
+### `Function`
+
+| Nullable Support? | Android (Java) | iOS |
+| ----------------- | -------------- | --- |
+| `?Function`       | -              | -   |
+
+### `Promise<*>`
+
+| Nullable Support? | Android (Java)                      | iOS                                             |
+| ----------------- | ----------------------------------- | ----------------------------------------------- |
+| `?Promise<*>`     | `com.facebook.react.bridge.Promise` | `RCTPromiseResolve` and `RCTPromiseRejectBlock` |
+
+### Type Unions
+
+Type unions are only supported as callbacks.
+
+**Example:** `'SUCCESS' | 'FAIL'`
+
+| Nullable Support?  | Android (Java) | iOS |
+| ------------------ | -------------- | --- |
+| Only as callbacks. | -              | -   |
+
+### Callbacks
+
+Callback functions are not type checked, and are generalized as `Object`s.
+
+**Example:** `() =>`
+
+| Nullable Support? | Android (Java)                       | iOS                      |
+| ----------------- | ------------------------------------ | ------------------------ |
+| Yes               | `com.facebook.react.bridge.Callback` | `RCTResponseSenderBlock` |
+
+:::note
 You may also find it useful to refer to the JavaScript specifications for the core modules in React Native. These are located inside the `Libraries/` directory in the React Native repository.
+:::
 
 ## II. Invoking the code-gen during development
 

--- a/docs/new-architecture-appendix.md
+++ b/docs/new-architecture-appendix.md
@@ -25,7 +25,7 @@ You may use the following table as a reference for which types are supported and
 
 ### Object literal
 
-This is recommended over simply using `Object`, for type safety.
+This is recommended over using plain `Object`, for type safety.
 
 **Example:** `{| foo: string, ... |}`
 


### PR DESCRIPTION
# Why

Displaying data in the table is quite compact, but in case of Types section in Appendix it's a bit too much condensed, which leads to layout overflow and poor mobile experience.

<img width="1416" alt="Screenshot 2022-03-28 at 20 28 02" src="https://user-images.githubusercontent.com/719641/160463000-98461c31-977c-486a-a88a-671cc4ef0c6d.png">

# How

This PR refactors the New Arch Appendix types section extracting each type to its own small section. This change increases the overall readability on mobile and fixes the page overflow on desktop.

⚠️ On thing which I'm not sure what to do is "Type aliases of the above" entry. It is removed in this version, because it was a bit hard to fit this in nicely after refactor. Maybe we can add this as a more general sentence which just list the supported types in type aliases? If anyone got an idea please suggest the change or directly contribute to the PR branch.

# Preview

<img width="1416" alt="Screenshot 2022-03-28 at 20 27 05" src="https://user-images.githubusercontent.com/719641/160462804-2547317d-4557-474c-a708-0392e22a40eb.png">

