### PR TITLE
Suggestion for improvement on Mac M1 chipset

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -43,13 +43,15 @@ Using the default Ruby available on macOS will require you to use `sudo` when in
 
 ```shell
 sudo gem install cocoapods
+
+// Or for M1 Mac chipset (ARM64) (prefer using latest brew version) as seen [here](https://github.com/CocoaPods/CocoaPods/issues/9907#issuecomment-962871846)
+sudo gem uninstall cocoapods
+brew install cocoapods
 ```
 
 Otherwise you can use a Ruby version manager, such as `rbenv`. Apps created with the command `npx react-native init` described below are configured to work well with `rbenv` and will pick the correct Ruby version requested by the template.
 
 For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
-
-<M1Cocoapods />
 
 ### React Native Command Line Interface
 


### PR DESCRIPTION
Currently, the documentation recommends installing cocoapods from gem.

Some users are asking for M1 support, especially on expo (eas-cli). Which makes it hard to play with rosetta CLI (`arch -x86_64 pod install`) bypass. (https://expo.canny.io/feature-requests/p/eas-build-support-for-mac-m1)



As seen here https://github.com/CocoaPods/CocoaPods/issues/9907 cocoapods has been updated to support arm64 m1 architecture, but you need to install it from brew.