### PR TITLE
Apply updated copyright to `*.js` files

### DIFF
--- a/.alexrc.js
+++ b/.alexrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Facebook, Inc. and its affiliates.
+Copyright (c) Meta Platforms, Inc. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -1,4 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 'use strict';
+
 const visit = require('unist-util-visit-parents');
 const u = require('unist-builder');
 const dedent = require('dedent');

--- a/plugins/remark-snackplayer/tests/index.js
+++ b/plugins/remark-snackplayer/tests/index.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const path = require('path');
 const fs = require('fs');
 const test = require('tape');

--- a/sync-api-docs/extractDocsFromRN.js
+++ b/sync-api-docs/extractDocsFromRN.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/generateMarkdown.js
+++ b/sync-api-docs/generateMarkdown.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/magic.js
+++ b/sync-api-docs/magic.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/methodFormatter.js
+++ b/sync-api-docs/methodFormatter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/preprocessGeneratedApiDocs.js
+++ b/sync-api-docs/preprocessGeneratedApiDocs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/propFormatter.js
+++ b/sync-api-docs/propFormatter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/sync-api-docs.js
+++ b/sync-api-docs/sync-api-docs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/sync-api-docs/utils.js
+++ b/sync-api-docs/utils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/core/DocsRating.js
+++ b/website/core/DocsRating.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import React, {useState} from 'react';
 

--- a/website/core/PrismTheme.js
+++ b/website/core/PrismTheme.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const theme = {
   plain: {
     color: '#FFFFFF',

--- a/website/core/TableRowWithCodeBlock.js
+++ b/website/core/TableRowWithCodeBlock.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React, {useState} from 'react';
 
 import CodeBlock from '@theme/CodeBlock';

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 const isMacOS = ExecutionEnvironment.canUseDOM

--- a/website/image-check.js
+++ b/website/image-check.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/snackPlayerInitializer.js
+++ b/website/snackPlayerInitializer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/animations/_dissectionAnimation.js
+++ b/website/src/pages/animations/_dissectionAnimation.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export function setupDissectionAnimation() {
   const section = document.querySelector('.NativeDevelopment');
   const dissection = document.querySelector('.NativeDevelopment .dissection');

--- a/website/src/pages/animations/_headerAnimation.js
+++ b/website/src/pages/animations/_headerAnimation.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export function setupHeaderAnimations() {
   const steps = ['full', 'mobile', 'desktop', 'laptop', 'mobile2', 'full2'];
   const intervals = [1250, 1500, 1500, 1500, 1500, 1250];

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React, {useEffect} from 'react';
 import GitHubButton from 'react-github-btn';
 

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/theme/BlogSidebar/Desktop/index.js
+++ b/website/src/theme/BlogSidebar/Desktop/index.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';

--- a/website/src/theme/BlogSidebar/Mobile/index.js
+++ b/website/src/theme/BlogSidebar/Mobile/index.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import Link from '@docusaurus/Link';
 import {NavbarSecondaryMenuFiller} from '@docusaurus/theme-common';

--- a/website/src/theme/DocItemFooter/index.js
+++ b/website/src/theme/DocItemFooter/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/theme/Icon/ExternalLink/index.js
+++ b/website/src/theme/Icon/ExternalLink/index.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import styles from './styles.module.css';
 

--- a/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,9 +1,10 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import React from 'react';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';


### PR DESCRIPTION
Applies the updated copyright header (with Meta Platforms, Inc. instead of Facebook, Inc.) to all `*.js` files.