### PR TITLE
Platform Specific Code: tweak wording

### DIFF
--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.60/platform-specific-code.md
+++ b/website/versioned_docs/version-0.60/platform-specific-code.md
@@ -95,7 +95,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -114,7 +114,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.61/platform-specific-code.md
+++ b/website/versioned_docs/version-0.61/platform-specific-code.md
@@ -95,7 +95,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -114,7 +114,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.62/platform-specific-code.md
+++ b/website/versioned_docs/version-0.62/platform-specific-code.md
@@ -108,7 +108,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -127,7 +127,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.63/platform-specific-code.md
+++ b/website/versioned_docs/version-0.63/platform-specific-code.md
@@ -108,7 +108,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -127,7 +127,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.64/platform-specific-code.md
+++ b/website/versioned_docs/version-0.64/platform-specific-code.md
@@ -108,7 +108,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -127,7 +127,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.65/platform-specific-code.md
+++ b/website/versioned_docs/version-0.65/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.66/platform-specific-code.md
+++ b/website/versioned_docs/version-0.66/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.67/platform-specific-code.md
+++ b/website/versioned_docs/version-0.67/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.68/platform-specific-code.md
+++ b/website/versioned_docs/version-0.68/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.69/platform-specific-code.md
+++ b/website/versioned_docs/version-0.69/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';

--- a/website/versioned_docs/version-0.70/platform-specific-code.md
+++ b/website/versioned_docs/version-0.70/platform-specific-code.md
@@ -110,7 +110,7 @@ BigButton.ios.js
 BigButton.android.js
 ```
 
-You can then require the component as follows:
+You can then import the component as follows:
 
 ```jsx
 import BigButton from './BigButton';
@@ -129,7 +129,7 @@ Container.js # picked up by Webpack, Rollup or any other Web bundler
 Container.native.js # picked up by the React Native bundler for both Android and iOS (Metro)
 ```
 
-You can still require it without the `.native` extension, as follows:
+You can still import it without the `.native` extension, as follows:
 
 ```jsx
 import Container from './Container';


### PR DESCRIPTION
# Why

Superseeds #3127

# How

Update the "require" word used in two places on the page, backport the correction to versioned docs.