### PR TITLE
Add missing semicolon in native modules guide

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -403,7 +403,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.63/native-modules-android.md
+++ b/website/versioned_docs/version-0.63/native-modules-android.md
@@ -274,7 +274,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.63/native-modules-ios.md
+++ b/website/versioned_docs/version-0.63/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.64/native-modules-android.md
+++ b/website/versioned_docs/version-0.64/native-modules-android.md
@@ -274,7 +274,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.64/native-modules-ios.md
+++ b/website/versioned_docs/version-0.64/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.65/native-modules-android.md
+++ b/website/versioned_docs/version-0.65/native-modules-android.md
@@ -274,7 +274,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.65/native-modules-ios.md
+++ b/website/versioned_docs/version-0.65/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.66/native-modules-android.md
+++ b/website/versioned_docs/version-0.66/native-modules-android.md
@@ -274,7 +274,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.66/native-modules-ios.md
+++ b/website/versioned_docs/version-0.66/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.67/native-modules-android.md
+++ b/website/versioned_docs/version-0.67/native-modules-android.md
@@ -274,7 +274,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.67/native-modules-ios.md
+++ b/website/versioned_docs/version-0.67/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.68/native-modules-android.md
+++ b/website/versioned_docs/version-0.68/native-modules-android.md
@@ -403,7 +403,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }

--- a/website/versioned_docs/version-0.68/native-modules-ios.md
+++ b/website/versioned_docs/version-0.68/native-modules-ios.md
@@ -229,7 +229,7 @@ This JavaScript file also becomes a good location for you to add any JavaScript 
 * 2. String location: A string representing the location of the event
 */
 import { NativeModules } from 'react-native';
-const { CalendarModule } = NativeModules
+const { CalendarModule } = NativeModules;
 interface CalendarInterface {
    createCalendarEvent(name: string, location: string): void;
 }


### PR DESCRIPTION
TypeScript example in native modules guide was missing trailing semicolon. 


To see the change locally, go to: http://localhost:3000/docs/0.67/native-modules-ios



Before:
<img width="819" alt="Screenshot 2022-04-01 at 09 52 43" src="https://user-images.githubusercontent.com/1733610/161219980-02c48bd9-1afe-4461-8d2a-8c8320aedd6a.png">

After:
<img width="832" alt="Screenshot 2022-04-01 at 09 52 26" src="https://user-images.githubusercontent.com/1733610/161219971-40d07be8-6793-4009-9d55-b6b7cc8931f8.png">