### PR TITLE
fix Prism CodeBlock appearance after the update

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -686,7 +686,7 @@ So we need to "revert" some CSS vars to not enforce dark mode
 
     .menu__list-item a {
       color: var(--ifm-color-emphasis-700);
-      padding: 5px 12px;
+      padding: 4px 12px;
     }
 
     .menu__list-item-collapsible a[class*="menuLinkText"] {
@@ -847,7 +847,7 @@ aside[class^="theme-doc-sidebar-container"] {
   .menu__link--sublist {
     font-size: 15px;
     font-weight: 600;
-    padding: 5px 12px !important;
+    padding: 4px 12px !important;
     color: var(--light);
 
     &:after {
@@ -860,7 +860,7 @@ aside[class^="theme-doc-sidebar-container"] {
     .menu__link {
       line-height: 20px;
       font-size: 13px;
-      padding: 5px 12px !important;
+      padding: 4px 12px !important;
       font-weight: 300;
       color: var(--ifm-font-color-base);
     }
@@ -869,24 +869,25 @@ aside[class^="theme-doc-sidebar-container"] {
       font-size: 14px !important;
     }
 
-    .menu__list .menu__link {
-      padding: 5px 12px 5px 16px !important;
-    }
-
     .menu__list .menu__link--active {
       padding-left: 12px !important;
     }
   }
 
   .menu__link.menu__link--active {
-    border-left-width: 4px;
-    border-left-style: solid;
     border-left-color: var(--ifm-menu-color-active) !important;
-    background: var(--ifm-code-background);
+    border-left-width: 0;
   }
 
   a[href].menu__link.menu__link--active {
+    background: var(--ifm-code-background);
     padding-left: 8px !important;
+    border-left-width: 4px;
+    border-left-style: solid;
+  }
+
+  a[href="#"].menu__link.menu__link--active {
+    border-left-width: 0;
   }
 
   .menu__list-item-collapsible {
@@ -898,6 +899,11 @@ aside[class^="theme-doc-sidebar-container"] {
       font-weight: 600;
       font-size: 15px;
       color: var(--subtle);
+      padding-left: 8px !important;
+
+      .menu__link {
+        padding-left: 12px !important;
+      }
     }
   }
 


### PR DESCRIPTION
# Why

After the latest Docusuaurs update it look like the theme variable overwrites the background color set in the custom Prism theme:
* https://github.com/facebook/react-native-website/blob/main/website/core/PrismTheme.js#L4

This results in display issues, especially in light mode:
<img width="623" alt="Screenshot 2022-06-01 203429" src="https://user-images.githubusercontent.com/719641/171481109-8ae429b5-b8ab-4582-a8b5-b929cae214fa.png">

# How

Overwrite the CodeBlock container background color, loose the class name selectors, remove the not working dark mode style.

I have re-enabled the `--deepdark` tweak, but it leads to the situation where Header and CodeBlocks have the same background color, so let's avoid that.

# Preview

<img width="628" alt="Screenshot 2022-06-01 205848" src="https://user-images.githubusercontent.com/719641/171481605-3f9c4b1d-f071-4206-8c94-d7f42cd13bcc.png">
