### PR TITLE
fix(native-modules-android.md): rename createCalendarEventCallback

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -615,7 +615,7 @@ In JavaScript, you can then check the first argument to see if an error was pass
 
 ```jsx
 const onPress = () => {
-  CalendarModule.createCalendarEventCallback(
+  CalendarModule.createCalendarEvent(
     'testName',
     'testLocation',
     (error, eventId) => {
@@ -659,7 +659,7 @@ Then in JavaScript you can add a separate callback for error and success respons
 
 ```jsx
 const onPress = () => {
-  CalendarModule.createCalendarEventCallback(
+  CalendarModule.createCalendarEvent(
     'testName',
     'testLocation',
     (error) => {


### PR DESCRIPTION
CalendarModule.createCalendarEvent is referenced as CalendarModule.createCalendarEventCallback a few times in the jsx code snippets, which is incorrect

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
