### PR TITLE
Recommend to use `es2019` and use community driven TS config `@tsconfig/react-native`

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -78,14 +78,14 @@ ignite new MyTSProject
 <TabItem value="npm">
 
 ```shell
-npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```shell
-yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
 ```
 
 </TabItem>
@@ -95,25 +95,7 @@ yarn add -D typescript @types/jest @types/react @types/react-native @types/react
 
 ```json
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "jsx": "react-native",
-    "lib": ["es2017"],
-    "types": ["react-native", "jest"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "strict": true,
-    "target": "esnext"
-  },
-  "exclude": [
-    "node_modules",
-    "babel.config.js",
-    "metro.config.js",
-    "jest.config.js"
-  ]
+  "extends": "@tsconfig/react-native/tsconfig.json"
 }
 ```
 

--- a/website/versioned_docs/version-0.69/typescript.md
+++ b/website/versioned_docs/version-0.69/typescript.md
@@ -78,14 +78,14 @@ ignite new MyTSProject
 <TabItem value="npm">
 
 ```shell
-npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```shell
-yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
 ```
 
 </TabItem>
@@ -95,24 +95,7 @@ yarn add -D typescript @types/jest @types/react @types/react-native @types/react
 
 ```json
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "jsx": "react-native",
-    "lib": ["es2017"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "strict": true,
-    "target": "esnext"
-  },
-  "exclude": [
-    "node_modules",
-    "babel.config.js",
-    "metro.config.js",
-    "jest.config.js"
-  ]
+  "extends": "@tsconfig/react-native/tsconfig.json"
 }
 ```
 

--- a/website/versioned_docs/version-0.70/typescript.md
+++ b/website/versioned_docs/version-0.70/typescript.md
@@ -78,14 +78,14 @@ ignite new MyTSProject
 <TabItem value="npm">
 
 ```shell
-npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```shell
-yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer
+yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
 ```
 
 </TabItem>
@@ -95,25 +95,7 @@ yarn add -D typescript @types/jest @types/react @types/react-native @types/react
 
 ```json
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "jsx": "react-native",
-    "lib": ["es2017"],
-    "types": ["react-native", "jest"],
-    "moduleResolution": "node",
-    "noEmit": true,
-    "strict": true,
-    "target": "esnext"
-  },
-  "exclude": [
-    "node_modules",
-    "babel.config.js",
-    "metro.config.js",
-    "jest.config.js"
-  ]
+  "extends": "@tsconfig/react-native/tsconfig.json"
 }
 ```
 


### PR DESCRIPTION
Issue: #3167

- Preview: https://deploy-preview-3342--react-native.netlify.app/docs/next/typescript

- `@tsconfig/react-native` already recommend `es2019` (see: [`bases/react-native.json#L10`](https://github.com/tsconfig/bases/blob/96274973952a623d9f2e310987ceb4a19dcc362c/bases/react-native.json#L10))
  - Commit: https://github.com/tsconfig/bases/commit/ff86e2c43c883837a5e07800697be435641a3b1d
- `react-native-template-typescript` use by default `@tsconfig/react-native` (see : [`template/tsconfig.json#L3`](https://github.com/react-native-community/react-native-template-typescript/blob/5b22365750a285feddf7a3db26450cda4fe4cd1d/template/tsconfig.json#L3)
  - PR: https://github.com/react-native-community/react-native-template-typescript/pull/281