### PR TITLE
Start TypeScriptify-ing the examples

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -23,22 +23,22 @@ const App = () => {
   useEffect(() => {
     const reduceMotionChangedSubscription = AccessibilityInfo.addEventListener(
       'reduceMotionChanged',
-      reduceMotionEnabled => {
-        setReduceMotionEnabled(reduceMotionEnabled);
+      isReduceMotionEnabled => {
+        setReduceMotionEnabled(isReduceMotionEnabled);
       },
     );
     const screenReaderChangedSubscription = AccessibilityInfo.addEventListener(
       'screenReaderChanged',
-      screenReaderEnabled => {
-        setScreenReaderEnabled(screenReaderEnabled);
+      isScreenReaderEnabled => {
+        setScreenReaderEnabled(isScreenReaderEnabled);
       },
     );
 
-    AccessibilityInfo.isReduceMotionEnabled().then(reduceMotionEnabled => {
-      setReduceMotionEnabled(reduceMotionEnabled);
+    AccessibilityInfo.isReduceMotionEnabled().then(isReduceMotionEnabled => {
+      setReduceMotionEnabled(isReduceMotionEnabled);
     });
-    AccessibilityInfo.isScreenReaderEnabled().then(screenReaderEnabled => {
-      setScreenReaderEnabled(screenReaderEnabled);
+    AccessibilityInfo.isScreenReaderEnabled().then(isScreenReaderEnabled => {
+      setScreenReaderEnabled(isScreenReaderEnabled);
     });
 
     return () => {
@@ -76,7 +76,10 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=AccessibilityInfo%20Class%20Component%20Example&supportedPlatforms=android,ios
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=AccessibilityInfo%20Class%20Component%20Example&supportedPlatforms=android,ios&ext=js
 import React, {Component} from 'react';
 import {AccessibilityInfo, View, Text, StyleSheet} from 'react-native';
 
@@ -142,6 +145,83 @@ const styles = StyleSheet.create({
 
 export default AccessibilityStatusExample;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=AccessibilityInfo%20Class%20Component%20Example&supportedPlatforms=android,ios&ext=tsx
+import React, {Component} from 'react';
+import {AccessibilityInfo, View, Text, StyleSheet} from 'react-native';
+import type {EmitterSubscription} from 'react-native';
+
+class AccessibilityStatusExample extends Component {
+  reduceMotionChangedSubscription?: EmitterSubscription;
+  screenReaderChangedSubscription?: EmitterSubscription;
+
+  state = {
+    reduceMotionEnabled: false,
+    screenReaderEnabled: false,
+  };
+
+  componentDidMount() {
+    this.reduceMotionChangedSubscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      reduceMotionEnabled => {
+        this.setState({reduceMotionEnabled});
+      },
+    );
+    this.screenReaderChangedSubscription = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      screenReaderEnabled => {
+        this.setState({screenReaderEnabled});
+      },
+    );
+
+    AccessibilityInfo.isReduceMotionEnabled().then(reduceMotionEnabled => {
+      this.setState({reduceMotionEnabled});
+    });
+    AccessibilityInfo.isScreenReaderEnabled().then(screenReaderEnabled => {
+      this.setState({screenReaderEnabled});
+    });
+  }
+
+  componentWillUnmount() {
+    this.reduceMotionChangedSubscription?.remove();
+    this.screenReaderChangedSubscription?.remove();
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.status}>
+          The reduce motion is{' '}
+          {this.state.reduceMotionEnabled ? 'enabled' : 'disabled'}.
+        </Text>
+        <Text style={styles.status}>
+          The screen reader is{' '}
+          {this.state.screenReaderEnabled ? 'enabled' : 'disabled'}.
+        </Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  status: {
+    margin: 30,
+  },
+});
+
+export default AccessibilityStatusExample;
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -26,7 +26,7 @@ const App = () => {
         if (buttonIndex === 0) {
           // cancel action
         } else if (buttonIndex === 1) {
-          setResult(Math.floor(Math.random() * 100) + 1);
+          setResult(String(Math.floor(Math.random() * 100) + 1));
         } else if (buttonIndex === 2) {
           setResult('🔮');
         }

--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -14,7 +14,7 @@ Displays a circular loading indicator.
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example
 import React from 'react';
-import {ActivityIndicator, StyleSheet, Text, View} from 'react-native';
+import {ActivityIndicator, StyleSheet, View} from 'react-native';
 
 const App = () => (
   <View style={[styles.container, styles.horizontal]}>
@@ -45,7 +45,7 @@ export default App;
 
 ```SnackPlayer name=ActivityIndicator%20Class%20Component%20Example
 import React, {Component} from 'react';
-import {ActivityIndicator, StyleSheet, Text, View} from 'react-native';
+import {ActivityIndicator, StyleSheet, View} from 'react-native';
 
 class App extends Component {
   render() {

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -17,7 +17,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android
-import React, {useState} from 'react';
+import React from 'react';
 import {View, StyleSheet, Button, Alert} from 'react-native';
 
 const App = () => {

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -49,6 +49,7 @@ const App = () => {
     Animated.timing(fadeAnim, {
       toValue: 1,
       duration: 5000,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -57,6 +58,7 @@ const App = () => {
     Animated.timing(fadeAnim, {
       toValue: 0,
       duration: 3000,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -128,6 +130,7 @@ class App extends Component {
     Animated.timing(this.state.fadeAnim, {
       toValue: 1,
       duration: 5000,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -136,6 +139,7 @@ class App extends Component {
     Animated.timing(this.state.fadeAnim, {
       toValue: 0,
       duration: 3000,
+      useNativeDriver: true,
     }).start();
   };
 
@@ -311,7 +315,7 @@ Config is an object that may have the following options:
 - `velocity`: Initial velocity. Required.
 - `deceleration`: Rate of decay. Default 0.997.
 - `isInteraction`: Whether or not this animation creates an "interaction handle" on the `InteractionManager`. Default true.
-- `useNativeDriver`: Uses the native driver when true. Default false.
+- `useNativeDriver`: Uses the native driver when true. Required.
 
 ---
 
@@ -329,7 +333,7 @@ Config is an object that may have the following options:
 - `easing`: Easing function to define curve. Default is `Easing.inOut(Easing.ease)`.
 - `delay`: Start the animation after delay (milliseconds). Default 0.
 - `isInteraction`: Whether or not this animation creates an "interaction handle" on the `InteractionManager`. Default true.
-- `useNativeDriver`: Uses the native driver when true. Default false.
+- `useNativeDriver`: Uses the native driver when true. Required.
 
 ---
 
@@ -366,7 +370,7 @@ Other configuration options are as follows:
 - `restSpeedThreshold`: The speed at which the spring should be considered at rest in pixels per second. Default 0.001.
 - `delay`: Start the animation after delay (milliseconds). Default 0.
 - `isInteraction`: Whether or not this animation creates an "interaction handle" on the `InteractionManager`. Default true.
-- `useNativeDriver`: Uses the native driver when true. Default false.
+- `useNativeDriver`: Uses the native driver when true. Required.
 
 ---
 
@@ -510,7 +514,7 @@ Takes an array of mappings and extracts values from each arg accordingly, then c
 Config is an object that may have the following options:
 
 - `listener`: Optional async listener.
-- `useNativeDriver`: Uses the native driver when true. Default false.
+- `useNativeDriver`: Uses the native driver when true. Required.
 
 ---
 

--- a/docs/animatedvaluexy.md
+++ b/docs/animatedvaluexy.md
@@ -26,7 +26,7 @@ const DraggableView = () => {
     onPanResponderRelease: () => {
       Animated.spring(
         pan, // Auto-multiplexed
-        {toValue: {x: 0, y: 0}}, // Back to zero
+        {toValue: {x: 0, y: 0}, useNativeDriver: true}, // Back to zero
       ).start();
     },
   });

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -77,7 +77,10 @@ If you don't want to see the AppState update from `active` to `inactive` on iOS 
 </TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=AppState%20Class%20Component%20Example
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=AppState%20Class%20Component%20Example&ext=js
 import React, {Component} from 'react';
 import {AppState, StyleSheet, Text, View} from 'react-native';
 
@@ -124,6 +127,62 @@ const styles = StyleSheet.create({
 
 export default AppStateExample;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=AppState%20Class%20Component%20Example&ext=tsx
+import React, {Component} from 'react';
+import {AppState, StyleSheet, Text, View} from 'react-native';
+import type {NativeEventSubscription} from 'react-native';
+
+class AppStateExample extends Component {
+  appStateSubscription?: NativeEventSubscription;
+  state = {
+    appState: AppState.currentState,
+  };
+
+  componentDidMount() {
+    this.appStateSubscription = AppState.addEventListener(
+      'change',
+      nextAppState => {
+        if (
+          this.state.appState.match(/inactive|background/) &&
+          nextAppState === 'active'
+        ) {
+          console.log('App has come to the foreground!');
+        }
+        this.setState({appState: nextAppState});
+      },
+    );
+  }
+
+  componentWillUnmount() {
+    this.appStateSubscription?.remove();
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>Current state is: {this.state.appState}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppStateExample;
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/backhandler.md
+++ b/docs/backhandler.md
@@ -99,7 +99,10 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=BackHandler&supportedPlatforms=android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=BackHandler&supportedPlatforms=android&ext=js
 import React, {Component} from 'react';
 import {Text, View, StyleSheet, BackHandler, Alert} from 'react-native';
 
@@ -152,69 +155,16 @@ export default App;
 ```
 
 </TabItem>
-</Tabs>
+<TabItem value="typescript">
 
-`BackHandler.addEventListener` creates an event listener & returns a `NativeEventSubscription` object which should be cleared using `NativeEventSubscription.remove` method.
-
-Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
-
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
-<TabItem value="functional">
-
-```SnackPlayer name=BackHandler&supportedPlatforms=android
-import React, {useEffect} from 'react';
-import {Text, View, StyleSheet, BackHandler, Alert} from 'react-native';
-
-const App = () => {
-  const backAction = () => {
-    Alert.alert('Hold on!', 'Are you sure you want to go back?', [
-      {
-        text: 'Cancel',
-        onPress: () => null,
-        style: 'cancel',
-      },
-      {text: 'YES', onPress: () => BackHandler.exitApp()},
-    ]);
-    return true;
-  };
-
-  useEffect(() => {
-    BackHandler.addEventListener('hardwareBackPress', backAction);
-
-    return () =>
-      BackHandler.removeEventListener('hardwareBackPress', backAction);
-  }, []);
-
-  return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Click Back button!</Text>
-    </View>
-  );
-};
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-});
-
-export default App;
-```
-
-</TabItem>
-<TabItem value="classical">
-
-```SnackPlayer name=BackHandler&supportedPlatforms=android
+```SnackPlayer name=BackHandler&supportedPlatforms=android&ext=tsx
 import React, {Component} from 'react';
 import {Text, View, StyleSheet, BackHandler, Alert} from 'react-native';
+import type {NativeEventSubscription} from 'react-native';
 
 class App extends Component {
+  backHandler?: NativeEventSubscription;
+
   backAction = () => {
     Alert.alert('Hold on!', 'Are you sure you want to go back?', [
       {
@@ -228,11 +178,14 @@ class App extends Component {
   };
 
   componentDidMount() {
-    BackHandler.addEventListener('hardwareBackPress', this.backAction);
+    this.backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      this.backAction,
+    );
   }
 
   componentWillUnmount() {
-    BackHandler.removeEventListener('hardwareBackPress', this.backAction);
+    this.backHandler?.remove();
   }
 
   render() {
@@ -261,6 +214,10 @@ export default App;
 
 </TabItem>
 </Tabs>
+</TabItem>
+</Tabs>
+
+`BackHandler.addEventListener` creates an event listener & returns a `NativeEventSubscription` object which should be cleared using `NativeEventSubscription.remove` method.
 
 ## Usage with React Navigation
 

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -11,7 +11,7 @@ This is a controlled component that requires an `onValueChange` callback that up
 
 ## Example
 
-```SnackPlayer name=CheckBox%20Component%20Example&supportedPlatforms=android,web
+```SnackPlayer name=CheckBox%20Component%20Example&supportedPlatforms=android,web&ext=js
 import React, {useState} from 'react';
 import {CheckBox, Text, StyleSheet, View} from 'react-native';
 

--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -46,23 +46,16 @@ import React, {Component} from 'react';
 import {DatePickerIOS, View, StyleSheet} from 'react-native';
 
 export default class App extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {chosenDate: new Date()};
-
-    this.setDate = this.setDate.bind(this);
-  }
-
-  setDate(newDate) {
-    this.setState({chosenDate: newDate});
-  }
+  state = {
+    chosenDate: new Date(),
+  };
 
   render() {
     return (
       <View style={styles.container}>
         <DatePickerIOS
           date={this.state.chosenDate}
-          onDateChange={this.setDate}
+          onDateChange={newDate => this.setState({chosenDate: newDate})}
         />
       </View>
     );

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -31,11 +31,14 @@ If you are targeting foldable devices or devices which can change the screen siz
 import React, {useState, useEffect} from 'react';
 import {View, StyleSheet, Text, Dimensions} from 'react-native';
 
-const window = Dimensions.get('window');
-const screen = Dimensions.get('screen');
+const windowDimensions = Dimensions.get('window');
+const screenDimensions = Dimensions.get('screen');
 
 const App = () => {
-  const [dimensions, setDimensions] = useState({window, screen});
+  const [dimensions, setDimensions] = useState({
+    window: windowDimensions,
+    screen: screenDimensions,
+  });
 
   useEffect(() => {
     const subscription = Dimensions.addEventListener(
@@ -83,18 +86,21 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=Dimensions
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Dimensions&ext=js
 import React, {Component} from 'react';
 import {View, StyleSheet, Text, Dimensions} from 'react-native';
 
-const window = Dimensions.get('window');
-const screen = Dimensions.get('screen');
+const windowDimensions = Dimensions.get('window');
+const screenDimensions = Dimensions.get('screen');
 
 class App extends Component {
   state = {
     dimensions: {
-      window,
-      screen,
+      window: windowDimensions,
+      screen: screenDimensions,
     },
   };
 
@@ -151,6 +157,83 @@ const styles = StyleSheet.create({
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Dimensions&ext=tsx
+import React, {Component} from 'react';
+import {View, StyleSheet, Text, Dimensions} from 'react-native';
+import type {EmitterSubscription, ScaledSize} from 'react-native';
+
+const windowDimensions = Dimensions.get('window');
+const screenDimensions = Dimensions.get('screen');
+
+class App extends Component {
+  dimensionsSubscription?: EmitterSubscription;
+  state = {
+    dimensions: {
+      window: windowDimensions,
+      screen: screenDimensions,
+    },
+  };
+
+  onChange = ({window, screen}: {window: ScaledSize; screen: ScaledSize}) => {
+    this.setState({dimensions: {window, screen}});
+  };
+
+  componentDidMount() {
+    this.dimensionsSubscription = Dimensions.addEventListener(
+      'change',
+      this.onChange,
+    );
+  }
+
+  componentWillUnmount() {
+    this.dimensionsSubscription?.remove();
+  }
+
+  render() {
+    const {
+      dimensions: {window, screen},
+    } = this.state;
+
+    return (
+      <View style={styles.container}>
+        <Text style={styles.header}>Window Dimensions</Text>
+        {Object.entries(window).map(([key, value]) => (
+          <Text>
+            {key} - {value}
+          </Text>
+        ))}
+        <Text style={styles.header}>Screen Dimensions</Text>
+        {Object.entries(screen).map(([key, value]) => (
+          <Text>
+            {key} - {value}
+          </Text>
+        ))}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  header: {
+    fontSize: 16,
+    marginVertical: 10,
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -3,7 +3,7 @@ id: direct-manipulation
 title: Direct Manipulation
 ---
 
-import NativeDeprecated from './the-new-architecture/\_markdown_native_deprecation.mdx'
+import NativeDeprecated from './the-new-architecture/\_markdown_native_deprecation.mdx'; import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 <NativeDeprecated />
 
@@ -65,7 +65,10 @@ If you look at the implementation of `setNativeProps` in [NativeMethodsMixin](ht
 
 Composite components are not backed by a native view, so you cannot call `setNativeProps` on them. Consider this example:
 
-```SnackPlayer name=setNativeProps%20with%20Composite%20Components
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=setNativeProps%20with%20Composite%20Components&ext=js
 import React from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 
@@ -84,13 +87,41 @@ const App = () => (
 export default App;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=setNativeProps%20with%20Composite%20Components&ext=tsx
+import React from 'react';
+import {Text, TouchableOpacity, View} from 'react-native';
+
+const MyButton = (props: {label: string}) => (
+  <View style={{marginTop: 50}}>
+    <Text>{props.label}</Text>
+  </View>
+);
+
+const App = () => (
+  <TouchableOpacity>
+    <MyButton label="Press me!" />
+  </TouchableOpacity>
+);
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
 If you run this you will immediately see this error: `Touchable child must either be native or forward setNativeProps to a native component`. This occurs because `MyButton` isn't directly backed by a native view whose opacity should be set. You can think about it like this: if you define a component with `createReactClass` you would not expect to be able to set a style prop on it and have that work - you would need to pass the style prop down to a child, unless you are wrapping a native component. Similarly, we are going to forward `setNativeProps` to a native-backed child component.
 
 #### Forward setNativeProps to a child
 
 Since the `setNativeProps` method exists on any ref to a `View` component, it is enough to forward a ref on your custom component to one of the `<View />` components that it renders. This means that a call to `setNativeProps` on the custom component will have the same effect as if you called `setNativeProps` on the wrapped `View` component itself.
 
-```SnackPlayer name=Forwarding%20setNativeProps
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Forwarding%20setNativeProps&ext=js
 import React from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 
@@ -108,6 +139,31 @@ const App = () => (
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Forwarding%20setNativeProps&ext=tsx
+import React from 'react';
+import {Text, TouchableOpacity, View} from 'react-native';
+
+const MyButton = React.forwardRef<View, {label: string}>((props, ref) => (
+  <View {...props} ref={ref} style={{marginTop: 50}}>
+    <Text>{props.label}</Text>
+  </View>
+));
+
+const App = () => (
+  <TouchableOpacity>
+    <MyButton label="Press me!" />
+  </TouchableOpacity>
+);
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 You can now use `MyButton` inside of `TouchableOpacity`!
 

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -20,7 +20,7 @@ In the following example, the red, orange, and green views are all children in t
 
 ```SnackPlayer name=Flex%20Example
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 
 const Flex = () => {
   return (
@@ -966,7 +966,7 @@ const BoxInfo = ({color, flexBasis, flexShrink, setStyle, flexGrow}) => (
       onChangeText={fB =>
         setStyle(value => ({
           ...value,
-          flexBasis: isNaN(parseInt(fB)) ? 'auto' : parseInt(fB),
+          flexBasis: isNaN(parseInt(fB, 10)) ? 'auto' : parseInt(fB, 10),
         }))
       }
     />
@@ -977,7 +977,7 @@ const BoxInfo = ({color, flexBasis, flexShrink, setStyle, flexGrow}) => (
       onChangeText={fS =>
         setStyle(value => ({
           ...value,
-          flexShrink: isNaN(parseInt(fS)) ? '' : parseInt(fS),
+          flexShrink: isNaN(parseInt(fS, 10)) ? '' : parseInt(fS, 10),
         }))
       }
     />
@@ -988,7 +988,7 @@ const BoxInfo = ({color, flexBasis, flexShrink, setStyle, flexGrow}) => (
       onChangeText={fG =>
         setStyle(value => ({
           ...value,
-          flexGrow: isNaN(parseInt(fG)) ? '' : parseInt(fG),
+          flexGrow: isNaN(parseInt(fG, 10)) ? '' : parseInt(fG, 10),
         }))
       }
     />
@@ -1296,13 +1296,7 @@ The `position` type of an element defines how it is positioned within its parent
 
 ```SnackPlayer name=Absolute%20%26%20Relative%20Layout
 import React, {useState} from 'react';
-import {
-  View,
-  SafeAreaView,
-  TouchableOpacity,
-  Text,
-  StyleSheet,
-} from 'react-native';
+import {View, TouchableOpacity, Text, StyleSheet} from 'react-native';
 
 const PositionLayout = () => {
   const [position, setPosition] = useState('relative');

--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -12,7 +12,7 @@ Users interact with mobile apps mainly through touch. They can use a combination
 ```jsx
 <Button
   onPress={() => {
-    alert('You tapped the button!');
+    consoele.log('You tapped the button!');
   }}
   title="Press Me"
 />
@@ -26,11 +26,11 @@ Go ahead and play around with the `Button` component using the example below. Yo
 
 ```SnackPlayer name=Button%20Basics
 import React, {Component} from 'react';
-import {Button, StyleSheet, View} from 'react-native';
+import {Alert, Button, StyleSheet, View} from 'react-native';
 
 export default class ButtonBasics extends Component {
   _onPressButton() {
-    alert('You tapped the button!');
+    Alert.alert('You tapped the button!');
   }
 
   render() {
@@ -92,6 +92,7 @@ Let's see all of these in action:
 ```SnackPlayer name=Touchables
 import React, {Component} from 'react';
 import {
+  Alert,
   Platform,
   StyleSheet,
   Text,
@@ -104,11 +105,11 @@ import {
 
 export default class Touchables extends Component {
   _onPressButton() {
-    alert('You tapped the button!');
+    Alert.alert('You tapped the button!');
   }
 
   _onLongPressButton() {
-    alert('You long-pressed the button!');
+    Alert.alert('You long-pressed the button!');
   }
 
   render() {

--- a/docs/image.md
+++ b/docs/image.md
@@ -65,7 +65,7 @@ export default DisplayAnImage;
 
 ```SnackPlayer name=Class%20Component%20Example
 import React, {Component} from 'react';
-import {AppRegistry, View, Image, StyleSheet} from 'react-native';
+import {View, Image, StyleSheet} from 'react-native';
 
 const styles = StyleSheet.create({
   container: {

--- a/docs/improvingux.md
+++ b/docs/improvingux.md
@@ -17,8 +17,14 @@ Check out [`TextInput` docs](textinput.md) for more configuration options.
 
 ```SnackPlayer name=TextInput%20form%20example
 import React, {useState, useRef} from 'react';
-import {Text, StatusBar, TextInput, View, StyleSheet} from 'react-native';
-import {Constants} from 'expo';
+import {
+  Alert,
+  Text,
+  StatusBar,
+  TextInput,
+  View,
+  StyleSheet,
+} from 'react-native';
 
 const App = () => {
   const emailInput = useRef(null);
@@ -26,7 +32,9 @@ const App = () => {
   const [email, setEmail] = useState('');
 
   const submit = () => {
-    alert(`Welcome, ${name}! Confirmation email has been sent to ${email}`);
+    Alert.alert(
+      `Welcome, ${name}! Confirmation email has been sent to ${email}`,
+    );
   };
 
   return (
@@ -43,7 +51,7 @@ const App = () => {
       <TextInput
         style={styles.input}
         value={name}
-        onChangeText={name => setName(name)}
+        onChangeText={text => setName(text)}
         placeholder="Full Name"
         autoFocus={true}
         autoCapitalize="words"
@@ -56,7 +64,7 @@ const App = () => {
       <TextInput
         style={styles.input}
         value={email}
-        onChangeText={email => setEmail(email)}
+        onChangeText={text => setEmail(text)}
         ref={emailInput}
         placeholder="email@example.com"
         autoCapitalize="none"
@@ -105,6 +113,7 @@ Software keyboard takes almost half of the screen. If you have interactive eleme
 ```SnackPlayer name=KeyboardAvoidingView%20example
 import React, {useState, useRef} from 'react';
 import {
+  Alert,
   Text,
   Button,
   StatusBar,
@@ -120,7 +129,7 @@ const App = () => {
 
   const submit = () => {
     emailInput.current.blur();
-    alert(`Confirmation email has been sent to ${email}`);
+    Alert.alert(`Confirmation email has been sent to ${email}`);
   };
 
   return (
@@ -138,7 +147,7 @@ const App = () => {
         <TextInput
           style={styles.input}
           value={email}
-          onChangeText={email => setEmail(email)}
+          onChangeText={text => setEmail(text)}
           ref={emailInput}
           placeholder="email@example.com"
           autoCapitalize="none"
@@ -200,7 +209,7 @@ export default App;
 On mobile phones it's hard to be very precise when pressing buttons. Make sure all interactive elements are 44x44 or larger. One way to do this is to leave enough space for the element, `padding`, `minWidth` and `minHeight` style values can be useful for that. Alternatively, you can use [`hitSlop` prop](touchablewithoutfeedback.md#hitslop) to increase interactive area without affecting the layout. Here's a demo:
 
 ```SnackPlayer name=HitSlop%20example
-import React, {Component} from 'react';
+import React from 'react';
 import {
   Text,
   StatusBar,

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -54,7 +54,7 @@ const App = () => {
   };
 
   const changeSetting = (value, options, setterFunction) => {
-    if (value == options.length - 1) {
+    if (value === options.length - 1) {
       setterFunction(0);
       return;
     }
@@ -124,7 +124,7 @@ const App = () => {
             <Button
               title="Delete Square"
               onPress={() =>
-                setSquares(squares.filter((v, i) => i != squares.length - 1))
+                setSquares(squares.filter((v, i) => i !== squares.length - 1))
               }
             />
           </View>
@@ -167,7 +167,7 @@ const Square = () => (
 
 const randomHexColor = () => {
   return '#000000'.replace(/0/g, () => {
-    return (~~(Math.random() * 16)).toString(16);
+    return Math.round(Math.random() * 16).toString(16);
   });
 };
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -108,7 +108,7 @@ const App = () => {
       ) : (
         <FlatList
           data={data}
-          keyExtractor={({id}, index) => id}
+          keyExtractor={({id}) => id}
           renderItem={({item}) => (
             <Text>
               {item.title}, {item.releaseYear}
@@ -166,7 +166,7 @@ export default class App extends Component {
         ) : (
           <FlatList
             data={data}
-            keyExtractor={({id}, index) => id}
+            keyExtractor={({id}) => id}
             renderItem={({item}) => (
               <Text>
                 {item.title}, {item.releaseYear}

--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -28,7 +28,6 @@ import React from 'react';
 import {
   Button,
   PermissionsAndroid,
-  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,
@@ -93,7 +92,6 @@ import React, {Component} from 'react';
 import {
   Button,
   PermissionsAndroid,
-  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -14,8 +14,8 @@ import {Button, Settings, StyleSheet, Text, View} from 'react-native';
 const App = () => {
   const [data, setData] = useState(Settings.get('data'));
 
-  const storeData = data => {
-    Settings.set(data);
+  const storeData = inputData => {
+    Settings.set(inputData);
     setData(Settings.get('data'));
   };
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -12,7 +12,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android
 import React from 'react';
-import {Share, View, Button} from 'react-native';
+import {Alert, Share, View, Button} from 'react-native';
 
 const ShareExample = () => {
   const onShare = async () => {
@@ -31,7 +31,7 @@ const ShareExample = () => {
         // dismissed
       }
     } catch (error) {
-      alert(error.message);
+      Alert.alert(error.message);
     }
   };
   return (
@@ -49,7 +49,7 @@ export default ShareExample;
 
 ```SnackPlayer name=Class%20Component%20Example&supportedPlatforms=ios,android
 import React, {Component} from 'react';
-import {Share, View, Button} from 'react-native';
+import {Alert, Share, View, Button} from 'react-native';
 
 class ShareExample extends Component {
   onShare = async () => {
@@ -69,7 +69,7 @@ class ShareExample extends Component {
         // dismissed
       }
     } catch (error) {
-      alert(error.message);
+      Alert.alert(error.message);
     }
   };
 

--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -277,7 +277,7 @@ const CustomPicker = ({label, data, currentIndex, onSelected}) => {
           bounces
           horizontal
           data={data}
-          keyExtractor={(item, idx) => String(item)}
+          keyExtractor={item => String(item)}
           renderItem={({item, index}) => {
             const selected = index === currentIndex;
             return (

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -47,7 +47,7 @@ const App = () => {
 
 const randomHexColor = () => {
   return '#000000'.replace(/0/g, function () {
-    return (~~(Math.random() * 16)).toString(16);
+    return Math.round(Math.random() * 16).toString(16);
   });
 };
 

--- a/docs/using-a-listview.md
+++ b/docs/using-a-listview.md
@@ -102,7 +102,7 @@ const SectionListBasics = () => {
         renderSectionHeader={({section}) => (
           <Text style={styles.sectionHeader}>{section.title}</Text>
         )}
-        keyExtractor={(item, index) => `basicListEntry-${item.title}`}
+        keyExtractor={item => `basicListEntry-${item.title}`}
       />
     </View>
   );

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -49,7 +49,7 @@ const App = () => {
         <Button title="Vibrate once" onPress={() => Vibration.vibrate()} />
       </View>
       <Separator />
-      {Platform.OS == 'android'
+      {Platform.OS === 'android'
         ? [
             <View>
               <Button
@@ -147,7 +147,7 @@ class App extends Component {
           <Button title="Vibrate once" onPress={() => Vibration.vibrate()} />
         </View>
         <Separator />
-        {Platform.OS == 'android'
+        {Platform.OS === 'android'
           ? [
               <View>
                 <Button

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -22,12 +22,12 @@ import {
 
 const DATA = [];
 
-const getItem = (data, index) => ({
+const getItem = (_data, index) => ({
   id: Math.random().toString(12).substring(0),
   title: `Item ${index + 1}`,
 });
 
-const getItemCount = data => 50;
+const getItemCount = _data => 50;
 
 const Item = ({title}) => (
   <View style={styles.item}>

--- a/scripts/lint-examples/bin/eslint-examples-js.js
+++ b/scripts/lint-examples/bin/eslint-examples-js.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const lintExamples = require('../src/lintExamples');
+
+lintExamples({
+  command: 'eslint',
+  args: ['--max-warnings=0', '.'],
+  extension: 'js',
+  writeBack: true,
+});

--- a/scripts/lint-examples/bin/eslint-examples-tsx.js
+++ b/scripts/lint-examples/bin/eslint-examples-tsx.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const lintExamples = require('../src/lintExamples');
+
+lintExamples({
+  command: 'eslint',
+  args: ['--max-warnings=0', '.'],
+  extension: 'tsx',
+  writeBack: true,
+});

--- a/scripts/lint-examples/bin/tsc-examples.js
+++ b/scripts/lint-examples/bin/tsc-examples.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const lintExamples = require('../src/lintExamples');
+
+lintExamples({
+  command: 'tsc',
+  extension: 'tsx',
+  writeBack: true,
+});

--- a/scripts/lint-examples/bin/tsc-examples.js
+++ b/scripts/lint-examples/bin/tsc-examples.js
@@ -13,5 +13,5 @@ const lintExamples = require('../src/lintExamples');
 lintExamples({
   command: 'tsc',
   extension: 'tsx',
-  writeBack: true,
+  writeBack: false,
 });

--- a/scripts/lint-examples/package.json
+++ b/scripts/lint-examples/package.json
@@ -3,14 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "bin": {
-    "lint-examples": "./lint-examples.js"
+    "eslint-examples-js": "./bin/eslint-examples-js.js",
+    "eslint-examples-tsx": "./bin/eslint-examples-tsx.js",
+    "tsc-examples": "./bin/tsc-examples.js"
   },
-  "dependencies": {
+  "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.14.0",
     "@babel/runtime": "^7.12.5",
     "@react-native-community/eslint-config": "^3.0.0",
     "@tsconfig/react-native": "^2.0.2",
+    "@types/jest": "^29.2.3",
     "@types/react": "^18.0.24",
     "eslint": "^8.19.0",
     "glob-promise": "^4.2.2",

--- a/scripts/lint-examples/tsconfig.json
+++ b/scripts/lint-examples/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "@tsconfig/react-native/tsconfig.json"
+  "extends": "@tsconfig/react-native/tsconfig.json",
+  "include": ["./out"]
 }

--- a/website/core/TabsConstants.js
+++ b/website/core/TabsConstants.js
@@ -33,10 +33,16 @@ const androidLanguages = [
 const defaultAndroidLanguage = 'java';
 
 const javaScriptSpecLanguages = [
-  {label: 'Flow', value: 'flow'},
   {label: 'TypeScript', value: 'typescript'},
+  {label: 'Flow', value: 'flow'},
 ];
 const defaultJavaScriptSpecLanguages = 'typescript';
+
+const snackLanguages = [
+  {label: 'TypeScript', value: 'typescript'},
+  {label: 'JavaScript', value: 'javascript'},
+];
+const defaultSnackLanguage = 'typescript';
 
 const guides = [
   {label: 'Expo Go Quickstart', value: 'quickstart'},
@@ -81,4 +87,6 @@ export default {
   syntax,
   androidLanguages,
   javaScriptSpecLanguages,
+  snackLanguages,
+  defaultSnackLanguage,
 };

--- a/website/package.json
+++ b/website/package.json
@@ -21,14 +21,14 @@
     "format:source": "prettier --write {{core,src}/**/*.js,*.js}",
     "format:markdown": "prettier --write ../docs/*.md && prettier --write {versioned_docs/**/*.md,blog/*.md}",
     "format:style": "prettier --write src/**/*.{scss,css}",
-    "format:examples": "lint-examples --fix",
+    "format:examples": "eslint-examples-js --fix && eslint-examples-tsx --fix",
     "prettier": "yarn format:source && yarn format:markdown && yarn format:style",
     "lint": "eslint ../docs/** blog/** core/** src/**/*.js ./*.js",
-    "lint:examples": "lint-examples",
+    "lint:examples": "eslint-examples-js && eslint-examples-tsx",
     "lint:versioned": "eslint versioned_docs/**",
     "language:lint": "cd ../ && alex && case-police 'docs/*.md' -p brands,general,products,softwares",
     "language:lint:versioned": "cd ../ && alex . && case-police '**/*.md' -p brands,general,products,softwares",
-    "ci:lint": "yarn lint && yarn lint-examples && yarn lint:versioned && yarn language:lint:versioned",
+    "ci:lint": "yarn lint && yarn lint:examples && yarn lint:versioned && yarn language:lint:versioned",
     "pwa:generate": "npx pwa-asset-generator ./static/img/header_logo.svg ./static/img/pwa --padding '40px' --background 'rgb(32, 35, 42)' --icon-only --opaque true"
   },
   "browserslist": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,6 +1765,13 @@
     "@types/node" "*"
     jest-mock "^29.3.1"
 
+"@jest/expect-utils@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.3.1.tgz#531f737039e9b9e27c42449798acb5bba01935b6"
+  integrity sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==
+  dependencies:
+    jest-get-type "^29.2.0"
+
 "@jest/fake-timers@^29.3.1":
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.3.1.tgz#b140625095b60a44de820876d4c14da1aa963f67"
@@ -1947,9 +1954,9 @@
     fastq "^1.6.0"
 
 "@pnpm/network.ca-file@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@pnpm/network.ca-file/-/network.ca-file-1.0.1.tgz#16f88d057c68cd5419c1ef3dfa281296ea80b047"
-  integrity sha512-gkINruT2KUhZLTaiHxwCOh1O4NVnFT0wLjWFBHmTz9vpKag/C/noIMJXBxFe4F0mYpUVX2puLwAieLYFg2NvoA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz#2ab05e09c1af0cdf2fcf5035bea1484e222f7983"
+  integrity sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==
   dependencies:
     graceful-fs "4.2.10"
 
@@ -2510,9 +2517,9 @@
     "@types/serve-static" "*"
 
 "@types/glob@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
-  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
@@ -2570,6 +2577,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^29.2.3":
+  version "29.2.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.3.tgz#f5fd88e43e5a9e4221ca361e23790d48fcf0a211"
+  integrity sha512-6XwoEbmatfyoCjWRX7z0fKMmgYKe9+/HrviJ5k0X/tjJWHGAezZOfYaxqQKuzG/TvQyr+ktjm4jgbk0s4/oF2w==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/js-yaml@^4.0.0":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
@@ -2592,7 +2607,12 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
-"@types/minimatch@*", "@types/minimatch@^3.0.3":
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
+
+"@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -3758,16 +3778,16 @@ cacheable-lookup@^7.0.0:
   integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
 
 cacheable-request@^10.2.1:
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.2.tgz#07c3d5afcaa2de2e9f66959bacb3ff78da3735fd"
-  integrity sha512-KxjQZM3UIo7/J6W4sLpwFvu1GB3Whv8NtZ8ZrUL284eiQjiXeeqWTdhixNrp/NLZ/JNuFBo6BD4ZaO8ZJ5BN8Q==
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.3.tgz#25277efe121308ab722c28b4164e51382b4adeb1"
+  integrity sha512-6BehRBOs7iurNjAYN9iPazTwFDaMQavJO8W1MEm3s2pH8q/tkPTtLDRUZaweWK87WFGf2Y5wLAlaCJlR5kOz3w==
   dependencies:
     "@types/http-cache-semantics" "^4.0.1"
     get-stream "^6.0.1"
     http-cache-semantics "^4.1.0"
-    keyv "^4.5.0"
+    keyv "^4.5.2"
     mimic-response "^4.0.0"
-    normalize-url "^7.2.0"
+    normalize-url "^8.0.0"
     responselike "^3.0.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
@@ -4818,6 +4838,11 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
+diff-sequences@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
+  integrity sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==
+
 diff@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
@@ -5654,6 +5679,17 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expect@^29.0.0:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.3.1.tgz#92877aad3f7deefc2e3f6430dd195b92295554a6"
+  integrity sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==
+  dependencies:
+    "@jest/expect-utils" "^29.3.1"
+    jest-get-type "^29.2.0"
+    jest-matcher-utils "^29.3.1"
+    jest-message-util "^29.3.1"
+    jest-util "^29.3.1"
+
 express@^4.17.3:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
@@ -6005,9 +6041,9 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     tapable "^1.0.0"
 
 form-data-encoder@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.3.tgz#682cd821a8423605093992ff895e6b2ed5a9d429"
-  integrity sha512-KqU0nnPMgIJcCOFTNJFEA8epcseEaoox4XZffTgy8jlI6pL/5EFyR54NRG7CnCJN0biY7q52DO3MH6/sJ/TKlQ==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
+  integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
 format@^0.2.0:
   version "0.2.2"
@@ -7464,6 +7500,16 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
+jest-diff@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.3.1.tgz#d8215b72fed8f1e647aed2cae6c752a89e757527"
+  integrity sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.3.1"
+    jest-get-type "^29.2.0"
+    pretty-format "^29.3.1"
+
 jest-environment-node@^29.2.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.3.1.tgz#5023b32472b3fba91db5c799a0d5624ad4803e74"
@@ -7480,6 +7526,21 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^29.2.0:
+  version "29.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.2.0.tgz#726646f927ef61d583a3b3adb1ab13f3a5036408"
+  integrity sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==
+
+jest-matcher-utils@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.3.1.tgz#6e7f53512f80e817dfa148672bd2d5d04914a572"
+  integrity sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.3.1"
+    jest-get-type "^29.2.0"
+    pretty-format "^29.3.1"
 
 jest-message-util@^29.3.1:
   version "29.3.1"
@@ -7729,7 +7790,7 @@ jsonpointer@^5.0.0:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
-keyv@^4.5.0:
+keyv@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.2.tgz#0e310ce73bf7851ec702f2eaf46ec4e3805cce56"
   integrity sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==
@@ -9367,10 +9428,10 @@ normalize-url@^6.0.1:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
-normalize-url@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-7.2.0.tgz#5317f78cff95f5fa1e76cc0b5e33245c43781e11"
-  integrity sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==
+normalize-url@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.0.0.tgz#593dbd284f743e8dcf6a5ddf8fadff149c82701a"
+  integrity sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -10273,7 +10334,7 @@ pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^29.3.1:
+pretty-format@^29.0.0, pretty-format@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.3.1.tgz#1841cac822b02b4da8971dacb03e8a871b4722da"
   integrity sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==


### PR DESCRIPTION
This change starts migrating the examples to TypeScript. Every example is now linted as both tsx and js, unless an extension is specified. All of the existing ESLint warnings, minus those for inline styles which I have disabled for now, are addressed, so we can now flag new lint warnings when examples are added. A script `tsc-examples` is added, in addition to ESLint, but I haven't folded it into `lint:examples` yet because not everything has been fixed, and doing so will take multiple PRs.

100/171 examples are clean for both ESLint and TypeScript in strict mode, with an additional in this change opted out of typechecking (Clipboard) since it has been removed and is no longer part of typings. Most examples are already valid as both JSX and strict TSX, but some are separated into tabs (where TypeScript is shown first and by default), require changes so that TypeScript can infer the types (while still being valid JS), or require fixup (e.g. due to changed APIs). Some pages like Systrace are out of date/broken and will need to be opted out of typechecking (and given a warning) while they are in disrepair.
