### PR TITLE
feat: Update fontVariant supported types docs

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -405,9 +405,11 @@ Set to `false` to remove extra font padding intended to make space for certain a
 
 ### `fontVariant`
 
-| Type                                                                                                       | Default |
-| ---------------------------------------------------------------------------------------------------------- | ------- |
-| array of enum(`'small-caps'`, `'oldstyle-nums'`, `'lining-nums'`, `'tabular-nums'`, `'proportional-nums'`) | `[]`    |
+Allows you to set all the font variants for a font. Can be set by using an array of enums or a space-separated string e.g. `'small-caps common-ligatures'`.
+
+| Type                                                                                                                 | Default |
+| -------------------------------------------------------------------------------------------------------------------- | ------- |
+| array of enum(`'small-caps'`, `'oldstyle-nums'`, `'lining-nums'`, `'tabular-nums'`, `'proportional-nums'`) or string | `[]`    |
 
 ---
 


### PR DESCRIPTION
This PR updates the `fontVariant` style prop documentation to also support space-separated strings.

Related to https://github.com/facebook/react-native/commit/09d420707f586710bb0f00981aca989b00f8761a

![image](https://user-images.githubusercontent.com/11707729/196713419-38e957df-f58f-4dc4-afca-9acaa271d6c7.png)

