### PR TITLE
Update version compare from latest to right now

### DIFF
--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -30,7 +30,7 @@ const VersionItem = ({version, currentVersion}) => {
   let releaseNotesURL = 'https://github.com/facebook/react-native/releases';
   let releaseNotesTitle = 'Changelog';
   if (isNext) {
-    releaseNotesURL = `https://github.com/facebook/react-native/compare/${latestMajorVersion}-stable...master`;
+    releaseNotesURL = `https://github.com/facebook/react-native/compare/${latestMajorVersion}-stable...main`;
     releaseNotesTitle = 'Commits since ' + latestMajorVersion;
   } else if (!isRC) {
     releaseNotesURL = `https://github.com/facebook/react-native/releases/tag/v${version}.0`;


### PR DESCRIPTION
# Current Issue
GitHub main branch has been renamed from master to main.
Though some links had 'master' in them, it still worked as GitHub alerted the users it was renamed.
However, comparing does not work here as there is no branch by the name of master.
Changed master to main to properly check out the latest commits.

# Current Link
![nothing](https://user-images.githubusercontent.com/78584173/166150740-f3c25a9d-a9a0-4134-9f58-7d8df79619f1.png)

# Updated Link
![updated](https://user-images.githubusercontent.com/78584173/166150783-ae323086-6f48-4f8a-a26f-422f72a2f502.png)
