### PR TITLE
Cleanup mentions of RN versions in Hermes docs

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -10,16 +10,16 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 </a>
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size.
-As of React Native 0.70, Hermes is the default engine and no additional configuration is required to enable it.
+Hermes is now the default engine and no additional configuration is required to enable it.
 
 ## Bundled Hermes
 
-Starting with React Native 0.69.0, every version of React Native will come with a **bundled version** of Hermes.
+React Native comes with a **bundled version** of Hermes.
 We will be building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 Historically, we had problems with matching versions of Hermes with versions of React Native. This fully eliminates this problem, and offers users a JS engine that is compatible with the specific React Native version.
 
-This change is fully transparent to users of React Native. You can still enable/disable Hermes using the command described in this page.
+This change is fully transparent to users of React Native. You can still disable Hermes using the command described in this page.
 You can [read more about the technical implementation on this page](/architecture/bundled-hermes).
 
 ## Confirming Hermes is in use

--- a/website/versioned_docs/version-0.69/hermes.md
+++ b/website/versioned_docs/version-0.69/hermes.md
@@ -126,7 +126,7 @@ This will compile JavaScript to bytecode during build time which will improve yo
 
 ## Bundled Hermes
 
-Starting with React Native 0.69.0, every version of React Native will come with a **bundled version** of Hermes.
+React Native comes with a **bundled version** of Hermes.
 We will be building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 Historically, we had problems with matching versions of Hermes with versions of React Native. This fully eliminates this problem, and offers users a JS engine that is compatible with the specific React Native version.

--- a/website/versioned_docs/version-0.70/hermes.md
+++ b/website/versioned_docs/version-0.70/hermes.md
@@ -10,16 +10,16 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 </a>
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size.
-As of React Native 0.70, Hermes is the default engine and no additional configuration is required to enable it.
+Hermes is now the default engine and no additional configuration is required to enable it.
 
 ## Bundled Hermes
 
-Starting with React Native 0.69.0, every version of React Native will come with a **bundled version** of Hermes.
+React Native comes with a **bundled version** of Hermes.
 We will be building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 Historically, we had problems with matching versions of Hermes with versions of React Native. This fully eliminates this problem, and offers users a JS engine that is compatible with the specific React Native version.
 
-This change is fully transparent to users of React Native. You can still enable/disable Hermes using the command described in this page.
+This change is fully transparent to users of React Native. You can still disable Hermes using the command described in this page.
 You can [read more about the technical implementation on this page](/architecture/bundled-hermes).
 
 ## Confirming Hermes is in use


### PR DESCRIPTION
Hermes is the default as of React Native 0.70, and bundled Hermes was introduced in 0.69.

The versioned docs for 0.69 and 0.70 have been updated to remove the explicit mention of their own version numbers:

- When looking at versions of the docs for 0.69 and later, we just mention that Hermes is now bundled into RN.
- When looking at versions of the docs for 0.70 and later, we just mention that Hermes is now the default.

Since the docs are versioned, we do not need to call out when something was introduced unless it is directly relevant, e.g. we still make the caveat that Hermes by default is a 0.70+ feature under "Enabling Hermes on Older Versions of React Native" (relevancy) and in "Architecture/Bundled Hermes" (unversioned guide).

