### PR TITLE
Change links in main home page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -108,15 +108,15 @@ function HomeCallToAction() {
     <>
       <ActionButton
         type="primary"
-        href={useBaseUrl('docs/getting-started')}
+        href={useBaseUrl('docs/environment-setup')}
         target="_self">
         Get started
       </ActionButton>
       <ActionButton
         type="secondary"
-        href={useBaseUrl('docs/tutorial')}
+        href={useBaseUrl('docs/getting-started')}
         target="_self">
-        Learn basics
+        Learn the basics
       </ActionButton>
     </>
   );


### PR DESCRIPTION
This is a follow up to a conversation in the RN Discord; this changes the links that the call to actions sends you to - these two seemed more appropriate than what was there before.

I didn't fully remove the tutorial page because with a quick check it seems like that it's cross-referenced in other places, and I wanted to keep this PR minimal. If we agree to merging this we can revisit what to do with that tutorial page.
