### PR TITLE
Add Build Tools for Visual Studio 2022 to Bundled Hermes

### DIFF
--- a/website/architecture/bundled-hermes.md
+++ b/website/architecture/bundled-hermes.md
@@ -84,8 +84,8 @@ Users building React Native App, with the New Architecture, on Windows machines 
 * Make sure the [environment is configured properly](https://reactnative.dev/docs/environment-setup), with Android SDK & node.
 * Install [cmake](https://community.chocolatey.org/packages/cmake) with Chocolatey
 * Install either:
-  * [Visual Studio 22 Community edition](https://visualstudio.microsoft.com/vs/community/) - Picking only the C++ desktop development is sufficient.
   * [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
+  * [Visual Studio 22 Community Edition](https://visualstudio.microsoft.com/vs/community/) - Picking only the C++ desktop development is sufficient.
 * Make sure the [Visual Studio Command Prompt](https://docs.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022) is configured correctly. This is required as the proper C++ compiler environment variable is configured in those command prompt.
 * Run the app with `npx react-native run-android` inside a Visual Studio Command Prompt.
 

--- a/website/architecture/bundled-hermes.md
+++ b/website/architecture/bundled-hermes.md
@@ -83,7 +83,9 @@ Users building React Native App, with the New Architecture, on Windows machines 
 
 * Make sure the [environment is configured properly](https://reactnative.dev/docs/environment-setup), with Android SDK & node.
 * Install [cmake](https://community.chocolatey.org/packages/cmake) with Chocolatey
-* Install [Visual Studio 22 Community edition](https://visualstudio.microsoft.com/vs/community/) - Picking only the C++ desktop development is sufficient.
+* Install either:
+  * [Visual Studio 22 Community edition](https://visualstudio.microsoft.com/vs/community/) - Picking only the C++ desktop development is sufficient.
+  * [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
 * Make sure the [Visual Studio Command Prompt](https://docs.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022) is configured correctly. This is required as the proper C++ compiler environment variable is configured in those command prompt.
 * Run the app with `npx react-native run-android` inside a Visual Studio Command Prompt.
 


### PR DESCRIPTION
Just a small nit proposed in https://github.com/reactwg/react-native-releases/discussions/21