### PR TITLE
Tweak homepage text to more broadly refer to platforms

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -33,7 +33,7 @@ same native platform APIs other apps do.
 <br/><br/>
 <strong>Many platforms</strong>, one React. Create platform-specific versions of components
 so a single codebase can share code across platforms. With React Native,
-one team can maintain two platforms and share a common technology—React.
+one team can maintain multiple platforms and share a common technology—React.
   `,
   codeExample: `
 import React from 'react';
@@ -288,7 +288,7 @@ function NativeApps() {
         reverse
         columnOne={
           <TextColumn
-            title="Create native apps for Android and iOS using React"
+            title="Create native apps for Android, iOS, and more using React"
             text={textContent.intro}
           />
         }


### PR DESCRIPTION
Following internal discussion, this opens up wording on our homepage (significantly, the secondary tagline) to align with our [Many Platform Vision](https://reactnative.dev/blog/2021/08/26/many-platform-vision).

### Test plan

Text wrapping is not negatively affected across desktop and mobile breakpoints.

**Desktop**

<img width="992" alt="image" src="https://user-images.githubusercontent.com/2547783/199457975-eed2fe98-24c0-4a07-8cbf-e890e57d456d.png">

**Mobile**

<img width="449" alt="image" src="https://user-images.githubusercontent.com/2547783/199457864-32cfc5da-b0d7-47f9-9c46-496a568d8d60.png">
