### PR TITLE
Move the "Using `forwardRef`" and "Using a `getter`" sections to a lower hierarchy level

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -277,7 +277,7 @@ We can’t convert this call to `this._ref.measure` because `this._ref` is an in
 
 `ChildComponent` renders a `View`, which is a HostComponent, so we need to get a reference to `View` instead. There are typically two approaches to get what we need. If the component we need to get the ref from is a function component using `forwardRef` is probably the right choice. If it is a class component with other public methods, adding a public method for getting the ref is an option. Here are examples of those two forms:
 
-### Using `forwardRef`
+#### Using `forwardRef`
 
 ```jsx
 class ParentComponent extends React.Component<Props> {
@@ -307,7 +307,7 @@ const ChildComponent = React.forwardRef((props, forwardedRef) => {
 });
 ```
 
-### Using a getter, (note the addition of `getViewRef`)
+#### Using a getter, (note the addition of `getViewRef`)
 
 ```tsx
 class ParentComponent extends React.Component<Props> {


### PR DESCRIPTION
The two section [Using `forwardRef`](https://reactnative.dev/docs/next/new-architecture-library-intro#using-forwardref) and [Using a `getter`](https://reactnative.dev/docs/next/new-architecture-library-intro#using-a-getter-note-the-addition-of-getviewref) are alternative solutions to get rid of `findNodeHandle`, based on the type of component (function or class). 
However, the current structure of the doc leads the reader to think that these are two other API that needs to be migrated: they are at the same level of the `findNodeHandle` one and they also appear in the ToC of the page, on the right.

This PR moves them down one level, reducing the importance of their title and it should make them disappear from the ToC on the right.
