### PR TITLE
added a note in running your app on real device section

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -43,7 +43,9 @@ emulator-5554 offline   # Google emulator
 
 Seeing `device` in the right column means the device is connected. You must have **only one device connected** at a time.
 
-> If you see `unauthorized` in the list you will need to run `adb reverse tcp:8081 tcp:8081` and press allow USB debugging on the device.
+:::note
+If you see `unauthorized` in the list you will need to run `adb reverse tcp:8081 tcp:8081` and press allow USB debugging on the device.
+:::
 
 ### 3. Run your app
 

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -42,6 +42,7 @@ emulator-5554 offline   # Google emulator
 ```
 
 Seeing `device` in the right column means the device is connected. You must have **only one device connected** at a time.
+
 > If you see `unauthorized` in the list you will need to run `adb reverse tcp:8081 tcp:8081` and press allow USB debugging on the device.
 
 ### 3. Run your app

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -42,6 +42,7 @@ emulator-5554 offline   # Google emulator
 ```
 
 Seeing `device` in the right column means the device is connected. You must have **only one device connected** at a time.
+> If you see `unauthorized` in the list you will need to run `adb reverse tcp:8081 tcp:8081` and press allow USB debugging on the device.
 
 ### 3. Run your app
 


### PR DESCRIPTION
While I was trying to run an app on my tablet I faced an issue that the device was listed as unauthorized, and while it was the only device listed on the list when I run `npm run android` the emulator was opened
I did a google search and end up with this fix

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
