### PR TITLE
feat: Add alt prop to Image docs

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -237,6 +237,16 @@ The text that's read by the screen reader when the user interacts with the image
 
 ---
 
+### `alt`
+
+A string that defines an alternative text description of the image, which will be read by the screen reader when the user interacts with it. Using this will automatically mark this element as accessible.
+
+| Type   |
+| ------ |
+| string |
+
+---
+
 ### `blurRadius`
 
 blurRadius: the blur radius of the blur filter added to the image.


### PR DESCRIPTION
This PR adds the `alt` prop to the Image documentation

Related to https://github.com/facebook/react-native/commit/71fda5e0c2093380d08761c945f1e3029af6697f