### PR TITLE
feat: Add inputMode prop to TextInput docs

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -373,6 +373,27 @@ An optional identifier which links a custom [InputAccessoryView](inputaccessoryv
 
 ---
 
+### `inputMode`
+
+Works like the `inputmode` attribute in HTML, it determines which keyboard to open, e.g. `numeric` and has precedence over `keyboardType`.
+
+Support the following values:
+
+- `none`
+- `text`
+- `decimal`
+- `numeric`
+- `tel`
+- `search`
+- `email`
+- `url`
+
+| Type                                                                        |
+| --------------------------------------------------------------------------- |
+| enum('decimal', 'email', 'none', 'numeric', 'search', 'tel', 'text', 'url') |
+
+---
+
 ### `keyboardAppearance` <div class="label ios">iOS</div>
 
 Determines the color of the keyboard.


### PR DESCRIPTION
This PR adds the `inputMode` prop to the TextInput documentation

Related to https://github.com/facebook/react-native/commit/9fac88574e2f8c2f46b7f081273845f833fe1b75

![image](https://user-images.githubusercontent.com/11707729/187554196-03574900-a60f-4883-bf0b-db754744da1c.png)
