### PR TITLE
Fix invocation of bump script command

### DIFF
--- a/website/contributing/release-candidate-minor.md
+++ b/website/contributing/release-candidate-minor.md
@@ -40,7 +40,7 @@ Before continuing further, follow the [testing](/contributing/release-testing) g
 git push origin 0.68-stable
 
 # This will walk you through what version you are releasing
-./scripts/bump-oss-version.js -v 0.68.0-rc.0 -t <YOUR_CIRCLE_CI_TOKEN>
+./scripts/bump-oss-version.js --to-version 0.68.0-rc.0 --token <YOUR_CIRCLE_CI_TOKEN>
 ```
 
 - Once you have run that script, head to CircleCI and you should see under the releases workflow, a `prepare-package-for-release` job.

--- a/website/contributing/release-candidate-patch.md
+++ b/website/contributing/release-candidate-patch.md
@@ -30,7 +30,7 @@ Before continuing further, follow the [testing](/contributing/release-testing) g
 ```bash
 # run a script to bump the version
 # You most likely **don't** want this release marked as "latest"
-./scripts/bump-oss-version.js -v x.y.z-rc.x --token circle-ci-token
+./scripts/bump-oss-version.js --to-version x.y.z-rc.x --token <YOUR_CIRCLE_CI_TOKEN>
 ```
 
 ### 4. Similar to cutting new branch, watch CircleCI to ensure right jobs are being triggered

--- a/website/contributing/release-candidate-patch.md
+++ b/website/contributing/release-candidate-patch.md
@@ -30,7 +30,7 @@ Before continuing further, follow the [testing](/contributing/release-testing) g
 ```bash
 # run a script to bump the version
 # You most likely **don't** want this release marked as "latest"
-./scripts/bump-oss-version.js --version x.y.z-rc.x --token circle-ci-token
+./scripts/bump-oss-version.js -v x.y.z-rc.x --token circle-ci-token
 ```
 
 ### 4. Similar to cutting new branch, watch CircleCI to ensure right jobs are being triggered

--- a/website/contributing/release-stable-minor.md
+++ b/website/contributing/release-stable-minor.md
@@ -13,7 +13,7 @@ title: Release Stable Minor
 
 ```bash
 # In your react-native checkout, on the release branch of the version
-./scripts/bump-oss-version.js -v x.y.z -t <YOUR_CIRCLE_CI_TOKEN>
+./scripts/bump-oss-version.js --to-version x.y.z --token <YOUR_CIRCLE_CI_TOKEN>
 > Do you want this to be latest?
 # Generally yes. This updates npm registry to point to this version as "latest"
 ```

--- a/website/contributing/release-stable-patch.md
+++ b/website/contributing/release-stable-patch.md
@@ -30,7 +30,7 @@ Before continuing further, follow the [testing](/contributing/release-testing) g
 ```bash
 # run a script to bump the version
 # You most likely **don't** want this release marked as "latest"
-./scripts/bump-oss-version.js -v x.y.z --token circle-ci-token
+./scripts/bump-oss-version.js --to-version x.y.z --token <YOUR_CIRCLE_CI_TOKEN>
 ```
 
 ### 4. Verify Upgrade helper is updated

--- a/website/contributing/release-stable-patch.md
+++ b/website/contributing/release-stable-patch.md
@@ -30,7 +30,7 @@ Before continuing further, follow the [testing](/contributing/release-testing) g
 ```bash
 # run a script to bump the version
 # You most likely **don't** want this release marked as "latest"
-./scripts/bump-oss-version.js --version x.y.z-rc.x --token circle-ci-token
+./scripts/bump-oss-version.js -v x.y.z --token circle-ci-token
 ```
 
 ### 4. Verify Upgrade helper is updated


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

When doing the latest release, we have noticed the `--version` flag in the patch releases guide is incorrect and it should be `-v` instead.
