### PR TITLE
feat(font): Adding Stylistics As New FontVariant Values

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -405,9 +405,29 @@ Set to `false` to remove extra font padding intended to make space for certain a
 
 ### `fontVariant`
 
-| Type                                                                                                       | Default |
-| ---------------------------------------------------------------------------------------------------------- | ------- |
-| array of enum(`'small-caps'`, `'oldstyle-nums'`, `'lining-nums'`, `'tabular-nums'`, `'proportional-nums'`) | `[]`    |
+| Type | Default |
+| ---- | ------- |
+
+| array of enum(`'small-caps'`, `'oldstyle-nums'`, `'lining-nums'`, `'tabular-nums'`, `'proportional-nums' `,`'stylistic-one'`,
+, `'stylistic-two'`
+, `'stylistic-three'`
+, `'stylistic-four'`
+, `'stylistic-five'`
+, `'stylistic-six'`
+, `'stylistic-seven'`
+, `'stylistic-eight'`
+, `'stylistic-nine'`
+, `'stylistic-ten'`
+, `'stylistic-eleven'`
+, `'stylistic-twelve'`
+, `'stylistic-thirteen'`
+, `'stylistic-fourteen'`
+, `'stylistic-fifteen'`
+, `'stylistic-sixteen'`
+, `'stylistic-seventeen'`
+, `'stylistic-eighteen'`
+, `'stylistic-nineteen'`
+, `'stylistic-twenty'`) | `[]` |
 
 ---
 


### PR DESCRIPTION
PR Reference 
https://github.com/facebook/react-native/pull/34003

Adding stylistics as new fontvariant values.

```
fontVariant?: $ReadOnlyArray<
    | 'small-caps'
    | 'oldstyle-nums'
    | 'lining-nums'
    | 'tabular-nums'
    | 'proportional-nums'
    | 'stylistic-one'
    | 'stylistic-two'
    | 'stylistic-three'
    | 'stylistic-four'
    | 'stylistic-five'
    | 'stylistic-six'
    | 'stylistic-seven'
    | 'stylistic-eight'
    | 'stylistic-nine'
    | 'stylistic-ten'
    | 'stylistic-eleven'
    | 'stylistic-twelve'
    | 'stylistic-thirteen'
    | 'stylistic-fourteen'
    | 'stylistic-fifteen'
    | 'stylistic-sixteen'
    | 'stylistic-seventeen'
    | 'stylistic-eighteen'
    | 'stylistic-nineteen'
    | 'stylistic-twenty',
  >,
```