### PR TITLE
feat: Add tabIndex prop to View docs

### DIFF
--- a/docs/view.md
+++ b/docs/view.md
@@ -617,9 +617,9 @@ Supports the following values:
 - `0` - View is focusable
 - `-1` - View is not focusable
 
-| Type   |
-| ------ |
-| number |
+| Type        |
+| ----------- |
+| enum(0, -1) |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -609,6 +609,20 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
+### `tabIndex` <div class="label android">Android</div>
+
+Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
+Supports the following values:
+
+- `0` - View is focusable
+- `-1` - View is not focusable
+
+| Type   |
+| ------ |
+| number |
+
+---
+
 ### `testID`
 
 Used to locate this view in end-to-end tests.


### PR DESCRIPTION
This PR adds the `tabIndex` Android-only prop to the View documentation

Related to  https://github.com/facebook/react-native/commit/621f4cf3b12979b62d2e1d49d63eaf85e0707026

![image](https://user-images.githubusercontent.com/11707729/187342595-5db1d8ae-f6a1-40b7-8657-13be747f52af.png)
