### PR TITLE
update release related docs page

### DIFF
--- a/website/contributing/_markdown-async-testing-note.mdx
+++ b/website/contributing/_markdown-async-testing-note.mdx
@@ -1,0 +1,3 @@
+:::info
+Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
+:::

--- a/website/contributing/release-branch-cut-and-rc0.md
+++ b/website/contributing/release-branch-cut-and-rc0.md
@@ -45,6 +45,10 @@ git push origin 0.69-stable
 
 Before continuing further, follow the [testing guide](/contributing/release-testing) to ensure the code doesn't have any major issues.
 
+:::info
+Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
+:::
+
 ### 3. Kick off the build of 0.{minor}.0-rc.0
 
 Once you're done with the testing, you can kick-off the bump and publishing of RC0:

--- a/website/contributing/release-branch-cut-and-rc0.md
+++ b/website/contributing/release-branch-cut-and-rc0.md
@@ -3,6 +3,8 @@ id: release-branch-cut-and-rc0
 title: Branch Cut & RC0
 ---
 
+import AsyncTestingNote from './\_markdown-async-testing-note.mdx';
+
 :::info
 Documents in this section go over steps to run different types of React Native release updates. Its intended audience is those in [relevant release roles](./release-roles-responsibilites.md).
 :::
@@ -45,9 +47,7 @@ git push origin 0.69-stable
 
 Before continuing further, follow the [testing guide](/contributing/release-testing) to ensure the code doesn't have any major issues.
 
-:::info
-Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
-:::
+<AsyncTestingNote/>
 
 ### 3. Kick off the build of 0.{minor}.0-rc.0
 

--- a/website/contributing/release-candidate-patch.md
+++ b/website/contributing/release-candidate-patch.md
@@ -30,6 +30,10 @@ git cherry-pick <commit-hash>
 
 Before continuing further, follow the [testing guide](/contributing/release-testing) to ensure the source code doesn't have any major issues.
 
+:::info
+Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
+:::
+
 ### 3. Run `bump-oss-version` script
 
 ```bash

--- a/website/contributing/release-candidate-patch.md
+++ b/website/contributing/release-candidate-patch.md
@@ -3,6 +3,8 @@ id: release-candidate-patch
 title: RC Patches
 ---
 
+import AsyncTestingNote from './\_markdown-async-testing-note.mdx';
+
 :::info
 Documents in this section go over steps to run different types of React Native release updates. Its intended audience is those in [relevant release roles](./release-roles-responsibilites.md).
 :::
@@ -30,9 +32,7 @@ git cherry-pick <commit-hash>
 
 Before continuing further, follow the [testing guide](/contributing/release-testing) to ensure the source code doesn't have any major issues.
 
-:::info
-Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
-:::
+<AsyncTestingNote/>
 
 ### 3. Run `bump-oss-version` script
 

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -5,22 +5,19 @@ title: Roles and Responsibilities
 
 Here we set guidelines to apply the "dividi et impera" approach to React Native releases: it is an involved process and we need to clarify the work to allow for easier rotations of folks in various positions.
 
-In a normal situation, we expect that the release crew at any given point is composed of 2+2 releasers (two people from the community, two from Meta).
+In a normal situation, we expect that the Release Crew at any given point is composed of 2+2 releasers (two people from the community, two from Meta).
 
 ---
 
-## Release Role #1: Meta Releasers (x2)
+## Release Role #1: Meta Releaser
 
 ### Details
 
-Two sub-roles:
+- 2 people per each release
 
-- 1 **release captain** as main point of contact per minor release (aiming for every 2 months)
-- 1 **reverse shadow** per minor release — working on high-need tooling (perhaps from retrospective of previous minor release) and serves as backup if release captain is out
+**Time commitment:** about 4 hours/week of work.
 
-**Time commitment:** about 4 hours/week of work for each release captain and reverse shadow.
-
-### Release Captain Responsibilities
+### Role Responsibilities
 
 - Drives the initial cut and sets up release scaffolding (re: blogpost draft, documentation bump, etc)
 - Is informed of the pre-release & stable release status and any blocking issues and communicates to appropriate channels
@@ -30,41 +27,34 @@ Two sub-roles:
     - the [pre-release](https://github.com/reactwg/react-native-releases/discussions/categories/releases)
     - the [stable release (for patches)](https://github.com/reactwg/react-native-releases/discussions/categories/patches)
 - Make final call on release decisions
-  - Decide when to promote pre-release to stable (in consult with **co-pilot** and **release supporters**)
+  - Decide when to promote pre-release to stable (in consult with the release crew)
   - Decide when to release a patch on stable
 - Ensures blocking issues have owners
   - Escalate internally if release community is blocked by Meta-owned dependencies (metro, folly, flipper, hermes, etc)
-  - Coordinate with release co-pilot & supporters on any community library blockers (reanimated, cli, etc.)
+  - Coordinate with release crew on any community library blockers (reanimated, cli, etc.)
 - Escalates security alerts
   - When a security alert gets raised, communicates it quickly to relevant partners and internally
-  - If the security fix commit lands and it’s important, coordinates with the **copilot** on which stable branches should get the releases and produces the patch releases accordingly
-- Can perform release or delegate release steps (as well as **release co-pilot/reverse shadow**)
-
-### Reverse Shadow Responsibilities
-
-- Is informed of the minor release status and current stable status
-- Supports release captain
-  - Fills in for release captain if current release captain is unavailable
-- Actions on high-priority tooling, retrospective action items when relevant
+  - If the security fix commit lands and it’s important, coordinates with the release crew on which stable branches should get the releases and produces the patch releases accordingly
+- Can perform release or delegate release steps
 
 ### Who can fill it
 
-- These roles must be filled by Meta engineers
+- This role can only be filled by Meta engineers
 
 ---
 
-## Release Role #2 : Community Releasers
+## Release Role #2: Community Releaser
 
 ### Details
 
 - 2 people per each release
 
-**Time commitment:** can be more flexible but, most likely, a few hours per week.
+**Time commitment:** flexible but, most likely, a few hours per week.
 
-### Responsibilities
+### Role Responsibilities
 
 - Is informed of the minor release status and current stable status
-  - attends weekly release meeting
+  - prepares agenda & attends weekly release meeting
   - updates and monitors #releases channel
   - updates and monitors discussion in [react-wg/react-native-releases](https://github.com/reactwg/react-native-releases/discussions) discussion for both:
     - the [pre-release](https://github.com/reactwg/react-native-releases/discussions/categories/releases)
@@ -80,11 +70,10 @@ Two sub-roles:
   - Merge cherry-picks (as agreed with main releaser)
   - Create the changelog & release entry in GH
   - Makes documentation PR and blogpost PR
-  - Trigger the rn-diff-purge script to update upgrade-helper (this should be automated for 0.68 onwards)
-- Help release testing via [local E2E script](/contributing/release-testing)
+  - Trigger the rn-diff-purge script to update upgrade-helper (this is automated for 0.68 onwards)
+- Coordinates the [release testing](/contributing/release-testing)
 - Runs a release retrospective after a new minor is released
 
 ### Who can fill it
 
 - This role can be filled by anyone with write access to the necessary repos (react-native)
-- Engineers from key companies in the React Native ecosystem are preferred.

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -5,7 +5,9 @@ title: Roles and Responsibilities
 
 Here we set guidelines to apply the "dividi et impera" approach to React Native releases: it is an involved process and we need to clarify the work to allow for easier rotations of folks in various positions.
 
-In a normal situation, we expect that the Release Crew at any given point is composed of 2+2 releasers (two people from the community, two from Meta).
+In a standard situation, we expect that the Release Crew is composed of 2+2 releasers (two people from the community, two from Meta). Organically, the Release Crew will identify one Meta and Community drivers that will lead the effort, but that can change based on day-to-day availability of the members.
+
+A Release Crew effort starts with the work on a new minor; meaning, at least one week ahead of the branch cut. It is part of the current Release Crew responsibilities to identify when to "pass the baton" to the next one.
 
 ---
 

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -5,9 +5,7 @@ title: Roles and Responsibilities
 
 Here we set guidelines to apply the "dividi et impera" approach to React Native releases: it is an involved process and we need to clarify the work to allow for easier rotations of folks in various positions.
 
-The roles should be imagined as "concentric", with #1 in the centre: this means that anything in role #3 can be done by #2 or #1, and anything on role #2 can be done by #1.
-
-The goal of this structure is that #1 doesn’t have to do everything: to do so the suggestion is to at least always have a person per each role in each release.
+In a normal situation, we expect that the release crew at any given point is composed of 2+2 releasers (two people from the community, two from Meta).
 
 ---
 
@@ -20,7 +18,7 @@ Two sub-roles:
 - 1 **release captain** as main point of contact per minor release (aiming for every 2 months)
 - 1 **reverse shadow** per minor release — working on high-need tooling (perhaps from retrospective of previous minor release) and serves as backup if release captain is out
 
-**Time commitment:** maximum 4 hours/week of work for each release captain and reverse shadow.
+**Time commitment:** around 4 hours/week of work for each release captain and reverse shadow.
 
 ### Release Captain Responsibilities
 
@@ -55,13 +53,13 @@ Two sub-roles:
 
 ---
 
-## Release Role #2 : Release Copilot
+## Release Role #2 : Community Releasers
 
 ### Details
 
-- 1 or 2 people (the second one being backup)
+- 2 people per each release
 
-**Time commitment:** can be more flexible and doesn’t have to align with minor release schedule, but we should update the release schedule when needed. Most likely, a couple hours per week.
+**Time commitment:** can be more flexible but, m most likely, a few hours per week.
 
 ### Responsibilities
 
@@ -89,47 +87,4 @@ Two sub-roles:
 ### Who can fill it
 
 - This role can be filled by anyone with write access to the necessary repos (react-native)
-
----
-
-## Release Role #3: Release Supporter
-
-### Details
-
-- 0 to N **release supporters**
-- 0 to N **release testers**
-
-**Time commitment:** as much or as little as available by each person.
-
-No strict coupling with any specific release - active supports and testers will be thanked in the release notes of versions they help with.
-
-### Release Supporter Responsibilities
-
-- Surface release issues either on stable or release candidate by triaging [release issues in the react-native repo](https://github.com/facebook/react-native/labels?q=release)
-  - Some issues might not be tagged appropriately, so keep an eye out on incoming issues and surface any
-- Watch the [release discussions repo](https://github.com/reactwg/react-native-releases/discussions)
-  - Help answer/debug/escalate issues
-- Work on any [release improvements](https://github.com/facebook/react-native/projects/18) or if you see something that can be improved; please add!
-- Help [test release candidates](/contributing/release-testing) with your configuration or improve it
-- Engage/help out with discussion in the release related channels (#supporters-feed, #testers-feedback, #release-coordination)
-
-### Release Tester Responsibilities
-
-This role is about helping test release candidates against your production app/workflows
-
-- Helps surface release issues either on stable or release candidate by them testing out against their production apps and workflows
-  - Perhaps integrate either the [npm `next` or `nightly` versions of react-native](https://www.npmjs.com/package/react-native) in your app's CI and raise any issues that might come up.
-- Support regression fixes if relevant
-- Engage/help out with discussion in the release related channels (#supporters-feed, #testers-feedback, #release-coordination)
-
-### Who can fill it
-
-- Anyone interested in supporting the React Native Open Source project and its releases!
-  - To start, you can participate in the [discussion repo](https://github.com/reactwg/react-native-releases/discussions) -- testing release candidates, surfacing any release issues you've seen or encountered yourself
-  - We also have some [discussions about improvements](https://github.com/reactwg/react-native-releases/discussions/categories/improvements) here as well as some issues related to [improving the release process in this project board](https://github.com/facebook/react-native/projects/18).
-    - If you are up for any specific tasks, let us know by commenting on it.
-- For release testers, it's preferred (as it's very valuable) that you are able to test the releases against a production app in order to also verify non-trivial parts of the flow like archiving a release for the App Store.
-
-#### Apply to the role
-
-For both supporters and testers, you can let us know that you want to help out in this [dedicated discussion](https://github.com/reactwg/react-native-releases/discussions/11). We will provide you access to a dedicated RN Discord server that folks involved the releasers use to coordinate.
+- Engineers from key companies in the React Native ecosystem are preferred

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -87,4 +87,4 @@ Two sub-roles:
 ### Who can fill it
 
 - This role can be filled by anyone with write access to the necessary repos (react-native)
-- Engineers from key companies in the React Native ecosystem are preferred
+- Engineers from key companies in the React Native ecosystem are preferred.

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -59,7 +59,7 @@ Two sub-roles:
 
 - 2 people per each release
 
-**Time commitment:** can be more flexible but, m most likely, a few hours per week.
+**Time commitment:** can be more flexible but, most likely, a few hours per week.
 
 ### Responsibilities
 

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -18,7 +18,7 @@ Two sub-roles:
 - 1 **release captain** as main point of contact per minor release (aiming for every 2 months)
 - 1 **reverse shadow** per minor release — working on high-need tooling (perhaps from retrospective of previous minor release) and serves as backup if release captain is out
 
-**Time commitment:** around 4 hours/week of work for each release captain and reverse shadow.
+**Time commitment:** about 4 hours/week of work for each release captain and reverse shadow.
 
 ### Release Captain Responsibilities
 

--- a/website/contributing/release-stable-patch.md
+++ b/website/contributing/release-stable-patch.md
@@ -3,6 +3,8 @@ id: release-stable-patch
 title: Minor Stable Patches
 ---
 
+import AsyncTestingNote from './\_markdown-async-testing-note.mdx';
+
 :::info
 Documents in this section go over steps to run different types of React Native release updates. Its intended audience is those in [relevant release roles](./release-roles-responsibilites.md).
 :::
@@ -29,9 +31,7 @@ git cherry-pick <commit>
 
 Before continuing further, follow the [testing guide](/contributing/release-testing) to ensure the source code doesn't have any major issues.
 
-:::info
-Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
-:::
+<AsyncTestingNote/>
 
 ### 3. Run `bump-oss-version` script
 

--- a/website/contributing/release-stable-patch.md
+++ b/website/contributing/release-stable-patch.md
@@ -29,6 +29,10 @@ git cherry-pick <commit>
 
 Before continuing further, follow the [testing guide](/contributing/release-testing) to ensure the source code doesn't have any major issues.
 
+:::info
+Since testing is a time consuming activity (>1 hrs) it is recommended that the release crew coordinates on the steps above then do testing on at least two separate systems in an async way.
+:::
+
 ### 3. Run `bump-oss-version` script
 
 ```bash

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,15 +1664,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@^0.3.0":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
-  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
-"@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.0", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
   integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==


### PR DESCRIPTION
This PR wants to update the docs as a follow up items from the RN69 retro we did last week.

3 main changes:
* add a note about doing testing async since it takes time
* reword the roles page to default to a 2+2 composition of the crew at all times
* remove testers & supporters since we have decided to not have those roles anymore

Also, for some reason there's yarn.lock change that keeps popping up so I just integrated it