### PR TITLE
chore: Fix documentation typos

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -24,7 +24,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -218,7 +218,7 @@ Represents the current value for range-based components, such as sliders and pro
 
 ### `aria-valuetext`
 
-Repersents the textual description of the component.
+Represents the textual description of the component.
 
 ### `aria-modal` <div class="label ios">iOS</div>
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -286,7 +286,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/docs/react-18-and-react-native.md
+++ b/docs/react-18-and-react-native.md
@@ -107,7 +107,7 @@ On iOS, you'll have access to the `concurrentRootEnabled` method on your `AppDel
 ///
 /// @see: https://reactjs.org/blog/2022/03/29/react-v18.html
 /// @note: This requires to be rendering on Fabric (i.e. on the New Architecture).
-/// @return: `true` if the `concurrentRoot` feture is enabled. Otherwise, it returns `false`.
+/// @return: `true` if the `concurrentRoot` feature is enabled. Otherwise, it returns `false`.
 - (BOOL)concurrentRootEnabled
 {
   // Switch this bool to turn on and off the concurrent root

--- a/docs/the-new-architecture/backward-compatibility.md
+++ b/docs/the-new-architecture/backward-compatibility.md
@@ -9,13 +9,13 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 Creating a backward compatible module is important to provide a library that works in both the **Old Architecture** and the **New Architecture**. Not all the users of your library will immediately jump on the New Architecture ship: it is a good thing that they will be able to use your library even if they are still using the old architecture.
 
-The trick to create a good backward compatible module is to minimize the changes required to adopt the new version. In that way, users of the module can smoothly move to the new version and migrate to the New Architecture when they are ready, ideally by issueing one different command.
+The trick to create a good backward compatible module is to minimize the changes required to adopt the new version. In that way, users of the module can smoothly move to the new version and migrate to the New Architecture when they are ready, ideally by issuing one different command.
 
 To achieve this result, we have to perform few changes in our **Turbo Native Module** and **Fabric Native Component** configurations. The steps we have to follow are:
 
 1. **Update the installation configuration** to avoid using code that is not needed by the Old Architecture.
 1. **Update the code** to support both architectures. Both Android and iOS build pipelines gives you mechanism to provide a library that will compile with the correct React Native Architecture.
-1. **Configure the specs to load the proper implementation**, so that the JavaScript layer leverages the New Architecture whan it is available.
+1. **Configure the specs to load the proper implementation**, so that the JavaScript layer leverages the New Architecture when it is available.
 
 :::info
 The next sections requires that you are familiar with the [Pillars](pillars) of the **New Architecture**.

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -251,7 +251,7 @@ Represents the current value for range-based components, such as sliders and pro
 
 ### `aria-valuetext`
 
-Repersents the textual description of the component. Has precedence over the `text` value in the `accessibilityValue` prop.
+Represents the textual description of the component. Has precedence over the `text` value in the `accessibilityValue` prop.
 
 | Type   |
 | ------ |

--- a/website/versioned_docs/version-0.60/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-windows-android.md
@@ -20,7 +20,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.61/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-windows-android.md
@@ -20,7 +20,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.62/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-windows-android.md
@@ -20,7 +20,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.64/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.64/image.md
+++ b/website/versioned_docs/version-0.64/image.md
@@ -271,7 +271,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.65/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.65/image.md
+++ b/website/versioned_docs/version-0.65/image.md
@@ -273,7 +273,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.66/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.66/image.md
+++ b/website/versioned_docs/version-0.66/image.md
@@ -273,7 +273,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.67/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.67/image.md
+++ b/website/versioned_docs/version-0.67/image.md
@@ -273,7 +273,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.68/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.68/image.md
+++ b/website/versioned_docs/version-0.68/image.md
@@ -273,7 +273,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.69/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-windows-android.md
@@ -22,7 +22,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.69/image.md
+++ b/website/versioned_docs/version-0.69/image.md
@@ -273,7 +273,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.69/react-18-and-react-native.md
+++ b/website/versioned_docs/version-0.69/react-18-and-react-native.md
@@ -104,7 +104,7 @@ On iOS, you'll have access to the `concurrentRootEnabled` method on your `AppDel
 ///
 /// @see: https://reactjs.org/blog/2022/03/29/react-v18.html
 /// @note: This requires to be rendering on Fabric (i.e. on the New Architecture).
-/// @return: `true` if the `concurrentRoot` feture is enabled. Otherwise, it returns `false`.
+/// @return: `true` if the `concurrentRoot` feature is enabled. Otherwise, it returns `false`.
 - (BOOL)concurrentRootEnabled
 {
   // Switch this bool to turn on and off the concurrent root

--- a/website/versioned_docs/version-0.70/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-windows-android.md
@@ -24,7 +24,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 
-> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the lastest releases of Gradle](https://gradle.org/releases/).
+> If you're using the latest version of Java Development Kit, you'll need to change the Gradle version of your project so it can recognize the JDK. You can do that by going to `{project root folder}\android\gradle\wrapper\gradle-wrapper.properties` and changing the `distributionUrl` value to upgrade the Gradle version. You can check out [here the latest releases of Gradle](https://gradle.org/releases/).
 
 <h3>Android development environment</h3>
 

--- a/website/versioned_docs/version-0.70/image.md
+++ b/website/versioned_docs/version-0.70/image.md
@@ -273,7 +273,7 @@ A static image to display while loading the image source.
 
 ### `fadeDuration` <div class="label android">Android</div>
 
-Fade animation duration in miliseconds.
+Fade animation duration in milliseconds.
 
 | Type   | Default |
 | ------ | ------- |

--- a/website/versioned_docs/version-0.70/react-18-and-react-native.md
+++ b/website/versioned_docs/version-0.70/react-18-and-react-native.md
@@ -107,7 +107,7 @@ On iOS, you'll have access to the `concurrentRootEnabled` method on your `AppDel
 ///
 /// @see: https://reactjs.org/blog/2022/03/29/react-v18.html
 /// @note: This requires to be rendering on Fabric (i.e. on the New Architecture).
-/// @return: `true` if the `concurrentRoot` feture is enabled. Otherwise, it returns `false`.
+/// @return: `true` if the `concurrentRoot` feature is enabled. Otherwise, it returns `false`.
 - (BOOL)concurrentRootEnabled
 {
   // Switch this bool to turn on and off the concurrent root

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility.md
@@ -9,13 +9,13 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 Creating a backward compatible module is important to provide a library that works in both the **Old Architecture** and the **New Architecture**. Not all the users of your library will immediately jump on the New Architecture ship: it is a good thing that they will be able to use your library even if they are still using the old architecture.
 
-The trick to create a good backward compatible module is to minimize the changes required to adopt the new version. In that way, users of the module can smoothly move to the new version and migrate to the New Architecture when they are ready, ideally by issueing one different command.
+The trick to create a good backward compatible module is to minimize the changes required to adopt the new version. In that way, users of the module can smoothly move to the new version and migrate to the New Architecture when they are ready, ideally by issuing one different command.
 
 To achieve this result, we have to perform few changes in our **Turbo Native Module** and **Fabric Native Component** configurations. The steps we have to follow are:
 
 1. **Update the installation configuration** to avoid using code that is not needed by the Old Architecture.
 1. **Update the code** to support both architectures. Both Android and iOS build pipelines gives you mechanism to provide a library that will compile with the correct React Native Architecture.
-1. **Configure the specs to load the proper implementation**, so that the JavaScript layer leverages the New Architecture whan it is available.
+1. **Configure the specs to load the proper implementation**, so that the JavaScript layer leverages the New Architecture when it is available.
 
 :::info
 The next sections requires that you are familiar with the [Pillars](pillars) of the **New Architecture**.


### PR DESCRIPTION
While working on some updates for docs/accessibility.md I noticed that a couple of words inside the docs were misspelled, this gave me the idea to test other files as well using the VS Code extension [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) which unveiled a few other typos.

