### PR TITLE
Allow TypeScript in Snacks (and optional "ext" parameter)

### DIFF
--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -32,8 +32,16 @@ const processNode = (node, parent) => {
       const description = params.description
         ? decodeURIComponent(params.description)
         : 'Example usage';
-      const sampleCode = node.value;
-      const encodedSampleCode = encodeURIComponent(sampleCode);
+      const ext = params.ext ? decodeURIComponent(params.ext) : 'tsx';
+      const filename = `App.${ext}`;
+      const files = encodeURIComponent(
+        JSON.stringify({
+          [filename]: {
+            type: 'CODE',
+            contents: node.value,
+          },
+        })
+      );
       const dependencies = params.dependencies || '';
       const platform = params.platform || 'web';
       const supportedPlatforms = params.supportedPlatforms || 'ios,android,web';
@@ -49,7 +57,7 @@ const processNode = (node, parent) => {
             class="snack-player"
             data-snack-name="${name}"
             data-snack-description="${description}"
-            data-snack-code="${encodedSampleCode}"
+            data-snack-files="${files}"
             data-snack-dependencies="${dependencies}"
             data-snack-platform="${platform}"
             data-snack-supported-platforms="${supportedPlatforms}"

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -51,15 +51,12 @@ const processNode = (node, parent) => {
 
       // Generate Node for SnackPlayer
       // See https://github.com/expo/snack/blob/main/docs/embedding-snacks.md
-      // An empty data-snack-code must be given to workaround the issue fixed
-      // by https://github.com/expo/snack/pull/361
       const snackPlayerDiv = u('html', {
         value: dedent`
           <div
             class="snack-player"
             data-snack-name="${name}"
             data-snack-description="${description}"
-            data-snack-code=""
             data-snack-files="${files}"
             data-snack-dependencies="${dependencies}"
             data-snack-platform="${platform}"

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -51,12 +51,15 @@ const processNode = (node, parent) => {
 
       // Generate Node for SnackPlayer
       // See https://github.com/expo/snack/blob/main/docs/embedding-snacks.md
+      // An empty data-snack-code must be given to workaround the issue fixed
+      // by https://github.com/expo/snack/pull/361
       const snackPlayerDiv = u('html', {
         value: dedent`
           <div
             class="snack-player"
             data-snack-name="${name}"
             data-snack-description="${description}"
+            data-snack-code=""
             data-snack-files="${files}"
             data-snack-dependencies="${dependencies}"
             data-snack-platform="${platform}"


### PR DESCRIPTION
This makes a couple changes in preparation for TypeScript examples. Going through 20 pages for core components, most examples can be shifted to be both JavaScript and strict TypeScript. Some are not compatible as both, and need to be separated as JS examples vs TS examples.

**Add parameter to SnackPlayer blocks**

Snack defaults a code block to represent a file named [`App.js`](https://github.com/expo/snack/blob/main/docs/url-query-parameters.md#parameters). This extension effects how the file is parsed during bundling, and the syntax highlighting it is given in the editor. We allow passing the extension, so that specific examples can specifically target JS vs TS. This directive will later be used to determine how the file is used during linting.

**Change default example extension to `.tsx`**

This is needed for Snack to parse an input as TypeScript during bundling and syntax highlighting. Vanilla JS is still allowed, and it seems to create an identical result to before in the snack player.