### PR TITLE
Add Kotlin to docs/new-architecture-library-intro

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -562,6 +562,28 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
 
 **Android**
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+    fun receiveCommand(
+        view: ReactMapDrawerView?, commandId: String?, @Nullable args: ReadableArray?
+    ) {
+        when (commandId) {
+            "moveToRegion" -> {
+                if (args == null) {
+                    break
+                }
+                val region: ReadableMap = args.getMap(0)
+                val durationMs: Int = args.getInt(1)
+            }
+        }
+    }
+```
+
+</TabItem>
+<TabItem value="java">
+
 ```java
 // receiveCommand signature has changed to receive String commandId
 @Override
@@ -580,3 +602,5 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
     }
   }
 ```
+</TabItem>
+</Tabs>


### PR DESCRIPTION
Added Kotlin example to docs/new-architecture-library-intr
<img width="794" alt="Screenshot 2022-05-13 at 13 00 24" src="https://user-images.githubusercontent.com/105487795/168281593-e71d27f7-566c-4b2d-9b00-bdb504fd235f.png">
<img width="799" alt="Screenshot 2022-05-13 at 13 00 19" src="https://user-images.githubusercontent.com/105487795/168281598-69314803-bf97-4e1c-a9fd-60cd3cd5e908.png">
o