### PR TITLE
Fix extra whitespace on debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -115,7 +115,7 @@ react-devtools
 
 ![React DevTools](/docs/assets/ReactDevTools.png)
 
-It should connect to your simulator within a few seconds. 
+It should connect to your simulator within a few seconds.
 
 :::info
 If connecting to the emulator proves troublesome (especially Android 12), try running `adb reverse tcp:8097 tcp:8097` in a new terminal.


### PR DESCRIPTION
I accidentally broke the CI, my bad. I rebase and merged https://github.com/facebook/react-native-website/pull/3222 without waiting for CI results.

Here is the fix.

As a side note, should we enable automerge?
