### PR TITLE
Adding Android 13 Permissions into PermissionsAndroid

### DIFF
--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -185,6 +185,8 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `READ_MEDIA_AUDIO`: 'android.permission.READ_MEDIA_AUDIO'
 - `POST_NOTIFICATION`: 'android.permission.POST_NOTIFICATIONS'
 - `NEARBY_WIFI_DEVICES`: 'android.permission.NEARBY_WIFI_DEVICES'
+- `READ_VOICEMAIL`: 'com.android.voicemail.permission.READ_VOICEMAIL',
+- `WRITE_VOICEMAIL`: 'com.android.voicemail.permission.WRITE_VOICEMAIL',
 
 ### Result strings for requesting permissions
 

--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -179,6 +179,12 @@ Available as constants under `PermissionsAndroid.PERMISSIONS`:
 - `ANSWER_PHONE_CALLS`: 'android.permission.ANSWER_PHONE_CALLS'
 - `READ_PHONE_NUMBERS`: 'android.permission.READ_PHONE_NUMBERS'
 - `UWB_RANGING`: 'android.permission.UWB_RANGING'
+- `BODY_SENSORS_BACKGROUND`: 'android.permission.BODY_SENSORS_BACKGROUND'
+- `READ_MEDIA_IMAGES`: 'android.permission.READ_MEDIA_IMAGES'
+- `READ_MEDIA_VIDEO`: 'android.permission.READ_MEDIA_VIDEO'
+- `READ_MEDIA_AUDIO`: 'android.permission.READ_MEDIA_AUDIO'
+- `POST_NOTIFICATION`: 'android.permission.POST_NOTIFICATIONS'
+- `NEARBY_WIFI_DEVICES`: 'android.permission.NEARBY_WIFI_DEVICES'
 
 ### Result strings for requesting permissions
 


### PR DESCRIPTION
Android 13 introduces multiple new permission. 

This PR aims to updates the documentation for multiple new permission that android 13 introduce that have been merged to master in the core repo. 


```
- `BODY_SENSORS_BACKGROUND`: 'android.permission.BODY_SENSORS_BACKGROUND'
- `READ_MEDIA_IMAGES`: 'android.permission.READ_MEDIA_IMAGES'
- `READ_MEDIA_VIDEO`: 'android.permission.READ_MEDIA_VIDEO'
- `READ_MEDIA_AUDIO`: 'android.permission.READ_MEDIA_AUDIO'
- `POST_NOTIFICATION`: 'android.permission.POST_NOTIFICATIONS'
- `NEARBY_WIFI_DEVICES`: 'android.permission.NEARBY_WIFI_DEVICES'
```

Related PR
https://github.com/facebook/react-native/pull/33471

Based on the commit, this should be available in React Native starting from [v0.70.0-rc.0](https://github.com/facebook/react-native/releases/tag/v0.70.0-rc.0)
