### PR TITLE
Don't document VirtualizedList context

### DIFF
--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -514,25 +514,6 @@ flashScrollIndicators();
 
 ---
 
-### `getChildContext()`
-
-```jsx
-getChildContext () => Object;
-```
-
-The `Object` returned consist of:
-
-- 'virtualizedList' (Object). This object consist of the following
-  - getScrollMetrics' (Function). Returns an object with following properties: `{ contentLength: number, dOffset: number, dt: number, offset: number, timestamp: number, velocity: number, visibleLength: number }`.
-  - 'horizontal' (boolean) - Optional.
-  - 'getOutermostParentListRef' (Function).
-  - 'getNestedChildState' (Function) - Returns ChildListState .
-  - 'registerAsNestedChild' (Function). This accept an object with following properties `{ cellKey: string, key: string, ref: VirtualizedList, parentDebugInfo: ListDebugInfo }`. It returns a ChildListState
-  - 'unregisterAsNestedChild' (Function). This takes an object with following properties, `{ key: string, state: ChildListState }`
-  - 'debugInfo' (ListDebugInfo).
-
----
-
 ### `getScrollableNode()`
 
 ```jsx


### PR DESCRIPTION
VirtualizeList internally uses contexts to allow buidling tree of nested VirtualizedList refs. This is an API really meant to only be called by VirtualizedList, but is public so other VirtualizedList instances can call it. The object shape, parameters, etc can change (and did change a bit in 0.71). Remove it from documentation, since folks should not rely on it.