### PR TITLE
Fabric component example java classname typo fixed

### DIFF
--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -314,7 +314,7 @@ import com.facebook.react.uimanager.ViewManager;
 import java.util.Collections;
 import java.util.List;
 
-public class RTNCenteredTextPackage implements ReactPackage {
+public class CenteredTextPackage implements ReactPackage {
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {


### PR DESCRIPTION
There was a typo in `CenteredTextPackage.java` it should be `CenteredTextPackage` and not `RTNCenteredTextPackage`.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
