### PR TITLE
Update signed-apk-android.md

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -29,7 +29,7 @@ It will output the directory of the JDK, which will look something like this:
 
     /Library/Java/JavaVirtualMachines/jdkX.X.X_XXX.jdk/Contents/Home
 
-Navigate to that directory by using the command `cd /your/jdk/path` and use the keytool command with sudo permission as shown below.
+Navigate to that directory by using the command `cd /your/jdk/path` and use the keytool command with sudo permission as shown below. Remember to edit `my-upload-key` and `my-key-alias`.
 
     sudo keytool -genkey -v -keystore my-upload-key.keystore -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
 
@@ -38,7 +38,8 @@ Navigate to that directory by using the command `cd /your/jdk/path` and use the 
 ## Setting up Gradle variables
 
 1. Place the `my-upload-key.keystore` file under the `android/app` directory in your project folder.
-2. Edit the file `~/.gradle/gradle.properties` or `android/gradle.properties`, and add the following (replace `*****` with the correct keystore password, alias and key password),
+2. Edit the file `~/.gradle/gradle.properties` or `android/gradle.properties`, and add the following
+3. Replace `*****` with the correct keystore (line 3) and key (line 4) passwords, if you were not prompted to create a key password it will be the same as keystore password
 
 ```
 MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore


### PR DESCRIPTION
# Problem

When I was following the documentation to Publish my app to Google Play, I got stuck for ±20 minutes before figuring out that keystore and key password were the same. This time could easily be saved by clarifying the documentation.

# Suggestion

Adjust the documentation to make clear the use of Keystore and key passwords. As the `keytool` command doesn't prompt to create a key password, it will use the same password for keystore and key.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
