### PR TITLE
Fix for "Type 'Timeout' is not assignable to type 'number'"

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -104,6 +104,7 @@ yarn add -D typescript @types/jest @types/react @types/react-native @types/react
     "isolatedModules": true,
     "jsx": "react-native",
     "lib": ["es2017"],
+    "types": ["react-native", "jest"],
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
- TS Config: `compilerOptions.types`: https://www.typescriptlang.org/tsconfig#types
- Preview: https://deploy-preview-3166--react-native.netlify.app/docs/next/typescript

---

The issue:

![001](https://user-images.githubusercontent.com/95620376/174558439-6468cc6e-d85b-4d82-91f5-b22d02ed8e07.png)

---

After fix:

![00022](https://user-images.githubusercontent.com/4661784/174561275-b558779e-c447-46df-aebe-ae9a3446be28.png)


---

<details>
<summary>`yarn why @types/node`</summary>

```java
yarn why v1.22.17
[1/4] Why do we have the module "@types/node"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "@types/node@18.0.0"
info Reasons this module exists
   - "@jest#types" depends on it
   - Hoisted from "@jest#types#@types#node"
   - Hoisted from "jest-haste-map#@types#node"
   - Hoisted from "jest-util#@types#node"
   - Hoisted from "jest-worker#@types#node"
   - Hoisted from "jest#@jest#core#@types#node"
   - Hoisted from "jest-haste-map#@types#graceful-fs#@types#node"
   - Hoisted from "jest-haste-map#jest-serializer#@types#node"
   - Hoisted from "jest#@jest#core#@jest#console#@types#node"
   - Hoisted from "react-native#@jest#create-cache-key-function#@jest#types#@types#node"
   - Hoisted from "jest#@jest#core#jest-runner#@types#node"
   - Hoisted from "jest#@jest#core#jest-watcher#@types#node"
   - Hoisted from "jest#@jest#core#jest-runner#@jest#environment#@types#node"
   - Hoisted from "jest#@jest#core#jest-runtime#@jest#fake-timers#@types#node"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#@types#node"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-node#@types#node"
   - Hoisted from "jest#@jest#core#jest-config#jest-jasmine2#@types#node"
   - Hoisted from "jest#@jest#core#jest-runtime#jest-mock#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro-core#jest-haste-map#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro#jest-haste-map#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro-core#jest-haste-map#@jest#types#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro#jest-haste-map#@jest#types#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro-core#jest-haste-map#jest-serializer#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro#jest-haste-map#jest-serializer#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro-core#jest-haste-map#jest-util#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro#jest-haste-map#jest-util#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro-core#jest-haste-map#jest-worker#@types#node"
   - Hoisted from "react-native#@react-native-community#cli#@react-native-community#cli-plugin-metro#metro#jest-haste-map#jest-worker#@types#node"
info Disk size without dependencies: "1.75MB"
info Disk size with unique dependencies: "1.75MB"
info Disk size with transitive dependencies: "1.75MB"
info Number of shared dependencies: 0
```

</details>