### PR TITLE
Make the 'new' badge float right in mobile

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1480,6 +1480,7 @@ td .label {
   position: relative;
   top: 1px;
   margin-right: -6px;
+  margin-left: auto;
   padding: 3px 6px;
   border: 1px solid #86b300;
   border-radius: 3px;


### PR DESCRIPTION
# Issue
![before - mobile - ipad](https://user-images.githubusercontent.com/78584173/166149317-b5f2fdac-474b-4f36-9ed0-967352c181d1.png)

As seen on the picture above, the 'new' badge is right next to 'pressable' text.

In current React Native website, the 'new' badge (on computers) floats right.

However, switching the screen to mobile/ipad, the badge appears next to the text instead of floating right.

# What changed
Using `margin-left: auto;` will make the button flat right inside the div in mobile screens.

# After
![after - mobile - ipad](https://user-images.githubusercontent.com/78584173/166149605-fe54cda0-18a4-4413-afd0-34b201ec6892.png)

