### PR TITLE
Adding cursorColor Props On TextInput Android

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -281,6 +281,16 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
+### `cursorColor` <div class="label android">Android</div>
+
+When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `disableFullscreenUI` <div class="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.


### PR DESCRIPTION
While working on `D36140890` There is already behavior implemented to set the TextInput caret/cursor color independently from the selection box color in Android. However this handy prop, was not documented.

The behavior can be found here:
[https://www.internalfb.com/code/fbsource/[f116d651b2e8]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java?lines=512](https://www.internalfb.com/code/fbsource/[f116d651b2e8]/xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java?lines=512)

If you are a Meta employee, you can view the diff that implemented the cursorColor [on Phabricator](https://www.internalfb.com/diff/D36208656).

This diff is already synced into OSS and should be available starting from [v0.70.0-rc.0](https://github.com/facebook/react-native/releases/tag/v0.70.0-rc.0)
Ref commit here https://github.com/facebook/react-native/commit/f2e23215ca14c3c630aa931cdd114187589ac0fb
