### PR TITLE
[Fix] Add Missing Line in Podfile

### DIFF
--- a/docs/new-architecture-app-intro.md
+++ b/docs/new-architecture-app-intro.md
@@ -219,6 +219,7 @@ After upgrading the project, there are a few changes you need to apply:
 ```diff
 - platform :ios, '11.0'
 + platform :ios, '12.4'
++ install! 'cocoapods', :deterministic_uuids => false
 ```
 
 3. Create an `.xcode.env` file to export the locaion of the NODE_BINARY. Navigate to the `ios` folder and run this command:


### PR DESCRIPTION
In the guide to migrate an App to the New Architecture, we were missing a line that has to be added in the Podfile by the user.
This PR adds that mising line.
