### PR TITLE
fix incorrect link to re-enable prod deploy

### DIFF
--- a/website/versioned_docs/version-0.68/build-speed.md
+++ b/website/versioned_docs/version-0.68/build-speed.md
@@ -6,7 +6,7 @@ title: Speeding up your Build phase
 Building your React Native app could be **expensive** and take several minutes of developers time.
 This can be problematic as your project grows and generally in bigger organizations with multiple React Native developers.
 
-With [the New React Native Architecture](/docs/next/new-architecture-app-modules-android), this problem is becoming more critical
+With [the New React Native Architecture](/docs/new-architecture-app-modules-android), this problem is becoming more critical
 as you might have to compile some native C++ code in your project with the Android NDK in addition to the native code already necessary for the iOS and Android platforms.
 
 To mitigate this performance hit, this page shares some suggestions on how to **improve your build time**.


### PR DESCRIPTION
# Why

<img width="885" alt="Screenshot 2022-09-19 200948" src="https://user-images.githubusercontent.com/719641/191086811-de303070-a458-418c-bd51-4cc320271157.png">

Unfortunately, we currently have the broken link in the code on `main` which prevents PROD deployment from ending successfully.

This is also a reason why the new Showcase entries are not visible on the website.

# How

Fix incorrect link listed by Docusaurus check.