### PR TITLE
Typescriptify Examples K-P

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -19,7 +19,7 @@ import React, {useState, useEffect} from 'react';
 import {Keyboard, Text, TextInput, StyleSheet, View} from 'react-native';
 
 const Example = () => {
-  const [keyboardStatus, setKeyboardStatus] = useState(undefined);
+  const [keyboardStatus, setKeyboardStatus] = useState('');
 
   useEffect(() => {
     const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
@@ -69,13 +69,16 @@ export default Example;
 </TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=Keyboard%20Class%20Component%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Keyboard%20Class%20Component%20Example&supportedPlatforms=ios,android&ext=js
 import React, {Component} from 'react';
 import {Keyboard, Text, TextInput, StyleSheet, View} from 'react-native';
 
 class Example extends Component {
   state = {
-    keyboardStatus: undefined,
+    keyboardStatus: '',
   };
 
   componentDidMount() {
@@ -130,6 +133,78 @@ const style = StyleSheet.create({
 
 export default Example;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Keyboard%20Class%20Component%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {Component} from 'react';
+import {Keyboard, Text, TextInput, StyleSheet, View} from 'react-native';
+import type {EmitterSubscription} from 'react-native';
+
+class Example extends Component {
+  keyboardDidShowSubscription?: EmitterSubscription;
+  keyboardDidHideSubscription?: EmitterSubscription;
+
+  state = {
+    keyboardStatus: undefined,
+  };
+
+  componentDidMount() {
+    this.keyboardDidShowSubscription = Keyboard.addListener(
+      'keyboardDidShow',
+      () => {
+        this.setState({keyboardStatus: 'Keyboard Shown'});
+      },
+    );
+    this.keyboardDidHideSubscription = Keyboard.addListener(
+      'keyboardDidHide',
+      () => {
+        this.setState({keyboardStatus: 'Keyboard Hidden'});
+      },
+    );
+  }
+
+  componentWillUnmount() {
+    this.keyboardDidShowSubscription?.remove();
+    this.keyboardDidHideSubscription?.remove();
+  }
+
+  render() {
+    return (
+      <View style={style.container}>
+        <TextInput
+          style={style.input}
+          placeholder="Click here…"
+          onSubmitEditing={Keyboard.dismiss}
+        />
+        <Text style={style.status}>{this.state.keyboardStatus}</Text>
+      </View>
+    );
+  }
+}
+
+const style = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 36,
+  },
+  input: {
+    padding: 10,
+    borderWidth: 0.5,
+    borderRadius: 4,
+  },
+  status: {
+    padding: 10,
+    textAlign: 'center',
+  },
+});
+
+export default Example;
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -3,13 +3,18 @@ id: layout-props
 title: Layout Props
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 > More detailed examples about those properties can be found on the [Layout with Flexbox](flexbox) page.
 
 ### Example
 
 The following example shows how different properties can affect or shape a React Native layout. You can try for example to add or remove squares from the UI while changing the values of the property `flexWrap`.
 
-```SnackPlayer name=LayoutProps%20Example
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=LayoutProps%20Example&ext=js
 import React, {useState} from 'react';
 import {
   Button,
@@ -173,6 +178,186 @@ const randomHexColor = () => {
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=LayoutProps%20Example&ext=tsx
+import React, {useState} from 'react';
+import {
+  Button,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+const App = () => {
+  const flexDirections = [
+    'row',
+    'row-reverse',
+    'column',
+    'column-reverse',
+  ] as const;
+  const justifyContents = [
+    'flex-start',
+    'flex-end',
+    'center',
+    'space-between',
+    'space-around',
+    'space-evenly',
+  ] as const;
+  const alignItemsArr = [
+    'flex-start',
+    'flex-end',
+    'center',
+    'stretch',
+    'baseline',
+  ] as const;
+  const wraps = ['nowrap', 'wrap', 'wrap-reverse'] as const;
+  const directions = ['inherit', 'ltr', 'rtl'] as const;
+  const [flexDirection, setFlexDirection] = useState(0);
+  const [justifyContent, setJustifyContent] = useState(0);
+  const [alignItems, setAlignItems] = useState(0);
+  const [direction, setDirection] = useState(0);
+  const [wrap, setWrap] = useState(0);
+
+  const hookedStyles = {
+    flexDirection: flexDirections[flexDirection],
+    justifyContent: justifyContents[justifyContent],
+    alignItems: alignItemsArr[alignItems],
+    direction: directions[direction],
+    flexWrap: wraps[wrap],
+  };
+
+  const changeSetting = (
+    value: number,
+    options: readonly unknown[],
+    setterFunction: (index: number) => void,
+  ) => {
+    if (value === options.length - 1) {
+      setterFunction(0);
+      return;
+    }
+    setterFunction(value + 1);
+  };
+  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
+  return (
+    <>
+      <View style={{paddingTop: StatusBar.currentHeight}} />
+      <View style={[styles.container, styles.playingSpace, hookedStyles]}>
+        {squares.map(elem => elem)}
+      </View>
+      <ScrollView style={styles.container}>
+        <View style={styles.controlSpace}>
+          <View style={styles.buttonView}>
+            <Button
+              title="Change Flex Direction"
+              onPress={() =>
+                changeSetting(flexDirection, flexDirections, setFlexDirection)
+              }
+            />
+            <Text style={styles.text}>{flexDirections[flexDirection]}</Text>
+          </View>
+          <View style={styles.buttonView}>
+            <Button
+              title="Change Justify Content"
+              onPress={() =>
+                changeSetting(
+                  justifyContent,
+                  justifyContents,
+                  setJustifyContent,
+                )
+              }
+            />
+            <Text style={styles.text}>{justifyContents[justifyContent]}</Text>
+          </View>
+          <View style={styles.buttonView}>
+            <Button
+              title="Change Align Items"
+              onPress={() =>
+                changeSetting(alignItems, alignItemsArr, setAlignItems)
+              }
+            />
+            <Text style={styles.text}>{alignItemsArr[alignItems]}</Text>
+          </View>
+          <View style={styles.buttonView}>
+            <Button
+              title="Change Direction"
+              onPress={() => changeSetting(direction, directions, setDirection)}
+            />
+            <Text style={styles.text}>{directions[direction]}</Text>
+          </View>
+          <View style={styles.buttonView}>
+            <Button
+              title="Change Flex Wrap"
+              onPress={() => changeSetting(wrap, wraps, setWrap)}
+            />
+            <Text style={styles.text}>{wraps[wrap]}</Text>
+          </View>
+          <View style={styles.buttonView}>
+            <Button
+              title="Add Square"
+              onPress={() => setSquares([...squares, <Square />])}
+            />
+          </View>
+          <View style={styles.buttonView}>
+            <Button
+              title="Delete Square"
+              onPress={() =>
+                setSquares(squares.filter((v, i) => i !== squares.length - 1))
+              }
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: '50%',
+  },
+  playingSpace: {
+    backgroundColor: 'white',
+    borderColor: 'blue',
+    borderWidth: 3,
+  },
+  controlSpace: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    backgroundColor: '#F5F5F5',
+  },
+  buttonView: {
+    width: '50%',
+    padding: 10,
+  },
+  text: {textAlign: 'center'},
+});
+
+const Square = () => (
+  <View
+    style={{
+      width: 50,
+      height: 50,
+      backgroundColor: randomHexColor(),
+    }}
+  />
+);
+
+const randomHexColor = () => {
+  return '#000000'.replace(/0/g, () => {
+    return Math.round(Math.random() * 16).toString(16);
+  });
+};
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 ---
 

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -114,7 +114,10 @@ You can handle these events with `Linking.getInitialURL()` - it returns a Promis
 
 ### Open Links and Deep Links (Universal Links)
 
-```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
 import React, {useCallback} from 'react';
 import {Alert, Button, Linking, StyleSheet, View} from 'react-native';
 
@@ -159,9 +162,68 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {useCallback} from 'react';
+import {Alert, Button, Linking, StyleSheet, View} from 'react-native';
+
+const supportedURL = 'https://google.com';
+
+const unsupportedURL = 'slack://open?team=123456';
+
+type OpenURLButtonProps = {
+  url: string;
+  children: string;
+};
+
+const OpenURLButton = ({url, children}: OpenURLButtonProps) => {
+  const handlePress = useCallback(async () => {
+    // Checking if the link is supported for links with custom URL scheme.
+    const supported = await Linking.canOpenURL(url);
+
+    if (supported) {
+      // Opening the link with some app, if the URL scheme is "http" the web link should be opened
+      // by some browser in the mobile
+      await Linking.openURL(url);
+    } else {
+      Alert.alert(`Don't know how to open this URL: ${url}`);
+    }
+  }, [url]);
+
+  return <Button title={children} onPress={handlePress} />;
+};
+
+const App = () => {
+  return (
+    <View style={styles.container}>
+      <OpenURLButton url={supportedURL}>Open Supported URL</OpenURLButton>
+      <OpenURLButton url={unsupportedURL}>Open Unsupported URL</OpenURLButton>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
 ### Open Custom Settings
 
-```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
 import React, {useCallback} from 'react';
 import {Button, Linking, StyleSheet, View} from 'react-native';
 
@@ -193,9 +255,54 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {useCallback} from 'react';
+import {Button, Linking, StyleSheet, View} from 'react-native';
+
+type OpenSettingsButtonProps = {
+  children: string;
+};
+
+const OpenSettingsButton = ({children}: OpenSettingsButtonProps) => {
+  const handlePress = useCallback(async () => {
+    // Open the custom settings if the app has one
+    await Linking.openSettings();
+  }, []);
+
+  return <Button title={children} onPress={handlePress} />;
+};
+
+const App = () => {
+  return (
+    <View style={styles.container}>
+      <OpenSettingsButton>Open Settings</OpenSettingsButton>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
 ### Get the Deep Link
 
-```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
 import React, {useState, useEffect} from 'react';
 import {Linking, StyleSheet, Text, View} from 'react-native';
 
@@ -246,9 +353,69 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {useState, useEffect} from 'react';
+import {Linking, StyleSheet, Text, View} from 'react-native';
+
+const useInitialURL = () => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(true);
+
+  useEffect(() => {
+    const getUrlAsync = async () => {
+      // Get the deep link used to open the app
+      const initialUrl = await Linking.getInitialURL();
+
+      // The setTimeout is just for testing purpose
+      setTimeout(() => {
+        setUrl(initialUrl);
+        setProcessing(false);
+      }, 1000);
+    };
+
+    getUrlAsync();
+  }, []);
+
+  return {url, processing};
+};
+
+const App = () => {
+  const {url: initialUrl, processing} = useInitialURL();
+
+  return (
+    <View style={styles.container}>
+      <Text>
+        {processing
+          ? 'Processing the initial url from a deep link'
+          : `The deep link is: ${initialUrl || 'None'}`}
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
 ### Send Intents (Android)
 
-```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=android&ext=js
 import React, {useCallback} from 'react';
 import {Alert, Button, Linking, StyleSheet, View} from 'react-native';
 
@@ -274,7 +441,8 @@ const App = () => {
         action="android.settings.APP_NOTIFICATION_SETTINGS"
         extras={[
           {
-            'android.provider.extra.APP_PACKAGE': 'com.facebook.katana',
+            key: 'android.provider.extra.APP_PACKAGE',
+            value: 'com.facebook.katana',
           },
         ]}>
         App Notification Settings
@@ -293,6 +461,72 @@ const styles = StyleSheet.create({
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Linking%20Function%20Component%20Example&ext=tsx
+import React, {useCallback} from 'react';
+import {Alert, Button, Linking, StyleSheet, View} from 'react-native';
+
+type SendIntentButtonProps = {
+  action: string;
+  children: string;
+  extras?: Array<{
+    key: string;
+    value: string | number | boolean;
+  }>;
+};
+
+const SendIntentButton = ({
+  action,
+  extras,
+  children,
+}: SendIntentButtonProps) => {
+  const handlePress = useCallback(async () => {
+    try {
+      await Linking.sendIntent(action, extras);
+    } catch (e: any) {
+      Alert.alert(e.message);
+    }
+  }, [action, extras]);
+
+  return <Button title={children} onPress={handlePress} />;
+};
+
+const App = () => {
+  return (
+    <View style={styles.container}>
+      <SendIntentButton action="android.intent.action.POWER_USAGE_SUMMARY">
+        Power Usage Summary
+      </SendIntentButton>
+      <SendIntentButton
+        action="android.settings.APP_NOTIFICATION_SETTINGS"
+        extras={[
+          {
+            key: 'android.provider.extra.APP_PACKAGE',
+            value: 'com.facebook.katana',
+          },
+        ]}>
+        App Notification Settings
+      </SendIntentButton>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 # Reference
 

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -107,10 +107,6 @@ class App extends Component {
     modalVisible: false,
   };
 
-  setModalVisible = visible => {
-    this.setState({modalVisible: visible});
-  };
-
   render() {
     const {modalVisible} = this.state;
     return (
@@ -121,14 +117,14 @@ class App extends Component {
           visible={modalVisible}
           onRequestClose={() => {
             Alert.alert('Modal has been closed.');
-            this.setModalVisible(!modalVisible);
+            this.setState({modalVisible: !modalVisible});
           }}>
           <View style={styles.centeredView}>
             <View style={styles.modalView}>
               <Text style={styles.modalText}>Hello World!</Text>
               <Pressable
                 style={[styles.button, styles.buttonClose]}
-                onPress={() => this.setModalVisible(!modalVisible)}>
+                onPress={() => this.setState({modalVisible: !modalVisible})}>
                 <Text style={styles.textStyle}>Hide Modal</Text>
               </Pressable>
             </View>
@@ -136,7 +132,7 @@ class App extends Component {
         </Modal>
         <Pressable
           style={[styles.button, styles.buttonOpen]}
-          onPress={() => this.setModalVisible(true)}>
+          onPress={() => this.setState({modalVisible: true})}>
           <Text style={styles.textStyle}>Show Modal</Text>
         </Pressable>
       </View>

--- a/docs/network.md
+++ b/docs/network.md
@@ -77,7 +77,10 @@ Don't forget to catch any errors that may be thrown by `fetch`, otherwise they w
 <Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
-```SnackPlayer name=Fetch%20Example
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Fetch%20Example&ext=js
 import React, {useEffect, useState} from 'react';
 import {ActivityIndicator, FlatList, Text, View} from 'react-native';
 
@@ -124,9 +127,70 @@ export default App;
 ```
 
 </TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Fetch%20Example&ext=tsx
+import React, {useEffect, useState} from 'react';
+import {ActivityIndicator, FlatList, Text, View} from 'react-native';
+
+type Movie = {
+  id: string;
+  title: string;
+  releaseYear: string;
+};
+
+const App = () => {
+  const [isLoading, setLoading] = useState(true);
+  const [data, setData] = useState<Movie[]>([]);
+
+  const getMovies = async () => {
+    try {
+      const response = await fetch('https://reactnative.dev/movies.json');
+      const json = await response.json();
+      setData(json.movies);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    getMovies();
+  }, []);
+
+  return (
+    <View style={{flex: 1, padding: 24}}>
+      {isLoading ? (
+        <ActivityIndicator />
+      ) : (
+        <FlatList
+          data={data}
+          keyExtractor={({id}) => id}
+          renderItem={({item}) => (
+            <Text>
+              {item.title}, {item.releaseYear}
+            </Text>
+          )}
+        />
+      )}
+    </View>
+  );
+};
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=Fetch%20Example
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Fetch%20Example&ext=js
 import React, {Component} from 'react';
 import {ActivityIndicator, FlatList, Text, View} from 'react-native';
 
@@ -179,6 +243,73 @@ export default class App extends Component {
   }
 }
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Fetch%20Example&ext=tsx
+import React, {Component} from 'react';
+import {ActivityIndicator, FlatList, Text, View} from 'react-native';
+
+type Movie = {
+  id: string;
+  title: string;
+  releaseYear: string;
+};
+
+type AppState = {
+  data: Movie[];
+  isLoading: boolean;
+};
+
+export default class App extends Component {
+  state: AppState = {
+    data: [],
+    isLoading: true,
+  };
+
+  async getMovies() {
+    try {
+      const response = await fetch('https://reactnative.dev/movies.json');
+      const json = await response.json();
+      this.setState({data: json.movies});
+    } catch (error) {
+      console.log(error);
+    } finally {
+      this.setState({isLoading: false});
+    }
+  }
+
+  componentDidMount() {
+    this.getMovies();
+  }
+
+  render() {
+    const {data, isLoading} = this.state;
+
+    return (
+      <View style={{flex: 1, padding: 24}}>
+        {isLoading ? (
+          <ActivityIndicator />
+        ) : (
+          <FlatList
+            data={data}
+            keyExtractor={({id}) => id}
+            renderItem={({item}) => (
+              <Text>
+                {item.title}, {item.releaseYear}
+              </Text>
+            )}
+          />
+        )}
+      </View>
+    );
+  }
+}
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/panresponder.md
+++ b/docs/panresponder.md
@@ -93,15 +93,9 @@ const App = () => {
   const panResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: () => true,
-      onPanResponderGrant: () => {
-        pan.setOffset({
-          x: pan.x._value,
-          y: pan.y._value,
-        });
-      },
       onPanResponderMove: Animated.event([null, {dx: pan.x, dy: pan.y}]),
       onPanResponderRelease: () => {
-        pan.flattenOffset();
+        pan.extractOffset();
       },
     }),
   ).current;
@@ -153,18 +147,12 @@ class App extends Component {
   pan = new Animated.ValueXY();
   panResponder = PanResponder.create({
     onMoveShouldSetPanResponder: () => true,
-    onPanResponderGrant: () => {
-      this.pan.setOffset({
-        x: this.pan.x._value,
-        y: this.pan.y._value,
-      });
-    },
     onPanResponderMove: Animated.event([
       null,
       {dx: this.pan.x, dy: this.pan.y},
     ]),
     onPanResponderRelease: () => {
-      this.pan.flattenOffset();
+      this.pan.extractOffset();
     },
   });
 

--- a/docs/props.md
+++ b/docs/props.md
@@ -3,6 +3,8 @@ id: props
 title: Props
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 Most components can be customized when they are created, with different parameters. These created parameters are called `props`, short for properties.
 
 For example, one basic React Native component is the `Image`. When you create an image, you can use a prop named `source` to control what image it shows.
@@ -27,7 +29,10 @@ Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX.
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place by referring to `props` in your `render` function. Here's an example:
 
-```SnackPlayer name=Props
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Props&ext=js
 import React from 'react';
 import {Text, View} from 'react-native';
 
@@ -51,6 +56,41 @@ const LotsOfGreetings = () => {
 
 export default LotsOfGreetings;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Props&ext=tsx
+import React from 'react';
+import {Text, View} from 'react-native';
+
+type GreetingsProps = {
+  name: string;
+};
+
+const Greeting = (props: GreetingsProps) => {
+  return (
+    <View style={{alignItems: 'center'}}>
+      <Text>Hello {props.name}!</Text>
+    </View>
+  );
+};
+
+const LotsOfGreetings = () => {
+  return (
+    <View style={{alignItems: 'center', top: 50}}>
+      <Greeting name="Rexxar" />
+      <Greeting name="Jaina" />
+      <Greeting name="Valeera" />
+    </View>
+  );
+};
+
+export default LotsOfGreetings;
+```
+
+</TabItem>
+</Tabs>
 
 Using `name` as a prop lets us customize the `Greeting` component, so we can reuse that component for each of our greetings. This example also uses the `Greeting` component in JSX, similar to the [Core Components](intro-react-native-components). The power to do this is what makes React so cool - if you find yourself wishing that you had a different set of UI primitives to work with, you can invent new ones.
 


### PR DESCRIPTION
This makes examples in documents starting from K-P valid for TypeScript. This leaves 23 examples left. Verified these pages locally after the change.