### PR TITLE
feat: Add tintColor prop to Image docs

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -446,6 +446,14 @@ A unique identifier for this element to be used in UI Automation testing scripts
 | ------ |
 | string |
 
+### `tintColor`
+
+Changes the color of all the non-transparent pixels to the tintColor.
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
 ## Methods
 
 ### `abortPrefetch()` <div class="label android">Android</div>

--- a/docs/image.md
+++ b/docs/image.md
@@ -448,7 +448,7 @@ A unique identifier for this element to be used in UI Automation testing scripts
 
 ### `tintColor`
 
-Changes the color of all the non-transparent pixels to the tintColor.
+Changes the color of all non-transparent pixels to the `tintColor`.
 
 | Type               |
 | ------------------ |


### PR DESCRIPTION
This PR adds the `tintColor` prop to the Image documentation

Related to https://github.com/facebook/react-native/commit/7a6f0e44b26b7a6eddb25d5e05948a1992a1629e

![image](https://user-images.githubusercontent.com/11707729/187807262-e9108672-af92-4d7e-8625-a4a54a7aa6c1.png)

