### PR TITLE
Fix typo in the sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -109,7 +109,7 @@
         ]
       }
     ],
-    "Migrati to the New Architecture": [
+    "Migration to the New Architecture": [
       "new-architecture-intro",
       {
         "type": "category",


### PR DESCRIPTION
This PR fixes a typo in the sidebar (from `Migrati` to `Migration`)
