### PR TITLE
Modify the top navbar to be less full

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -310,7 +310,7 @@ module.exports = {
                 to: 'help',
               },
               {
-                label: "Who's using React Native?",
+                label: 'Showcase',
                 to: 'showcase',
               },
               {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -298,7 +298,7 @@ module.exports = {
               },
               {
                 label: 'Architecture',
-                to: 'docs/architecture/overview',
+                to: 'architecture/overview',
               },
             ],
           },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -229,7 +229,7 @@ module.exports = {
                 docId: 'components-and-apis',
               },
               {
-                label: 'API',
+                label: 'APIs',
                 type: 'doc',
                 docId: 'accessibilityinfo',
               },
@@ -293,7 +293,7 @@ module.exports = {
                 to: 'docs/components-and-apis',
               },
               {
-                label: 'API',
+                label: 'APIs',
                 to: 'docs/accessibilityinfo',
               },
               {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -282,23 +282,23 @@ module.exports = {
         style: 'dark',
         links: [
           {
-            title: 'Docs',
+            title: 'Development',
             items: [
               {
-                label: 'Getting Started',
+                label: 'Guides',
                 to: 'docs/getting-started',
               },
               {
-                label: 'Tutorial',
-                to: 'docs/tutorial',
-              },
-              {
-                label: 'Components and APIs',
+                label: 'Components',
                 to: 'docs/components-and-apis',
               },
               {
-                label: 'More Resources',
-                to: 'docs/more-resources',
+                label: 'API',
+                to: 'docs/accessibilityinfo',
+              },
+              {
+                label: 'Architecture',
+                to: 'docs/architecture/overview',
               },
             ],
           },
@@ -306,20 +306,20 @@ module.exports = {
             title: 'Community',
             items: [
               {
-                label: 'The React Native Community',
-                to: 'help',
-              },
-              {
                 label: 'Showcase',
                 to: 'showcase',
               },
               {
-                label: 'Ask Questions on Stack Overflow',
-                href: 'https://stackoverflow.com/questions/tagged/react-native',
+                label: 'Contributing',
+                to: 'contributing',
               },
               {
-                label: 'DEV Community',
-                href: 'https://dev.to/t/reactnative',
+                label: 'The React Native Community',
+                to: 'help',
+              },
+              {
+                label: 'Ask Questions on Stack Overflow',
+                href: 'https://stackoverflow.com/questions/tagged/react-native',
               },
             ],
           },
@@ -344,7 +344,7 @@ module.exports = {
             title: 'More',
             items: [
               {
-                label: 'React',
+                label: 'ReactJS',
                 href: 'https://reactjs.org/',
               },
               {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -214,19 +214,15 @@ module.exports = {
         style: 'dark',
         items: [
           {
-            label: 'Developer',
+            label: 'Development',
             type: 'dropdown',
             position: 'right',
             items: [
               {
-                label: 'Guides',
+                label: 'Architecture',
                 type: 'doc',
-                docId: 'getting-started',
-              },
-              {
-                label: 'Components',
-                type: 'doc',
-                docId: 'components-and-apis',
+                docId: 'architecture-overview',
+                docsPluginId: 'architecture',
               },
               {
                 label: 'API',
@@ -234,10 +230,14 @@ module.exports = {
                 docId: 'accessibilityinfo',
               },
               {
-                label: 'Architecture',
+                label: 'Components',
                 type: 'doc',
-                docId: 'architecture-overview',
-                docsPluginId: 'architecture',
+                docId: 'components-and-apis',
+              },
+              {
+                label: 'Guides',
+                type: 'doc',
+                docId: 'getting-started',
               },
             ],
           },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -214,29 +214,32 @@ module.exports = {
         style: 'dark',
         items: [
           {
-            label: 'Guides',
-            type: 'doc',
-            docId: 'getting-started',
+            label: 'Developer',
+            type: 'dropdown',
             position: 'right',
-          },
-          {
-            label: 'Components',
-            type: 'doc',
-            docId: 'components-and-apis',
-            position: 'right',
-          },
-          {
-            label: 'API',
-            type: 'doc',
-            docId: 'accessibilityinfo',
-            position: 'right',
-          },
-          {
-            label: 'Architecture',
-            type: 'doc',
-            docId: 'architecture-overview',
-            position: 'right',
-            docsPluginId: 'architecture',
+            items: [
+              {
+                label: 'Guides',
+                type: 'doc',
+                docId: 'getting-started',
+              },
+              {
+                label: 'Components',
+                type: 'doc',
+                docId: 'components-and-apis',
+              },
+              {
+                label: 'API',
+                type: 'doc',
+                docId: 'accessibilityinfo',
+              },
+              {
+                label: 'Architecture',
+                type: 'doc',
+                docId: 'architecture-overview',
+                docsPluginId: 'architecture',
+              },
+            ],
           },
           {
             type: 'doc',
@@ -244,6 +247,11 @@ module.exports = {
             label: 'Contributing',
             position: 'right',
             docsPluginId: 'contributing',
+          },
+          {
+            to: '/showcase',
+            label: 'Showcase',
+            position: 'right',
           },
           {
             to: '/blog',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -219,15 +219,9 @@ module.exports = {
             position: 'right',
             items: [
               {
-                label: 'Architecture',
+                label: 'Guides',
                 type: 'doc',
-                docId: 'architecture-overview',
-                docsPluginId: 'architecture',
-              },
-              {
-                label: 'API',
-                type: 'doc',
-                docId: 'accessibilityinfo',
+                docId: 'getting-started',
               },
               {
                 label: 'Components',
@@ -235,9 +229,15 @@ module.exports = {
                 docId: 'components-and-apis',
               },
               {
-                label: 'Guides',
+                label: 'API',
                 type: 'doc',
-                docId: 'getting-started',
+                docId: 'accessibilityinfo',
+              },
+              {
+                label: 'Architecture',
+                type: 'doc',
+                docId: 'architecture-overview',
+                docsPluginId: 'architecture',
               },
             ],
           },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -311,7 +311,7 @@ module.exports = {
               },
               {
                 label: 'Contributing',
-                to: 'contributing',
+                to: 'contributing/overview',
               },
               {
                 label: 'The React Native Community',

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -886,8 +886,7 @@ aside[class^="theme-doc-sidebar-container"] {
   }
 
   .menu__link--sublist {
-    font-size: 15px;
-    font-weight: 600;
+    font-size: 17px;
     padding: 4px 12px !important;
     color: var(--light);
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -596,10 +596,10 @@ a[class*="tagRegular"] {
       user-select: none;
     }
 
-    &.dropdown {
+    &.dropdown:not(.dropdown--right) {
       a {
         font-weight: 400;
-        font-size: 17px;
+        font-size: 14px;
       }
       ul {
         /* Control navbar dropdown alignment */
@@ -607,6 +607,18 @@ a[class*="tagRegular"] {
         left: 0;
       }
     }
+
+    &.dropdown--right {
+      .dropdown__menu {
+        min-width: 168px;
+      }
+    }
+  }
+
+  .dropdown > .navbar__link:after {
+    margin-left: 8px;
+    top: 1px;
+    opacity: 0.75;
   }
 
   .navbar__logo {
@@ -886,7 +898,7 @@ aside[class^="theme-doc-sidebar-container"] {
   }
 
   .menu__link--sublist {
-    font-size: 17px;
+    font-size: 15px;
     padding: 4px 12px !important;
     color: var(--light);
 
@@ -894,6 +906,10 @@ aside[class^="theme-doc-sidebar-container"] {
       background-size: 1.66rem 1.66rem;
       margin-right: -6px;
     }
+  }
+
+  .menu__link--sublist-caret {
+    font-size: 17px;
   }
 
   .menu__list {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -599,7 +599,7 @@ a[class*="tagRegular"] {
     &.dropdown {
       a {
         font-weight: 400;
-        font-size: 14px;
+        font-size: 17px;
       }
       ul {
         /* Control navbar dropdown alignment */


### PR DESCRIPTION
This is a follow-up to a conversation that happened in the RN Discord; I saw the [Flutter website](https://flutter.dev/) having a clean and organised navbar and I wondered if that could have been replicated for the RN website.

Luckily, as pointed out by @slorber, Docusaurus supports this dropdown behaviour directly: https://docusaurus.io/docs/next/api/themes/configuration#navbar-dropdown

so the changes are fairly minimal, from a code perspective.

What I ended up doing for this first iteration is to group under "development" the 4 elements (in alphabetical order) "Architecture", "API", "Components", "Guides" and then re-add to the navbar the "Showcase" element.

Here are a few screenshots to show the result:
<img width="667" alt="Screenshot 2022-07-08 at 14 53 14" src="https://user-images.githubusercontent.com/16104054/178009695-77a7a14e-1fb4-4694-99b8-a496bf1ec642.png">

<img width="338" alt="Screenshot 2022-07-08 at 14 57 01" src="https://user-images.githubusercontent.com/16104054/178009733-f00a2d5b-99d9-467f-a3f0-176794913d89.png">

(but also ofc verify via the deployed preview)

---

A potential "second iteration" of this idea might make a second "dropdown" that could be something like "Community" -> "Get Help", "Events", "Contributing" or something along those lines... but first the get-help page needs a big update (it really needs one) and the confs stuff would have to be split out from that. Again, I'm just thinking out loud atm.