### PR TITLE
Update RN Geolocation library URL.

### DIFF
--- a/docs/communication-ios.md
+++ b/docs/communication-ios.md
@@ -99,7 +99,7 @@ The fact that native modules are singletons limits the mechanism in the context 
 
 Although this solution is complex, it is used in `RCTUIManager`, which is an internal React Native class that manages all React Native views.
 
-Native modules can also be used to expose existing native libraries to JS. The [Geolocation library](https://github.com/react-native-community/react-native-geolocation) is a living example of the idea.
+Native modules can also be used to expose existing native libraries to JS. The [Geolocation library](https://github.com/michalchudziak/react-native-geolocation) is a living example of the idea.
 
 > **_Warning_**: All native modules share the same namespace. Watch out for name collisions when creating new ones.
 


### PR DESCRIPTION
The repository has been moved from `react-native-community`.