### PR TITLE
[ci] switch to next-gen CircleCI img

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
 
 # -------------------------
 #        COMMANDS


### PR DESCRIPTION
# Why
<img width="819" alt="Screenshot 2022-04-07 at 20 42 30" src="https://user-images.githubusercontent.com/719641/162274540-ec9070c8-f6c8-469e-95e0-ba311c80e9a2.png">

Ref: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

# How

this PR changes the CircleCI Docker image name according to the docs:
* https://circleci.com/developer/images/image/cimg/node

# Test plan

Run the CI! 😉 
