### PR TITLE
Note on connecting to React Native simulator.

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -115,7 +115,7 @@ react-devtools
 
 ![React DevTools](/docs/assets/ReactDevTools.png)
 
-It should connect to your simulator within a few seconds.
+It should connect to your simulator within a few seconds. If it doesn't, try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
 
 > Note: if you prefer to avoid global installations, you can add `react-devtools` as a project dependency. Add the `react-devtools` package to your project using `npm install --save-dev react-devtools`, then add `"react-devtools": "react-devtools"` to the `scripts` section in your `package.json`, and then run `npm run react-devtools` from your project folder to open the DevTools.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -115,7 +115,9 @@ react-devtools
 
 ![React DevTools](/docs/assets/ReactDevTools.png)
 
-It should connect to your simulator within a few seconds. If it doesn't, try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
+It should connect to your simulator within a few seconds. 
+
+> Note: If you have trouble connecting to your simulator, especially if using an Android 12 simulator, try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
 
 > Note: if you prefer to avoid global installations, you can add `react-devtools` as a project dependency. Add the `react-devtools` package to your project using `npm install --save-dev react-devtools`, then add `"react-devtools": "react-devtools"` to the `scripts` section in your `package.json`, and then run `npm run react-devtools` from your project folder to open the DevTools.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -117,9 +117,13 @@ react-devtools
 
 It should connect to your simulator within a few seconds. 
 
-> Note: If connecting to the emulator proves troublesome (especially Android 12), try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
+:::info
+If connecting to the emulator proves troublesome (especially Android 12), try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
+:::
 
-> Note: if you prefer to avoid global installations, you can add `react-devtools` as a project dependency. Add the `react-devtools` package to your project using `npm install --save-dev react-devtools`, then add `"react-devtools": "react-devtools"` to the `scripts` section in your `package.json`, and then run `npm run react-devtools` from your project folder to open the DevTools.
+:::info
+If you prefer to avoid global installations, you can add `react-devtools` as a project dependency. Add the `react-devtools` package to your project using `npm install --save-dev react-devtools`, then add `"react-devtools": "react-devtools"` to the `scripts` section in your `package.json`, and then run `npm run react-devtools` from your project folder to open the DevTools.
+:::
 
 ### Integration with React Native Inspector
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -117,7 +117,7 @@ react-devtools
 
 It should connect to your simulator within a few seconds. 
 
-> Note: If you have trouble connecting to your simulator, especially if using an Android 12 simulator, try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
+> Note: If connecting to the emulator proves troublesome (especially Android 12), try running `adb reverse tcp:8097 tcp:8097` in a new terminal.
 
 > Note: if you prefer to avoid global installations, you can add `react-devtools` as a project dependency. Add the `react-devtools` package to your project using `npm install --save-dev react-devtools`, then add `"react-devtools": "react-devtools"` to the `scripts` section in your `package.json`, and then run `npm run react-devtools` from your project folder to open the DevTools.
 


### PR DESCRIPTION
Standalone react-devtools frequently has trouble connecting to a running simulator instance, as noted in the docs, on the GH repo, and on [SO](https://stackoverflow.com/questions/50867874/react-native-cannot-connect-to-react-devtools-using-android-simulator). 

Often, it is necessary to run `adb reverse tcp:8097 tcp:8097` to get standalone react-devtools to connect to a running simulator instance. It would be helpful to note this in the docs here, rather than forcing users to search the GH docs, and SO. (Also, a note - the GH docs state that this is only necessary when not using a local emulator, but this is not the case, as evidenced by the aforementioned [SO question](https://stackoverflow.com/questions/50867874/react-native-cannot-connect-to-react-devtools-using-android-simulator), where the user notes using an emulator, and in my own experience - I must do this to get react-devtools to connect to an Android Studio emulator, which I assume would count as a local emulator.)