### PR TITLE
Upgrade toast Android example to camelCase

### DIFF
--- a/docs/toastandroid.md
+++ b/docs/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.62/toastandroid.md
+++ b/website/versioned_docs/version-0.62/toastandroid.md
@@ -91,12 +91,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.63/toastandroid.md
+++ b/website/versioned_docs/version-0.63/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.64/toastandroid.md
+++ b/website/versioned_docs/version-0.64/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.65/toastandroid.md
+++ b/website/versioned_docs/version-0.65/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.66/toastandroid.md
+++ b/website/versioned_docs/version-0.66/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.67/toastandroid.md
+++ b/website/versioned_docs/version-0.67/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.68/toastandroid.md
+++ b/website/versioned_docs/version-0.68/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (

--- a/website/versioned_docs/version-0.69/toastandroid.md
+++ b/website/versioned_docs/version-0.69/toastandroid.md
@@ -90,12 +90,12 @@ const Toast = ({ visible, message }) => {
 };
 
 const App = () => {
-  const [visibleToast, setvisibleToast] = useState(false);
+  const [visibleToast, setVisibleToast] = useState(false);
 
-  useEffect(() => setvisibleToast(false), [visibleToast]);
+  useEffect(() => setVisibleToast(false), [visibleToast]);
 
   const handleButtonPress = () => {
-    setvisibleToast(true);
+    setVisibleToast(true);
   };
 
   return (


### PR DESCRIPTION
Hello everybody!

The example of the file that talks about Toasts on Android, is without camelCase in `useState`.

This PR includes the camelCase pattern in referenced articles.

😉