### PR TITLE
Update TypeScript Page and References to TypeScript

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -97,11 +97,7 @@ If you want to start a new project with a specific React Native version, you can
 npx react-native init AwesomeProject --version X.XX.X
 ```
 
-You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
-
-```shell
-npx react-native init AwesomeTSProject --template react-native-template-typescript
-```
+You can also start a project with a custom React Native template with the `--template` argument.
 
 <h2>Preparing the Android device</h2>
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -109,11 +109,7 @@ If you want to start a new project with a specific React Native version, you can
 npx react-native init AwesomeProject --version X.XX.X
 ```
 
-You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
-
-```shell
-npx react-native init AwesomeTSProject --template react-native-template-typescript
-```
+You can also start a project with a custom React Native template with the `--template` argument.
 
 <h2>Preparing the Android device</h2>
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -105,11 +105,7 @@ If you want to start a new project with a specific React Native version, you can
 npx react-native init AwesomeProject --version X.XX.X
 ```
 
-You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
-
-```shell
-npx react-native init AwesomeTSProject --template react-native-template-typescript
-```
+You can also start a project with a custom React Native template with the `--template` argument.
 
 > **Note** If the above command is failing, you may have old version of `react-native` or `react-native-cli` installed globally on your pc. Try uninstalling the cli and run the cli using `npx`.
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -128,11 +128,7 @@ If you want to start a new project with a specific React Native version, you can
 npx react-native init AwesomeProject --version X.XX.X
 ```
 
-You can also start a project with a custom React Native template, like TypeScript, with `--template` argument:
-
-```shell
-npx react-native init AwesomeTSProject --template react-native-template-typescript
-```
+You can also start a project with a custom React Native template with the `--template` argument.
 
 <h2>Preparing the Android device</h2>
 

--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -180,7 +180,7 @@ The final step is to register the ViewManager to the application, this happens i
 
 ### 5. Implement the JavaScript module
 
-The very final step is to create the JavaScript module that defines the interface layer between Java/Kotlin and JavaScript for the users of your new view. It is recommended for you to document the component interface in this module (e.g. using Flow, TypeScript, or plain old comments).
+The very final step is to create the JavaScript module that defines the interface layer between Java/Kotlin and JavaScript for the users of your new view. It is recommended for you to document the component interface in this module (e.g. using TypeScript, Flow, or plain old comments).
 
 ```jsx title="ImageView.js"
 import { requireNativeComponent } from 'react-native';

--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -29,7 +29,7 @@ The first step to improve your code quality is to start using static analysis to
 - **Linters** analyze code to catch common errors such as unused code and to help avoid pitfalls, to flag style guide no-nos like using tabs instead of spaces (or vice versa, depending on your configuration).
 - **Type checking** ensures that the construct you’re passing to a function matches what the function was designed to accept, preventing passing a string to a counting function that expects a number, for instance.
 
-React Native comes with two such tools configured out of the box: [ESLint](https://eslint.org/) for linting and [Flow](https://flow.org/en/docs/) for type checking. You can also use [TypeScript](typescript), which is a typed language that compiles to plain JavaScript.
+React Native comes with two such tools configured out of the box: [ESLint](https://eslint.org/) for linting and [TypeScript](typescript) for type checking.
 
 ## Writing Testable Code
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -5,91 +5,43 @@ title: Using TypeScript
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-[TypeScript][ts] is a language which extends JavaScript by adding type definitions, much like [Flow][flow]. While React Native is built in Flow, it supports both TypeScript _and_ Flow by default.
+[TypeScript][ts] is a language which extends JavaScript by adding type definitions. New React Native projects target TypeScript by default, but also support JavaScript and Flow.
+
 
 ## Getting Started with TypeScript
 
-If you're starting a new project, there are a few different ways to get started.
+New projects created by the [React Native CLI](http://localhost:3000/docs/next/environment-setup#creating-a-new-application) or popular templates like [Ignite][ignite] will use TypeScript by default.
 
-You can use the [TypeScript template][ts-template]:
-
-```shell
-npx react-native init MyApp --template react-native-template-typescript
-```
-
-:::note
-
-If the above command is failing, you may have an old version of `react-native` or `react-native-cli` installed globally on your system. To fix the issue try uninstalling the CLI:
-
-- `npm uninstall -g react-native-cli` or `yarn global remove react-native-cli`
-
-and then run the `npx` command again.
-Optionally, you can also use the command given below to get started with your template.
-
-- `npx react-native --ignore-existing init MyApp --template react-native-template-typescript`
-
-:::
-
-You can use [Expo][expo], which maintains TypeScript templates, or will prompt you to automatically install and configure TypeScript when a `.ts` or `.tsx` file is added to your project:
-
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
-<TabItem value="npm">
+TypeScript may also be used with [Expo][expo], which maintains TypeScript templates, or will prompt you to automatically install and configure TypeScript when a `.ts` or `.tsx` file is added to your project.
 
 ```shell
 npx create-expo-app --template
 ```
 
-</TabItem>
-<TabItem value="yarn">
-
-```shell
-yarn create expo-app --template
-```
-
-</TabItem>
-</Tabs>
-
-Or you could use [Ignite][ignite], which also has a TypeScript template:
-
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
-<TabItem value="npm">
-
-```shell
-npm install -g ignite-cli
-ignite new MyTSProject
-```
-
-</TabItem>
-<TabItem value="yarn">
-
-```shell
-yarn global add ignite-cli
-ignite new MyTSProject
-```
-
-</TabItem>
-</Tabs>
-
 ## Adding TypeScript to an Existing Project
 
-1. Add TypeScript and the types for React Native and Jest to your project.
+1. Add TypeScript, types, and ESLint plugins to your project.
 
 <Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
-npm install -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
+npm install -D @tsconfig/react-native @types/jest @types/react @types/react-test-renderer @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```shell
-yarn add -D typescript @types/jest @types/react @types/react-native @types/react-test-renderer @tsconfig/react-native
+yarn add --dev @tsconfig/react-native @types/jest @types/react @types/react-test-renderer @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
 ```
 
 </TabItem>
 </Tabs>
+
+:::note
+This command adds the latest version of every dependency. The versions may need to be changed to match the existing packages used by your project. You can use a tool like [React Native Upgrade Helper](https://react-native-community.github.io) to see the versions shipped by React Native.
+:::
 
 2. Add a TypeScript config file. Create a `tsconfig.json` in the root of your project:
 
@@ -99,12 +51,14 @@ yarn add -D typescript @types/jest @types/react @types/react-native @types/react
 }
 ```
 
-3. Create a `jest.config.js` file to configure Jest to use TypeScript
+3. Update your `.eslintrc.js` to enable TypeScript specific linting rules:
 
-```js
+```diff
 module.exports = {
-  preset: 'react-native',
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+  root: true,
+  extends: '@react-native-community',
++  parser: '@typescript-eslint/parser',
++  plugins: ['@typescript-eslint'],
 };
 ```
 
@@ -114,9 +68,13 @@ module.exports = {
 
 5. Run `yarn tsc` to type-check your new TypeScript files.
 
+## Using JavaScript Instead of TypeScript
+
+React Native defaults new applications to TypeScript, but JavaScript may still be used by default. Files with a `.jsx` extension are treated as JavaScript instead of TypeScript, and will not be typechecked. JavaScript modules may still be imported by TypeScript modules, along with the reverse.
+
 ## How TypeScript and React Native works
 
-Out of the box, transforming your files to JavaScript works via the same [Babel infrastructure][babel] as a non-TypeScript React Native project. We recommend that you use the TypeScript compiler only for type checking. If you have existing TypeScript code being ported to React Native, there are [one or two caveats][babel-7-caveats] to using Babel instead of TypeScript.
+Out of the box, TypeScript sources are transformed by [Babel][babel] during bundling. We recommend that you use the TypeScript compiler only for type checking. This is the default behavior of `tsc` for newly created applications. If you have existing TypeScript code being ported to React Native, there are [one or two caveats][babel-7-caveats] to using Babel instead of TypeScript.
 
 ## What does React Native + TypeScript look like
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -7,7 +7,6 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 [TypeScript][ts] is a language which extends JavaScript by adding type definitions. New React Native projects target TypeScript by default, but also support JavaScript and Flow.
 
-
 ## Getting Started with TypeScript
 
 New projects created by the [React Native CLI](http://localhost:3000/docs/next/environment-setup#creating-a-new-application) or popular templates like [Ignite][ignite] will use TypeScript by default.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -69,7 +69,7 @@ module.exports = {
 
 ## Using JavaScript Instead of TypeScript
 
-React Native defaults new applications to TypeScript, but JavaScript may still be used by default. Files with a `.jsx` extension are treated as JavaScript instead of TypeScript, and will not be typechecked. JavaScript modules may still be imported by TypeScript modules, along with the reverse.
+React Native defaults new applications to TypeScript, but JavaScript may still be used. Files with a `.jsx` extension are treated as JavaScript instead of TypeScript, and will not be typechecked. JavaScript modules may still be imported by TypeScript modules, along with the reverse.
 
 ## How TypeScript and React Native works
 

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -36,7 +36,7 @@ const javaScriptSpecLanguages = [
   {label: 'Flow', value: 'flow'},
   {label: 'TypeScript', value: 'typescript'},
 ];
-const defaultJavaScriptSpecLanguages = 'flow';
+const defaultJavaScriptSpecLanguages = 'typescript';
 
 const guides = [
   {label: 'Expo Go Quickstart', value: 'quickstart'},


### PR DESCRIPTION
This change updates the main TypeScript page with new instructions for 0.71, where TypeScript is the default language, and RN types are included by default.

This does not yet update samples for TS, which is still a work in progress. I also chose to omit information about the 0.70 to 0.71 migration, since it seems like it might make more sense in either the release announcement or a separate blog post instead of long-term in the documentation, but I would be open to feedback on that.
