### PR TITLE
Updated TextInput multiline property

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -439,7 +439,11 @@ Limits the maximum number of characters that can be entered. Use this instead of
 
 If `true`, the text input can be multiple lines. The default value is `false`. 
 
-> It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.
+:::note
+
+It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.
+
+:::
 
 | Type |
 | ---- |

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -437,7 +437,7 @@ Limits the maximum number of characters that can be entered. Use this instead of
 
 ### `multiline`
 
-If `true`, the text input can be multiple lines. The default value is `false`. 
+If `true`, the text input can be multiple lines. The default value is `false`.
 
 :::note
 It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -437,7 +437,9 @@ Limits the maximum number of characters that can be entered. Use this instead of
 
 ### `multiline`
 
-If `true`, the text input can be multiple lines. The default value is `false`. It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.
+If `true`, the text input can be multiple lines. The default value is `false`. 
+
+> It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.
 
 | Type |
 | ---- |

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -440,9 +440,7 @@ Limits the maximum number of characters that can be entered. Use this instead of
 If `true`, the text input can be multiple lines. The default value is `false`. 
 
 :::note
-
 It is important to note that this aligns the text to the top on iOS, and centers it on Android. Use with `textAlignVertical` set to `top` for the same behavior in both platforms.
-
 :::
 
 | Type |


### PR DESCRIPTION
Updated the TextInput multiline property's docs. Part of the text needs to be styled as a note.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
