### PR TITLE
fix: remove isTurboModuleEnabled check from docs

### DIFF
--- a/docs/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/docs/the-new-architecture/backward-compatibility-turbomodules.md
@@ -347,7 +347,7 @@ For a Turbo Native Module, the source of truth is the `Native<MyModule>.js` (or 
 import MyModule from 'your-module/src/index';
 ```
 
-The **goal** is to conditionally `export` the proper object from the `index` file , given the architecture chosen by the user. We can achieve this with a code that looks like this:
+Since `TurboModuleRegistry.get` taps into the old `NativeModules` API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
 <Tabs groupId="turbomodule-backward-compatibility"
       defaultValue={constants.defaultTurboModuleSpecLanguage}
@@ -356,43 +356,15 @@ The **goal** is to conditionally `export` the proper object from the `index` fil
 
 ```ts
 // @flow
-
-import { NativeModules } from 'react-native'
-
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
-
-const myModule = isTurboModuleEnabled ?
-    require('./Native<MyModule>').default :
-    NativeModules.<MyModule>;
-
-export default myModule;
+export default require('./Native<MyModule>').default;
 ```
 
 </TabItem>
 <TabItem value="TypeScript">
 
 ```ts
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
-
-const myModule = isTurboModuleEnabled
-  ? require('./Native<MyModule>').default
-  : require('./<MyModule>').default;
-
-export default myModule;
+export default require('./Native<MyModule>').default;
 ```
 
 </TabItem>
 </Tabs>
-
-:::note
-If you are using TypeScript and you want to follow the example, ensure to `export` the `NativeModule` in a separate `ts` file called `<MyModule>.ts`.
-:::
-
-Whether you are using Flow or TypeScript for your specs, we understand which architecture is running by checking whether the `global.__turboModuleProxy` object has been set or not.
-
-:::caution
-The `global.__turboModuleProxy` API may change in the future for a function that encapsulates this check.
-:::
-
-- If that object is `null`, the app has not enabled the Turbo Native Module feature. It's running on the Old Architecture, and the fallback is to use the default [`Legacy Native Module` implementation](../native-modules-intro).
-- If that object is set, the app is running with the Turbo Native Modules enabled, and it should use the `Native<MyModule>` spec to access the Turbo Native Module.

--- a/docs/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/docs/the-new-architecture/backward-compatibility-turbomodules.md
@@ -347,7 +347,7 @@ For a Turbo Native Module, the source of truth is the `Native<MyModule>.js` (or 
 import MyModule from 'your-module/src/index';
 ```
 
-Since `TurboModuleRegistry.get` taps into the old `NativeModules` API under the hood, we need to re-export our module, to avoid registering it multiple times.
+Since `TurboModuleRegistry.get` taps into the old Native Modules API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
 <Tabs groupId="turbomodule-backward-compatibility"
       defaultValue={constants.defaultTurboModuleSpecLanguage}

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
@@ -332,7 +332,7 @@ For a Turbo Native Module, the source of truth is the `Native<MyModule>.js` (or 
 import MyModule from 'your-module/src/index';
 ```
 
-Since `TurboModuleRegistry.get` taps into the old `NativeModules` API under the hood, we need to re-export our module, to avoid registering it multiple times.
+Since `TurboModuleRegistry.get` taps into the old Native Modules API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
 <Tabs groupId="turbomodule-backward-compatibility"
       defaultValue={constants.defaultTurboModuleSpecLanguage}

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
@@ -332,7 +332,7 @@ For a Turbo Native Module, the source of truth is the `Native<MyModule>.js` (or 
 import MyModule from 'your-module/src/index';
 ```
 
-The **goal** is to conditionally `export` from the `index` file the proper object, given the architecture chosen by the user. We can achieve this with a code that looks like this:
+Since `TurboModuleRegistry.get` taps into the old `NativeModules` API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
 <Tabs groupId="turbomodule-backward-compatibility"
       defaultValue={constants.defaultTurboModuleSpecLanguage}
@@ -341,43 +341,15 @@ The **goal** is to conditionally `export` from the `index` file the proper objec
 
 ```ts
 // @flow
-
-import { NativeModules } from 'react-native'
-
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
-
-const myModule = isTurboModuleEnabled ?
-    require('./Native<MyModule>').default :
-    NativeModules.<MyModule>;
-
-export default myModule;
+export default require('./Native<MyModule>').default;
 ```
 
 </TabItem>
 <TabItem value="TypeScript">
 
 ```ts
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
-
-const myModule = isTurboModuleEnabled
-  ? require('./Native<MyModule>').default
-  : require('./<MyModule>').default;
-
-export default myModule;
+export default require('./Native<MyModule>').default;
 ```
 
 </TabItem>
 </Tabs>
-
-:::note
-If you are using TypeScript and you want to follow the example, make sure to `export` the `NativeModule` in a separate `ts` file called `<MyModule>.ts`.
-:::
-
-Whether you are using Flow or TypeScript for your specs, we understand which architecture is running by checking whether the `global.__turboModuleProxy` object has been set or not.
-
-:::caution
-The `global.__turboModuleProxy` API may change in the future for a function that encapsulate this check.
-:::
-
-- If that object is `null`, the app has not enabled the Turbo Native Module feature. It's running on the Old Architecture, and the fallback is to use the default [`Legacy Native Module` implementation](../native-modules-intro).
-- If that object is set, the app is running with the Turbo Native Modules enabled, and it should use the `Native<MyModule>` spec to access the Turbo Native Module.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Hello,

This PR removes `isTurboModuleEnabled` check from the docs, since it's no longer needed. 
