### PR TITLE
Update linking.md

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -81,7 +81,7 @@ If you're targeting iOS 8.x or older, you can use the following code instead:
 }
 ```
 
-If your app is using [Universal Links](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html), you'll need to add the following code as well:
+If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```objectivec
 - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity


### PR DESCRIPTION
From the documenation https://developer.apple.com/library/archive/navigation/ , it looks like the link was in an archived documentation so the change is to refactor to current documenation with latest API reference.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
