### PR TITLE
Add kotlin code sample to new-architecture-library-android.md

### DIFF
--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -129,17 +129,18 @@ import com.example.samplelibrary.NativeAwesomeManagerSpec
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 
-class NativeAwesomeManager(reactContext: ReactApplicationContext) :
+class NativeAwesomeManager(reactContext: ReactApplicationContext?) :
     NativeAwesomeManagerSpec(reactContext) {
-    val NAME = "NativeAwesomeManager"
     override fun getString(id: String?, promise: Promise?) {
         // Implement this method
     }
 
-    override fun getName(): String {
-        return NAME
+    companion object {
+        val NAME = "NativeAwesomeManager"
+            get() = Companion.field
     }
 }
+
 ```
 
 </TabItem>

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -137,10 +137,10 @@ class NativeAwesomeManager(reactContext: ReactApplicationContext?) :
 
     companion object {
         val NAME = "NativeAwesomeManager"
-            get() = Companion.field
     }
-}
 
+    override fun getName() = NAME
+}
 ```
 
 </TabItem>

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -129,9 +129,9 @@ import com.example.samplelibrary.NativeAwesomeManagerSpec
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 
-class NativeAwesomeManager(reactContext: ReactApplicationContext?) :
+class NativeAwesomeManager(reactContext: ReactApplicationContext) :
     NativeAwesomeManagerSpec(reactContext) {
-    override fun getString(id: String?, promise: Promise?) {
+    override fun getString(id: String, promise: Promise) {
         // Implement this method
     }
 

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -135,11 +135,11 @@ class NativeAwesomeManager(reactContext: ReactApplicationContext) :
         // Implement this method
     }
 
+    override fun getName() = NAME
+
     companion object {
         val NAME = "NativeAwesomeManager"
     }
-
-    override fun getName() = NAME
 }
 ```
 

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -3,7 +3,7 @@ id: new-architecture-library-android
 title: Enabling in Android Library
 ---
 
-import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx';
+import NewArchitectureWarning from './\_markdown-new-architecture-warning.mdx'; import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 <NewArchitectureWarning/>
 
@@ -88,6 +88,10 @@ Update your native module or component to ensure it **extends the abstract class
 
 Following the example set forth in the previous section, your library might import `NativeAwesomeManagerSpec`, implement the relevant native interface and the necessary methods for it:
 
+<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+
+<TabItem value="java">
+
 ```java
 import androidx.annotation.NonNull;
 
@@ -115,5 +119,30 @@ public class NativeAwesomeManager extends NativeAwesomeManagerSpec {
     }
 }
 ```
+
+</TabItem>
+
+<TabItem value="kotlin">
+
+```kotlin
+import com.example.samplelibrary.NativeAwesomeManagerSpec
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+
+class NativeAwesomeManager(reactContext: ReactApplicationContext) :
+    NativeAwesomeManagerSpec(reactContext) {
+    val NAME = "NativeAwesomeManager"
+    override fun getString(id: String?, promise: Promise?) {
+        // Implement this method
+    }
+
+    override fun getName(): String {
+        return NAME
+    }
+}
+```
+
+</TabItem>
+</Tabs>
 
 Please note that the **generated abstract class** that you’re now extending (`MyAwesomeSpec` in this example), is itself extending `ReactContextBaseJavaModule`. Therefore you should not use access to any of the method/fields you were previously using (e.g. the `ReactApplicationContext` and so on). Moreover the generated class will now also implement the `TurboModule` interface for you.


### PR DESCRIPTION
This PR adds kotlin code sample to the file "new-architecture-library-android.md"
Looks like so on my local website
<img width="862" alt="Screenshot 2022-07-05 at 15 18 33" src="https://user-images.githubusercontent.com/12739932/177337540-5ee28ab6-4b7c-4d3e-9864-c7129a3b80c6.png">
<img width="822" alt="Screenshot 2022-07-07 at 15 15 29" src="https://user-images.githubusercontent.com/12739932/177782619-77e2f5b7-df51-40a9-9089-50bbf081f30f.png">





references #3018