### PR TITLE
Follow up from #3267 with minor fixes

### DIFF
--- a/docs/appregistry.md
+++ b/docs/appregistry.md
@@ -6,7 +6,7 @@ title: AppRegistry
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
   <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through [registerRootComponent](https://docs.expo.dev/versions/latest/sdk/register-root-component/)). You do not need to use this API.
+    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
   </p>
 </div>
 

--- a/docs/more-resources.md
+++ b/docs/more-resources.md
@@ -26,7 +26,7 @@ We recommend using the [VS Code](https://code.visualstudio.com/) code editor and
 
 ## Platforms to try
 
-[Expo](https://docs.expo.dev/) is a framework of tools and services for React Native that focuses on letting you build React Native apps without ever touching Xcode or Android Studio. If you have a web development background, this might appeal to you.
+[Expo](https://docs.expo.dev/) is a framework of tools and services for React Native that focuses on helping you build, ship, and iterate on your app, to use preview deployment workflows that are popular with web development, and to automate your development workflows. Expo also makes it possible to build React Native apps without ever touching Xcode or Android Studio, and it doesn't get in the way if you want to use those tools.
 
 [Ignite](https://github.com/infinitered/ignite) is a starter kit CLI with several React Native boilerplates. The latest, [Ignite Bowser](https://github.com/infinitered/ignite-bowser), uses MobX-State-Tree for state management, React Navigation, and other common libraries. It has generators for components, models, and more, and supports Expo out of the box. If you are looking for a preconfigured tech stack, Ignite could be perfect for you.
 

--- a/website/versioned_docs/version-0.69/appregistry.md
+++ b/website/versioned_docs/version-0.69/appregistry.md
@@ -6,7 +6,7 @@ title: AppRegistry
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
   <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through [registerRootComponent](https://docs.expo.dev/versions/latest/sdk/register-root-component/)). You do not need to use this API.
+    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
   </p>
 </div>
 


### PR DESCRIPTION
- AppRegistry banner with Expo-specific content was using markdown where it wasn't supported. Switched to using anchor tag directly.
- Copied over changes from **more-resources.md* for 0.69 to the unversioned docs page.