### PR TITLE
replace old blockquotes with admonitions, add codeblocks titles (part 1)

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -6,7 +6,9 @@ description: Create mobile apps accessible to assistive technology with React Na
 
 Both Android and iOS provide APIs for integrating apps with assistive technologies like the bundled screen readers VoiceOver (iOS) and TalkBack (Android). React Native has complementary APIs that let your app accommodate all users.
 
-> Android and iOS differ slightly in their approaches, and thus the React Native implementations may vary by platform.
+:::info
+Android and iOS differ slightly in their approaches, and thus the React Native implementations may vary by platform.
+:::
 
 ## Accessibility properties
 

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -41,13 +41,17 @@ React Native supports also colors as an `int` values (in RGB color mode):
 
 - `0xff00ff00` (0xrrggbbaa)
 
-> **_Note:_** This might appear similar to the Android [Color](https://developer.android.com/reference/android/graphics/Color) ints representation but on Android values are stored in SRGB color mode (0xaarrggbb).
+:::caution
+This might appear similar to the Android [Color](https://developer.android.com/reference/android/graphics/Color) ints representation but on Android values are stored in SRGB color mode (0xaarrggbb).
+:::
 
 ### Named colors
 
 In React Native you can also use color name strings as values.
 
-> **_Note:_** React Native only supports lowercase color names. Uppercase color names are not supported.
+:::info
+React Native only supports lowercase color names. Uppercase color names are not supported.
+:::
 
 #### `transparent`
 

--- a/docs/communication-ios.md
+++ b/docs/communication-ios.md
@@ -57,11 +57,11 @@ rootView.appProperties = @{@"images" : imageList};
 
 It is fine to update properties anytime. However, updates have to be performed on the main thread. You use the getter on any thread.
 
-> **_Note:_** Currently, there is a known issue where setting appProperties during the bridge startup, the change can be lost. See https://github.com/facebook/react-native/issues/20115 for more information.
+:::note
+Currently, there is a known issue where setting appProperties during the bridge startup, the change can be lost. See https://github.com/facebook/react-native/issues/20115 for more information.
+:::
 
 There is no way to update only a few properties at a time. We suggest that you build it into your own wrapper instead.
-
-> **_Note:_** Currently, JS function `componentWillUpdateProps` of the top level RN component will not be called after a prop update. However, you can access the new props in `componentDidMount` function.
 
 ### Passing properties from React Native to native
 
@@ -101,7 +101,9 @@ Although this solution is complex, it is used in `RCTUIManager`, which is an int
 
 Native modules can also be used to expose existing native libraries to JS. The [Geolocation library](https://github.com/michalchudziak/react-native-geolocation) is a living example of the idea.
 
-> **_Warning_**: All native modules share the same namespace. Watch out for name collisions when creating new ones.
+:::caution
+All native modules share the same namespace. Watch out for name collisions when creating new ones.
+:::
 
 ## Layout computation flow
 
@@ -119,9 +121,7 @@ The general scenario is when we have a React Native app with a fixed size, which
 
 For instance, to make an RN app 200 (logical) pixels high, and the hosting view's width wide, we could do:
 
-```objectivec
-// SomeViewController.m
-
+```objectivec title='SomeViewController.m'
 - (void)viewDidLoad
 {
   [...]
@@ -146,9 +146,7 @@ In some cases we'd like to render content of initially unknown size. Let's say t
 
 `RCTRootView` supports 4 different size flexibility modes:
 
-```objectivec
-// RCTRootView.h
-
+```objectivec title='RCTRootView.h'
 typedef NS_ENUM(NSInteger, RCTRootViewSizeFlexibility) {
   RCTRootViewSizeFlexibilityNone = 0,
   RCTRootViewSizeFlexibilityWidth,
@@ -159,13 +157,13 @@ typedef NS_ENUM(NSInteger, RCTRootViewSizeFlexibility) {
 
 `RCTRootViewSizeFlexibilityNone` is the default value, which makes a root view's size fixed (but it still can be updated with `setFrame:`). The other three modes allow us to track React Native content's size updates. For instance, setting mode to `RCTRootViewSizeFlexibilityHeight` will cause React Native to measure the content's height and pass that information back to `RCTRootView`'s delegate. An arbitrary action can be performed within the delegate, including setting the root view's frame, so the content fits. The delegate is called only when the size of the content has changed.
 
-> **_Warning:_** Making a dimension flexible in both JS and native leads to undefined behavior. For example - don't make a top-level React component's width flexible (with `flexbox`) while you're using `RCTRootViewSizeFlexibilityWidth` on the hosting `RCTRootView`.
+:::caution
+Making a dimension flexible in both JS and native leads to undefined behavior. For example - don't make a top-level React component's width flexible (with `flexbox`) while you're using `RCTRootViewSizeFlexibilityWidth` on the hosting `RCTRootView`.
+:::
 
 Let's look at an example.
 
-```objectivec
-// FlexibleSizeExampleView.m
-
+```objectivec title='FlexibleSizeExampleView.m'
 - (instancetype)initWithFrame:(CGRect)frame
 {
   [...]
@@ -195,6 +193,12 @@ You can checkout full source code of the example [here](https://github.com/faceb
 
 It's fine to change root view's size flexibility mode dynamically. Changing flexibility mode of a root view will schedule a layout recalculation and the delegate `rootViewDidChangeIntrinsicSize:` method will be called once the content size is known.
 
-> **_Note:_** React Native layout calculation is performed on a separate thread, while native UI view updates are done on the main thread. This may cause temporary UI inconsistencies between native and React Native. This is a known problem and our team is working on synchronizing UI updates coming from different sources.
+:::note
+React Native layout calculation is performed on a separate thread, while native UI view updates are done on the main thread.
+This may cause temporary UI inconsistencies between native and React Native. This is a known problem and our team is working on synchronizing UI updates coming from different sources.
+:::
 
-> **_Note:_** React Native does not perform any layout calculations until the root view becomes a subview of some other views. If you want to hide React Native view until its dimensions are known, add the root view as a subview and make it initially hidden (use `UIView`'s `hidden` property). Then change its visibility in the delegate method.
+:::note
+React Native does not perform any layout calculations until the root view becomes a subview of some other views.
+If you want to hide React Native view until its dimensions are known, add the root view as a subview and make it initially hidden (use `UIView`'s `hidden` property). Then change its visibility in the delegate method.
+:::

--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -5,9 +5,14 @@ title: Direct Manipulation
 
 It is sometimes necessary to make changes directly to a component without using state/props to trigger a re-render of the entire subtree. When using React in the browser for example, you sometimes need to directly modify a DOM node, and the same is true for views in mobile apps. `setNativeProps` is the React Native equivalent to setting properties directly on a DOM node.
 
-> Use setNativeProps when frequent re-rendering creates a performance bottleneck
->
-> Direct manipulation will not be a tool that you reach for frequently; you will typically only be using it for creating continuous animations to avoid the overhead of rendering the component hierarchy and reconciling many views. `setNativeProps` is imperative and stores state in the native layer (DOM, UIView, etc.) and not within your React components, which makes your code more difficult to reason about. Before you use it, try to solve your problem with `setState` and [shouldComponentUpdate](https://reactjs.org/docs/optimizing-performance.html#shouldcomponentupdate-in-action).
+:::caution
+Use `setNativeProps` when frequent re-rendering creates a performance bottleneck!
+
+Direct manipulation will not be a tool that you reach for frequently. You will typically only be using it for creating continuous animations to avoid the overhead of rendering the component hierarchy and reconciling many views.
+`setNativeProps` is imperative and stores state in the native layer (DOM, UIView, etc.) and not within your React components, which makes your code more difficult to reason about.
+
+Before you use it, try to solve your problem with `setState` and [`shouldComponentUpdate`](https://reactjs.org/docs/optimizing-performance.html#shouldcomponentupdate-in-action).
+:::
 
 ## setNativeProps with TouchableOpacity
 
@@ -185,7 +190,9 @@ Determines the location of the given view in the window and returns the values v
 
 Like `measure()`, but measures the view relative to an ancestor, specified with `relativeToNativeComponentRef` reference. This means that the returned coordinates are relative to the origin `x`, `y` of the ancestor view.
 
-> Note: This method can also be called with a `relativeToNativeNode` handler (instead of reference), but this variant is deprecated.
+:::note
+This method can also be called with a `relativeToNativeNode` handler (instead of reference), but this variant is deprecated.
+:::
 
 ```SnackPlayer name=measureLayout%20example&supportedPlatforms=android,ios
 import React, { useEffect, useRef, useState } from "react";

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -7,7 +7,10 @@ A component can specify the layout of its children using the Flexbox algorithm. 
 
 You will normally use a combination of `flexDirection`, `alignItems`, and `justifyContent` to achieve the right layout.
 
-> Flexbox works the same way in React Native as it does in CSS on the web, with a few exceptions. The defaults are different, with `flexDirection` defaulting to `column` instead of `row`, `alignContent` defaulting to `flex-start` instead of `stretch`, `flexShrink` defaulting to `0` instead of `1`, the `flex` parameter only supporting a single number.
+:::caution
+Flexbox works the same way in React Native as it does in CSS on the web, with a few exceptions.
+The defaults are different, with `flexDirection` defaulting to `column` instead of `row`, `alignContent` defaulting to `flex-start` instead of `stretch`, `flexShrink` defaulting to `0` instead of `1`, the `flex` parameter only supporting a single number.
+:::
 
 ## Flex
 
@@ -429,7 +432,9 @@ export default JustifyContentBasics;
 
 - `baseline` Align children of a container along a common baseline. Individual children can be set to be the reference baseline for their parents.
 
-> For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
+:::info
+For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
+:::
 
 You can learn more [here](https://yogalayout.com/docs/align-items).
 

--- a/docs/height-and-width.md
+++ b/docs/height-and-width.md
@@ -34,13 +34,17 @@ export default FixedDimensionsBasics;
 
 Setting dimensions this way is common for components whose size should always be fixed to a number of points and not calculated based on screen size.
 
-> There is no universal mapping from points to physical units of measurement. This means that a component with fixed dimensions might not have the same physical size, across different devices and screen sizes. However, this difference is unnoticable for most use cases.
+:::caution
+There is no universal mapping from points to physical units of measurement. This means that a component with fixed dimensions might not have the same physical size, across different devices and screen sizes. However, this difference is unnoticeable for most use cases.
+:::
 
 ## Flex Dimensions
 
 Use `flex` in a component's style to have the component expand and shrink dynamically based on available space. Normally you will use `flex: 1`, which tells a component to fill all available space, shared evenly amongst other components with the same parent. The larger the `flex` given, the higher the ratio of space a component will take compared to its siblings.
 
-> A component can only expand to fill available space if its parent has dimensions greater than `0`. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of `0` and the `flex` children will not be visible.
+:::info
+A component can only expand to fill available space if its parent has dimensions greater than `0`. If a parent does not have either a fixed `width` and `height` or `flex`, the parent will have dimensions of `0` and the `flex` children will not be visible.
+:::
 
 ```SnackPlayer name=Flex%20Dimensions
 import React from 'react';

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -15,13 +15,14 @@ First, ensure you're using at least version 0.60.4 of React Native.
 
 If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
 
-> ## Note for RN compatibility.
->
-> Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
+:::caution Note for React Native compatibility
+Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly.
+Version mismatch can result in instant crash of your apps in the worst case scenario.
+:::
 
-> ## Note for Windows users.
->
-> Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
+:::info Note for Windows users
+Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145).
+:::
 
 ## Enabling Hermes
 
@@ -56,9 +57,9 @@ That's it! You should now be able to develop and deploy your app as usual:
 $ npx react-native run-android
 ```
 
-> ## Note about Android App Bundles
->
-> Android app bundles are supported from react-native 0.62.0 and up.
+:::note Note about Android App Bundles
+Android app bundles are supported from React Native 0.62 and up.
+:::
 
 ### iOS
 
@@ -104,7 +105,10 @@ A `HermesInternal` global variable will be available in JavaScript that can be u
 const isHermes = () => !!global.HermesInternal;
 ```
 
-> If you are using a non-standard way of loading the JS bundle, it is possible that the `HermesInternal` variable is available but you aren't using the highly optimised pre-compiled bytecode. Confirm that you are using the `.hbc` file and also benchmark the before/after as detailed below.
+:::caution
+If you are using a non-standard way of loading the JS bundle, it is possible that the `HermesInternal` variable is available but you aren't using the highly optimised pre-compiled bytecode.
+Confirm that you are using the `.hbc` file and also benchmark the before/after as detailed below.
+:::
 
 To see the benefits of Hermes, try making a release build/deployment of your app to compare. For example:
 
@@ -134,7 +138,9 @@ You can [read more about the technical implementation on this page](/architectur
 
 Hermes supports the Chrome debugger by implementing the Chrome inspector protocol. This means Chrome's tools can be used to directly debug JavaScript running on Hermes, on an emulator or on a real, physical, device.
 
-> Note that this is very different with the "Remote JS Debugging" from the In-App Developer Menu documented in the [Debugging](debugging#debugging-using-a-custom-javascript-debugger) section, which actually runs the JS code on Chrome's V8 on your development machine (laptop or desktop).
+:::info
+Note that this is very different with the "Remote JS Debugging" from the In-App Developer Menu documented in the [Debugging](debugging#debugging-using-a-custom-javascript-debugger) section, which actually runs the JS code on Chrome's V8 on your development machine (laptop or desktop).
+:::
 
 Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -132,7 +132,9 @@ If you would like to set such things as the HTTP-Verb, Headers or a Body along w
 
 Sometimes, you might be getting encoded image data from a REST API call. You can use the `'data:'` uri scheme to use these images. Same as for network resources, _you will need to manually specify the dimensions of your image_.
 
-> This is recommended for very small and dynamic images only, like icons in a list from a DB.
+:::info
+This is recommended for very small and dynamic images only, like icons in a list from a DB.
+:::
 
 ```jsx
 // include at least width and height!

--- a/docs/linking-libraries-ios.md
+++ b/docs/linking-libraries-ios.md
@@ -9,7 +9,10 @@ With that in mind we exposed many of these features as independent static librar
 
 For most of the libs it will be as quick as dragging two files, sometimes a third step will be necessary, but no more than that.
 
-_All the libraries we ship with React Native live in the `Libraries` folder in the root of the repository. Some of them are pure JavaScript, and you only need to `require` it. Other libraries also rely on some native code, in that case you'll have to add these files to your app, otherwise the app will throw an error as soon as you try to use the library._
+:::note
+All the libraries we ship with React Native live in the `Libraries` folder in the root of the repository. Some of them are pure JavaScript, and you only need to `require` it.
+Other libraries also rely on some native code, in that case you'll have to add these files to your app, otherwise the app will throw an error as soon as you try to use the library.
+:::
 
 ## Here are the few steps to link your libraries that contain native code
 
@@ -23,7 +26,9 @@ Install a library with native dependencies:
 npm install <library-with-native-dependencies> --save
 ```
 
-> **_Note:_** `--save` or `--save-dev` flag is very important for this step. React Native will link your libs based on `dependencies` and `devDependencies` in your `package.json` file.
+:::info
+`--save` or `--save-dev` flag is very important for this step. React Native will link your libs based on `dependencies` and `devDependencies` in your `package.json` file.
+:::
 
 #### Step 2
 
@@ -35,7 +40,10 @@ npx react-native link
 
 Done! All libraries with native dependencies should be successfully linked to your iOS/Android project.
 
-> **_Note:_** If your iOS project is using CocoaPods (contains `Podfile`) and linked library has `podspec` file, then `npx react-native link` will link library using Podfile. To support non-trivial Podfiles add `# Add new pods below this line` comment to places where you expect pods to be added.
+:::note
+If your iOS project is using CocoaPods (contains `Podfile`) and linked library has `podspec` file, then `npx react-native link` will link library using Podfile.
+To support non-trivial Podfiles add `# Add new pods below this line` comment to places where you expect pods to be added.
+:::
 
 ### Manual linking
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -45,7 +45,9 @@ Next, install the required peer dependencies. You need to run different commands
   cd ..
   ```
 
-> Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
+:::note
+You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
+:::
 
 <M1Cocoapods />
 

--- a/docs/profile-hermes.md
+++ b/docs/profile-hermes.md
@@ -7,7 +7,9 @@ You can visualize JavaScript's performance in a React Native app using [Hermes](
 
 In this section, you will learn how to profile your React Native app running on Hermes and how to visualize the profile using [the Performance tab on Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/reference)
 
-> Be sure to [enable hermes in your app](hermes) before you get started!
+:::caution
+Be sure to [enable Hermes in your app](Hermes) before you get started!
+:::
 
 Follow the instructions below to get started profiling:
 
@@ -50,7 +52,9 @@ project.ext.react = [
 ]
 ```
 
-> Be sure to clean the build whenever you make any changes to `build.gradle`
+:::info
+Be sure to clean the build whenever you make any changes to `build.gradle`
+:::
 
 2. Clean the build by running:
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -41,7 +41,9 @@ After opening the trace in your browser (preferably Chrome), you should see some
 
 ![Example](/docs/assets/SystraceExample.png)
 
-> **HINT**: Use the WASD keys to strafe and zoom
+:::note Hint
+Use the WASD keys to strafe and zoom.
+:::
 
 If your trace .html file isn't opening correctly, check your browser console for the following:
 
@@ -53,13 +55,13 @@ Since `Object.observe` was deprecated in recent browsers, you may have to open t
 - Selecting load
 - Selecting the html file generated from the previous command.
 
-> **Enable VSync highlighting**
->
-> Check this checkbox at the top right of the screen to highlight the 16ms frame boundaries:
->
-> ![Enable VSync Highlighting](/docs/assets/SystraceHighlightVSync.png)
->
-> You should see zebra stripes as in the screenshot above. If you don't, try profiling on a different device: Samsung has been known to have issues displaying vsyncs while the Nexus series is generally pretty reliable.
+:::info Enable VSync highlighting
+Check this checkbox at the top right of the screen to highlight the 16ms frame boundaries:
+
+![Enable VSync Highlighting](/docs/assets/SystraceHighlightVSync.png)
+
+You should see zebra stripes as in the screenshot above. If you don't, try profiling on a different device: Samsung has been known to have issues displaying vsyncs while the Nexus series is generally pretty reliable.
+:::
 
 ### 3. Find your process
 

--- a/docs/publishing-to-app-store.md
+++ b/docs/publishing-to-app-store.md
@@ -5,7 +5,9 @@ title: Publishing to Apple App Store
 
 The publishing process is the same as any other native iOS app, with some additional considerations to take into account.
 
-> If you are using Expo then read the Expo Guide for [Building Standalone Apps](https://docs.expo.dev/classic/building-standalone-apps/).
+:::info
+If you are using Expo then read the Expo Guide for [Building Standalone Apps](https://docs.expo.dev/classic/building-standalone-apps/).
+:::
 
 ### 1. Enable App Transport Security
 
@@ -13,7 +15,9 @@ App Transport Security is a security feature introduced in iOS 9 that rejects al
 
 You should re-enable ATS prior to building your app for production by removing the `localhost` entry from the `NSExceptionDomains` dictionary and setting `NSAllowsArbitraryLoads` to `false` in your `Info.plist` file in the `ios/` folder. You can also re-enable ATS from within Xcode by opening your target properties under the Info pane and editing the App Transport Security Settings entry.
 
-> If your application needs to access HTTP resources on production, learn how to configure ATS on your project.
+:::note
+If your application needs to access HTTP resources on production, learn how to configure ATS on your project.
+:::
 
 ### 2. Configure release scheme
 
@@ -46,7 +50,9 @@ The static bundle is built every time you target a physical device, even in Debu
 
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
-> You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
+:::info
+You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
+:::
 
 Once you are done with the testing and ready to publish to App Store, follow along with this guide.
 
@@ -54,7 +60,9 @@ Once you are done with the testing and ready to publish to App Store, follow alo
 - Double click on YOUR_APP_NAME.xcworkspace. It should launch XCode.
 - Click on `Product` → `Archive`. Make sure to set the device to "Any iOS Device (arm64)".
 
-> Note: Check your Bundle Identifier and make sure it is exactly same as the one you have created in the Identifers in Apple Developer Dashboard
+:::note
+Check your Bundle Identifier and make sure it is exactly same as the one you have created in the Identifiers in Apple Developer Dashboard.
+:::
 
 - After the archive is completed, in the archive window, click on `Distribute App`.
 - Click on `App Store Connect` now (if you want to publish in App Store).

--- a/docs/ram-bundles-inline-requires.md
+++ b/docs/ram-bundles-inline-requires.md
@@ -13,9 +13,7 @@ Before react-native can execute JS code, that code must be loaded into memory an
 
 Inline requires delay the requiring of a module or file until that file is actually needed. A basic example would look like this:
 
-### VeryExpensive.js
-
-```js
+```js title='VeryExpensive.js'
 import React, { Component } from 'react';
 import { Text } from 'react-native';
 // ... import some very expensive modules
@@ -31,9 +29,7 @@ export default class VeryExpensive extends Component {
 }
 ```
 
-### Optimized.js
-
-```js
+```js title='Optimized.js'
 import React, { Component } from 'react';
 import { TouchableOpacity, View, Text } from 'react-native';
 
@@ -96,7 +92,9 @@ project.ext.react = [
 ]
 ```
 
-> **_Note_**: If you are using [Hermes JS Engine](https://github.com/facebook/hermes), you **should not** have RAM bundles feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, because those mechanisms are not compatible with each other.
+:::info
+If you are using [Hermes JS Engine](https://github.com/facebook/hermes), you **should not** have RAM bundles feature enabled. In Hermes, when loading the bytecode, `mmap` ensures that the entire file is not loaded. Using Hermes with RAM bundles might lead to issues, because those mechanisms are not compatible with each other.
+:::
 
 ## Configure Preloading and Inline Requires
 

--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -33,7 +33,9 @@ Navigate to that directory by using the command `cd /your/jdk/path` and use the 
 
     sudo keytool -genkey -v -keystore my-upload-key.keystore -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
 
-> Note: Remember to keep the keystore file private. In case you've lost upload key or it's been compromised you should [follow these instructions](https://support.google.com/googleplay/android-developer/answer/7384423#reset).
+:::caution
+Remember to keep the keystore file private. In case you've lost upload key or it's been compromised you should [follow these instructions](https://support.google.com/googleplay/android-developer/answer/7384423#reset).
+:::
 
 ## Setting up Gradle variables
 
@@ -49,15 +51,19 @@ MYAPP_UPLOAD_KEY_PASSWORD=*****
 
 These are going to be global Gradle variables, which we can later use in our Gradle config to sign our app.
 
-> Note about using git: Saving the above Gradle variables in `~/.gradle/gradle.properties` instead of `android/gradle.properties` prevents them from being checked in to git. You may have to create the `~/.gradle/gradle.properties` file in your user's home directory before you can add the variables.
+:::note Note about using git
+Saving the above Gradle variables in `~/.gradle/gradle.properties` instead of `android/gradle.properties` prevents them from being checked in to git. You may have to create the `~/.gradle/gradle.properties` file in your user's home directory before you can add the variables.
+:::
 
-> Note about security: If you are not keen on storing your passwords in plaintext, and you are running macOS, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`.
+:::note Note about security
+If you are not keen on storing your passwords in plaintext, and you are running macOS, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`.
+:::
 
 ## Adding signing config to your app's Gradle config
 
 The last configuration step that needs to be done is to setup release builds to be signed using upload key. Edit the file `android/app/build.gradle` in your project folder, and add the signing config,
 
-```gradle
+```groovy
 ...
 android {
     ...
@@ -93,7 +99,9 @@ cd android
 
 Gradle's `bundleRelease` will bundle all the JavaScript needed to run your app into the AAB ([Android App Bundle](https://developer.android.com/guide/app-bundle)). If you need to change the way the JavaScript bundle and/or drawable resources are bundled (e.g. if you changed the default file/folder names or the general structure of the project), have a look at `android/app/build.gradle` to see how you can update it to reflect these changes.
 
-> Note: Make sure `gradle.properties` does not include `org.gradle.configureondemand=true` as that will make the release build skip bundling JS and assets into the app binary.
+:::note
+Make sure `gradle.properties` does not include `org.gradle.configureondemand=true` as that will make the release build skip bundling JS and assets into the app binary.
+:::
 
 The generated AAB can be found under `android/app/build/outputs/bundle/release/app-release.aab`, and is ready to be uploaded to Google Play.
 
@@ -136,11 +144,13 @@ Upload both these files to markets which support device targeting, such as [Goog
 
 Proguard is a tool that can slightly reduce the size of the APK. It does this by stripping parts of the React Native Java bytecode (and its dependencies) that your app is not using.
 
-> **IMPORTANT**: Make sure to thoroughly test your app if you've enabled Proguard. Proguard often requires configuration specific to each native library you're using. See `app/proguard-rules.pro`.
+:::caution Important
+Make sure to thoroughly test your app if you've enabled Proguard. Proguard often requires configuration specific to each native library you're using. See `app/proguard-rules.pro`.
+:::
 
 To enable Proguard, edit `android/app/build.gradle`:
 
-```gradle
+```groovy
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -18,7 +18,10 @@ Timers are an important part of an application and React Native implements the [
 
 The `Promise` implementation uses `setImmediate` as its asynchronicity implementation.
 
-> Note: when debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate. Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S%3N`" `` on your debugger machine. Root access is required for the use in real device.
+:::note
+When debugging on Android, if the times between the debugger and device have drifted; things such as animation, event behavior, etc., might not work properly or the results may not be accurate.
+Please correct this by running `` adb shell "date `date +%m%d%H%M%Y.%S%3N`" `` on your debugger machine. Root access is required for the use in real device.
+:::
 
 ## InteractionManager
 


### PR DESCRIPTION
# Why

This PR is the first in series, in which I going to replace legacy styling and workarounds with new Docusuaurs features (I have decided to split the changes into few PR so the amount of changes won't be overwhelming for the reviewers).

# How

The first change is to replace the the old `blockquote` blocks which were used for emphasising the content before the [Admonitions](https://docusaurus.io/docs/markdown-features/admonitions) was a thing. I have chosen the styling and added a custom tile (if needed) based on the current "notes" content.

Ideally, we want to get rid of all `blockquote` like that, to be able to use the component for the regular quotes, but this might take a longer while, so ATM I have put my focus on the unversioned docs.

The second change is that CodeBlock now supports `title` parameter, and in this PR I have replaced names in comments by this parameter for the affected CodeBlocks.

# Test plan

The changes have been tested by running the docs website locally.