### PR TITLE
Update Hermes docs with recent changes

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -10,16 +10,16 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 </a>
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size.
-As of React Native 0.70, Hermes is the default engine and no additional configuration is required to enable it.
+Hermes is now the default engine and no additional configuration is required to enable it.
 
 ## Bundled Hermes
 
-Starting with React Native 0.69.0, every version of React Native will come with a **bundled version** of Hermes.
+React Native comes with a **bundled version** of Hermes.
 We will be building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 Historically, we had problems with matching versions of Hermes with versions of React Native. This fully eliminates this problem, and offers users a JS engine that is compatible with the specific React Native version.
 
-This change is fully transparent to users of React Native. You can still enable/disable Hermes using the command described in this page.
+This change is fully transparent to users of React Native. You can still disable Hermes using the command described in this page.
 You can [read more about the technical implementation on this page](/architecture/bundled-hermes).
 
 ## Confirming Hermes is in use

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -9,8 +9,8 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 <img width={300} height={300} className="hermes-logo" src="/docs/assets/HermesLogo.svg" />
 </a>
 
-[Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size.
-Hermes is now the default engine and no additional configuration is required to enable it.
+[Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, using Hermes will result in improved start-up time, decreased memory usage, and smaller app size when compared to JavaScriptCore.
+Hermes is used by default by React Native and no additional configuration is required to enable it.
 
 ## Bundled Hermes
 
@@ -174,7 +174,7 @@ $ npx react-native run-ios
 
 ## Switching back to JavaScriptCore
 
-React Native also supports using JavaScriptCore as the JS engine. Follow these instructions to opt-out of Hermes.
+React Native also supports using JavaScriptCore as the [JavaScript engine](javascript-environment). Follow these instructions to opt-out of Hermes.
 
 ### Android
 

--- a/docs/javascript-environment.md
+++ b/docs/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
-- In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- In most cases, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
+- If Hermes is disabled, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />

--- a/website/architecture/bundled-hermes.md
+++ b/website/architecture/bundled-hermes.md
@@ -40,7 +40,7 @@ On iOS, we've moved the `hermes-engine` you're using.
 Prior to React Native 0.69, users would download a pod (here you can find the [podspec](https://github.com/CocoaPods/Specs/blob/master/Specs/5/d/0/hermes-engine/0.11.0/hermes-engine.podspec.json)).
 
 On React Native 0.69, users would instead use a podspec that is defined inside the `sdks/hermes-engine/hermes-engine.podspec` file in the `react-native` NPM package.
-That podspec relies on a pre-built tarball of Hermes that we upload on GitHub Releases, as part of the React Native release process (i.e. [see the assets of this release](https://github.com/facebook/react-native/releases/tag/v0.69.0-rc.6)).
+That podspec relies on a pre-built tarball of Hermes that we upload to Maven and to the React Native GitHub Release, as part of the React Native release process (i.e. [see the assets of this release](https://github.com/facebook/react-native/releases/tag/v0.70.4)).
 
 ### Android Users
 
@@ -81,21 +81,20 @@ You can find instructions to optimize your build time and reduce the impact on y
 
 Users building React Native App, with the New Architecture, on Windows machines need to follow those extra steps to let the build work correctly:
 
-* Make sure the [environment is configured properly](https://reactnative.dev/docs/environment-setup), with Android SDK & node.
-* Install [cmake](https://community.chocolatey.org/packages/cmake) with Chocolatey
-* Install either:
-  * [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
-  * [Visual Studio 22 Community Edition](https://visualstudio.microsoft.com/vs/community/) - Picking only the C++ desktop development is sufficient.
-* Make sure the [Visual Studio Command Prompt](https://docs.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022) is configured correctly. This is required as the proper C++ compiler environment variable is configured in those command prompt.
-* Run the app with `npx react-native run-android` inside a Visual Studio Command Prompt.
+- Make sure the [environment is configured properly](https://reactnative.dev/docs/environment-setup), with Android SDK & node.
+- Install [cmake](https://community.chocolatey.org/packages/cmake) with Chocolatey
+- Install either:
+  - [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022).
+  - [Visual Studio 22 Community Edition](https://visualstudio.microsoft.com/vs/community/) - Picking only the C++ desktop development is sufficient.
+- Make sure the [Visual Studio Command Prompt](https://docs.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022) is configured correctly. This is required as the proper C++ compiler environment variable is configured in those command prompt.
+- Run the app with `npx react-native run-android` inside a Visual Studio Command Prompt.
 
 ### Can users still use another engine?
 
 Yes, users are free to enable/disable Hermes (with the `enableHermes` variable on Android, `hermes_enabled` on iOS).
 The 'Bundled Hermes' change will impact only **how Hermes is built and bundled** for you.
 
-Please note that, at the time of writing, the default for `enableHermes`/`hermes_enabled` is `false`.
-We're looking into updating the template to have it default to `true` in the near future.
+Starting with React Native 0.70, the default for `enableHermes`/`hermes_enabled` is `true`.
 
 ## How this will impact contributor and extension developers
 
@@ -107,7 +106,7 @@ This mechanism relies on **downloading a tarball** with the Hermes source code f
 
 When building React Native from `main`, we will be fetching a tarball of `main` of facebook/hermes and building it as part of the build process of React Native.
 
-When building React Native from a release branch (say `0.69-stable`), we will instead use a **tag** on the Hermes repo to **syncronize the code** between the two repos. The specific tag name used will then be stored inside the `sdks/.hermesversion` file inside React Native in the release branch (e.g. [this is the file](https://github.com/facebook/react-native/blob/0.69-stable/sdks/.hermesversion) on the 0.69 release branch).
+When building React Native from a release branch (say `0.69-stable`), we will instead use a **tag** on the Hermes repo to **synchronize the code** between the two repos. The specific tag name used will then be stored inside the `sdks/.hermesversion` file inside React Native in the release branch (e.g. [this is the file](https://github.com/facebook/react-native/blob/0.69-stable/sdks/.hermesversion) on the 0.69 release branch).
 
 In a sense, you can think of this approach similarly to a **git submodule**.
 
@@ -144,10 +143,22 @@ This is needed as React Native is consuming `fbjni` using the non-prefab approac
 
 The iOS implementation relies on a series of scripts that lives in the following locations:
 
-* [`/scripts/hermes`](https://github.com/facebook/react-native/tree/main/scripts/hermes). Those scripts contain logic to download the hermes tarball, unzip it, and configure the iOS build. They're invoked at `pod install` time if you have the `hermes_enabled` field set to `true`.
-* [`/sdks/hermes-engine`](https://github.com/facebook/react-native/tree/main/sdks/hermes-engine). Those scripts contain the build logic that is effectively building Hermes. They were copied and adapted from the `facebook/hermes` repo to properly work within React Native. Specifically, the scripts inside the `utils` folder are responsible of building Hermes for all the Mac platforms.
+- [`/scripts/hermes`](https://github.com/facebook/react-native/tree/main/scripts/hermes). Those scripts contain logic to download the Hermes tarball, unzip it, and configure the iOS build. They're invoked at `pod install` time if you have the `hermes_enabled` field set to `true`.
+- [`/sdks/hermes-engine`](https://github.com/facebook/react-native/tree/main/sdks/hermes-engine). Those scripts contain the build logic that is effectively building Hermes. They were copied and adapted from the `facebook/hermes` repo to properly work within React Native. Specifically, the scripts inside the `utils` folder are responsible of building Hermes for all the Mac platforms.
 
-To distribute a prebuilt for iOS, we rely on the `build_hermes_macos` Job on CircleCI. The job will produce as artifact a tarball which will be downloaded by the `hermes-engine` podspec (i.e. [those are the artifacts for an execution for React Native 0.69](https://app.circleci.com/pipelines/github/facebook/react-native/13679/workflows/5172f8e4-6b02-4ccb-ab97-7cb954911fae/jobs/258701/artifacts)).
+Hermes is built as part of the `build_hermes_macos` Job on CircleCI. The job will produce as artifact a tarball which will be downloaded by the `hermes-engine` podspec when using a published React Native release ([here is an example of the artifacts created for React Native 0.69 in `build_hermes_macos`](https://app.circleci.com/pipelines/github/facebook/react-native/13679/workflows/5172f8e4-6b02-4ccb-ab97-7cb954911fae/jobs/258701/artifacts)).
+
+##### Prebuilt Hermes
+
+If there are no prebuilt artifacts for the React Native version that is being used (i.e. you may be working with React Native from the `main` branch), then Hermes will need to be built from source. First, the Hermes compiler, `hermesc`, will be built for macOS during `pod install`, then Hermes itself will be built as part of the Xcode build pipeline using the `build-hermes-xcode.sh` script.
+
+##### Building Hermes from source
+
+Hermes is always built from source when using React Native from the `main` branch. If you are using a stable React Native version, you can force Hermes to be built from source by setting the `CI` envvar to `true` when using CocoaPods: `CI=true pod install`.
+
+##### Debug symbols
+
+The prebuilt artifacts for Hermes do not contain debug symbols (dSYMs) by default. We're planning on distributing these debug symbols for each release in the future. Until then, if you need the debug symbols for Hermes, you will need to build Hermes from source. A `hermes.framework.dSYM` will be created in the build directory alongside each of the Hermes frameworks.
 
 ### I'm afraid this change is impacting me
 

--- a/website/versioned_docs/version-0.60/hermes.md
+++ b/website/versioned_docs/version-0.60/hermes.md
@@ -9,13 +9,19 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for running React Native apps on Android. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
+> ## Note for RN compatibility.
+>
+> Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
 
 > ## Note for Windows users.
 >
 > Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
+
+## Enabling Hermes
+
+First, ensure you're using at least version 0.60.4 of React Native.
+
+If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
 
 Edit your `android/app/build.gradle` file and make the change illustrated below:
 

--- a/website/versioned_docs/version-0.61/hermes.md
+++ b/website/versioned_docs/version-0.61/hermes.md
@@ -9,13 +9,15 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for running React Native apps on Android. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
+> ## Note for RN compatibility.
+>
+> Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
 
 > ## Note for Windows users.
 >
 > Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
+
+## Enabling Hermes
 
 Edit your `android/app/build.gradle` file and make the change illustrated below:
 

--- a/website/versioned_docs/version-0.61/javascript-environment.md
+++ b/website/versioned_docs/version-0.61/javascript-environment.md
@@ -5,12 +5,13 @@ title: JavaScript Environment
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 

--- a/website/versioned_docs/version-0.62/hermes.md
+++ b/website/versioned_docs/version-0.62/hermes.md
@@ -9,13 +9,15 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for running React Native apps on Android. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
+> ## Note for RN compatibility.
+>
+> Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
 
 > ## Note for Windows users.
 >
 > Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
+
+## Enabling Hermes
 
 Edit your `android/app/build.gradle` file and make the change illustrated below:
 

--- a/website/versioned_docs/version-0.62/javascript-environment.md
+++ b/website/versioned_docs/version-0.62/javascript-environment.md
@@ -5,12 +5,13 @@ title: JavaScript Environment
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 

--- a/website/versioned_docs/version-0.63/hermes.md
+++ b/website/versioned_docs/version-0.63/hermes.md
@@ -9,10 +9,6 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for running React Native apps on Android. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 > ## Note for RN compatibility.
 >
 > Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
@@ -20,6 +16,8 @@ If you have an existing app based on an earlier version of React Native, you wil
 > ## Note for Windows users.
 >
 > Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
+
+## Enabling Hermes
 
 Edit your `android/app/build.gradle` file and make the change illustrated below:
 

--- a/website/versioned_docs/version-0.63/javascript-environment.md
+++ b/website/versioned_docs/version-0.63/javascript-environment.md
@@ -5,12 +5,13 @@ title: JavaScript Environment
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 

--- a/website/versioned_docs/version-0.64/hermes.md
+++ b/website/versioned_docs/version-0.64/hermes.md
@@ -9,10 +9,6 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. Make especially sure that all changes to `android/app/build.gradle` have been applied, as detailed by the [React Native upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.59.0). After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 > ## Note for RN compatibility.
 >
 > Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
@@ -60,7 +56,7 @@ $ npx react-native run-android
 
 ### iOS
 
-Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit your `ios/Podfile` file and make the change illustrated below:
+To enable Hermes for iOS, edit your `ios/Podfile` file and make the change illustrated below:
 
 ```diff
    use_react_native!(

--- a/website/versioned_docs/version-0.64/javascript-environment.md
+++ b/website/versioned_docs/version-0.64/javascript-environment.md
@@ -5,12 +5,13 @@ title: JavaScript Environment
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 

--- a/website/versioned_docs/version-0.65/hermes.md
+++ b/website/versioned_docs/version-0.65/hermes.md
@@ -9,10 +9,6 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 > ## Note for RN compatibility.
 >
 > Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.
@@ -60,7 +56,7 @@ $ npx react-native run-android
 
 ### iOS
 
-Since React Native 0.64, Hermes also runs on iOS. To enable Hermes for iOS, edit your `ios/Podfile` file and make the change illustrated below:
+To enable Hermes for iOS, edit your `ios/Podfile` file and make the change illustrated below:
 
 ```diff
    use_react_native!(

--- a/website/versioned_docs/version-0.65/javascript-environment.md
+++ b/website/versioned_docs/version-0.65/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />

--- a/website/versioned_docs/version-0.66/hermes.md
+++ b/website/versioned_docs/version-0.66/hermes.md
@@ -9,10 +9,6 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 > ## Note for RN compatibility.
 >
 > Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.

--- a/website/versioned_docs/version-0.66/javascript-environment.md
+++ b/website/versioned_docs/version-0.66/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />

--- a/website/versioned_docs/version-0.67/hermes.md
+++ b/website/versioned_docs/version-0.67/hermes.md
@@ -9,10 +9,6 @@ title: Using Hermes
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 > ## Note for RN compatibility.
 >
 > Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.

--- a/website/versioned_docs/version-0.67/javascript-environment.md
+++ b/website/versioned_docs/version-0.67/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />

--- a/website/versioned_docs/version-0.68/hermes.md
+++ b/website/versioned_docs/version-0.68/hermes.md
@@ -11,10 +11,6 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 > ## Note for RN compatibility.
 >
 > Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly. Version mismatch can result in instant crash of your apps in the worst case scenario.

--- a/website/versioned_docs/version-0.68/javascript-environment.md
+++ b/website/versioned_docs/version-0.68/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />

--- a/website/versioned_docs/version-0.69/hermes.md
+++ b/website/versioned_docs/version-0.69/hermes.md
@@ -126,7 +126,7 @@ This will compile JavaScript to bytecode during build time which will improve yo
 
 ## Bundled Hermes
 
-Starting with React Native 0.69.0, every version of React Native will come with a **bundled version** of Hermes.
+React Native comes with a **bundled version** of Hermes.
 We will be building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 Historically, we had problems with matching versions of Hermes with versions of React Native. This fully eliminates this problem, and offers users a JS engine that is compatible with the specific React Native version.

--- a/website/versioned_docs/version-0.69/hermes.md
+++ b/website/versioned_docs/version-0.69/hermes.md
@@ -11,6 +11,8 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
+## Enabling Hermes
+
 First, ensure you're using at least version 0.60.4 of React Native.
 
 If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
@@ -23,8 +25,6 @@ Version mismatch can result in instant crash of your apps in the worst case scen
 :::info Note for Windows users
 Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145).
 :::
-
-## Enabling Hermes
 
 ### Android
 

--- a/website/versioned_docs/version-0.69/hermes.md
+++ b/website/versioned_docs/version-0.69/hermes.md
@@ -11,12 +11,6 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size. At this time Hermes is an **opt-in** React Native feature, and this guide explains how to enable it.
 
-## Enabling Hermes
-
-First, ensure you're using at least version 0.60.4 of React Native.
-
-If you have an existing app based on an earlier version of React Native, you will have to upgrade it first. See [Upgrading to new React Native Versions](/docs/upgrading) for how to do this. After upgrading the app, make sure everything works before trying to switch to Hermes.
-
 :::caution Note for React Native compatibility
 Each Hermes release is aimed at a specific RN version. The rule of thumb is to always follow [Hermes releases](https://github.com/facebook/hermes/releases) strictly.
 Version mismatch can result in instant crash of your apps in the worst case scenario.
@@ -25,6 +19,8 @@ Version mismatch can result in instant crash of your apps in the worst case scen
 :::info Note for Windows users
 Hermes requires [Microsoft Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145).
 :::
+
+## Enabling Hermes
 
 ### Android
 

--- a/website/versioned_docs/version-0.69/javascript-environment.md
+++ b/website/versioned_docs/version-0.69/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
 - In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- If enabled, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />

--- a/website/versioned_docs/version-0.70/hermes.md
+++ b/website/versioned_docs/version-0.70/hermes.md
@@ -10,16 +10,16 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 </a>
 
 [Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size.
-As of React Native 0.70, Hermes is the default engine and no additional configuration is required to enable it.
+Hermes is now the default engine and no additional configuration is required to enable it.
 
 ## Bundled Hermes
 
-Starting with React Native 0.69.0, every version of React Native will come with a **bundled version** of Hermes.
+React Native comes with a **bundled version** of Hermes.
 We will be building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 Historically, we had problems with matching versions of Hermes with versions of React Native. This fully eliminates this problem, and offers users a JS engine that is compatible with the specific React Native version.
 
-This change is fully transparent to users of React Native. You can still enable/disable Hermes using the command described in this page.
+This change is fully transparent to users of React Native. You can still disable Hermes using the command described in this page.
 You can [read more about the technical implementation on this page](/architecture/bundled-hermes).
 
 ## Confirming Hermes is in use

--- a/website/versioned_docs/version-0.70/hermes.md
+++ b/website/versioned_docs/version-0.70/hermes.md
@@ -9,8 +9,8 @@ import M1Cocoapods from './\_markdown-m1-cocoapods.mdx';
 <img width={300} height={300} className="hermes-logo" src="/docs/assets/HermesLogo.svg" />
 </a>
 
-[Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, enabling Hermes will result in improved start-up time, decreased memory usage, and smaller app size.
-Hermes is now the default engine and no additional configuration is required to enable it.
+[Hermes](https://hermesengine.dev) is an open-source JavaScript engine optimized for React Native. For many apps, using Hermes will result in improved start-up time, decreased memory usage, and smaller app size when compared to JavaScriptCore.
+Hermes is used by default by React Native and no additional configuration is required to enable it.
 
 ## Bundled Hermes
 
@@ -174,7 +174,7 @@ $ npx react-native run-ios
 
 ## Switching back to JavaScriptCore
 
-React Native also supports using JavaScriptCore as the JS engine. Follow these instructions to opt-out of Hermes.
+React Native also supports using JavaScriptCore as the [JavaScript engine](javascript-environment). Follow these instructions to opt-out of Hermes.
 
 ### Android
 

--- a/website/versioned_docs/version-0.70/javascript-environment.md
+++ b/website/versioned_docs/version-0.70/javascript-environment.md
@@ -7,12 +7,13 @@ import TableRow from '@site/core/TableRowWithCodeBlock';
 
 ## JavaScript Runtime
 
-When using React Native, you're going to be running your JavaScript code in two environments:
+When using React Native, you're going to be running your JavaScript code in up to three environments:
 
-- In most cases, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
+- In most cases, React Native will use [Hermes](hermes), an open-source JavaScript engine optimized for React Native.
+- If Hermes is disabled, React Native will use [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore), the JavaScript engine that powers Safari. Note that on iOS, JavaScriptCore does not use JIT due to the absence of writable executable memory in iOS apps.
 - When using Chrome debugging, all JavaScript code runs within Chrome itself, communicating with native code via WebSockets. Chrome uses [V8](https://v8.dev/) as its JavaScript engine.
 
-While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JavaScript engines in the future, so it's best to avoid relying on specifics of any runtime.
+While these environments are very similar, you may end up hitting some inconsistencies. It is best to avoid relying on specifics of any runtime.
 
 ## JavaScript Syntax Transformers
 
@@ -65,7 +66,7 @@ A full list of React Native's enabled transformations can be found in [metro-rea
   <tr><td className="table-heading" colSpan="2">ECMAScript 2022 (ES13)</td></tr>
   <TableRow name="Class Fields" code="class Bork { static a = 'foo'; static b; x = 'bar'; y; }" url="https://babeljs.io/docs/en/babel-plugin-proposal-class-properties" />
   <tr><td className="table-heading" colSpan="2">Stage 1 Proposal</td></tr>
-  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />  
+  <TableRow name="Export Default From" code="export v from 'mod';" url="https://babeljs.io/docs/en/babel-plugin-proposal-export-default-from" />
   <tr><td className="table-heading" colSpan="2">Miscellaneous</td></tr>
   <TableRow name="Babel Template" code="template(`const %%importName%% = require(%%source%%);`);" url="https://babeljs.io/docs/en/babel-template" />
   <TableRow name="Flow" code="function foo(x: ?number): string {};" url="https://flowtype.org/" />


### PR DESCRIPTION
##  Hermes

Hermes is the default as of React Native 0.70, and bundled Hermes was introduced in 0.69.

The versioned docs for 0.69 and 0.70 have been updated to remove the explicit mention of their own version numbers:

- When looking at versions of the docs for 0.69 and later, we just mention that Hermes is now bundled into RN.
- When looking at versions of the docs for 0.70 and later, we just mention that Hermes is now the default.

And for the versioned docs for 0.61 - 0.69:

- When enabling Hermes, no need to specify 0.60.4 as the minimum, as the docs are for version 0.61 and up.

Since the docs are versioned, we do not need to call out when something was introduced unless it is directly relevant, e.g. we still make the caveat that Hermes by default is a 0.70+ feature under "Enabling Hermes on Older Versions of React Native" (relevancy) and in "Architecture/Bundled Hermes" (unversioned guide).

## JavaScript Environment

Mention Hermes starting in 0.60. As of 0.70, make it clear that Hermes is the default unless disabled.

## Bundled Hermes

Added more details on the iOS implementation, including instructions on obtaining iOS dSYMs.

# Test Plan

```
cd website
yarn start
```

Please take a look at the generated previews:

- Hermes
  - [Next (0.71)](https://deploy-preview-3393--react-native.netlify.app/docs/next/hermes)
  - [0.70](https://deploy-preview-3393--react-native.netlify.app/docs/hermes)
- JavaScript Environment
  - [0.70 and newer](https://deploy-preview-3393--react-native.netlify.app/docs/javascript-environment)
  - [0.61 to 0.69](https://deploy-preview-3393--react-native.netlify.app/docs/0.69/javascript-environment)
- Bundled Hermes
  - [Unversioned Guide](https://deploy-preview-3393--react-native.netlify.app/architecture/bundled-hermes)