### PR TITLE
Add Kotlin to /docs/new-architecture-library-intro.md

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -562,6 +562,28 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
 
 **Android**
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<TabItem value="kotlin">
+
+```kotlin
+    fun receiveCommand(
+        view: ReactMapDrawerView?, commandId: String?, @Nullable args: ReadableArray?
+    ) {
+        when (commandId) {
+            "moveToRegion" -> {
+                if (args == null) {
+                    break
+                }
+                val region: ReadableMap = args.getMap(0)
+                val durationMs: Int = args.getInt(1)
+            }
+        }
+    }
+```
+
+</TabItem>
+<TabItem value="java">
+
 ```java
 // receiveCommand signature has changed to receive String commandId
 @Override
@@ -580,3 +602,5 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
     }
   }
 ```
+</TabItem>
+</Tabs>


### PR DESCRIPTION
Added Kotlin example to /docs/new-architecture-library-intro.m
<img width="794" alt="Screenshot 2022-05-13 at 13 00 24" src="https://user-images.githubusercontent.com/105487795/168283251-7501a4d9-1fbe-4085-8066-af38f09a89a8.png">
<img width="799" alt="Screenshot 2022-05-13 at 13 00 19" src="https://user-images.githubusercontent.com/105487795/168283257-9c0fac27-0c9c-4779-bb2b-2024f547affb.png">
d