### PR TITLE
Added enterKeyHint prop to textInput docs

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -321,6 +321,32 @@ If `true`, the keyboard disables the return key when there is no text and automa
 
 ---
 
+### `enterKeyHint`
+
+Determines what text should be shown to the return key. Has precedence over the `returnKeyType`
+
+_Cross platform_
+
+The following values work across platforms:
+
+- `enter`
+- `done`
+- `next`
+- `search`
+- `send`
+
+_Android Only_
+
+The following values work on Android only:
+
+- `previous`
+
+| Type                                                        |
+| ----------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+
+---
+
 ### `importantForAutofill` <div class="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -323,9 +323,7 @@ If `true`, the keyboard disables the return key when there is no text and automa
 
 ### `enterKeyHint`
 
-Determines what text should be shown to the return key. Has precedence over the `returnKeyType`
-
-_Cross platform_
+Determines what text should be shown to the return key. Has precedence over the `returnKeyType` prop.
 
 The following values work across platforms:
 


### PR DESCRIPTION
This PR adds the `enterKeyHint` prop to the `TextInput` documentation

Related to https://github.com/facebook/react-native/commit/8c882b4f3d361be715c8ec2793c545c687711b5e

