### PR TITLE
Update sdk root path for linux getting started

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -56,7 +56,7 @@ The React Native tools require some environment variables to be set up in order 
 Add the following lines to your `$HOME/.bash_profile` or `$HOME/.bashrc` (if you are using `zsh` then `~/.zprofile` or `~/.zshrc`) config file:
 
 ```shell
-export ANDROID_SDK_ROOT=$HOME/Library/Android/Sdk
+export ANDROID_SDK_ROOT=$HOME/Android/Sdk
 export PATH=$PATH:$ANDROID_SDK_ROOT/emulator
 export PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
 ```


### PR DESCRIPTION
Normally, android sdk in linux distributions is installed in `/Android/Sdk`