### PR TITLE
Added Documentation for crossOrigin, referrerPolicy, width, height, src and srcSet props to Image

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -264,12 +264,11 @@ When the image is resized, the corners of the size specified by `capInsets` will
 A string of a keyword specifying the CORS mode to use when fetching the image resource. It works similar to crossorigin attribute in HTML.
 
 - `anonymous`: No exchange of user credentials in the image request.
-
 - `use-credentials`: Sets `Access-Control-Allow-Credentials` header value to `true` in the image request.
 
-| Type                                     |
-| ---------------------------------------- |
-| enum(`'anonymous'`, `'use-credentials'`) |
+| Type                                     | Default       |
+| ---------------------------------------- | ------------- |
+| enum(`'anonymous'`, `'use-credentials'`) | `'anonymous'` |
 
 ---
 
@@ -419,11 +418,11 @@ More details about `resize` and `scale` can be found at http://frescolib.org/doc
 
 ### `referrerPolicy`
 
-A string indicating which referrer to use when fetching the resource. Sets the value for `Referrer-Policy` header in the image request. Works similar to referrerpolicy attribute in HTML.
+A string indicating which referrer to use when fetching the resource. Sets the value for `Referrer-Policy` header in the image request. Works similar to `referrerpolicy` attribute in HTML.
 
-| Type                                                                                                                                                                                     |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enum(`'no-referrer'`, `'no-referrer-when-downgrade'`, `'origin'`, `'origin-when-cross-origin'`, `'same-origin'`, `'strict-origin'`, `'strict-origin-when-cross-origin'`, `'unsafe-url'`) |
+| Type                                                                                                                                                                                     | Default                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| enum(`'no-referrer'`, `'no-referrer-when-downgrade'`, `'origin'`, `'origin-when-cross-origin'`, `'same-origin'`, `'strict-origin'`, `'strict-origin-when-cross-origin'`, `'unsafe-url'`) | `'strict-origin-when-cross-origin'` |
 
 ---
 
@@ -480,7 +479,7 @@ A string representing the remote URL of the image. This prop has precedence over
 
 A string representing comma separated list of possible candidate image source. Each image source contains a URL of an image and a pixel density descriptor. If no descriptor is specified, it defaults to descriptor of `1x`.
 
-If srcSet does not contain a `1x` descriptor, the value in src, if provided, is used as image source with `1x` descriptor.
+If `srcSet` does not contain a `1x` descriptor, the value in `src` is used as image source with `1x` descriptor (if provided).
 
 This prop has precedence over both the `src` and `source` props.
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -259,6 +259,20 @@ When the image is resized, the corners of the size specified by `capInsets` will
 
 ---
 
+### `crossOrigin`
+
+A string of a keyword specifying the CORS mode to use when fetching the image resource. It works similar to crossorigin attribute in HTML.
+
+- `anonymous`: No exchange of user credentials in the image request.
+
+- `use-credentials`: Sets `Access-Control-Allow-Credentials` header value to `true` in the image request.
+
+| Type                                     |
+| ---------------------------------------- |
+| enum(`'anonymous'`, `'use-credentials'`) |
+
+---
+
 ### `defaultSource`
 
 A static image to display while loading the image source.
@@ -278,6 +292,16 @@ Fade animation duration in miliseconds.
 | Type   | Default |
 | ------ | ------- |
 | number | `300`   |
+
+---
+
+### `height`
+
+Height of the image component.
+
+| Type   |
+| ------ |
+| number |
 
 ---
 
@@ -393,6 +417,16 @@ More details about `resize` and `scale` can be found at http://frescolib.org/doc
 
 ---
 
+### `referrerPolicy`
+
+A string indicating which referrer to use when fetching the resource. Sets the value for `Referrer-Policy` header in the image request. Works similar to referrerpolicy attribute in HTML.
+
+| Type                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enum(`'no-referrer'`, `'no-referrer-when-downgrade'`, `'origin'`, `'origin-when-cross-origin'`, `'same-origin'`, `'strict-origin'`, `'strict-origin-when-cross-origin'`, `'unsafe-url'`) |
+
+---
+
 ### `resizeMode`
 
 Determines how to resize the image when the frame doesn't match the raw image dimensions. Defaults to `cover`.
@@ -430,6 +464,34 @@ The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, 
 
 ---
 
+### `src`
+
+A string representing the remote URL of the image. This prop has precedence over `source` prop.
+
+**Example:** `src={'https://reactnative.dev/img/tiny_logo.png'}`
+
+| Type   |
+| ------ |
+| string |
+
+---
+
+### `srcSet`
+
+A string representing comma separated list of possible candidate image source. Each image source contains a URL of an image and a pixel density descriptor. If no descriptor is specified, it defaults to descriptor of `1x`.
+
+If srcSet does not contain a `1x` descriptor, the value in src, if provided, is used as image source with `1x` descriptor.
+
+This prop has precedence over both the `src` and `source` props.
+
+**Example:** `srcSet={'https://reactnative.dev/img/tiny_logo.png 1x, https://reactnative.dev/img/header_logo.svg 2x'}`
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `style`
 
 | Type                                                                                                                                                 |
@@ -446,6 +508,8 @@ A unique identifier for this element to be used in UI Automation testing scripts
 | ------ |
 | string |
 
+---
+
 ### `tintColor`
 
 Changes the color of all non-transparent pixels to the `tintColor`.
@@ -453,6 +517,16 @@ Changes the color of all non-transparent pixels to the `tintColor`.
 | Type               |
 | ------------------ |
 | [color](colors.md) |
+
+---
+
+### `width`
+
+Width of the image component.
+
+| Type   |
+| ------ |
+| number |
 
 ## Methods
 


### PR DESCRIPTION
This PR adds documentation for crossOrigin, referrerPolicy, width, height, src and srcSet props to the Image doc
Related to commit https://github.com/facebook/react-native/commit/47a05bc26ab76add640183c1d9d8cbba39d7d0d2
and issue https://github.com/facebook/react-native/issues/34424

<img width="843" alt="Screenshot 2022-09-08 at 4 26 13 PM" src="https://user-images.githubusercontent.com/32268377/189105760-650a108d-3065-4c38-ba32-cb0c8dd9b550.png">
<img width="849" alt="Screenshot 2022-09-08 at 4 25 25 PM" src="https://user-images.githubusercontent.com/32268377/189105764-565f07e2-a910-46b8-a9c0-a1ce8e558e30.png">
<img width="848" alt="Screenshot 2022-09-08 at 4 26 04 PM" src="https://user-images.githubusercontent.com/32268377/189105772-23a01a83-e3a0-44a7-9d15-5195ec434a99.png">
<img width="847" alt="Screenshot 2022-09-08 at 4 25 47 PM" src="https://user-images.githubusercontent.com/32268377/189105776-f1666d26-4644-4154-9127-b56430777d79.png">
<img width="842" alt="Screenshot 2022-09-08 at 4 25 36 PM" src="https://user-images.githubusercontent.com/32268377/189105779-e7ed5292-b583-4852-a73c-aeb54d84d2cc.png">

