### PR TITLE
fix: remove explicit folly version as it's not needed anymore

### DIFF
--- a/docs/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/docs/the-new-architecture/backward-compatibility-fabric-components.md
@@ -51,7 +51,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -80,7 +79,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-RCTFabric"
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"
@@ -95,7 +94,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-- folly_version = '2021.07.22.00'
 - folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -124,7 +122,7 @@ Pod::Spec.new do |s|
 -
 -  s.dependency "React-RCTFabric"
 -  s.dependency "React-Codegen"
--  s.dependency "RCT-Folly", folly_version
+-  s.dependency "RCT-Folly"
 -  s.dependency "RCTRequired"
 -  s.dependency "RCTTypeSafety"
 -  s.dependency "ReactCommon/turbomodule/core"

--- a/docs/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/docs/the-new-architecture/backward-compatibility-turbomodules.md
@@ -51,7 +51,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -78,7 +77,7 @@ Pod::Spec.new do |s|
   }
 
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"
@@ -94,7 +93,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
--folly_version = '2021.07.22.00'
 -folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -122,7 +120,7 @@ Pod::Spec.new do |s|
 -  }
 -
 -  s.dependency "React-Codegen"
--  s.dependency "RCT-Folly", folly_version
+-  s.dependency "RCT-Folly"
 -  s.dependency "RCTRequired"
 -  s.dependency "RCTTypeSafety"
 -  s.dependency "ReactCommon/turbomodule/core"

--- a/website/versioned_docs/version-0.68/new-architecture-library-ios.md
+++ b/website/versioned_docs/version-0.68/new-architecture-library-ios.md
@@ -20,9 +20,6 @@ We'll need to ensure Folly is configured properly in any projects that consume y
 Add these to your `Pod::Spec.new` block:
 
 ```ruby
-# folly_version must match the version used in React Native
-# See folly_version in react-native/React/FBReactNativeSpec/FBReactNativeSpec.podspec
-folly_version = '2021.06.28.00-v2'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -36,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-RCTFabric" # This is for fabric component
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"

--- a/website/versioned_docs/version-0.69/new-architecture-library-ios.md
+++ b/website/versioned_docs/version-0.69/new-architecture-library-ios.md
@@ -20,9 +20,6 @@ We'll need to ensure Folly is configured properly in any projects that consume y
 Add these to your `Pod::Spec.new` block:
 
 ```ruby
-# folly_version must match the version used in React Native
-# See folly_version in react-native/React/FBReactNativeSpec/FBReactNativeSpec.podspec
-folly_version = '2021.06.28.00-v2'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -36,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-RCTFabric" # This is for fabric component
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
@@ -47,7 +47,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -76,7 +75,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-RCTFabric"
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
@@ -53,7 +53,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -80,7 +79,7 @@ Pod::Spec.new do |s|
   }
 
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
@@ -192,7 +192,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -219,7 +218,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-RCTFabric"
   s.dependency "React-Codegen"
-  s.dependency "RCT-Folly", folly_version
+  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Hey, 

This PR removes explicit folly versions as specifying them is not needed anymore.
