### PR TITLE
feat: Add rows prop to TextInput docs

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -681,6 +681,16 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
+### `rows` <div class="label android">Android</div>
+
+Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
+
+| Type   |
+| ------ |
+| number |
+
+---
+
 ### `scrollEnabled` <div class="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.


### PR DESCRIPTION
This PR adds the `rows` Android only prop to the TextInput documentation

Related to https://github.com/facebook/react-native/pull/34488

![image](https://user-images.githubusercontent.com/11707729/186788820-8d2726a1-a6f5-41ab-ab02-1564caa1cdbe.png)
