### PR TITLE
Update accessibilityIgnoresInvertColors property

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -85,7 +85,7 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 
 ### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
 
-Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be false so that these specific views won't have their colors inverted.
+Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be true so that these specific views won't have their colors inverted.
 
 ### `accessibilityLiveRegion` <div class="label android">Android</div>
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -85,7 +85,7 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 
 ### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
 
-Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be true so that these specific views won't have their colors inverted.
+Inverting screen colors is an Accessibility feature that makes the iPhone and iPad easier on the eyes for some people with a sensitivity to brightness, easier to distinguish for some people with color blindness, and easier to make out for some people with low vision. However, sometimes you have views such as photos that you don't want to be inverted. In this case, you can set this property to be `true` so that these specific views won't have their colors inverted.
 
 ### `accessibilityLiveRegion` <div class="label android">Android</div>
 


### PR DESCRIPTION
The description for Accessibility property "accessibilityIgnoresInvertColors" incorrectly states that the value should be set to "false" to prevent color inversion. Correct value is "true" per the Apple documentation (https://developer.apple.com/documentation/uikit/uiview/2865843-accessibilityignoresinvertcolors) and my personal testing.