### PR TITLE
Fix rendering of snacks on route update on mobile

### DIFF
--- a/website/snackPlayerInitializer.js
+++ b/website/snackPlayerInitializer.js
@@ -74,7 +74,7 @@ export default (() => {
 
   return {
     onRouteDidUpdate({location}) {
-      // console.log('onRouteUpdate', {location});
+      // console.log('onRouteDidUpdate', {location});
 
       initSnackPlayers();
       setupTabPanelsMutationObservers();

--- a/website/snackPlayerInitializer.js
+++ b/website/snackPlayerInitializer.js
@@ -73,15 +73,11 @@ export default (() => {
   setupThemeSynchronization();
 
   return {
-    onRouteUpdate({location}) {
+    onRouteDidUpdate({location}) {
       // console.log('onRouteUpdate', {location});
 
-      // TODO temporary, because onRouteUpdate fires before the new route renders...
-      // see https://github.com/facebook/docusaurus/issues/3399#issuecomment-704401189
-      setTimeout(() => {
-        initSnackPlayers();
-        setupTabPanelsMutationObservers();
-      }, 0);
+      initSnackPlayers();
+      setupTabPanelsMutationObservers();
     },
   };
 })();


### PR DESCRIPTION
Switching pages on mobile currently causes a blank snack example to show.

![image](https://user-images.githubusercontent.com/835219/206591425-88897137-368e-4848-9b1e-a3c23d97a4de.png)


This is root caused to a workaround on the `onRouteUpdate` callback to read the DOM after mutation, which seems to work on desktop, but not on the mobile version of the site. This change moves to a newer lifecycle method called after the document is rendered to the DOM, which fixes the issue.
