### PR TITLE
Suggest Zulu11 for all the users (regardless of M1 or not)

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -19,12 +19,14 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 <h3>Java Development Kit</h3>
 
-We recommend installing the OpenJDK distribution called Temurin using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
+We recommend installing the OpenJDK distribution called Azul **Zulu** using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
 
 ```shell
 brew tap homebrew/cask-versions
-brew install --cask temurin11
+brew install --cask zulu11
 ```
+
+The Zulu OpenJDK distribution offers JDKs for **both Intel and M1 Macs**. This will make sure your build are faster on M1 Macs compared to using an Intel-based JDK.
 
 If you have already installed JDK on your system, make sure it is JDK 11 or newer.
 

--- a/website/blog/2022-03-30-version-068.md
+++ b/website/blog/2022-03-30-version-068.md
@@ -26,7 +26,7 @@ Hello everyone! Today we are announcing the 0.68.0 release of React Native, with
 This version brings along a few breaking changes:
 
 - React Native has been updated to Node 16, the latest LTS. Since on CI we test for LTS and the previous LTS, this change means that users are now required to use a version of Node >= 14.
-- Android Gradle Plugin was updated to 7.0.1, enforcing JDK 11 for Android builds, so make sure to upgrade your configurations (we recommend you use the `temurin11` JDK flavor or Azul Zulu 11 for arm64 / m1)
+- Android Gradle Plugin was updated to 7.0.1, enforcing JDK 11 for Android builds, so make sure to upgrade your configurations (we recommend you use the `zulu11` JDK flavor for both Intel and M1 Macs)
 - Removed `fallbackResource` from `RCTBundleURLProvider` API on iOS. This parameter can be safely removed from the method call without replacement.
 
 Tooling has also been updated - here are the main bumps:

--- a/website/versioned_docs/version-0.68/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-macos-android.md
@@ -19,12 +19,14 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 <h3>Java Development Kit</h3>
 
-We recommend installing the OpenJDK distribution called Temurin using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
+We recommend installing the OpenJDK distribution called Azul **Zulu** using [Homebrew](http://brew.sh/). Run the following commands in a Terminal after installing Homebrew:
 
 ```shell
 brew tap homebrew/cask-versions
-brew install --cask temurin11
+brew install --cask zulu11
 ```
+
+The Zulu OpenJDK distribution offers JDKs for **both Intel and M1 Macs**. This will make sure your build are faster on M1 Macs compared to using an Intel-based JDK.
 
 If you have already installed JDK on your system, make sure it is JDK 11 or newer.
 


### PR DESCRIPTION
I've been evaluating some OpenJDK distributions recently and I tested Zulu11 on a clean M1 Mac. I believe we should be good moving from temurin11 to zulu11.

If we believe this is creating to much confusion for users as we recently moved from adoptopenjdk to temurin, I can update the doc to mention zulu11 only for M1 users.

As a rule of thumb, I'd be happy to offer a command that works for users on both archs.

cc @danilobuerger 