### PR TITLE
New Architecture landing page

### DIFF
--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -3,11 +3,26 @@ id: landing-page
 title: Introduction
 ---
 
-This section is the entry point for the new guide’s documentation.
-It contains some basic information about the New Architecture: its pillars, the version from which it has been made available and other very high-level information. Then, it should present the guide’s structure itself.
+Starting in version 0.68, React Native provides a New Architecture that improves several aspects of how JavaScript code and host platforms can integrate, such as:
 
-This section should also contains a sort of Driving guide based on the user use-cases:
+- synchronously measure and render React Native views at the same time as native views
+- support for prioritization of events that update the app's layout, like user interactions
+- improved type safety and consistency of communication between JavaScript and native code
 
-- New user: link to how to use the new [app template](use-app-template)
-- New Library developer: link to the [pillars](pillars)
-- Old library developer/app developer: link to [the migration guide](../new-architecture-intro)
+This is made possible by these [Pillars of the New Architecture](pillars):
+
+- [Fabric renderer and components](pillars-fabric-components), and the capabilities they offer for layout and interaction events
+- [TurboModules](pillars-turbo-modules), which supports faster loading of and communication with native code
+- [CodeGen](pillars-codegen), which generates code you can use to interface with native modules, via static typing in JavaScript
+
+## Get started with the New Architecture
+
+### For app developers
+
+To **create a new app** using the New Architecture, head over to [Creating a New Architecture App](use-app-template.md), which will get you up and running in a few easy steps with the new app template.
+
+To **migrate an existing app** to the New Architecture, follow [Adopting the New Architecture](../new-architecture-intro.md).
+
+### For library maintainers
+
+If you are adding support for the New Architecture to a library, head to the [Pillars]([pillars]) section to learn more about supporting apps that have migrated to the New Architecture, while still maintaining backwards compatibility for apps that haven't.

--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -3,13 +3,9 @@ id: landing-page
 title: Introduction
 ---
 
-Starting in version 0.68, React Native provides a New Architecture that improves several aspects of how JavaScript code and host platforms can integrate, such as:
+Starting in version 0.68, React Native provides the New Architecture, which offers developers new capabilities for building highly performant and responsive apps. Visit [Why a New Architecture](why) to learn more about what drove the decision to re-architect, and the benefits it provides.
 
-- synchronously measure and render React Native views at the same time as native views
-- support for prioritization of events that update the app's layout, like user interactions
-- improved type safety and consistency of communication between JavaScript and native code
-
-This is made possible by these [Pillars of the New Architecture](pillars):
+The core concepts are explained by the [Pillars of the New Architecture](pillars):
 
 - [Fabric renderer and components](pillars-fabric-components), and the capabilities they offer for layout and interaction events
 - [TurboModules](pillars-turbomodules), which supports faster loading of and communication with native code
@@ -25,7 +21,7 @@ To **migrate an existing app** to the New Architecture, follow [Adopting the New
 
 ### For library maintainers
 
-First, you'll need to learn about the primary components of the New Architecture: TurboModules, Fabric, and CodeGen. Learn more about these concepts in the [Pillars](pillars) section.
+First, read up on the core concepts outlined in the [Pillars](pillars) section.
 
 Then, for a **how-to guide** on supporting the New Architecture, check out the [Migration](../new-architecture-library-info) guide.
 

--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -12,7 +12,7 @@ Starting in version 0.68, React Native provides a New Architecture that improves
 This is made possible by these [Pillars of the New Architecture](pillars):
 
 - [Fabric renderer and components](pillars-fabric-components), and the capabilities they offer for layout and interaction events
-- [TurboModules](pillars-turbo-modules), which supports faster loading of and communication with native code
+- [TurboModules](pillars-turbomodules), which supports faster loading of and communication with native code
 - [CodeGen](pillars-codegen), which generates code you can use to interface with native modules, via static typing in JavaScript
 
 ## Get started with the New Architecture
@@ -25,4 +25,8 @@ To **migrate an existing app** to the New Architecture, follow [Adopting the New
 
 ### For library maintainers
 
-If you are adding support for the New Architecture to a library, head to the [Pillars]([pillars]) section to learn more about supporting apps that have migrated to the New Architecture, while still maintaining backwards compatibility for apps that haven't.
+First, you'll need to learn about the primary components of the New Architecture: TurboModules, Fabric, and CodeGen. Learn more about these concepts in the [Pillars](pillars) section.
+
+Then, for a **how-to guide** on supporting the New Architecture, check out the [Migration](../new-architecture-library-info) guide.
+
+For information on **supporting both the Old and New Architectures**, see the [Backwards Compatibility](backward-compatibility) guide.

--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -7,9 +7,9 @@ Starting in version 0.68, React Native provides the New Architecture, which offe
 
 In order to achieve these benefits, we had to rethink how Native Modules and Native Components work. This led us to develop the [Pillars of the New Architecture](pillars):
 
-- [Fabric renderer and components](pillars-fabric-components), and the capabilities they offer for layout and interaction events
-- [TurboModules](pillars-turbomodules), which supports faster loading of and communication with native code
-- [CodeGen](pillars-codegen), which generates code you can use to interface with native modules, via static typing in JavaScript
+- [TurboModules](pillars-turbomodules), a framework to support efficient and flexible integration with native code
+- [Fabric renderer and components](pillars-fabric-components), which offer improved capabilities, cross-platform consistency, and performance in rendering
+- [CodeGen](pillars-codegen), which generates boilerplate C++ required by the New Architecture, via static typing in JavaScript
 
 ## Get started with the New Architecture
 

--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -5,7 +5,7 @@ title: Introduction
 
 Starting in version 0.68, React Native provides the New Architecture, which offers developers new capabilities for building highly performant and responsive apps. Visit [Why a New Architecture](why) to learn more about what drove the decision to re-architect, and the benefits it provides.
 
-The core concepts are explained by the [Pillars of the New Architecture](pillars):
+In order to achieve these benefits, we had to rethink how Native Modules and Native Components work. This led us to develop the [Pillars of the New Architecture](pillars):
 
 - [Fabric renderer and components](pillars-fabric-components), and the capabilities they offer for layout and interaction events
 - [TurboModules](pillars-turbomodules), which supports faster loading of and communication with native code

--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -19,7 +19,7 @@ This is made possible by these [Pillars of the New Architecture](pillars):
 
 ### For app developers
 
-To **create a new app** using the New Architecture, head over to [Creating a New Architecture App](use-app-template.md), which will get you up and running in a few easy steps with the new app template.
+To **create a new app** using the New Architecture, head over to [Creating a New Architecture App](use-app-template.md), which will get you up and running in a few quick steps with the new app template.
 
 To **migrate an existing app** to the New Architecture, follow [Adopting the New Architecture](../new-architecture-intro.md).
 

--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -15,9 +15,9 @@ The core concepts are explained by the [Pillars of the New Architecture](pillars
 
 ### For app developers
 
-To **create a new app** using the New Architecture, head over to [Creating a New Architecture App](use-app-template.md), which will get you up and running in a few quick steps with the new app template.
+To **create a new app** using the New Architecture, head over to [Creating a New Architecture App](use-app-template), which will get you up and running in a few quick steps with the new app template.
 
-To **migrate an existing app** to the New Architecture, follow [Adopting the New Architecture](../new-architecture-intro.md).
+To **migrate an existing app** to the New Architecture, follow [Adopting the New Architecture](../new-architecture-intro).
 
 ### For library maintainers
 


### PR DESCRIPTION
Adds content to the New Architecture landing page, which should introduce the New Architecture and direct the reader to the relevant content for them.