### PR TITLE
alternative fix for the CodeBlocks background

### DIFF
--- a/website/core/PrismTheme.js
+++ b/website/core/PrismTheme.js
@@ -1,7 +1,7 @@
-var theme = {
+const theme = {
   plain: {
     color: '#FFFFFF',
-    background: '#282C34',
+    backgroundColor: '#282C34',
   },
   styles: [
     {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -300,7 +300,6 @@ hr {
   div[class*="codeBlockContent"] {
     display: inline-grid;
     min-width: 100%;
-    background-color: var(--dark);
   }
 
   div[class*="codeBlockLines"] {


### PR DESCRIPTION
As mentioned in https://github.com/facebook/react-native-website/pull/3143#issuecomment-1144607744, there is an alternative way to fix the Prism code block background issues.

It looks like the custom theme was using legacy field, IIRC this came from the days when VSCode themes could be used as Prism themes.

Let's fix the field name and remove the CSS overwrite.