### PR TITLE
Fix iOS and Android labels under accessibilityHint

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -63,9 +63,11 @@ To use, set the `accessibilityHint` property to a custom string on your View, Te
 ```
 
 <div class="label ios basic">iOS</div>
+
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
 <div class="label android basic">Android</div>
+
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
 ### `accessibilityLanguage` <div class="label ios">iOS</div>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -63,7 +63,7 @@ To use, set the `accessibilityHint` property to a custom string on your View, Te
 ```
 
 <div class="label ios basic">iOS</div>
-In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for accessibilityHint in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
+In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
 <div class="label android basic">Android</div>
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -62,9 +62,11 @@ To use, set the `accessibilityHint` property to a custom string on your View, Te
 </TouchableOpacity>
 ```
 
-iOS In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for accessibilityHint in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
+<div class="label ios basic">iOS</div>
+In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for accessibilityHint in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-Android In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
+<div class="label android basic">Android</div>
+In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
 ### `accessibilityLanguage` <div class="label ios">iOS</div>
 


### PR DESCRIPTION
These labels were starting the sentence and made it look off.

Before: 
https://reactnative.dev/docs/accessibility#accessibilityhint
<img width="852" alt="Screen Shot 2022-04-07 at 5 07 24 PM" src="https://user-images.githubusercontent.com/3081483/162333729-796faa0a-6c71-4cc9-8b8e-83dfe43bf491.png">

After: 
<img width="1101" alt="Screen Shot 2022-04-08 at 8 50 28 AM" src="https://user-images.githubusercontent.com/3081483/162464057-86b86a1e-50c3-4b9c-befb-ddffb016dd7c.png">


## Validation
- Pull down this branch
- Run `yarn start`
- Go to [http://localhost:3000/docs/next/accessibility](http://localhost:3000/docs/next/accessibility)
- Verify that the iOS and Android labels look correct