### PR TITLE
feat(images): Adding iOS Image Cache Limits

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -232,7 +232,7 @@ Image decoding can take more than a frame-worth of time. This is one of the majo
 
 ## Configuring iOS Image Cache Limits
 
-On iOS, we expose an API to override React Native's default image cache limits. This should be called from within your native AppDelegate code (e.g. within (e.g. within didFinishLaunchingWithOptions).
+On iOS, we expose an API to override React Native's default image cache limits. This should be called from within your native AppDelegate code (e.g. within `didFinishLaunchingWithOptions`).
 
 ```objectivec
 RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);

--- a/docs/images.md
+++ b/docs/images.md
@@ -232,7 +232,7 @@ Image decoding can take more than a frame-worth of time. This is one of the majo
 
 ## Configuring iOS Image Cache Limits
 
-By default React Native would set `NSCache.totalCostLimit` to 20MB and the single image size limit to 2MB (bitmap size). The default cache size may not be enough for applications that make heavy use of images. 
+By default React Native would set `NSCache.totalCostLimit` to 20MB and the single image size limit to 2MB (bitmap size). The default cache size may not be enough for applications that make heavy use of images.
 
 You can configure the image cache size on iOS by adding `RCTSetImageCacheLimits` in your app App Delegate.
 
@@ -242,9 +242,9 @@ RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
 
 **Parameters:**
 
-| Name     | Type                     | Required | Description                                  |
-| -------- | ------------------------ | -------- | -------------------------------------------- |
-| imageSizeLimit | number | Yes       | Image cache size limit. |
-| totalCostLimit | number | Yes       | Total cache cost limit. |
+| Name           | Type   | Required | Description             |
+| -------------- | ------ | -------- | ----------------------- |
+| imageSizeLimit | number | Yes      | Image cache size limit. |
+| totalCostLimit | number | Yes      | Total cache cost limit. |
 
 Based on the code above the single image size limit would be set to 4 MB and the total cost limit would be set to 200 MB.

--- a/docs/images.md
+++ b/docs/images.md
@@ -229,3 +229,22 @@ Please note that the following corner specific, border radius style properties m
 ## Off-thread Decoding
 
 Image decoding can take more than a frame-worth of time. This is one of the major sources of frame drops on the web because decoding is done in the main thread. In React Native, image decoding is done in a different thread. In practice, you already need to handle the case when the image is not downloaded yet, so displaying the placeholder for a few more frames while it is decoding does not require any code change.
+
+## Configuring iOS Image Cache Limits
+
+By default React Native would set `NSCache.totalCostLimit` to 20MB and the single image size limit to 2MB (bitmap size). The default cache size may not be enough for applications that make heavy use of images. 
+
+You can configure the image cache size on iOS by adding `RCTSetImageCacheLimits` in your app App Delegate.
+
+```objectivec
+RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
+```
+
+**Parameters:**
+
+| Name     | Type                     | Required | Description                                  |
+| -------- | ------------------------ | -------- | -------------------------------------------- |
+| imageSizeLimit | number | Yes       | Image cache size limit. |
+| totalCostLimit | number | Yes       | Total cache cost limit. |
+
+Based on the code above the single image size limit would be set to 4 MB and the total cost limit would be set to 200 MB.

--- a/docs/images.md
+++ b/docs/images.md
@@ -232,9 +232,7 @@ Image decoding can take more than a frame-worth of time. This is one of the majo
 
 ## Configuring iOS Image Cache Limits
 
-By default React Native would set `NSCache.totalCostLimit` to 20MB and the single image size limit to 2MB (bitmap size). The default cache size may not be enough for applications that make heavy use of images.
-
-You can configure the image cache size on iOS by adding `RCTSetImageCacheLimits` in your app App Delegate.
+ac
 
 ```objectivec
 RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);

--- a/docs/images.md
+++ b/docs/images.md
@@ -232,8 +232,6 @@ Image decoding can take more than a frame-worth of time. This is one of the majo
 
 ## Configuring iOS Image Cache Limits
 
-ac
-
 ```objectivec
 RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
 ```

--- a/docs/images.md
+++ b/docs/images.md
@@ -232,6 +232,8 @@ Image decoding can take more than a frame-worth of time. This is one of the majo
 
 ## Configuring iOS Image Cache Limits
 
+On iOS, we expose an API to override React Native's default image cache limits. This should be called from within your native AppDelegate code (e.g. within (e.g. within didFinishLaunchingWithOptions).
+
 ```objectivec
 RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
 ```
@@ -243,4 +245,4 @@ RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
 | imageSizeLimit | number | Yes      | Image cache size limit. |
 | totalCostLimit | number | Yes      | Total cache cost limit. |
 
-Based on the code above the single image size limit would be set to 4 MB and the total cost limit would be set to 200 MB.
+In the above code example the image size limit is set to 4 MB and the total cost limit is set to 200 MB.

--- a/website/versioned_docs/version-0.69/images.md
+++ b/website/versioned_docs/version-0.69/images.md
@@ -229,3 +229,20 @@ Please note that the following corner specific, border radius style properties m
 ## Off-thread Decoding
 
 Image decoding can take more than a frame-worth of time. This is one of the major sources of frame drops on the web because decoding is done in the main thread. In React Native, image decoding is done in a different thread. In practice, you already need to handle the case when the image is not downloaded yet, so displaying the placeholder for a few more frames while it is decoding does not require any code change.
+
+## Configuring iOS Image Cache Limits
+
+On iOS, we expose an API to override React Native's default image cache limits. This should be called from within your native AppDelegate code (e.g. within `didFinishLaunchingWithOptions`).
+
+```objectivec
+RCTSetImageCacheLimits(4*1024*1024, 200*1024*1024);
+```
+
+**Parameters:**
+
+| Name           | Type   | Required | Description             |
+| -------------- | ------ | -------- | ----------------------- |
+| imageSizeLimit | number | Yes      | Image cache size limit. |
+| totalCostLimit | number | Yes      | Total cache cost limit. |
+
+In the above code example the image size limit is set to 4 MB and the total cost limit is set to 200 MB.


### PR DESCRIPTION
By default React Native would set `NSCache.totalCostLimit` to 20MB and the single image size limit to 2MB (bitmap size). The default cache size may not be enough for applications that make heavy use of images. 

But thanks to this [commit](https://github.com/facebook/react-native/commit/61b013e7ad8a1cc28ee39434d2fd96b74b96cf5f) now you can configure the image cache size on iOS by adding `RCTSetImageCacheLimits` in your app App Delegate.

This feature should be available from [v0.69.0-rc.0](https://github.com/facebook/react-native/releases/tag/v0.69.0-rc.0)