### PR TITLE
feat: Update aspectRatio supported types docs

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -211,9 +211,9 @@ Aspect ratio controls the size of the undefined dimension of a node. See https:/
 - On a node with flex grow/shrink, aspect ratio controls the size of the node in the cross axis if unset
 - Aspect ratio takes min/max dimensions into account
 
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
+| Type           | Required |
+| -------------- | -------- |
+| number, string | No       |
 
 ---
 


### PR DESCRIPTION
This PR updates the `aspectRatio` style prop documentation to also support strings.

Related to https://github.com/facebook/react-native/commit/14c91cdf59949959dd2e39af4fed5bee01c3cba1

![image](https://user-images.githubusercontent.com/11707729/194379556-5f97aaf3-f818-4048-8a1d-0ac609489270.png)

