### PR TITLE
Updated the installation instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,12 +17,13 @@ This page will help you install and build your first React Native app.
 <Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
-Run the following command to create a new React Native project called "AwesomeProject":
+Run the following command to install expo cli and create a new React Native project called "AwesomeProject":
 
 <Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
+npm i -g expo-cli
 npx create-expo-app AwesomeProject
 
 cd AwesomeProject

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ Run the following command to install expo cli and create a new React Native proj
 <TabItem value="npm">
 
 ```shell
-npm i -g expo-cli
+npx expo start
 npx create-expo-app AwesomeProject
 
 cd AwesomeProject

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,17 +17,16 @@ This page will help you install and build your first React Native app.
 <Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
-Run the following command to install expo cli and create a new React Native project called "AwesomeProject":
+Run the following command to create a new React Native project called "AwesomeProject":
 
 <Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
-npx expo start
 npx create-expo-app AwesomeProject
 
 cd AwesomeProject
-npm start # you can also use: npx expo start
+npx expo start
 ```
 
 </TabItem>
@@ -37,7 +36,7 @@ npm start # you can also use: npx expo start
 yarn create expo-app AwesomeProject
 
 cd AwesomeProject
-yarn start # you can also use: yarn expo start
+yarn expo start
 ```
 
 </TabItem>


### PR DESCRIPTION
The guide needs to mention how to install the expo cli else the `expo start` command won't run, i have added it.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
