### PR TITLE
Remove type definitons from a JS file

### DIFF
--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -796,7 +796,6 @@ Here's an example App.js file using the `add` method:
  */
 import React from 'react';
 import { useState } from 'react';
-import type { Node } from 'react';
 import {
   SafeAreaView,
   StatusBar,
@@ -805,8 +804,8 @@ import {
 } from 'react-native';
 import RTNCalculator from 'rtn-calculator/js/NativeCalculator.js';
 
-const App: () => Node = () => {
-  const [result, setResult] = useState<number | null>(null);
+const App = () => {
+  const [result, setResult] = useState(null);
   return (
     <SafeAreaView>
       <StatusBar barStyle={'dark-content'} />


### PR DESCRIPTION
The example app is a JS file but there are type definitions used on it

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
