### PR TITLE
fix: missing paren in publishing

### DIFF
--- a/website/contributing/how-to-build-from-source.md
+++ b/website/contributing/how-to-build-from-source.md
@@ -162,7 +162,7 @@ Gradle build fails in `ndk-build`. See the section about `local.properties` file
 
 ## Publish your own version of React Native
 
-There is a docker image that helps you build the required Android sources without installing any additional tooling (other than [Docker](https://docs.docker.com/install/), which can be committed to a git branch as a fully functional React Native fork release.
+There is a docker image that helps you build the required Android sources without installing any additional tooling (other than [Docker](https://docs.docker.com/install/)), which can be committed to a git branch as a fully functional React Native fork release.
 
 Run this from a fork of the React Native [repo](https://github.com/facebook/react-native).
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Adding a missing paren in the sentence under **Publish your own version of React Native**.
