### PR TITLE
Add retrospective as a copilot responsibility

### DIFF
--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -84,6 +84,7 @@ Two sub-roles:
   - Makes documentation PR and blogpost PR
   - Trigger the rn-diff-purge script to update upgrade-helper (this should be automated for 0.68 onwards)
 - Help release testing via [local E2E script](/contributing/release-testing)
+- Runs a release retrospective after a new minor is released
 
 ### Who can fill it
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Copilot should run a retrospective after a new minor is released (at least in cases when there's enough to talk about) cc @kelset 
