### PR TITLE
Missing header in `docusaurus.config.js`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const users = require('./showcase.json');
 const versions = require('./versions.json');
 


### PR DESCRIPTION
Adds a missing header to `docusaurus.config.js`.