### PR TITLE
feat: Add readOnly prop to TextInput docs 

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -625,6 +625,16 @@ The text color of the placeholder string.
 
 ---
 
+### `readOnly`
+
+If `true`, text is not editable. The default value is `false`.
+
+| Type |
+| ---- |
+| bool |
+
+---
+
 ### `returnKeyLabel` <div class="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.


### PR DESCRIPTION
This PR adds the `readOnly` prop to the TextInput documentation  

Follow-up of https://github.com/facebook/react-native/pull/34444  

![image](https://user-images.githubusercontent.com/11707729/186535083-59da9ba1-3720-4b31-8806-4a49ab35e508.png)

 
