### PR TITLE
feat: Update colors docs regarding expanded support for CSS Colors

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -26,14 +26,27 @@ React Native supports `rgb()` and `rgba()` in both hexadecimal and functional no
 - `'#f0ff'` (#rgba)
 - `'#ff00ff00'` (#rrggbbaa)
 - `'rgb(255, 0, 255)'`
+- `'rgb(255 0 255)'`
 - `'rgba(255, 0, 255, 1.0)'`
+- `'rgba(255 0 255 / 1.0)'`
 
 ### Hue Saturation Lightness (HSL)
 
 React Native supports `hsl()` and `hsla()` in functional notation:
 
 - `'hsl(360, 100%, 100%)'`
+- `'hsl(360 100% 100%)'`
 - `'hsla(360, 100%, 100%, 1.0)'`
+- `'hsla(360 100% 100% / 1.0)'`
+
+### Hue Whiteness Blackness (HWB)
+
+React Native supports `hwb()` in functional notation:
+
+- `'hwb(0, 0%, 100%)'`
+- `'hwb(360, 100%, 100%)'`
+- `'hwb(0 0% 0%)'`
+- `'hwb(70 50% 0%)'`
 
 ### Color ints
 


### PR DESCRIPTION
This updates the Colors documentation with examples of the new format supported by `rgb`, `rgba`, `hsl` and `hsla`. It also adds a new section about the support for `hwb`.

Related to https://github.com/facebook/react-native/commit/ac1fe3b7eb8e16f5feddeeac846ff70080dc119e
