### PR TITLE
Typescriptify Examples H-J

### DIFF
--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -130,7 +130,7 @@ export default class Touchables extends Component {
           background={
             Platform.OS === 'android'
               ? TouchableNativeFeedback.SelectableBackground()
-              : ''
+              : undefined
           }>
           <View style={styles.button}>
             <Text style={styles.buttonText}>

--- a/docs/image-style-props.md
+++ b/docs/image-style-props.md
@@ -81,7 +81,7 @@ const DisplayAnImageWithStyle = () => {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'space-around',
     alignItems: 'center',
     height: '100%',
@@ -166,7 +166,7 @@ class DisplayAnImageWithStyle extends Component {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'space-around',
     alignItems: 'center',
     height: '100%',
@@ -209,7 +209,7 @@ const DisplayAnImageWithStyle = () => {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     height: '100%',
@@ -249,7 +249,7 @@ class DisplayAnImageWithStyle extends Component {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     height: '100%',
@@ -326,7 +326,7 @@ const DisplayAnImageWithStyle = () => {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'space-around',
     alignItems: 'center',
     height: '100%',
@@ -400,7 +400,7 @@ class DisplayAnImageWithStyle extends Component {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'space-around',
     alignItems: 'center',
     height: '100%',
@@ -443,7 +443,7 @@ const DisplayAnImageWithStyle = () => {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     height: '100%',
@@ -483,7 +483,7 @@ class DisplayAnImageWithStyle extends Component {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    flexDirection: 'vertical',
+    flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
     height: '100%',

--- a/docs/improvingux.md
+++ b/docs/improvingux.md
@@ -3,6 +3,8 @@ id: improvingux
 title: Improving User Experience
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 ## Configure text inputs
 
 Entering text on touch phone is a challenge - small screen, software keyboard. But based on what kind of data you need, you can make it easier by properly configuring the text inputs:
@@ -15,7 +17,10 @@ Entering text on touch phone is a challenge - small screen, software keyboard. B
 
 Check out [`TextInput` docs](textinput.md) for more configuration options.
 
-```SnackPlayer name=TextInput%20form%20example
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=TextInput%20form%20example&ext=js
 import React, {useState, useRef} from 'react';
 import {
   Alert,
@@ -106,11 +111,111 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=TextInput%20form%20example&ext=tsx
+import React, {useState, useRef} from 'react';
+import {
+  Alert,
+  Text,
+  StatusBar,
+  TextInput,
+  View,
+  StyleSheet,
+} from 'react-native';
+
+const App = () => {
+  const emailInput = useRef<TextInput>(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  const submit = () => {
+    Alert.alert(
+      `Welcome, ${name}! Confirmation email has been sent to ${email}`,
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <View style={styles.header}>
+        <Text style={styles.description}>
+          This demo shows how using available TextInput customizations can make
+          forms much easier to use. Try completing the form and notice that
+          different fields have specific optimizations and the return key
+          changes from focusing next input to submitting the form.
+        </Text>
+      </View>
+      <TextInput
+        style={styles.input}
+        value={name}
+        onChangeText={text => setName(text)}
+        placeholder="Full Name"
+        autoFocus={true}
+        autoCapitalize="words"
+        autoCorrect={true}
+        keyboardType="default"
+        returnKeyType="next"
+        onSubmitEditing={() => emailInput.current?.focus()}
+        blurOnSubmit={false}
+      />
+      <TextInput
+        style={styles.input}
+        value={email}
+        onChangeText={text => setEmail(text)}
+        ref={emailInput}
+        placeholder="email@example.com"
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="email-address"
+        returnKeyType="send"
+        onSubmitEditing={submit}
+        blurOnSubmit={true}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 64,
+    padding: 20,
+    backgroundColor: '#282c34',
+  },
+  description: {
+    fontSize: 14,
+    color: 'white',
+  },
+  input: {
+    margin: 20,
+    marginBottom: 0,
+    height: 34,
+    paddingHorizontal: 10,
+    borderRadius: 4,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    fontSize: 16,
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
 ## Manage layout when keyboard is visible
 
 Software keyboard takes almost half of the screen. If you have interactive elements that can get covered by the keyboard, make sure they are still accessible by using the [`KeyboardAvoidingView` component](keyboardavoidingview.md).
 
-```SnackPlayer name=KeyboardAvoidingView%20example
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=KeyboardAvoidingView%20example&ext=js
 import React, {useState, useRef} from 'react';
 import {
   Alert,
@@ -203,6 +308,106 @@ const styles = StyleSheet.create({
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=KeyboardAvoidingView%20example&ext=tsx
+import React, {useState, useRef} from 'react';
+import {
+  Alert,
+  Text,
+  Button,
+  StatusBar,
+  TextInput,
+  KeyboardAvoidingView,
+  View,
+  StyleSheet,
+} from 'react-native';
+
+const App = () => {
+  const emailInput = useRef<TextInput>(null);
+  const [email, setEmail] = useState('');
+
+  const submit = () => {
+    emailInput.current?.blur();
+    Alert.alert(`Confirmation email has been sent to ${email}`);
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <View style={styles.header}>
+        <Text style={styles.description}>
+          This demo shows how to avoid covering important UI elements with the
+          software keyboard. Focus the email input below and notice that the
+          Sign Up button and the text adjusted positions to make sure they are
+          not hidden under the keyboard.
+        </Text>
+      </View>
+      <KeyboardAvoidingView behavior="padding" style={styles.form}>
+        <TextInput
+          style={styles.input}
+          value={email}
+          onChangeText={text => setEmail(text)}
+          ref={emailInput}
+          placeholder="email@example.com"
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="email-address"
+          returnKeyType="send"
+          onSubmitEditing={submit}
+          blurOnSubmit={true}
+        />
+        <View>
+          <Button title="Sign Up" onPress={submit} />
+          <Text style={styles.legal}>Some important legal fine print here</Text>
+        </View>
+      </KeyboardAvoidingView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 64,
+    padding: 20,
+    backgroundColor: '#282c34',
+  },
+  description: {
+    fontSize: 14,
+    color: 'white',
+  },
+  input: {
+    margin: 20,
+    marginBottom: 0,
+    height: 34,
+    paddingHorizontal: 10,
+    borderRadius: 4,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    fontSize: 16,
+  },
+  legal: {
+    margin: 10,
+    color: '#333',
+    fontSize: 12,
+    textAlign: 'center',
+  },
+  form: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 ## Make tappable areas larger
 

--- a/docs/interactionmanager.md
+++ b/docs/interactionmanager.md
@@ -3,6 +3,8 @@ id: interactionmanager
 title: InteractionManager
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 InteractionManager allows long-running work to be scheduled after any interactions/animations have completed. In particular, this allows JavaScript animations to run smoothly.
 
 Applications can schedule tasks to run after interactions with the following:
@@ -41,7 +43,10 @@ By default, queued tasks are executed together in a loop in one `setImmediate` b
 
 ### Basic
 
-```SnackPlayer name=InteractionManager%20Function%20Component%20Basic%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=InteractionManager%20Function%20Component%20Basic%20Example&supportedPlatforms=ios,android&ext=js
 import React, {useState, useEffect} from 'react';
 import {
   Alert,
@@ -70,6 +75,7 @@ const useFadeIn = (duration = 5000) => {
     Animated.timing(opacity, {
       toValue: 1,
       duration,
+      useNativeDriver: true,
     }).start();
   }, [duration, opacity]);
 
@@ -116,9 +122,98 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=InteractionManager%20Function%20Component%20Basic%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {useState, useEffect} from 'react';
+import {
+  Alert,
+  Animated,
+  InteractionManager,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+const instructions = Platform.select({
+  ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
+  android:
+    'Double tap R on your keyboard to reload,\n' +
+    'Shake or press menu button for dev menu',
+});
+
+const useFadeIn = (duration = 5000) => {
+  const [opacity] = useState(new Animated.Value(0));
+
+  // Running the animation when the component is mounted
+  useEffect(() => {
+    // Animated.timing() create a interaction handle by default, if you want to disabled that
+    // behaviour you can set isInteraction to false to disabled that.
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration,
+      useNativeDriver: true,
+    }).start();
+  }, [duration, opacity]);
+
+  return opacity;
+};
+
+type BallProps = {
+  onShown: () => void;
+};
+
+const Ball = ({onShown}: BallProps) => {
+  const opacity = useFadeIn();
+
+  // Running a method after the animation
+  useEffect(() => {
+    const interactionPromise = InteractionManager.runAfterInteractions(() =>
+      onShown(),
+    );
+    return () => interactionPromise.cancel();
+  }, [onShown]);
+
+  return <Animated.View style={[styles.ball, {opacity}]} />;
+};
+
+const App = () => {
+  return (
+    <View style={styles.container}>
+      <Text>{instructions}</Text>
+      <Ball onShown={() => Alert.alert('Animation is done')} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  ball: {
+    width: 100,
+    height: 100,
+    backgroundColor: 'salmon',
+    borderRadius: 100,
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
 ### Advanced
 
-```SnackPlayer name=InteractionManager%20Function%20Component%20Advanced%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=InteractionManager%20Function%20Component%20Advanced%20Example&supportedPlatforms=ios,android&ext=js
 import React, {useEffect} from 'react';
 import {
   Alert,
@@ -188,6 +283,87 @@ const styles = StyleSheet.create({
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=InteractionManager%20Function%20Component%20Advanced%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {useEffect} from 'react';
+import {
+  Alert,
+  Animated,
+  InteractionManager,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+const instructions = Platform.select({
+  ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
+  android:
+    'Double tap R on your keyboard to reload,\n' +
+    'Shake or press menu button for dev menu',
+});
+
+// You can create a custom interaction/animation and add
+// support for InteractionManager
+const useCustomInteraction = (timeLocked = 2000) => {
+  useEffect(() => {
+    const handle = InteractionManager.createInteractionHandle();
+
+    setTimeout(
+      () => InteractionManager.clearInteractionHandle(handle),
+      timeLocked,
+    );
+
+    return () => InteractionManager.clearInteractionHandle(handle);
+  }, [timeLocked]);
+};
+
+type BallProps = {
+  onInteractionIsDone: () => void;
+};
+
+const Ball = ({onInteractionIsDone}: BallProps) => {
+  useCustomInteraction();
+
+  // Running a method after the interaction
+  useEffect(() => {
+    InteractionManager.runAfterInteractions(() => onInteractionIsDone());
+  }, [onInteractionIsDone]);
+
+  return <Animated.View style={[styles.ball]} />;
+};
+
+const App = () => {
+  return (
+    <View style={styles.container}>
+      <Text>{instructions}</Text>
+      <Ball onInteractionIsDone={() => Alert.alert('Interaction is done')} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  ball: {
+    width: 100,
+    height: 100,
+    backgroundColor: 'salmon',
+    borderRadius: 100,
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 > **Note**: `InteractionManager.runAfterInteractions()` is not working properly on web. It triggers immediately without waiting until the interaction is finished.
 

--- a/docs/intro-react.md
+++ b/docs/intro-react.md
@@ -145,7 +145,10 @@ export default Cat;
 
 Any JavaScript expression will work between curly braces, including function calls like `{getFullName("Rum", "Tum", "Tugger")}`:
 
-```SnackPlayer name=Curly%20Braces
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Curly%20Braces&ext=js
 import React from 'react';
 import {Text} from 'react-native';
 
@@ -159,6 +162,31 @@ const Cat = () => {
 
 export default Cat;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Curly%20Braces&ext=tsx
+import React from 'react';
+import {Text} from 'react-native';
+
+const getFullName = (
+  firstName: string,
+  secondName: string,
+  thirdName: string,
+) => {
+  return firstName + ' ' + secondName + ' ' + thirdName;
+};
+
+const Cat = () => {
+  return <Text>Hello, I am {getFullName('Rum', 'Tum', 'Tugger')}!</Text>;
+};
+
+export default Cat;
+```
+
+</TabItem>
+</Tabs>
 
 You can think of curly braces as creating a portal into JS functionality in your JSX!
 
@@ -245,7 +273,10 @@ You can put as many cats in your cafe as you like. Each `<Cat>` renders a unique
 
 **Props** is short for “properties”. Props let you customize React components. For example, here you pass each `<Cat>` a different `name` for `Cat` to render:
 
-```SnackPlayer name=Multiple%20Props
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Multiple%20Props&ext=js
 import React from 'react';
 import {Text, View} from 'react-native';
 
@@ -269,6 +300,41 @@ const Cafe = () => {
 
 export default Cafe;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Multiple%20Props&ext=tsx
+import React from 'react';
+import {Text, View} from 'react-native';
+
+type CatProps = {
+  name: string;
+};
+
+const Cat = (props: CatProps) => {
+  return (
+    <View>
+      <Text>Hello, I am {props.name}!</Text>
+    </View>
+  );
+};
+
+const Cafe = () => {
+  return (
+    <View>
+      <Cat name="Maru" />
+      <Cat name="Jellylorum" />
+      <Cat name="Spot" />
+    </View>
+  );
+};
+
+export default Cafe;
+```
+
+</TabItem>
+</Tabs>
 
 Most of React Native’s Core Components can be customized with props, too. For example, when using [`Image`](image), you pass it a prop named [`source`](image#source) to define what image it shows:
 
@@ -312,7 +378,10 @@ The following example takes place in a cat cafe where two hungry cats are waitin
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)
 
-```SnackPlayer name=State
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=State&ext=js
 import React, {useState} from 'react';
 import {Button, Text, View} from 'react-native';
 
@@ -347,6 +416,51 @@ const Cafe = () => {
 export default Cafe;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=State&ext=tsx
+import React, {useState} from 'react';
+import {Button, Text, View} from 'react-native';
+
+type CatProps = {
+  name: string;
+};
+
+const Cat = (props: CatProps) => {
+  const [isHungry, setIsHungry] = useState(true);
+
+  return (
+    <View>
+      <Text>
+        I am {props.name}, and I am {isHungry ? 'hungry' : 'full'}!
+      </Text>
+      <Button
+        onPress={() => {
+          setIsHungry(false);
+        }}
+        disabled={!isHungry}
+        title={isHungry ? 'Pour me some milk, please!' : 'Thank you!'}
+      />
+    </View>
+  );
+};
+
+const Cafe = () => {
+  return (
+    <>
+      <Cat name="Munkustrap" />
+      <Cat name="Spot" />
+    </>
+  );
+};
+
+export default Cafe;
+```
+
+</TabItem>
+</Tabs>
+
 First, you will want to import `useState` from React like so:
 
 ```jsx
@@ -355,8 +469,8 @@ import React, { useState } from 'react';
 
 Then you declare the component’s state by calling `useState` inside its function. In this example, `useState` creates an `isHungry` state variable:
 
-```jsx
-const Cat = (props) => {
+```tsx
+const Cat = (props: CatProps) => {
   const [isHungry, setIsHungry] = useState(true);
   // ...
 };
@@ -412,7 +526,10 @@ const Cafe = () => {
 
 The older class components approach is a little different when it comes to state.
 
-```SnackPlayer name=State%20and%20Class%20Components
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=State%20and%20Class%20Components&ext=js
 import React, {Component} from 'react';
 import {Button, Text, View} from 'react-native';
 
@@ -453,6 +570,58 @@ class Cafe extends Component {
 
 export default Cafe;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=State%20and%20Class%20Components&ext=tsx
+import React, {Component} from 'react';
+import {Button, Text, View} from 'react-native';
+
+type CatProps = {
+  name: string;
+};
+
+class Cat extends Component<CatProps> {
+  state = {isHungry: true};
+
+  render() {
+    return (
+      <View>
+        <Text>
+          I am {this.props.name}, and I am
+          {this.state.isHungry ? ' hungry' : ' full'}!
+        </Text>
+        <Button
+          onPress={() => {
+            this.setState({isHungry: false});
+          }}
+          disabled={!this.state.isHungry}
+          title={
+            this.state.isHungry ? 'Pour me some milk, please!' : 'Thank you!'
+          }
+        />
+      </View>
+    );
+  }
+}
+
+class Cafe extends Component {
+  render() {
+    return (
+      <>
+        <Cat name="Munkustrap" />
+        <Cat name="Spot" />
+      </>
+    );
+  }
+}
+
+export default Cafe;
+```
+
+</TabItem>
+</Tabs>
 
 As always with class components, you must import the `Component` class from React:
 


### PR DESCRIPTION
This makes examples in documents starting from H-J valid for TypeScript. This leaves 36 examples left. Verified these pages locally after the change.