### PR TITLE
[FIX] iOS: Setup Folly Title

### DIFF
--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -202,7 +202,7 @@ You can implement the `jsExecutorFactoryForBridge:` method like this:
 }
 ```
 
-## iOS: Setup Folly
+## iOS: Setup Folly
 
 The previous step will incorporate in your iOS app a dependency called Folly. Folly requires some extra compiler flags to works properly. To set them up, follow these steps:
 


### PR DESCRIPTION
This PR fixes the title and anchoring for the `iOS: Setup Folly` section of the playbook.
| Before | After |
| --- | --- |
| <img width="1138" alt="Screenshot 2022-05-18 at 21 22 51" src="https://user-images.githubusercontent.com/11162307/169149178-19257391-f86e-405d-b1bc-4116ad5ad9bc.png"> | <img width="1090" alt="Screenshot 2022-05-18 at 21 22 06" src="https://user-images.githubusercontent.com/11162307/169149062-a39ba1db-19d7-407c-90cc-304973e73dec.png">|

