### PR TITLE
Update to Docusaurus stable release, fix alert admonition styling

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -42,9 +42,9 @@
     ]
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-rc.1",
-    "@docusaurus/plugin-pwa": "^2.0.0-rc.1",
-    "@docusaurus/preset-classic": "^2.0.0-rc.1",
+    "@docusaurus/core": "^2.0.1",
+    "@docusaurus/plugin-pwa": "^2.0.1",
+    "@docusaurus/preset-classic": "^2.0.1",
     "docusaurus-plugin-sass": "^0.2.2",
     "esbuild-loader": "^2.19.0",
     "react": "^17.0.2",
@@ -53,7 +53,7 @@
     "sass": "^1.53.0"
   },
   "devDependencies": {
-    "@docusaurus/types": "^2.0.0-rc.1",
+    "@docusaurus/types": "^2.0.1",
     "alex": "^10.0.0",
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -506,7 +506,7 @@ html[data-theme="dark"].community-page {
   }
 
   .margin-top--md {
-    margin-top: 8px !important;
+    margin-top: 0.33rem !important;
   }
 }
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -22,7 +22,7 @@
   --ifm-code-font-size: 90%;
   --ifm-code-border-radius: 3px;
   --ifm-blockquote-color: var(--ifm-font-color-base);
-  --ifm-blockquote-font-size: 15px;
+  --ifm-blockquote-font-size: 16px;
   --ifm-table-head-color: var(--subtle);
   --ifm-link-hover-decoration: none;
   --ifm-navbar-background-color: var(--deepdark);
@@ -405,13 +405,13 @@ html[data-theme="dark"] article .badge {
   margin-bottom: 1.5rem !important;
 
   div[class^="admonitionContent"] {
-    h5 {
-      font-size: 14px;
-    }
-
     a {
       border-bottom: 0;
     }
+  }
+
+  div[class^="admonitionHeading"] {
+    font-size: 14px;
   }
 }
 
@@ -490,15 +490,23 @@ html[data-theme="dark"].community-page {
 
 /* Version warning */
 
-.theme-doc-version-banner.alert--warning {
+.theme-doc-version-banner {
   background-color: rgba(100, 215, 255, 0.3);
   border-style: none;
   color: var(--ifm-font-color-base);
   box-shadow: none;
+  font-size: 15px;
+  line-height: var(--ifm-pre-line-height);
+  text-align: center;
+
   a {
     color: var(--ifm-font-color-base) !important;
     text-decoration: underline !important;
     text-decoration-thickness: 1px !important;
+  }
+
+  .margin-top--md {
+    margin-top: 8px !important;
   }
 }
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -22,7 +22,7 @@
   --ifm-code-font-size: 90%;
   --ifm-code-border-radius: 3px;
   --ifm-blockquote-color: var(--ifm-font-color-base);
-  --ifm-blockquote-font-size: 16px;
+  --ifm-blockquote-font-size: 15px;
   --ifm-table-head-color: var(--subtle);
   --ifm-link-hover-decoration: none;
   --ifm-navbar-background-color: var(--deepdark);
@@ -399,24 +399,24 @@ html[data-theme="dark"] article .badge {
 
 /* Admonitions & notes */
 
-.alert--warning {
-  background-color: var(--rn-note-background);
-  font-size: 14px;
-  text-align: center;
+.admonition,
+.theme-admonition {
+  font-size: var(--ifm-blockquote-font-size);
+  margin-bottom: 1.5rem !important;
 
-  .margin-top--md {
-    margin-top: 0.33rem !important;
+  div[class^="admonitionContent"] {
+    h5 {
+      font-size: 14px;
+    }
+
+    a {
+      border-bottom: 0;
+    }
   }
 }
 
-.admonition {
-  text-align: left;
-  font-size: var(--ifm-blockquote-font-size);
-  line-height: var(--ifm-pre-line-height);
-
-  h5 {
-    font-size: 14px;
-  }
+.alert--warning {
+  background-color: var(--rn-note-background);
 }
 
 .alert--secondary {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,7 +1205,7 @@
     "@docsearch/css" "3.2.0"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.1", "@docusaurus/core@^2.0.0-rc.1":
+"@docusaurus/core@2.0.1", "@docusaurus/core@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.1.tgz#a2b0d653e8f18eacddda4778a46b638dd1f0f45c"
   integrity sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==
@@ -1427,7 +1427,7 @@
     "@docusaurus/utils-validation" "2.0.1"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-pwa@^2.0.0-rc.1":
+"@docusaurus/plugin-pwa@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-pwa/-/plugin-pwa-2.0.1.tgz#e49f2a846f0beca58cb09e7a114393c43cd438b8"
   integrity sha512-zN+dCx2V1yIK8+U3cey/IA44ynfmZQm/tdVhXy6EsXbkaEW8ZZu0AIpARFxJ2lmR2sPkG1ohkXIoOOCMOld1Xw==
@@ -1466,7 +1466,7 @@
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@^2.0.0-rc.1":
+"@docusaurus/preset-classic@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz#21a806e16b61026d2a0efa6ca97e17397065d894"
   integrity sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==
@@ -1573,7 +1573,7 @@
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.0.1", "@docusaurus/types@^2.0.0-rc.1":
+"@docusaurus/types@2.0.1", "@docusaurus/types@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.1.tgz#8696a70e85c4b9be80b38ac592d520f6fe72618b"
   integrity sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==


### PR DESCRIPTION
# Why & How

This PR updates the Docusuaurs to the latest and stable release! 🎉

There is no changelog published yet from latest RC, but there were almost no changes between those versions.

Testing the bump locally I was not bale to spot any visual regressions.

I have also utilize this bump to address the warning admonitions style, which since bump to RC started to match again against one of our legacy CSS selectors, which lead to unexpected effect (text centered, small font), those issue have been fixes as well as double underline for links in admonitions.

# Preview

<img width="647" alt="Screenshot 2022-08-08 140012" src="https://user-images.githubusercontent.com/719641/183413189-b8dba37f-ceae-4b38-b627-2e6b98bfc6e5.png">
