### PR TITLE
Renamed to MyApplication to MainApplication.

### DIFF
--- a/docs/new-architecture-app-modules-android.md
+++ b/docs/new-architecture-app-modules-android.md
@@ -190,7 +190,7 @@ Then, you can provide the class you created to your `ReactNativeHost`. You can l
 Once you located it, you need to add the `getReactPackageTurboModuleManagerDelegateBuilder` method as from the snippet below:
 
 ```java
-public class MyApplication extends Application implements ReactApplication {
+public class MainApplication extends Application implements ReactApplication {
 
     private final ReactNativeHost mReactNativeHost =
         new ReactNativeHost(this) {
@@ -217,7 +217,7 @@ public class MyApplication extends Application implements ReactApplication {
 Still on the `ReactNativeHost` , we need to extend the the `getPackages()` method to include the newly created TurboModule. Update the method to include the following:
 
 ```java
-public class MyApplication extends Application implements ReactApplication {
+public class MainApplication extends Application implements ReactApplication {
 
     private final ReactNativeHost mReactNativeHost =
         new ReactNativeHost(this) {


### PR DESCRIPTION
I was searching for this file named `MyApplication` for a long time turned out it was `MainApplication` in the android directory.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
