### PR TITLE
Fix link in Introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -136,4 +136,4 @@ Menu paths are written in bold and use carets to navigate submenus. Example: **A
 
 ---
 
-Now that you know how this guide works, it's time to get to know the foundation of React Native: [Fabric Components](the-new-architecture/pillars-fabric-components).
+Now that you know how this guide works, it's time to get to know the foundation of React Native: [Native Components](intro-react-native-components.md).


### PR DESCRIPTION
The last link on the Introduction page should be linking to the next page in this section (which is written for beginners). It should not link to the new architecture guide (which is for advanced users). I believe this change was an accidental part of https://github.com/facebook/react-native-website/pull/3037, so I am sending a PR to undo that part. 