### PR TITLE
added documnetatuin for `aria-modal` prop

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -208,9 +208,9 @@ For example, in a window that contains sibling views `A` and `B`, setting `acces
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
-| Type |
-| ---- |
-| bool |
+| Type | Default |
+| ---- | ------- |
+| bool | false   |
 
 ---
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -204,6 +204,16 @@ A Boolean value indicating whether the accessibility elements contained within t
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
+### `aria-modal` <div class="label ios">iOS</div>
+
+Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
+
+| Type |
+| ---- |
+| bool |
+
+---
+
 ### `importantForAccessibility` <div class="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).

--- a/docs/view.md
+++ b/docs/view.md
@@ -253,9 +253,9 @@ When `true`, indicates that the view is an accessibility element. By default, al
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the `accessibilityViewIsModal` prop.
 
-| Type |
-| ---- |
-| bool |
+| Type | Default |
+| ---- | ------- |
+| bool | false   |
 
 ---
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -249,6 +249,16 @@ When `true`, indicates that the view is an accessibility element. By default, al
 
 ---
 
+### `aria-modal` <div class="label ios">iOS</div>
+
+Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the `accessibilityViewIsModal` prop.
+
+| Type |
+| ---- |
+| bool |
+
+---
+
 ### `collapsable` <div class="label android">Android</div>
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.


### PR DESCRIPTION
This PR adds documentation for the `aria-modal` prop.

Related to commit https://github.com/facebook/react-native/commit/095f19a681e22bd5f9438758112cc9628499b631

and issue https://github.com/facebook/react-native/issues/34424
