### PR TITLE
Update snippet in profile-hermes to be Groovy rather than Java

### DIFF
--- a/docs/profile-hermes.md
+++ b/docs/profile-hermes.md
@@ -46,7 +46,7 @@ A source map is used to enhance the profile and associate trace events with the 
 
 1. In your app's `android/app/build.gradle` file, add:
 
-```java
+```groovy
 project.ext.react = [
   bundleInDebug: true,
 ]


### PR DESCRIPTION
This is a nit, but I've realized that this snippet inside `profile-hermes` was originally marked as Java code while in reality is Groovy code (as it's from a .gradle file).
