### PR TITLE
Update instructions on integrating with native apps

### DIFF
--- a/docs/_integration-with-exisiting-apps-java.md
+++ b/docs/_integration-with-exisiting-apps-java.md
@@ -41,7 +41,7 @@ $ yarn add react-native
 
 This will print a message similar to the following (scroll up in the yarn output to see it):
 
-> warning "react-native@0.52.2" has unmet peer dependency "react@16.2.0".
+> warning "react-native@0.70.3" has unmet peer dependency "react@18.1.0".
 
 This is OK, it means we also need to install React:
 
@@ -57,14 +57,27 @@ Add `node_modules/` to your `.gitignore` file.
 
 ### Configuring maven
 
-Add the React Native and JSC dependency to your app's `build.gradle` file:
+Add the React Native and JavaScript engine dependencies to your `app/build.gradle` file:
 
 ```gradle
+project.ext.react = [
+    enableHermes: true,
+]
+
+def enableHermes = project.ext.react.get("enableHermes", false);
+
 dependencies {
-    implementation "com.android.support:appcompat-v7:27.1.1"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     ...
     implementation "com.facebook.react:react-native:+" // From node_modules
-    implementation "org.webkit:android-jsc:+"
+    if (enableHermes) {
+        //noinspection GradleDynamicVersion
+        implementation("com.facebook.react:hermes-engine:+") { // From node_modules
+            exclude group:'com.facebook.fbjni'
+        }
+    } else {
+        implementation "org.webkit:android-jsc:+"
+    }
 }
 ```
 
@@ -371,13 +384,11 @@ Once you reach your React-powered activity inside the app, it should load the Ja
 
 ### Creating a release build in Android Studio
 
-You can use Android Studio to create your release builds too! It’s as quick as creating release builds of your previously-existing native Android app. There’s one additional step, which you’ll have to do before every release build. You need to execute the following to create a React Native bundle, which will be included with your native Android app:
+You can use Android Studio to create your release builds too! It’s just as quick as creating release builds of your previously-existing native Android app. You just need to apply the `react.gradle` script in your `app/build.gradle`:
 
-```shell
-$ npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/com/your-company-name/app-package-name/src/main/assets/index.android.bundle --assets-dest android/com/your-company-name/app-package-name/src/main/res/
+```groovy
+apply from: "../../node_modules/react-native/react.gradle"
 ```
-
-> Don’t forget to replace the paths with correct ones and create the assets folder if it doesn’t exist.
 
 Now, create a release build of your native app from within Android Studio as usual and you should be good to go!
 

--- a/docs/_integration-with-exisiting-apps-objc.md
+++ b/docs/_integration-with-exisiting-apps-objc.md
@@ -58,7 +58,7 @@ yarn add react-native
 
 This will print a message similar to the following (scroll up in the yarn output to see it):
 
-> warning "react-native@0.52.2" has unmet peer dependency "react@16.2.0".
+> warning "react-native@0.70.3" has unmet peer dependency "react@18.1.0".
 
 This is OK, it means we also need to install React:
 
@@ -119,49 +119,44 @@ You can specify which `subspec`s your app will depend on in a `Podfile` file. Th
 pod init
 ```
 
-The `Podfile` will contain a boilerplate setup that you will tweak for your integration purposes.
+The `Podfile` contains a boilerplate setup that you need to tweak for your integration purposes. It's also a place that includes scripts necessary to support [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 
 > The `Podfile` version changes depending on your version of `react-native`. Refer to https://react-native-community.github.io/upgrade-helper/ for the specific version of `Podfile` you should be using.
 
 Ultimately, your `Podfile` should look something similar to this:
 
-```
+```ruby
+require_relative '../node_modules/react-native/scripts/react_native_pods'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+platform :ios, '12.4'
+install! 'cocoapods', :deterministic_uuids => false
+
 # The target name is most likely the name of your project.
-target 'NumberTileGame' do
+target 'MyReactNativeApp' do
+  config = use_native_modules!
 
-  # Your 'node_modules' directory is probably in the root of your project,
-  # but if not, adjust the `:path` accordingly
-  pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => '../node_modules/react-native/'
-  pod 'React-Core', :path => '../node_modules/react-native/'
-  pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
+  # Flags change depending on the env values.
+  flags = get_default_flags()
 
-  pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/callinvoker', :path => "../node_modules/react-native/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :hermes_enabled => true,
+    :fabric_enabled => false,
+    :flipper_configuration => FlipperConfiguration.disabled,
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
 
-  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
-
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      # Set `mac_catalyst_enabled` to `true` in order to apply patches
+      # necessary for Mac Catalyst builds
+      :mac_catalyst_enabled => false
+    )
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  end
 end
 ```
 
@@ -173,11 +168,17 @@ $ pod install
 
 You should see output such as:
 
-```
+```text
 Analyzing dependencies
-Fetching podspec for `React` from `../node_modules/react-native`
+Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
+[Codegen] Found FBReactNativeSpec
+...
 Downloading dependencies
-Installing React (0.62.0)
+...
+Installing React (0.70.3)
+Installing React-Codegen (0.70.3)
+Installing React-Core (0.70.3)
+...
 Generating Pods project
 Integrating client project
 Sending stats
@@ -273,7 +274,7 @@ You can add a new link on the main game menu to go to the "High Score" React Nat
 
 We will now add an event handler from the menu link. A method will be added to the main `ViewController` of your application. This is where `RCTRootView` comes into play.
 
-When you build a React Native application, you use the [Metro bundler][metro] to create an `index.bundle` that will be served by the React Native server. Inside `index.bundle` will be our `RNHighScore` module. So, we need to point our `RCTRootView` to the location of the `index.bundle` resource (via `NSURL`) and tie it to the module.
+When you build a React Native application, you use the [Metro bundler][metro] to create an `index.bundle` that will be served by the React Native server. Inside the `index.bundle` will be our `RNHighScore` module. So, we need to point our `RCTRootView` to the location of the `index.bundle` resource (via `NSURL`) and tie it to the module. In the development mode, the bundle will be fetched from the localhost development server, while in the release mode it will be read from the file system.
 
 We will, for debugging purposes, log that the event handler was invoked. Then, we will create a string with the location of our React Native code that exists inside the `index.bundle`. Finally, we will create the main `RCTRootView`. Notice how we provide `RNHighScores` as the `moduleName` that we created [above](#the-react-native-component) when writing the code for our React Native component.
 
@@ -281,6 +282,7 @@ First `import` the `RCTRootView` header.
 
 ```objectivec
 #import <React/RCTRootView.h>
+#import <React/RCTBundleURLProvider.h>
 ```
 
 > The `initialProperties` are here for illustration purposes so we have some data for our high score screen. In our React Native component, we will use `this.props` to get access to that data.
@@ -288,10 +290,9 @@ First `import` the `RCTRootView` header.
 ```objectivec
 - (IBAction)highScoreButtonPressed:(id)sender {
     NSLog(@"High Score Button Pressed");
-    NSURL *jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.bundle?platform=ios"];
 
     RCTRootView *rootView =
-      [[RCTRootView alloc] initWithBundleURL: jsCodeLocation
+      [[RCTRootView alloc] initWithBundleURL: [self jsCodeLocation]
                                   moduleName: @"RNHighScores"
                            initialProperties:
                              @{
@@ -310,6 +311,14 @@ First `import` the `RCTRootView` header.
     UIViewController *vc = [[UIViewController alloc] init];
     vc.view = rootView;
     [self presentViewController:vc animated:YES completion:nil];
+}
+
+- (NSURL *)jsCodeLocation {
+  #if DEBUG
+    return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+  #else
+    return [[NSBundle bundleForClass:[self class]] URLForResource:@"main" withExtension:@"jsbundle"];
+  #endif
 }
 ```
 
@@ -390,6 +399,21 @@ Here is the _React Native_ high score screen:
 ![High Scores](/docs/assets/react-native-add-react-native-integration-example-high-scores.png)
 
 > If you are getting module resolution issues when running your application please see [this GitHub issue](https://github.com/facebook/react-native/issues/4968) for information and possible resolution. [This comment](https://github.com/facebook/react-native/issues/4968#issuecomment-220941717) seemed to be the latest possible resolution.
+
+### Creating a release build
+
+In order to support bundling creating release builds in Xcode, we need to add a new Run Script Build Phase. Head to the `Target > Build Phases` in Xcode, press on the `+` button and choose `New Run Script Phase`. As it will `Bundle React Native code and images`, we can name it just that. It should invoke the `react-native-xcode.sh` script from node modules. Here are the exact script contents:
+
+```bash
+set -e
+
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
+
+/bin/sh -c "$WITH_ENVIRONMENT $REACT_NATIVE_XCODE"
+```
+
+Now, if you choose the `Release` scheme, you should be able to build the app without any problems.
 
 ### Now what?
 

--- a/docs/_integration-with-existing-apps-kotlin.md
+++ b/docs/_integration-with-existing-apps-kotlin.md
@@ -41,7 +41,7 @@ $ yarn add react-native
 
 This will print a message similar to the following (scroll up in the yarn output to see it):
 
-> warning "react-native@0.52.2" has unmet peer dependency "react@16.2.0".
+> warning "react-native@0.70.3" has unmet peer dependency "react@18.1.0".
 
 This is OK, it means we also need to install React:
 
@@ -57,14 +57,27 @@ Add `node_modules/` to your `.gitignore` file.
 
 ### Configuring maven
 
-Add the React Native and JSC dependency to your app's `build.gradle` file:
+Add the React Native and JavaScript engine dependencies to your `app/build.gradle` file:
 
 ```gradle
+project.ext.react = [
+    enableHermes: true,
+]
+
+def enableHermes = project.ext.react.get("enableHermes", false);
+
 dependencies {
-    implementation "com.android.support:appcompat-v7:27.1.1"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     ...
     implementation "com.facebook.react:react-native:+" // From node_modules
-    implementation "org.webkit:android-jsc:+"
+    if (enableHermes) {
+        //noinspection GradleDynamicVersion
+        implementation("com.facebook.react:hermes-engine:+") { // From node_modules
+            exclude group:'com.facebook.fbjni'
+        }
+    } else {
+        implementation "org.webkit:android-jsc:+"
+    }
 }
 ```
 
@@ -364,13 +377,11 @@ Once you reach your React-powered activity inside the app, it should load the Ja
 
 ### Creating a release build in Android Studio
 
-You can use Android Studio to create your release builds too! It’s as quick as creating release builds of your previously-existing native Android app. There’s one additional step, which you’ll have to do before every release build. You need to execute the following to create a React Native bundle, which will be included with your native Android app:
+You can use Android Studio to create your release builds too! It’s just as quick as creating release builds of your previously-existing native Android app. You just need to apply the `react.gradle` script in your `app/build.gradle`:
 
-```shell
-$ npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/com/your-company-name/app-package-name/src/main/assets/index.android.bundle --assets-dest android/com/your-company-name/app-package-name/src/main/res/
+```groovy
+apply from: "../../node_modules/react-native/react.gradle"
 ```
-
-> Don’t forget to replace the paths with correct ones and create the assets folder if it doesn’t exist.
 
 Now, create a release build of your native app from within Android Studio as usual and you should be good to go!
 


### PR DESCRIPTION
Updated the docs on integration with native apps:

- updated the Podfile template
- added instructions to build release mode on iOS
- updated instructions to build release mode on Android

I think it'll be great to include Fabric instructions in the near future as well :)
