### PR TITLE
feat: Add verticalAlign to Text Style Props docs

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -503,6 +503,14 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
+### `verticalAlign` <div class="label android">Android</div>
+
+| Type                                            | Default  |
+| ----------------------------------------------- | -------- |
+| enum(`'auto'`, `'top'`, `'bottom'`, `'middle'`) | `'auto'` |
+
+---
+
 ### `writingDirection` <div class="label ios">iOS</div>
 
 | Type                             | Default  |


### PR DESCRIPTION
This PR adds the `verticalAlign` style prop to the Text Style Props documentation.

Related to https://github.com/facebook/react-native/commit/32b6f319bafbd6bc2fdab458d38f2d83b0514ad2

![image](https://user-images.githubusercontent.com/11707729/194198676-6ef59557-7a5d-47aa-9c2c-21590c913b17.png)

