### PR TITLE
screenreader difference in behaviour between TalkBack and VoiceOver

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -27,6 +27,42 @@ On Android, `accessible={true}` property for a react-native View will be transla
 
 In the above example, we can't get accessibility focus separately on 'text one' and 'text two'. Instead we get focus on a parent view with 'accessible' property.
 
+```jsx
+<View accessible={true}>
+  <Text accessible={true}>text one</Text>
+  <Text>text two</Text>
+</View>
+```
+
+<div class="label ios basic">iOS</div>
+
+VoiceOver can't get accessibility focus separately on 'text one' and 'text two' in the above example. Instead, it focuses on the parent view with 'accessible' property.
+
+<div class="label android basic">Android</div>
+
+In the above example, the TalkBack screenreader focuses on the parent view with the 'accessible' property and uses the unfocusable child Text with the text "text two" as a label. The focus will then move to read the second focusable child Text with the text "text one".
+
+```jsx
+<View
+  accessible={true}
+  accessibilityLabel="a couple of text views">
+  <Text onPress={() => console.log('text one pressed')}>
+    text One
+  </Text>
+  <Text onPress={() => console.log('text two pressed')}>
+    text Two
+  </Text>
+</View>
+```
+
+<div class="label ios basic">iOS</div>
+
+VoiceOver can't get accessibility focus separately on 'text one' and 'text two' in the above example. Instead, it focuses on the parent view with 'accessible' property.
+
+<div class="label android basic">Android</div>
+
+In the above example, the TalkBack screenreader focuses on the parent view with the 'accessible' property and announces the accessibilityLabel 'a couple of text views'. The focus then moves to the next focusable child, the Text with 'text one' and 'text two'. Android elements with an onPress or onLongPress handler are focusable.
+
 ### `accessibilityLabel`
 
 When a view is marked as accessible, it is a good practice to set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected. VoiceOver will read this string when a user selects the associated element.


### PR DESCRIPTION
>Sometimes this will group's descendants that are also marked as accessible together into one focusable element (e.g. accessible with accessible descendants), and sometimes it does not (e.g. accessible with accessible descendants).
>It's definitely worth clarifying this behavior in the documentation

https://github.com/facebook/react-native/issues/30851#issuecomment-1194938293 https://github.com/facebook/react-native/issues/30851#issuecomment-1194944880 https://github.com/facebook/react-native/issues/30851#issuecomment-1194957300

>On iOS the default behavior (and really, the only reasonably possible behavior), would be that the outer view is focusable, and must be given an accessibilityLabel to describe it. No accessible element can have accessible descendants, and all accessible elements must have an accessibility label. Apple has has this very straightforward, and easy to understand for developers.

>Google on the other hand, has made things quite a bit more complicated.

>On Android, the default behavior in this situation would be that all three views (the outer View and the inner two Text views) would attempt to become focusable (assume that the accessible prop maps to Androids focusable view property), but in this case the outer view would actually need some sort of label to be provided, as it has no content that it could announce. If no label was given, the outer view would become unfocusable and only the inner views would end up being focusable, which is exactly what you are seeing happen with the "Nested Text Views" example. If a label was given (and this label was mapped to the contentDescription property), then all three views would become focusable.

- [x] [prepare documentation PR clarifying differences between iOS and Android](https://github.com/facebook/react-native/issues/30851#issuecomment-790136790) for scenarios [accessible parent view and one not accessible child](https://github.com/facebook/react-native/issues/30851#issuecomment-1194938293) and [parent view with accessibilityLabel does not over-ride children with onPress handler](https://github.com/facebook/react-native/issues/30851#issuecomment-1194957300)
- [ ] iOS documentation for [Nested Text is not accessible](https://github.com/facebook/react-native/issues/30851#issuecomment-944954575)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

this and other PRs will fixes https://github.com/facebook/react-native/issues/30851
