### PR TITLE
feat: Add aria Web props to component docs

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -293,6 +293,12 @@ Indicates that an element will be updated, and describes the types of updates th
 - **polite** Accessibility services should announce changes to this view.
 - **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
 
+| Type                                     | Default |
+| ---------------------------------------- | ------- |
+| enum(`'assertive'`, `'off'`, `'polite'`) | `'off'` |
+
+---
+
 ### `aria-modal` <div class="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.

--- a/docs/text.md
+++ b/docs/text.md
@@ -376,6 +376,64 @@ Sets the frequency of automatic hyphenation to use when determining word breaks 
 
 ---
 
+### `aria-busy`
+
+Indicates an element is being modified and that assistive technologies may want to wait until the changes are complete before informing the user about the update.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-checked`
+
+Indicates the state of a checkable element. This field can either take a boolean or the "mixed" string to represent mixed checkboxes.
+
+| Type             | Default |
+| ---------------- | ------- |
+| boolean, 'mixed' | false   |
+
+---
+
+### `aria-disabled`
+
+Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-expanded`
+
+Indicates whether an expandable element is currently expanded or collapsed.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-label`
+
+Defines a string value that labels an interactive element.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
+### `aria-selected`
+
+Indicates whether a selectable element is currently selected or not.
+
+| Type    |
+| ------- |
+| boolean |
+
 ### `dataDetectorType` <div class="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -265,11 +265,15 @@ Indicates that an element will be updated, and describes the types of updates th
 - **polite** Accessibility services should announce changes to this view.
 - **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
 
+| Type                                     | Default |
+| ---------------------------------------- | ------- |
+| enum(`'assertive'`, `'off'`, `'polite'`) | `'off'` |
+
 ---
 
 ### `aria-modal` <div class="label ios">iOS</div>
 
-Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the `accessibilityViewIsModal` prop.
+Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
 | Type    | Default |
 | ------- | ------- |

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -195,6 +195,98 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
+'aria-selected'?: ?boolean,
+
+### `aria-busy`
+
+Indicates an element is being modified and that assistive technologies may want to wait until the changes are complete before informing the user about the update.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-checked`
+
+Indicates the state of a checkable element. This field can either take a boolean or the "mixed" string to represent mixed checkboxes.
+
+| Type             | Default |
+| ---------------- | ------- |
+| boolean, 'mixed' | false   |
+
+---
+
+### `aria-disabled`
+
+Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-expanded`
+
+Indicates whether an expandable element is currently expanded or collapsed.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-hidden`
+
+Indicates whether the accessibility elements contained within this accessibility element are hidden.
+
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-label`
+
+Defines a string value that labels an interactive element.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
+### `aria-live` <div class="label android">Android</div>
+
+Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+
+- **off** Accessibility services should not announce changes to this view.
+- **polite** Accessibility services should announce changes to this view.
+- **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
+
+---
+
+### `aria-modal` <div class="label ios">iOS</div>
+
+Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the `accessibilityViewIsModal` prop.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-selected`
+
+Indicates whether a selectable element is currently selected or not.
+
+| Type    |
+| ------- |
+| boolean |
+
 ### `onAccessibilityAction`
 
 Invoked when the user performs the accessibility actions. The only argument to this function is an event containing the name of the action to perform.

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -195,8 +195,6 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-'aria-selected'?: ?boolean,
-
 ### `aria-busy`
 
 Indicates an element is being modified and that assistive technologies may want to wait until the changes are complete before informing the user about the update.

--- a/docs/view.md
+++ b/docs/view.md
@@ -287,15 +287,112 @@ Represents the textual description of the component. Has precedence over the `te
 | ------ |
 | string |
 
+### `aria-busy`
+
+Indicates an element is being modified and that assistive technologies may want to wait until the changes are complete before informing the user about the update.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-checked`
+
+Indicates the state of a checkable element. This field can either take a boolean or the "mixed" string to represent mixed checkboxes.
+
+| Type             | Default |
+| ---------------- | ------- |
+| boolean, 'mixed' | false   |
+
+---
+
+### `aria-disabled`
+
+Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-expanded`
+
+Indicates whether an expandable element is currently expanded or collapsed.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-hidden`
+
+Indicates whether the accessibility elements contained within this accessibility element are hidden.
+
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
+
+---
+
+### `aria-label`
+
+Defines a string value that labels an interactive element.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
+### `aria-labelledby` <div class="label android">Android</div>
+
+Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
+
+```jsx
+<View>
+  <Text nativeID="formLabel">Label for Input Field</Text>
+  <TextInput aria-label="input" aria-labelledby="formLabel" />
+</View>
+```
+
+| Type   |
+| ------ |
+| string |
+
+---
+
+### `aria-live` <div class="label android">Android</div>
+
+Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+
+- **off** Accessibility services should not announce changes to this view.
+- **polite** Accessibility services should announce changes to this view.
+- **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
+
+---
+
 ### `aria-modal` <div class="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the `accessibilityViewIsModal` prop.
 
-| Type | Default |
-| ---- | ------- |
-| bool | false   |
+| Type    | Default |
+| ------- | ------- |
+| boolean | false   |
 
 ---
+
+### `aria-selected`
+
+Indicates whether a selectable element is currently selected or not.
+
+| Type    |
+| ------- |
+| boolean |
 
 ### `collapsable` <div class="label android">Android</div>
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -249,44 +249,6 @@ When `true`, indicates that the view is an accessibility element. By default, al
 
 ---
 
-### `aria-valuemax`
-
-Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `max` value in the `accessibilityValue` prop.
-
-| Type   |
-| ------ |
-| number |
-
----
-
-### `aria-valuemin`
-
-Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
-
-| Type   |
-| ------ |
-| number |
-
----
-
-### `aria-valuenow`
-
-Represents the current value for range-based components, such as sliders and progress bars. Has precedence over the `now` value in the `accessibilityValue` prop.
-
-| Type   |
-| ------ |
-| number |
-
----
-
-### `aria-valuetext`
-
-Represents the textual description of the component. Has precedence over the `text` value in the `accessibilityValue` prop.
-
-| Type   |
-| ------ |
-| string |
-
 ### `aria-busy`
 
 Indicates an element is being modified and that assistive technologies may want to wait until the changes are complete before informing the user about the update.
@@ -393,6 +355,46 @@ Indicates whether a selectable element is currently selected or not.
 | Type    |
 | ------- |
 | boolean |
+
+### `aria-valuemax`
+
+Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `max` value in the `accessibilityValue` prop.
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `aria-valuemin`
+
+Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `aria-valuenow`
+
+Represents the current value for range-based components, such as sliders and progress bars. Has precedence over the `now` value in the `accessibilityValue` prop.
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `aria-valuetext`
+
+Represents the textual description of the component. Has precedence over the `text` value in the `accessibilityValue` prop.
+
+| Type   |
+| ------ |
+| string |
+
+---
 
 ### `collapsable` <div class="label android">Android</div>
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -336,11 +336,15 @@ Indicates that an element will be updated, and describes the types of updates th
 - **polite** Accessibility services should announce changes to this view.
 - **assertive** Accessibility services should interrupt ongoing speech to immediately announce changes to this view.
 
+| Type                                     | Default |
+| ---------------------------------------- | ------- |
+| enum(`'assertive'`, `'off'`, `'polite'`) | `'off'` |
+
 ---
 
 ### `aria-modal` <div class="label ios">iOS</div>
 
-Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the `accessibilityViewIsModal` prop.
+Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
 | Type    | Default |
 | ------- | ------- |


### PR DESCRIPTION
Follow up PR of https://github.com/facebook/react-native-website/pull/3396. 

This adds documentation to `View`, `Text` and `TouchableWithoutFeedback` regarding all aria Web props recently added to react-native due to  https://github.com/facebook/react-native/issues/34424. The description of most of these items was based on https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes.

Related to https://github.com/facebook/react-native/commit/98d84e571df64b00e1ed3484923a1d8169dcfda1, https://github.com/facebook/react-native/commit/ebdb23c6e060897112b060c25172135d50c78cd3, https://github.com/facebook/react-native/commit/720cdbc658aa0b513d106526eb81d749fa957c99, https://github.com/facebook/react-native/commit/f353119113d6fc85491765ba1e90ac83cb00fd61 and https://github.com/facebook/react-native/commit/7ea54a408734ccde9ee01a12942bf5722e9cf7c1
