### PR TITLE
add `case-police` checks, fix case issues

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -392,7 +392,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -353,7 +353,7 @@ You can also iterate quickly on a device using the development server. You only 
 
 ### Troubleshooting
 
-> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (WiFi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
+> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (Wi-Fi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
 
 When trying to connect to the development server you might get a [red screen with an error](debugging.md#in-app-errors-and-warnings) saying:
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -3,7 +3,7 @@ id: statusbar
 title: StatusBar
 ---
 
-Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, WiFi and cellular network information, battery level and/or other status icons.
+Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, Wi-Fi and cellular network information, battery level and/or other status icons.
 
 ### Usage with Navigator
 

--- a/docs/usewindowdimensions.md
+++ b/docs/usewindowdimensions.md
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "babel-eslint": "^10.1.0",
+    "case-police": "^0.5.1",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-mdx": "^1.16.0",

--- a/website/blog/2017-06-21-react-native-monthly-1.md
+++ b/website/blog/2017-06-21-react-native-monthly-1.md
@@ -72,7 +72,7 @@ As teams' plans might be of interest to a broader audience, we'll be sharing the
 ### Microsoft
 
 - [CodePush](https://github.com/Microsoft/code-push) has now been integrated into [Mobile Center](https://mobile.azure.com/). This is the first step in providing a much more integrated experience with distribution, analytics and other services. See their announcement [here](https://microsoft.github.io/code-push/articles/CodePushOnMobileCenter.html).
-- [VSCode](https://github.com/Microsoft/vscode) has a bug with debugging, they are working on fixing that right now and will have a new build.
+- [VS Code](https://github.com/Microsoft/vscode) has a bug with debugging, they are working on fixing that right now and will have a new build.
 - Investigating [Detox](https://github.com/wix/detox) for Integration testing, looking at JSC Context to get variables alongside crash reports.
 
 ### Shoutem

--- a/website/blog/2017-07-28-react-native-monthly-2.md
+++ b/website/blog/2017-07-28-react-native-monthly-2.md
@@ -78,7 +78,7 @@ Here are the notes from each team:
 - [CodePush](https://github.com/Microsoft/code-push) has now been integrated into [Mobile Center](https://mobile.azure.com/). Existing users will have no change in their workflow.
   - Some people have reported an issue with duplicate apps - they already had an app on Mobile Center. We are working on resolving them, but if you have two apps, let us know, and we can merge them for you.
 - Mobile Center now supports Push Notifications for CodePush. We also showed how a combination of Notifications and CodePush could be used for A/B testing apps - something unique to the ReactNative architecture.
-- [VSCode](https://github.com/Microsoft/vscode) has a known debugging issue with ReactNative - the next release of the extension in a couple of days will be fixing the issue.
+- [VS Code](https://github.com/Microsoft/vscode) has a known debugging issue with ReactNative - the next release of the extension in a couple of days will be fixing the issue.
 - Since there are many other teams also working on React Native inside Microsoft, we will work on getting better representation from all the groups for the next meeting.
 
 ### Shoutem

--- a/website/blog/2017-09-21-react-native-monthly-4.md
+++ b/website/blog/2017-09-21-react-native-monthly-4.md
@@ -12,7 +12,7 @@ The React Native monthly meeting continues! Here are the notes from each team:
 
 ### Callstack
 
-- [React Native EU](https://react-native.eu) is over. More than 300 participants from 33 countries have visited Wroclaw. Talks can be found [on Youtube](https://www.youtube.com/channel/UCUNE_g1mQPuyW975WjgjYxA/videos).
+- [React Native EU](https://react-native.eu) is over. More than 300 participants from 33 countries have visited Wroclaw. Talks can be found [on YouTube](https://www.youtube.com/channel/UCUNE_g1mQPuyW975WjgjYxA/videos).
 - We are slowly getting back to our open source schedule after the conference. One thing worth mentioning is that we are working on a next release of [react-native-opentok](https://github.com/callstack/react-native-opentok) that fixes most of the existing issues.
 
 ### GeekyAnts
@@ -27,7 +27,7 @@ Trying to lower the entry barrier for the developers embracing React Native with
 - Will release SDK 21 shortly, which adds support for react-native 0.48.3 and a bunch of bugfixes/reliability improvements/new features in the Expo SDK, including video recording, a new splash screen API, support for `react-native-gesture-handler`, and improved error handling.
 - Re: [react-native-gesture-handler](https://github.com/kmagiera/react-native-gesture-handler), [Krzysztof Magiera](https://github.com/kmagiera) of [Software Mansion](http://swmansion.com/) continues pushing this forward and we've been helping him with testing it and funding part of his development time. Having this integrated in Expo in SDK21 will allow people to play with it easily in Snack, so we're excited to see what people come up with.
 - Re: improved error logging / handling - see [this gist of an internal Expo PR](https://gist.github.com/brentvatne/00407710a854627aa021fdf90490b958) for details on logging, (in particular, "Problem 2"), and [this commit](https://github.com/expo/xdl/commit/1d62eca293dfb867fc0afc920c3dad94b7209987) for a change that handles failed attempts to import npm standard library modules. There is plenty of opportunity to improve error messages upstream in React Native in this way and we will work on follow up upstream PRs. It would be great for the community to get involved too.
-- [native.directory](http://native.directory/) continues to grow, you can add your projects from [the Github repo](https://github.com/react-community/native-directory).
+- [native.directory](http://native.directory/) continues to grow, you can add your projects from [the GitHub repo](https://github.com/react-community/native-directory).
 - Visit hackathons around North America, including [PennApps](http://pennapps.com/), [Hack The North](http://hackthenorth.com/), [HackMIT](https://hackmit.org/), and soon [MHacks](https://mhacks.org/).
 
 ### Facebook

--- a/website/blog/2021-03-08-GAAD-React-Native-Accessibility.md
+++ b/website/blog/2021-03-08-GAAD-React-Native-Accessibility.md
@@ -10,7 +10,7 @@ tags: [announcement]
 
 ## Hello React Native Community,
 
-In May 2020 Facebook was the first company to take the [GAAD pledge](https://diamond.la/GAADPledge/), by doing so they committed to making accessibility a core part of the React Native open source project. Since May, Facebook has spent that time thoughtfully reviewing and documenting accessibility gaps within React Native. So far the gap analysis has surfaced 90 issues, all of which have been translated to [Github issues](https://github.com/facebook/react-native/projects/15).
+In May 2020 Facebook was the first company to take the [GAAD pledge](https://diamond.la/GAADPledge/), by doing so they committed to making accessibility a core part of the React Native open source project. Since May, Facebook has spent that time thoughtfully reviewing and documenting accessibility gaps within React Native. So far the gap analysis has surfaced 90 issues, all of which have been translated to [GitHub issues](https://github.com/facebook/react-native/projects/15).
 
 Overall, we found that React Native APIs provide strong support for accessibility. However, we also found many core components do not yet fully utilize platform accessibility APIs and support is missing for some platform specific features.
 
@@ -22,9 +22,9 @@ Please join us in making React Native more accessible for everyone.
 
 ### How you can help:
 
-- New contributors should read the [contribution guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) and browse the list of 46 [good first issues](https://github.com/facebook/react-native/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22+label%3AAccessibility) in the React Native Github.
+- New contributors should read the [contribution guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) and browse the list of 46 [good first issues](https://github.com/facebook/react-native/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22+label%3AAccessibility) in the React Native GitHub.
 
-- Contributors interested in issues requiring a bit more effort should visit [the project page for Improved React Native Accessibility](https://github.com/facebook/react-native/projects/15) to see the Github issues that need their knowledge of React Native.
+- Contributors interested in issues requiring a bit more effort should visit [the project page for Improved React Native Accessibility](https://github.com/facebook/react-native/projects/15) to see the GitHub issues that need their knowledge of React Native.
 
 - Technical writers interested in updating React Native's documentation to reflect the accessibility gaps being closed should visit the [React Native Docs](https://github.com/facebook/react-native-website#-overview).
 

--- a/website/blog/2021-04-08-GAAD-March-Accessibility-Issue-Update.md
+++ b/website/blog/2021-04-08-GAAD-March-Accessibility-Issue-Update.md
@@ -8,7 +8,7 @@ authorTwitter: alexmarlette
 tags: [announcement]
 ---
 
-It has been four weeks since we reached out to the Github community with a thoroughly reviewed gap analysis and list of issues to improve React Native's accessibility. With the help of the React Native community, we are already making great progress on improving accessibility. Community members have been helping contributors, reviewing tests, and bringing attention to prior accessibility issues. Since March 8th the community has closed six issues with four pull requests and seven other pull requests are in the pipeline for review.
+It has been four weeks since we reached out to the GitHub community with a thoroughly reviewed gap analysis and list of issues to improve React Native's accessibility. With the help of the React Native community, we are already making great progress on improving accessibility. Community members have been helping contributors, reviewing tests, and bringing attention to prior accessibility issues. Since March 8th the community has closed six issues with four pull requests and seven other pull requests are in the pipeline for review.
 
 While this work continues, the React Native and Accessibility teams at Facebook are evaluating accessibility bugs and issues that were submitted prior to this initiative, to determine if they are already covered by our current gap analysis or if there are additional issues that need to be brought into the project. One new issue has already been discovered and moved into the project, four others directly mapped to existing issues and two others are expected to be closed by addressing existing issues that address the root cause of their issue.
 
@@ -64,9 +64,9 @@ Thank you to all the community members who have participated. You are truly movi
 
 ## Get involved!
 
-- New contributors should read the [contribution guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) and browse the list of 37 [good first issues](https://github.com/facebook/react-native/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22+label%3AAccessibility) in the React Native Github.
+- New contributors should read the [contribution guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) and browse the list of 37 [good first issues](https://github.com/facebook/react-native/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22+label%3AAccessibility) in the React Native GitHub.
 
-- Contributors interested in issues requiring a bit more effort should visit [the project page for Improved React Native Accessibility](https://github.com/facebook/react-native/projects/15) to see the Github issues that need their knowledge of React Native.
+- Contributors interested in issues requiring a bit more effort should visit [the project page for Improved React Native Accessibility](https://github.com/facebook/react-native/projects/15) to see the GitHub issues that need their knowledge of React Native.
 
 - Technical writers interested in updating React Native's documentation to reflect the accessibility gaps being closed should visit the [React Native Docs](https://github.com/facebook/react-native-website#-overview).
 

--- a/website/blog/2021-05-20-GAAD-One-Year-Later.md
+++ b/website/blog/2021-05-20-GAAD-One-Year-Later.md
@@ -10,7 +10,7 @@ tags: [announcement]
 
 It has been one year since Facebook took the [GAAD Pledge](https://diamond.la/GAADPledge/) to make React Native accessible and the project has exceeded our expectations. We are excited to announce that this project will continue throughout 2021 and want to update everyone on our progress so far. Following a thorough analysis of the accessibility gaps in React Native last year, work began on filling these gaps.
 
-We started with 90 outstanding gap analysis issues and from March 2021, when the project launched on Github, until now:
+We started with 90 outstanding gap analysis issues and from March 2021, when the project launched on GitHub, until now:
 
 - 11 issues have been closed by the community.
 
@@ -116,4 +116,4 @@ Join us in tackling the rest. There are still open accessibility issues on the [
 
 ### Learn More
 
-Read about how the gap analysis was conducted on the [Facebook Tech blog](https://tech.fb.com/react-native-accessibility/) or about the launch of the Github issues on the [React Native Blog](https://reactnative.dev/blog/2021/03/08/GAAD-React-Native-Accessibility).
+Read about how the gap analysis was conducted on the [Facebook Tech blog](https://tech.fb.com/react-native-accessibility/) or about the launch of the GitHub issues on the [React Native Blog](https://reactnative.dev/blog/2021/03/08/GAAD-React-Native-Accessibility).

--- a/website/blog/2021-10-01-version-066.md
+++ b/website/blog/2021-10-01-version-066.md
@@ -62,7 +62,7 @@ The process for migrating your project to a React Native nightly release is very
 #### Using Commitly Releases (Commitlies)
 
 <figure>
-  <img src="/blog/assets/0.66-artifact.png" alt="Screenshot of CircleCi artifact panel to find tarball" />
+  <img src="/blog/assets/0.66-artifact.png" alt="Screenshot of CircleCI artifact panel to find tarball" />
   <figcaption>
     Find the "build_npm_package-1" job related to a commit and head to the "Artifacts" panel to download the tarball for the commitly.
   </figcaption>

--- a/website/blog/2022-01-21-react-native-h2-2021-recap.md
+++ b/website/blog/2022-01-21-react-native-h2-2021-recap.md
@@ -84,6 +84,6 @@ Earlier in 2021, we shared our [Many Platform Vision](https://reactnative.dev/bl
 
 We’re looking forward to **converging patterns** that are platform-specific into the React Native experience.
 
-Finally, we want to thank again the community for the enormous support in H2 2021. It’s always amazing to see how contributors come together and support each other on Github, fixing bugs, sharing their and helping us deliver React Native to millions of users.
+Finally, we want to thank again the community for the enormous support in H2 2021. It’s always amazing to see how contributors come together and support each other on GitHub, fixing bugs, sharing their and helping us deliver React Native to millions of users.
 
 Stay tuned and looking forward to an **even more amazing 2022** 🎉!

--- a/website/package.json
+++ b/website/package.json
@@ -24,8 +24,8 @@
     "prettier": "yarn format:source && yarn format:markdown && yarn format:style",
     "lint": "eslint ../docs/** blog/** core/** src/**/*.{js,md} ./*.js",
     "lint:versioned": "eslint versioned_docs/**",
-    "language:lint": "cd ../ && alex",
-    "language:lint:versioned": "cd ../ && alex .",
+    "language:lint": "cd ../ && alex && case-police 'docs/*.md' -p brands,general,products,softwares",
+    "language:lint:versioned": "cd ../ && alex . && case-police '**/*.md' -p brands,general,products,softwares",
     "ci:lint": "yarn lint && yarn lint:versioned && yarn language:lint:versioned",
     "pwa:generate": "npx pwa-asset-generator ./static/img/header_logo.svg ./static/img/pwa --background #20232a --icon-only -opaque true --maskable true --type png"
   },

--- a/website/versioned_docs/version-0.60/native-modules-ios.md
+++ b/website/versioned_docs/version-0.60/native-modules-ios.md
@@ -126,7 +126,7 @@ CalendarManager.addEvent(
   'Birthday Party',
   '4 Privet Drive, Surrey',
   date.getTime()
-); // passing date as number of milliseconds since Unix epoch
+); // passing date as number of milliseconds since UNIX epoch
 ```
 
 or

--- a/website/versioned_docs/version-0.60/state.md
+++ b/website/versioned_docs/version-0.60/state.md
@@ -52,7 +52,7 @@ export default class BlinkApp extends Component {
 }
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.60/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.60/usewindowdimensions.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.61/native-modules-ios.md
+++ b/website/versioned_docs/version-0.61/native-modules-ios.md
@@ -126,7 +126,7 @@ CalendarManager.addEvent(
   'Birthday Party',
   '4 Privet Drive, Surrey',
   date.getTime()
-); // passing date as number of milliseconds since Unix epoch
+); // passing date as number of milliseconds since UNIX epoch
 ```
 
 or

--- a/website/versioned_docs/version-0.61/state.md
+++ b/website/versioned_docs/version-0.61/state.md
@@ -52,7 +52,7 @@ export default class BlinkApp extends Component {
 }
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.61/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.61/usewindowdimensions.md
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.62/native-modules-ios.md
+++ b/website/versioned_docs/version-0.62/native-modules-ios.md
@@ -126,7 +126,7 @@ CalendarManager.addEvent(
   'Birthday Party',
   '4 Privet Drive, Surrey',
   date.getTime()
-); // passing date as number of milliseconds since Unix epoch
+); // passing date as number of milliseconds since UNIX epoch
 ```
 
 or

--- a/website/versioned_docs/version-0.62/state.md
+++ b/website/versioned_docs/version-0.62/state.md
@@ -43,7 +43,7 @@ export default function BlinkApp() {
 }
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.62/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.62/usewindowdimensions.md
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.63/native-modules-android.md
+++ b/website/versioned_docs/version-0.63/native-modules-android.md
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/website/versioned_docs/version-0.63/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.63/out-of-tree-platforms.md
@@ -12,7 +12,7 @@ React Native is not only for Android and iOS - there are community-supported pro
 - [React Native macOS](https://github.com/ptmt/react-native-macos) - An experimental React Native fork targeting macOS and Cocoa
 - [React Native tvOS](https://github.com/react-native-community/react-native-tvos) - adaptation of React Native for Apple tvOS
 - [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program(微信小程序).
-- [Proton Native](https://github.com/kusti8/proton-native) - A wrapper for React Native, using Qt to target Linux, MacOS, and Windows.
+- [Proton Native](https://github.com/kusti8/proton-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows.
 
 ## Creating your own React Native platform
 

--- a/website/versioned_docs/version-0.63/state.md
+++ b/website/versioned_docs/version-0.63/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.63/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.63/usewindowdimensions.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.64/native-modules-android.md
+++ b/website/versioned_docs/version-0.64/native-modules-android.md
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/website/versioned_docs/version-0.64/running-on-device.md
+++ b/website/versioned_docs/version-0.64/running-on-device.md
@@ -355,7 +355,7 @@ You can also iterate quickly on a device using the development server. You only 
 
 ### Troubleshooting
 
-> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (WiFi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
+> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (Wi-Fi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
 
 When trying to connect to the development server you might get a [red screen with an error](debugging.md#in-app-errors-and-warnings) saying:
 

--- a/website/versioned_docs/version-0.64/state.md
+++ b/website/versioned_docs/version-0.64/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.64/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.64/usewindowdimensions.md
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.65/native-modules-android.md
+++ b/website/versioned_docs/version-0.65/native-modules-android.md
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/website/versioned_docs/version-0.65/running-on-device.md
+++ b/website/versioned_docs/version-0.65/running-on-device.md
@@ -355,7 +355,7 @@ You can also iterate quickly on a device using the development server. You only 
 
 ### Troubleshooting
 
-> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (WiFi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
+> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (Wi-Fi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
 
 When trying to connect to the development server you might get a [red screen with an error](debugging.md#in-app-errors-and-warnings) saying:
 

--- a/website/versioned_docs/version-0.65/state.md
+++ b/website/versioned_docs/version-0.65/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.65/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.65/usewindowdimensions.md
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.66/native-modules-android.md
+++ b/website/versioned_docs/version-0.66/native-modules-android.md
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/website/versioned_docs/version-0.66/running-on-device.md
+++ b/website/versioned_docs/version-0.66/running-on-device.md
@@ -355,7 +355,7 @@ You can also iterate quickly on a device using the development server. You only 
 
 ### Troubleshooting
 
-> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (WiFi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
+> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (Wi-Fi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
 
 When trying to connect to the development server you might get a [red screen with an error](debugging.md#in-app-errors-and-warnings) saying:
 

--- a/website/versioned_docs/version-0.66/state.md
+++ b/website/versioned_docs/version-0.66/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.66/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.66/usewindowdimensions.md
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.67/native-modules-android.md
+++ b/website/versioned_docs/version-0.67/native-modules-android.md
@@ -263,7 +263,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/website/versioned_docs/version-0.67/running-on-device.md
+++ b/website/versioned_docs/version-0.67/running-on-device.md
@@ -353,7 +353,7 @@ You can also iterate quickly on a device using the development server. You only 
 
 ### Troubleshooting
 
-> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (WiFi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
+> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (Wi-Fi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
 
 When trying to connect to the development server you might get a [red screen with an error](debugging.md#in-app-errors-and-warnings) saying:
 

--- a/website/versioned_docs/version-0.67/state.md
+++ b/website/versioned_docs/version-0.67/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.67/statusbar.md
+++ b/website/versioned_docs/version-0.67/statusbar.md
@@ -3,7 +3,7 @@ id: statusbar
 title: StatusBar
 ---
 
-Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, WiFi and cellular network information, battery level and/or other status icons.
+Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, Wi-Fi and cellular network information, battery level and/or other status icons.
 
 ### Usage with Navigator
 

--- a/website/versioned_docs/version-0.67/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.67/usewindowdimensions.md
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/website/versioned_docs/version-0.68/native-modules-android.md
+++ b/website/versioned_docs/version-0.68/native-modules-android.md
@@ -392,7 +392,7 @@ const { CalendarModule } = NativeModules;
 export default CalendarModule;
 ```
 
-This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like Typescript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
+This JavaScript file also becomes a good location for you to add any JavaScript side functionality. For example, if you use a type system like TypeScript you can add type annotations for your native module here. While React Native does not yet support Native to JS type safety, all your JS code will be type safe. Doing so will also make it easier for you to switch to type-safe native modules down the line. Below is an example of adding type safety to the CalendarModule:
 
 ```jsx
 /**

--- a/website/versioned_docs/version-0.68/running-on-device.md
+++ b/website/versioned_docs/version-0.68/running-on-device.md
@@ -353,7 +353,7 @@ You can also iterate quickly on a device using the development server. You only 
 
 ### Troubleshooting
 
-> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (WiFi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
+> If you have any issues, ensure that your Mac and device are on the same network and can reach each other. Many open wireless networks with captive portals are configured to prevent devices from reaching other devices on the network. You may use your device's Personal Hotspot feature in this case. You may also share your internet (Wi-Fi/Ethernet) connection from your Mac to your device via USB and connect to the bundler through this tunnel for very high transfer speeds.
 
 When trying to connect to the development server you might get a [red screen with an error](debugging.md#in-app-errors-and-warnings) saying:
 

--- a/website/versioned_docs/version-0.68/state.md
+++ b/website/versioned_docs/version-0.68/state.md
@@ -45,7 +45,7 @@ const BlinkApp = () => {
 export default BlinkApp;
 ```
 
-In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [Mobx](https://mobx.js.org/) to control your data flow. In that case you would use Redux or Mobx to modify your state rather than calling `setState` directly.
+In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 
 When setState is called, BlinkApp will re-render its Component. By calling setState within the Timer, the component will re-render every time the Timer ticks.
 

--- a/website/versioned_docs/version-0.68/statusbar.md
+++ b/website/versioned_docs/version-0.68/statusbar.md
@@ -3,7 +3,7 @@ id: statusbar
 title: StatusBar
 ---
 
-Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, WiFi and cellular network information, battery level and/or other status icons.
+Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, Wi-Fi and cellular network information, battery level and/or other status icons.
 
 ### Usage with Navigator
 

--- a/website/versioned_docs/version-0.68/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.68/usewindowdimensions.md
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
+- The [useDimensions](https://github.com/react-native-community/react-native-hooks#usedimensions) hook from the community [React Native hooks](https://github.com/react-native-community/react-native-hooks) library aims to make handling screen/window size changes easier to work with.
 - [React Native Responsive Dimensions](https://github.com/DaniAkash/react-native-responsive-dimensions) also comes with responsive hooks.
 
 ## Properties

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,6 +2906,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001280:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
   integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
+case-police@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/case-police/-/case-police-0.5.1.tgz#0206adecf9676dd74aa650dc0748815d5016ef8b"
+  integrity sha512-Om/kMuDjTZ/gS6mqcGZcevRqdcmNJdBPe9MnZxHHJ1oTpBdFGF57zf+4VMpQWtmyGMzI0us7+B61mdynjQco2Q==
+
 ccount@^1.0.0, ccount@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"


### PR DESCRIPTION
This PR adds the [`case-police`](https://github.com/antfu/case-police) check to the workspace. 

It has been attached to the `lanuage:lint` scripts. I have also decided to filter out abbreviates dict (https://github.com/antfu/case-police/tree/main/dict), since it leads to  too many false-positives in path, especially for Android (SDK, URI etc.).

The issues can be fixed automatically, just like most of ESLint warnings, by adding `--fix` flag at the end of script/command.

The changeset also includes all of the fixes listed by `case-police` after the initial configuration.
