### PR TITLE
[fix] add documentation about how to configure Folly properly

### DIFF
--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -201,3 +201,14 @@ You can implement the `jsExecutorFactoryForBridge:` method like this:
   );
 }
 ```
+
+## iOS: Setup Folly
+
+The previous step will incorporate in your iOS app a dependency called Folly. Folly requires some extra compiler flags to works properly. To set them up, follow these steps:
+
+1. In the **Project Navigator** (`cmd+1`), select your app project.
+1. In the **Targets** section, select the target with the name of your app.
+1. Select the **Build Settings** tab
+1. Search for **Other C++ Flags**
+1. Update the **Debug** configuration, adding following flags: `-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1`
+1. Update the **Release** configuration with the following flags: `-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1`


### PR DESCRIPTION
TurboModules requires Folly and Folly requires some specific flag to be set in the app to work properly.

The required flags and how to set where missing in the documentation. I choose to put them in that specific point because they appear after we make the `AppDelegate` conform to the `RCTCxxBridgeDelegate` protocol.
