### PR TITLE
Macos/Android Getting Started: M1 mac new system image

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -61,7 +61,7 @@ To do that, open Android Studio, click on "Configure" button and select "SDK Man
 Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 11 (R)` entry, then make sure the following items are checked:
 
 - `Android SDK Platform 30`
-- `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
+- `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image` or (for Apple M1 Silicon) `Google APIs ARM 64 v8a System Image`
 
 Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build-Tools" entry, then make sure that `30.0.2` is selected.
 


### PR DESCRIPTION
Apple M1 chip has a 64 bit ARM architecture also known as AArch64, so it requires the emulator setup with above image. You can find this problem all over stack overflow, i.e https://stackoverflow.com/questions/68312799/android-studio-the-emulator-process-for-avd-pixel-2-api-30-has-terminated-on

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
