### PR TITLE
[Documentation] add running your app on a daily basis section

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -162,6 +162,17 @@ Now that you have successfully run the app, let's modify it.
 - Open `App.js` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
+<h3>Running your app on a daily basis</h3>
+
+Once you have run your app for the first time, you don't necessarily have to run `npx react-native run-android` again the next morning to start it.
+
+`npx react-native run-android` builds a new app, and compiles the native code. If you haven't made any native change, you don't have to go through the native compilation again.
+
+To launch your app, you can:
+
+- Start Metro by running `react-native start`
+- Click on your app on your simulator
+
 <h3>That's it!</h3>
 
 Congratulations! You've successfully run and modified your first React Native app.

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -176,6 +176,17 @@ Now that you have successfully run the app, let's modify it.
 - Open `App.js` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`⌘M`) to see your changes!
 
+<h3>Running your app on a daily basis</h3>
+
+Once you have run your app for the first time, you don't necessarily have to run `npx react-native run-android` again the next morning to start it.
+
+`npx react-native run-android` builds a new app, and compiles the native code. If you haven't made any native change, you don't have to go through the native compilation again.
+
+To launch your app, you can:
+
+- Start Metro by running `react-native start`
+- Click on your app on your simulator
+
 <h3>That's it!</h3>
 
 Congratulations! You've successfully run and modified your first React Native app.

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -137,6 +137,17 @@ Now that you have successfully run the app, let's modify it.
 - Open `App.js` in your text editor of choice and edit some lines.
 - Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
 
+### Running your app on a daily basis
+
+Once you have run your app for the first time, you don't necessarily have to run `npx react-native run-ios` again the next morning to start it.
+
+`npx react-native run-ios` builds a new app, and compiles the native code. If you haven't made any native change, you don't have to go through the native compilation again.
+
+To launch your app, you can:
+
+- Start Metro by running `react-native start`
+- Click on your app on your simulator
+
 ### That's it!
 
 Congratulations! You've successfully run and modified your first React Native app.

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -195,6 +195,17 @@ Now that you have successfully run the app, let's modify it.
 - Open `App.js` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
+<h3>Running your app on a daily basis</h3>
+
+Once you have run your app for the first time, you don't necessarily have to run `npx react-native run-android` again the next morning to start it.
+
+`npx react-native run-android` builds a new app, and compiles the native code. If you haven't made any native change, you don't have to go through the native compilation again.
+
+To launch your app, you can:
+
+- Start Metro by running `react-native start`
+- Click on your app on your simulator
+
 <h3>That's it!</h3>
 
 Congratulations! You've successfully run and modified your first React Native app.


### PR DESCRIPTION
Add a section in the getting started documentation on how to launch an app without going through `react-native run-ios` every time.

I learned after one year of react-native development that I didn't actually need this command to open my app and start Metro. I hope this section can save time to other react-native beginners.

![Capture d’écran 2022-07-29 à 18 11 20](https://user-images.githubusercontent.com/34058526/181807090-bbe182e8-4abf-4aeb-a976-43c268ee10d6.png)
 