### PR TITLE
feat(image): Adding Notes on WebP Support for iOS

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -424,6 +424,8 @@ This prop can also contain several remote URLs, specified together with their wi
 
 The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 
+> Note: WebP support on iOS is only available starting from iOS 14. If your app targets a lower iOS version other than iOS 14 please consider adding a fallback image with format other than WebP.
+
 | Type                             |
 | -------------------------------- |
 | [ImageSource](image#imagesource) |

--- a/website/versioned_docs/version-0.69/image.md
+++ b/website/versioned_docs/version-0.69/image.md
@@ -421,6 +421,8 @@ This prop can also contain several remote URLs, specified together with their wi
 
 The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 
+> Note: WebP support on iOS is only available starting from iOS 14. If your app targets a lower iOS version other than iOS 14 please consider adding a fallback image with format other than WebP.
+
 | Type                             |
 | -------------------------------- |
 | [ImageSource](image#imagesource) |


### PR DESCRIPTION
WebP support on iOS is only available starting from iOS 14. If your app targets a lower iOS version other than iOS 14 react-native can't render the image. This PR aims to add notes about this limitation because there is no mention of this anywhere on React Native docs.

Repro 
https://github.com/putrautama007/image-issue-ios-rn


