### PR TITLE
correct redirect for Contributing section landing page

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -4,7 +4,7 @@
 /docs/android-setup             /docs/getting-started
 /docs/building-for-apple-tv     /docs/building-for-tv
 /docs/building-from-source      /contributing/how-to-build-from-source
-/docs/contributing              /contributing/contributing-intro
+/docs/contributing              /contributing/overview
 /docs/publishing-forks          /contributing/how-to-build-from-source#publish-your-own-version-of-react-native
 /docs/testing                   /contributing/how-to-run-and-write-tests
 /docs/understanding-cli         https://github.com/react-native-community/cli#react-native-cli


### PR DESCRIPTION
# Why

React Native core repository Readme file contains old, general link to the Contributing section of the website and after latest changes it leads to 404 page.

# How

Apply the correct redirect for the old Contributing section link.
