### PR TITLE
Update documentation for keyboard events on Android

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -170,7 +170,7 @@ This can be any of the following:
 - `keyboardWillChangeFrame`
 - `keyboardDidChangeFrame`
 
-> Note that if you set `android:windowSoftInputMode` to `adjustResize` or `adjustPan`, only `keyboardDidShow` and `keyboardDidHide` events will be available on Android. If you set `android:windowSoftInputMode` to `adjustNothing`, no events will be available on Android. `keyboardWillShow` as well as `keyboardWillHide` are generally not available on Android since there is no native corresponding event.
+> Note that only `keyboardDidShow` and `keyboardDidHide` events are available on Android. The events will not be fired when using Android 10 and under if your activity has `android:windowSoftInputMode` set to `adjustNothing`.
 
 ---
 


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/1e48274223ee647ac4fc2c21822b5240f3c47e4c fixed keyboard events on Android 11+ when an activity has set `android:windowSoftInputMode` to `adjustNothing`. Update the documentation to reflect the change.

