### PR TITLE
Added infoLink to Oculus

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -40,7 +40,7 @@
     "icon": "oculus.png",
     "linkAppStore": "https://apps.apple.com/us/app/oculus/id1366478176",
     "linkPlayStore": "https://play.google.com/store/apps/details?id=com.oculus.twilight&hl=en_US",
-    "infoLink": "",
+    "infoLink": "https://www.oculus.com/experiences/quest/",
     "infoTitle": "",
     "pinned": true
   },

--- a/website/showcase.json
+++ b/website/showcase.json
@@ -214,7 +214,7 @@
   },
   {
     "name": "Artsy",
-    "icon": "https://raw.githubusercontent.com/artsy/eigen/master/Artsy/Resources/Images.xcassets/AppIcon.appiconset/AppIcon167.png",
+    "icon": "https://avatars.githubusercontent.com/u/546231?s=200&v=4",
     "linkAppStore": "https://itunes.apple.com/us/app/artsy-collect-bid-on-fine/id703796080?mt=8",
     "infoLink": "https://artsy.github.io/series/react-native-at-artsy/",
     "infoTitle": "React Native at Artsy",


### PR DESCRIPTION
# #3196
fixed missing infoLink of oculus in website/showcase.json which was resulting in non clickable oculus icon at homepage of react native 
