### PR TITLE
update to microsoft-openjdk11

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -17,7 +17,7 @@ React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.
 Open an Administrator Command Prompt (right click Command Prompt and select "Run as Administrator"), then run the following command:
 
 ```powershell
-choco install -y nodejs-lts openjdk11
+choco install -y nodejs-lts microsoft-openjdk11
 ```
 
 If you have already installed Node on your system, make sure it is Node 14 or newer. If you already have a JDK on your system, we recommend JDK11. You may encounter problems using higher JDK versions.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#3379
-->

as `openjdk11` is [Deprecated](https://community.chocolatey.org/packages/openjdk11) 

update `openjdk11` to [`microsoft-openjdk11`](https://community.chocolatey.org/packages/microsoft-openjdk11)
```diff
- choco install -y nodejs-lts openjdk11
+ choco install -y nodejs-lts microsoft-openjdk11
```
#3379