### PR TITLE
Update valid values for keyboardType

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -387,6 +387,7 @@ The following values work across platforms:
 - `numeric`
 - `email-address`
 - `phone-pad`
+- `url`
 
 _iOS Only_
 
@@ -394,7 +395,6 @@ The following values work on iOS only:
 
 - `ascii-capable`
 - `numbers-and-punctuation`
-- `url`
 - `name-phone-pad`
 - `twitter`
 - `web-search`

--- a/website/versioned_docs/version-0.66/textinput.md
+++ b/website/versioned_docs/version-0.66/textinput.md
@@ -387,6 +387,7 @@ The following values work across platforms:
 - `numeric`
 - `email-address`
 - `phone-pad`
+- `url`
 
 _iOS Only_
 
@@ -394,7 +395,6 @@ The following values work on iOS only:
 
 - `ascii-capable`
 - `numbers-and-punctuation`
-- `url`
 - `name-phone-pad`
 - `twitter`
 - `web-search`

--- a/website/versioned_docs/version-0.67/textinput.md
+++ b/website/versioned_docs/version-0.67/textinput.md
@@ -387,6 +387,7 @@ The following values work across platforms:
 - `numeric`
 - `email-address`
 - `phone-pad`
+- `url`
 
 _iOS Only_
 
@@ -394,7 +395,6 @@ The following values work on iOS only:
 
 - `ascii-capable`
 - `numbers-and-punctuation`
-- `url`
 - `name-phone-pad`
 - `twitter`
 - `web-search`

--- a/website/versioned_docs/version-0.68/textinput.md
+++ b/website/versioned_docs/version-0.68/textinput.md
@@ -387,6 +387,7 @@ The following values work across platforms:
 - `numeric`
 - `email-address`
 - `phone-pad`
+- `url`
 
 _iOS Only_
 
@@ -394,7 +395,6 @@ The following values work on iOS only:
 
 - `ascii-capable`
 - `numbers-and-punctuation`
-- `url`
 - `name-phone-pad`
 - `twitter`
 - `web-search`


### PR DESCRIPTION
This reflects the changes introduced by #31781 which added support for the `url` type on Android

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
