### PR TITLE
Fixed pod install instructions

### DIFF
--- a/website/contributing/how-to-run-and-write-tests.md
+++ b/website/contributing/how-to-run-and-write-tests.md
@@ -25,11 +25,16 @@ yarn run lint
 
 ### iOS Tests
 
-Start off by running `pod install` inside the `RNTester` directory. This will set up your native dependencies and create a `RNTesterPods` Xcode workspace.
+Start off by going to the `packages/rn-tester` directory, then:
+1. Run `yarn`
+2. Run `pod install` (You may have to run `brew install cmake` prior)
+
+This will set up your native dependencies and create a `RNTesterPods` Xcode workspace. 
+**Note:** It may take a long time to complete "Installing hermes-engine (1000.0.0)" as it must build Hermes from source.
 
 Then, go back to the root of your React Native checkout and run `yarn` followed by `yarn start`. This will set up your JavaScript dependencies.
 
-At this point, you can run iOS tests by invoking the following script from the root of your React Native checkout:
+At this point, you can run iOS tests in a new window by invoking the following script from the root of your React Native checkout:
 
 ```bash
 ./scripts/objc-test.sh test


### PR DESCRIPTION
Yarn must be run prior to pod install, otherwise pod install fails with "Error: Cannot find module 'mkdirp'"

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
