### PR TITLE
Remove "Add Babel Plugins" Section

### DIFF
--- a/docs/new-architecture-app-renderer-ios.md
+++ b/docs/new-architecture-app-renderer-ios.md
@@ -83,21 +83,7 @@ The way to render your app with Fabric depends on your setup. Here is an example
 #endif
 ```
 
-## 3. Add Babel Plugins
-
-This will trigger the codegen that will run at the metro building time.
-
-```javascript title="babel.config.js"
-module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
-  plugins: [
-    '@babel/plugin-proposal-class-properties',
-    './node_modules/react-native/packages/babel-plugin-codegen'
-  ]
-};
-```
-
-## 4. Run pod install
+## 3. Run pod install
 
 ```bash
 // Run pod install with the flags


### PR DESCRIPTION
This PR removes The New Architecture/Enabling Fabric on iOS/[Add Babel Plugins](https://reactnative.dev/docs/next/new-architecture-app-renderer-ios#3-add-babel-plugins) section.
`babel-plugin-codegen` is not stabilized yet, and is not beneficial for Fabric as of now.
The plugin will become a part of the Metro preset in the future, so this section is effectively redundant.