### PR TITLE
For Windows Run command prompt as administrator

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -11,7 +11,7 @@ You can generate a private signing key using `keytool`.
 
 ### Windows
 
-On Windows `keytool` must be run from `C:\Program Files\Java\jdkx.x.x_x\bin`.
+On Windows `keytool` must be run from `C:\Program Files\Java\jdkx.x.x_x\bin`, as administrator.
 
     keytool -genkeypair -v -storetype PKCS12 -keystore my-upload-key.keystore -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
 


### PR DESCRIPTION
Run command prompt as administrator to generate RSA key pair from windows, otherwise error occurred `keytool error java.io.filenotfoundexception my-upload-key.keystore (access is denied)`

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
