### PR TITLE
chore(releases): remove old references to testers

### DIFF
--- a/website/contributing/release-branch-cut-and-rc0.md
+++ b/website/contributing/release-branch-cut-and-rc0.md
@@ -123,4 +123,4 @@ After creating it, make sure to link it in the relevant GitHub Release you creat
 Once all the steps above have been completed, it's time to signal to the community that RC0 is available for testing! Do so in the following channels:
 
 - [@reactnative](https://twitter.com/reactnative) on twitter
-- RN Discord `#releases-coordination` and to the testers in `#testers-feedback`
+- RN Discord `#releases-coordination`

--- a/website/contributing/release-candidate-patch.md
+++ b/website/contributing/release-candidate-patch.md
@@ -78,4 +78,4 @@ Go back to the "road to 0.XX.0" [discussion](https://github.com/reactwg/react-na
 
 Once all the steps above have been completed, it's time to signal to the community that the new RC is available for testing! Do so in the following channels:
 
-- RN Discord `#releases-coordination` and to the testers in `#testers-feedback`
+- RN Discord `#releases-coordination`


### PR DESCRIPTION
Since the testers group doesn't exist anymore, removing a couple of leftover references.
