### PR TITLE
Clarified 0.68 breaking changes

### DIFF
--- a/website/blog/2022-03-30-version-068.md
+++ b/website/blog/2022-03-30-version-068.md
@@ -26,8 +26,8 @@ Hello everyone! Today we are announcing the 0.68.0 release of React Native, with
 This version brings along a few breaking changes:
 
 - React Native has been updated to Node 16, the latest LTS. Since on CI we test for LTS and the previous LTS, this change means that users are now required to use a version of Node >= 14.
-- Android Gradle Plugin was updated to 7.0.1, enforcing JDK 11 for Android builds, so make sure to upgrade your configurations (we recommend you use the `temurin11` JDK flavor)
-- Removed `fallbackResource` from `RCTBundleURLProvider` API on iOS.
+- Android Gradle Plugin was updated to 7.0.1, enforcing JDK 11 for Android builds, so make sure to upgrade your configurations (we recommend you use the `temurin11` JDK flavor or Azul Zulu 11 for arm64 / m1)
+- Removed `fallbackResource` from `RCTBundleURLProvider` API on iOS. This parameter can be safely removed from the method call without replacement.
 
 Tooling has also been updated - here are the main bumps:
 


### PR DESCRIPTION
* Added hint for m1 jdk
* fallbackResource can just be safely removed without replacement
