### PR TITLE
Note for the plugin `transform-remove-console`

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -51,7 +51,7 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
-It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could call them.
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
 
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.60/performance.md
+++ b/website/versioned_docs/version-0.60/performance.md
@@ -39,7 +39,7 @@ JavaScript thread performance suffers greatly when running in dev mode. This is 
 
 When running a bundled app, these statements can cause a big bottleneck in the JavaScript thread. This includes calls from debugging libraries such as [redux-logger](https://github.com/evgenyrodionov/redux-logger), so make sure to remove them before bundling. You can also use this [babel plugin](https://babeljs.io/docs/plugins/transform-remove-console/) that removes all the `console.*` calls. You need to install it first with `npm i babel-plugin-transform-remove-console --save-dev`, and then edit the `.babelrc` file under your project directory like this:
 
-```jsxon
+```json
 {
   "env": {
     "production": {
@@ -50,6 +50,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 ```
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
+
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
 
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 

--- a/website/versioned_docs/version-0.61/performance.md
+++ b/website/versioned_docs/version-0.61/performance.md
@@ -39,7 +39,7 @@ JavaScript thread performance suffers greatly when running in dev mode. This is 
 
 When running a bundled app, these statements can cause a big bottleneck in the JavaScript thread. This includes calls from debugging libraries such as [redux-logger](https://github.com/evgenyrodionov/redux-logger), so make sure to remove them before bundling. You can also use this [babel plugin](https://babeljs.io/docs/plugins/transform-remove-console/) that removes all the `console.*` calls. You need to install it first with `npm i babel-plugin-transform-remove-console --save-dev`, and then edit the `.babelrc` file under your project directory like this:
 
-```jsxon
+```json
 {
   "env": {
     "production": {
@@ -50,6 +50,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 ```
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
+
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
 
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 

--- a/website/versioned_docs/version-0.62/performance.md
+++ b/website/versioned_docs/version-0.62/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.63/performance.md
+++ b/website/versioned_docs/version-0.63/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.64/performance.md
+++ b/website/versioned_docs/version-0.64/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.65/performance.md
+++ b/website/versioned_docs/version-0.65/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.66/performance.md
+++ b/website/versioned_docs/version-0.66/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.67/performance.md
+++ b/website/versioned_docs/version-0.67/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.

--- a/website/versioned_docs/version-0.68/performance.md
+++ b/website/versioned_docs/version-0.68/performance.md
@@ -51,6 +51,8 @@ When running a bundled app, these statements can cause a big bottleneck in the J
 
 This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
+It is recommended to use the plugin even if no `console.*` calls are made in your project. A third party library could also call them.
+
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 
 Use the new [`FlatList`](flatlist.md) or [`SectionList`](sectionlist.md) component instead. Besides simplifying the API, the new list components also have significant performance enhancements, the main one being nearly constant memory usage for any number of rows.


### PR DESCRIPTION
When I read the documentation, it did not think to install the plugin because we deactivate our logger in production.
When I debugged a production build last week, I noticed several `console.*` calls. These all came from third party libraries.
In order to make more aware of this problem, I have adapted the documentation.