### PR TITLE
Clarify how to enable hermes since RN 0.68

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -68,12 +68,17 @@ Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit
    use_react_native!(
      :path => config[:reactNativePath],
      # to enable hermes on iOS, change `false` to `true` and then install pods
--    :hermes_enabled => false
+     # By default, Hermes is disabled on Old Architecture, and enabled on New Architecture.
+     # You can enabled/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
+-    :hermes_enabled => flags[:hermes_enabled],
 +    :hermes_enabled => true
    )
 ```
 
-Next, install the Hermes pods:
+By default, you will be using Hermes if you're on the New Architecture. By specifying a value such
+as `true` or `false` you can enable/disable Hermes as you wish.
+
+Once you've configured it, you can install the Hermes pods with:
 
 ```shell
 $ cd ios && pod install

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -69,7 +69,7 @@ Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit
      :path => config[:reactNativePath],
      # to enable hermes on iOS, change `false` to `true` and then install pods
      # By default, Hermes is disabled on Old Architecture, and enabled on New Architecture.
-     # You can enabled/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
+     # You can enable/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
 -    :hermes_enabled => flags[:hermes_enabled],
 +    :hermes_enabled => true
    )

--- a/website/versioned_docs/version-0.68/hermes.md
+++ b/website/versioned_docs/version-0.68/hermes.md
@@ -68,12 +68,17 @@ Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit
    use_react_native!(
      :path => config[:reactNativePath],
      # to enable hermes on iOS, change `false` to `true` and then install pods
--    :hermes_enabled => false
+     # By default, Hermes is disabled on Old Architecture, and enabled on New Architecture.
+     # You can enabled/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
+-    :hermes_enabled => flags[:hermes_enabled],
 +    :hermes_enabled => true
    )
 ```
 
-Next, install the Hermes pods:
+By default, you will be using Hermes if you're on the New Architecture. By specifying a value such
+as `true` or `false` you can enable/disable Hermes as you wish.
+
+Once you've configured it, you can install the Hermes pods with:
 
 ```shell
 $ cd ios && pod install

--- a/website/versioned_docs/version-0.68/hermes.md
+++ b/website/versioned_docs/version-0.68/hermes.md
@@ -69,7 +69,7 @@ Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit
      :path => config[:reactNativePath],
      # to enable hermes on iOS, change `false` to `true` and then install pods
      # By default, Hermes is disabled on Old Architecture, and enabled on New Architecture.
-     # You can enabled/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
+     # You can enable/disable it manually by replacing `flags[:hermes_enabled]` with `true` or `false`.
 -    :hermes_enabled => flags[:hermes_enabled],
 +    :hermes_enabled => true
    )


### PR DESCRIPTION
Fixes #3105

The way how you can enable/disable Hermes since RN 0.68 has changed, but the website hasn't been updated. Here I'm fixing it.