### PR TITLE
Use monospace for method name on docs/easing

### DIFF
--- a/docs/easing.md
+++ b/docs/easing.md
@@ -3,7 +3,7 @@ id: easing
 title: Easing
 ---
 
-The `Easing` module implements common easing functions. This module is used by [Animated.timing()](animated.md#timing) to convey physically believable motion in animations.
+The `Easing` module implements common easing functions. This module is used by [`Animated.timing()`](animated.md#timing) to convey physically believable motion in animations.
 
 You can find a visualization of some common easing functions at http://easings.net/
 


### PR DESCRIPTION
Style fix. Consistent with other references to parameters or method names.