### PR TITLE
customTheme.css (Make Font size smaller in banner)

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1165,13 +1165,13 @@ div[class^="announcementBarContent"] {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
# Issue

The class for the font size in media seems to be incorrect. It does not make the font size of the banner smaller.

# Before
![before](https://user-images.githubusercontent.com/78584173/166114423-29601f37-d6d6-4473-936b-f0f6decd7ff9.png)

# After
![after](https://user-images.githubusercontent.com/78584173/166114453-ddc0b7c1-65f2-4a8b-bf47-99b8f1a0f2ac.png)

