### PR TITLE
Typescriptify Examples Q-S

### DIFF
--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -17,16 +17,14 @@ import {
   Text,
 } from 'react-native';
 
-const wait = timeout => {
-  return new Promise(resolve => setTimeout(resolve, timeout));
-};
-
 const App = () => {
   const [refreshing, setRefreshing] = React.useState(false);
 
   const onRefresh = React.useCallback(() => {
     setRefreshing(true);
-    wait(2000).then(() => setRefreshing(false));
+    setTimeout(() => {
+      setRefreshing(false);
+    }, 2000);
   }, []);
 
   return (

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -55,18 +55,16 @@ const DATA = [
   },
 ];
 
-const Item = ({title}) => (
-  <View style={styles.item}>
-    <Text style={styles.title}>{title}</Text>
-  </View>
-);
-
 const App = () => (
   <SafeAreaView style={styles.container}>
     <SectionList
       sections={DATA}
       keyExtractor={(item, index) => item + index}
-      renderItem={({item}) => <Item title={item} />}
+      renderItem={({item}) => (
+        <View style={styles.item}>
+          <Text style={styles.title}>{item}</Text>
+        </View>
+      )}
       renderSectionHeader={({section: {title}}) => (
         <Text style={styles.header}>{title}</Text>
       )}
@@ -130,12 +128,6 @@ const DATA = [
   },
 ];
 
-const Item = ({title}) => (
-  <View style={styles.item}>
-    <Text style={styles.title}>{title}</Text>
-  </View>
-);
-
 class App extends Component {
   render() {
     return (
@@ -143,7 +135,11 @@ class App extends Component {
         <SectionList
           sections={DATA}
           keyExtractor={(item, index) => item + index}
-          renderItem={({item}) => <Item title={item} />}
+          renderItem={({item}) => (
+            <View style={styles.item}>
+              <Text style={styles.title}>{item}</Text>
+            </View>
+          )}
           renderSectionHeader={({section: {title}}) => (
             <Text style={styles.header}>{title}</Text>
           )}

--- a/docs/segmentedcontrolios.md
+++ b/docs/segmentedcontrolios.md
@@ -3,7 +3,7 @@ id: segmentedcontrolios
 title: '🚧 SegmentedControlIOS'
 ---
 
-> **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.
+> **Removed from React Native.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 
@@ -13,7 +13,7 @@ The selected index can be changed on the fly by assigning the selectedIndex prop
 
 ## Example
 
-```SnackPlayer name=SegmentedControlIOS%20Example&supportedPlatforms=ios
+```SnackPlayer name=SegmentedControlIOS%20Example&supportedPlatforms=ios&ext=js
 import React, {useState} from 'react';
 import {SegmentedControlIOS, StyleSheet, Text, View} from 'react-native';
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,23 +12,24 @@ import React, {useState} from 'react';
 import {Button, Settings, StyleSheet, Text, View} from 'react-native';
 
 const App = () => {
-  const [data, setData] = useState(Settings.get('data'));
-
-  const storeData = inputData => {
-    Settings.set(inputData);
-    setData(Settings.get('data'));
-  };
+  const [data, setData] = useState(() => Settings.get('data'));
 
   return (
     <View style={styles.container}>
       <Text>Stored value:</Text>
       <Text style={styles.value}>{data}</Text>
       <Button
-        onPress={() => storeData({data: 'React'})}
+        onPress={() => {
+          Settings.set({data: 'React'});
+          setData(Settings.get('data'));
+        }}
         title="Store 'React'"
       />
       <Button
-        onPress={() => storeData({data: 'Native'})}
+        onPress={() => {
+          Settings.set({data: 'Native'});
+          setData(Settings.get('data'));
+        }}
         title="Store 'Native'"
       />
     </View>

--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -3,7 +3,12 @@ id: shadow-props
 title: Shadow Props
 ---
 
-```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios&ext=js
 import React, {useState} from 'react';
 import {Text, View, StyleSheet, Slider} from 'react-native';
 
@@ -45,21 +50,21 @@ const App = () => {
           minimumValue={-50}
           maximumValue={50}
           value={shadowOffsetWidth}
-          onValueChange={val => setShadowOffsetWidth(val)}
+          onValueChange={setShadowOffsetWidth}
         />
         <ShadowPropSlider
           label="shadowOffset - Y"
           minimumValue={-50}
           maximumValue={50}
           value={shadowOffsetHeight}
-          onValueChange={val => setShadowOffsetHeight(val)}
+          onValueChange={setShadowOffsetHeight}
         />
         <ShadowPropSlider
           label="shadowRadius"
           minimumValue={0}
           maximumValue={100}
           value={shadowRadius}
-          onValueChange={val => setShadowRadius(val)}
+          onValueChange={setShadowRadius}
         />
         <ShadowPropSlider
           label="shadowOpacity"
@@ -96,6 +101,111 @@ const styles = StyleSheet.create({
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios&ext=tsx
+import React, {useState} from 'react';
+import {Text, View, StyleSheet, Slider} from 'react-native';
+import type {SliderProps} from 'react-native';
+
+type ShadowPropSliderProps = SliderProps & {
+  label: string;
+};
+
+const ShadowPropSlider = ({label, value, ...props}: ShadowPropSliderProps) => {
+  return (
+    <>
+      <Text>
+        {label} ({value?.toFixed(2)})
+      </Text>
+      <Slider step={1} value={value} {...props} />
+    </>
+  );
+};
+
+const App = () => {
+  const [shadowOffsetWidth, setShadowOffsetWidth] = useState(0);
+  const [shadowOffsetHeight, setShadowOffsetHeight] = useState(0);
+  const [shadowRadius, setShadowRadius] = useState(0);
+  const [shadowOpacity, setShadowOpacity] = useState(0.1);
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={[
+          styles.square,
+          {
+            shadowOffset: {
+              width: shadowOffsetWidth,
+              height: -shadowOffsetHeight,
+            },
+            shadowOpacity,
+            shadowRadius,
+          },
+        ]}
+      />
+      <View style={styles.controls}>
+        <ShadowPropSlider
+          label="shadowOffset - X"
+          minimumValue={-50}
+          maximumValue={50}
+          value={shadowOffsetWidth}
+          onValueChange={setShadowOffsetWidth}
+        />
+        <ShadowPropSlider
+          label="shadowOffset - Y"
+          minimumValue={-50}
+          maximumValue={50}
+          value={shadowOffsetHeight}
+          onValueChange={setShadowOffsetHeight}
+        />
+        <ShadowPropSlider
+          label="shadowRadius"
+          minimumValue={0}
+          maximumValue={100}
+          value={shadowRadius}
+          onValueChange={setShadowRadius}
+        />
+        <ShadowPropSlider
+          label="shadowOpacity"
+          minimumValue={0}
+          maximumValue={1}
+          step={0.05}
+          value={shadowOpacity}
+          onValueChange={val => setShadowOpacity(val)}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+    backgroundColor: '#ecf0f1',
+    padding: 8,
+  },
+  square: {
+    alignSelf: 'center',
+    backgroundColor: 'white',
+    borderRadius: 4,
+    height: 150,
+    shadowColor: 'black',
+    width: 150,
+  },
+  controls: {
+    paddingHorizontal: 12,
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 # Reference
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -10,7 +10,10 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 <Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
-```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
 import React from 'react';
 import {Alert, Share, View, Button} from 'react-native';
 
@@ -45,9 +48,52 @@ export default ShareExample;
 ```
 
 </TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android&ext=tsx
+import React from 'react';
+import {Alert, Share, View, Button} from 'react-native';
+
+const ShareExample = () => {
+  const onShare = async () => {
+    try {
+      const result = await Share.share({
+        message:
+          'React Native | A framework for building native apps using React',
+      });
+      if (result.action === Share.sharedAction) {
+        if (result.activityType) {
+          // shared with activity type of result.activityType
+        } else {
+          // shared
+        }
+      } else if (result.action === Share.dismissedAction) {
+        // dismissed
+      }
+    } catch (error: any) {
+      Alert.alert(error.message);
+    }
+  };
+  return (
+    <View style={{marginTop: 50}}>
+      <Button onPress={onShare} title="Share" />
+    </View>
+  );
+};
+
+export default ShareExample;
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
 <TabItem value="classical">
 
-```SnackPlayer name=Class%20Component%20Example&supportedPlatforms=ios,android
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=Class%20Component%20Example&supportedPlatforms=ios,android&ext=js
 import React, {Component} from 'react';
 import {Alert, Share, View, Button} from 'react-native';
 
@@ -84,6 +130,50 @@ class ShareExample extends Component {
 
 export default ShareExample;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=Class%20Component%20Example&supportedPlatforms=ios,android&ext=tsx
+import React, {Component} from 'react';
+import {Alert, Share, View, Button} from 'react-native';
+
+class ShareExample extends Component {
+  onShare = async () => {
+    try {
+      const result = await Share.share({
+        message:
+          'React Native | A framework for building native apps using React',
+      });
+
+      if (result.action === Share.sharedAction) {
+        if (result.activityType) {
+          // shared with activity type of result.activityType
+        } else {
+          // shared
+        }
+      } else if (result.action === Share.dismissedAction) {
+        // dismissed
+      }
+    } catch (error: any) {
+      Alert.alert(error.message);
+    }
+  };
+
+  render() {
+    return (
+      <View style={{marginTop: 50}}>
+        <Button onPress={this.onShare} title="Share" />
+      </View>
+    );
+  }
+}
+
+export default ShareExample;
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/state.md
+++ b/docs/state.md
@@ -3,13 +3,18 @@ id: state
 title: State
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 There are two types of data that control a component: `props` and `state`. `props` are set by the parent and they are fixed throughout the lifetime of a component. For data that is going to change, we have to use `state`.
 
 In general, you should initialize `state` in the constructor, and then call `setState` when you want to change it.
 
 For example, let's say we want to make text that blinks all the time. The text itself gets set once when the blinking component gets created, so the text itself is a `prop`. The "whether the text is currently on or off" changes over time, so that should be kept in `state`.
 
-```SnackPlayer name=State
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=State&ext=js
 import React, {useState, useEffect} from 'react';
 import {Text, View} from 'react-native';
 
@@ -44,6 +49,52 @@ const BlinkApp = () => {
 
 export default BlinkApp;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=State&ext=tsx
+import React, {useState, useEffect} from 'react';
+import {Text, View} from 'react-native';
+
+type BlinkProps = {
+  text: string;
+};
+
+const Blink = (props: BlinkProps) => {
+  const [isShowingText, setIsShowingText] = useState(true);
+
+  useEffect(() => {
+    const toggle = setInterval(() => {
+      setIsShowingText(!isShowingText);
+    }, 1000);
+
+    return () => clearInterval(toggle);
+  });
+
+  if (!isShowingText) {
+    return null;
+  }
+
+  return <Text>{props.text}</Text>;
+};
+
+const BlinkApp = () => {
+  return (
+    <View style={{marginTop: 50}}>
+      <Blink text="I love to blink" />
+      <Blink text="Yes blinking is so great" />
+      <Blink text="Why did they ever take this out of HTML" />
+      <Blink text="Look at me look at me look at me" />
+    </View>
+  );
+};
+
+export default BlinkApp;
+```
+
+</TabItem>
+</Tabs>
 
 In a real application, you probably won't be setting state with a timer. You might set state when you have new data from the server, or from user input. You can also use a state container like [Redux](https://redux.js.org/) or [MobX](https://mobx.js.org/) to control your data flow. In that case you would use Redux or MobX to modify your state rather than calling `setState` directly.
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -9,7 +9,10 @@ Component to control the app's status bar. The status bar is the zone, typically
 
 It is possible to have multiple `StatusBar` components mounted at the same time. The props will be merged in the order the `StatusBar` components were mounted.
 
-```SnackPlayer name=StatusBar%20Component%20Example&supportedPlatforms=android,ios
+<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<TabItem value="javascript">
+
+```SnackPlayer name=StatusBar%20Component%20Example&supportedPlatforms=android,ios&ext=js
 import React, {useState} from 'react';
 import {
   Button,
@@ -105,6 +108,112 @@ const styles = StyleSheet.create({
 
 export default App;
 ```
+
+</TabItem>
+<TabItem value="typescript">
+
+```SnackPlayer name=StatusBar%20Component%20Example&supportedPlatforms=android,ios&ext=tsx
+import React, {useState} from 'react';
+import {
+  Button,
+  Platform,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import type {StatusBarStyle} from 'react-native';
+
+const STYLES = ['default', 'dark-content', 'light-content'] as const;
+const TRANSITIONS = ['fade', 'slide', 'none'] as const;
+
+const App = () => {
+  const [hidden, setHidden] = useState(false);
+  const [statusBarStyle, setStatusBarStyle] = useState<StatusBarStyle>(
+    STYLES[0],
+  );
+  const [statusBarTransition, setStatusBarTransition] = useState<
+    'fade' | 'slide' | 'none'
+  >(TRANSITIONS[0]);
+
+  const changeStatusBarVisibility = () => setHidden(!hidden);
+
+  const changeStatusBarStyle = () => {
+    const styleId = STYLES.indexOf(statusBarStyle) + 1;
+    if (styleId === STYLES.length) {
+      setStatusBarStyle(STYLES[0]);
+    } else {
+      setStatusBarStyle(STYLES[styleId]);
+    }
+  };
+
+  const changeStatusBarTransition = () => {
+    const transition = TRANSITIONS.indexOf(statusBarTransition) + 1;
+    if (transition === TRANSITIONS.length) {
+      setStatusBarTransition(TRANSITIONS[0]);
+    } else {
+      setStatusBarTransition(TRANSITIONS[transition]);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar
+        animated={true}
+        backgroundColor="#61dafb"
+        barStyle={statusBarStyle}
+        showHideTransition={statusBarTransition}
+        hidden={hidden}
+      />
+      <Text style={styles.textStyle}>
+        StatusBar Visibility:{'\n'}
+        {hidden ? 'Hidden' : 'Visible'}
+      </Text>
+      <Text style={styles.textStyle}>
+        StatusBar Style:{'\n'}
+        {statusBarStyle}
+      </Text>
+      {Platform.OS === 'ios' ? (
+        <Text style={styles.textStyle}>
+          StatusBar Transition:{'\n'}
+          {statusBarTransition}
+        </Text>
+      ) : null}
+      <View style={styles.buttonsContainer}>
+        <Button title="Toggle StatusBar" onPress={changeStatusBarVisibility} />
+        <Button title="Change StatusBar Style" onPress={changeStatusBarStyle} />
+        {Platform.OS === 'ios' ? (
+          <Button
+            title="Change StatusBar Transition"
+            onPress={changeStatusBarTransition}
+          />
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ECF0F1',
+  },
+  buttonsContainer: {
+    padding: 10,
+  },
+  textStyle: {
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+});
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 ### Imperative API
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -3,6 +3,8 @@ id: statusbar
 title: StatusBar
 ---
 
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
 Component to control the app's status bar. The status bar is the zone, typically at the top of the screen, that displays the current time, Wi-Fi and cellular network information, battery level and/or other status icons.
 
 ### Usage with Navigator

--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -194,7 +194,7 @@ const App = () => (
     <View style={styles.box1}>
       <Text style={styles.text}>1</Text>
     </View>
-    <View style={styles.box2}>
+    <View style={[styles.box2, StyleSheet.absoluteFill]}>
       <Text style={styles.text}>2</Text>
     </View>
     <View style={styles.box3}>
@@ -216,7 +216,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'red',
   },
   box2: {
-    ...StyleSheet.absoluteFill,
     width: 100,
     height: 100,
     backgroundColor: 'blue',
@@ -275,7 +274,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'red',
   },
   box2: {
-    ...StyleSheet.absoluteFill,
+    ...StyleSheet.absoluteFillObject,
     top: 120,
     left: 50,
     width: 100,
@@ -334,9 +333,3 @@ export default App;
 This constant will always be a round number of pixels (so a line defined by it can look crisp) and will try to match the standard width of a thin line on the underlying platform. However, you should not rely on it being a constant size, because on different platforms and screen densities its value may be calculated differently.
 
 A line with hairline width may not be visible if your simulator is downscaled.
-
----
-
-## `absoluteFill` vs. `absoluteFillObject`
-
-Currently, there is no difference between using `absoluteFill` vs. `absoluteFillObject`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sync-api-docs"
   ],
   "scripts": {
-    "postinstall": "yarn update-lock && patch-package",
+    "postinstall": "yarn update-lock && yarn workspace @react-native-website/lint-examples run patch-package",
     "update-lock": "yarn-deduplicate"
   },
   "husky": {

--- a/scripts/lint-examples/patches/react-native+0.71.0-rc.0.patch
+++ b/scripts/lint-examples/patches/react-native+0.71.0-rc.0.patch
@@ -1,3 +1,21 @@
+diff --git a/node_modules/react-native/Libraries/StyleSheet/StyleSheet.d.ts b/node_modules/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+index 95ad0dd..b332509 100644
+--- a/node_modules/react-native/Libraries/StyleSheet/StyleSheet.d.ts
++++ b/node_modules/react-native/Libraries/StyleSheet/StyleSheet.d.ts
+@@ -87,10 +87,10 @@ export namespace StyleSheet {
+    * an array, saving allocations and maintaining reference equality for
+    * PureComponent checks.
+    */
+-  export function compose<T>(
++  export function compose<T, U>(
+     style1: StyleProp<T> | Array<StyleProp<T>>,
+-    style2: StyleProp<T> | Array<StyleProp<T>>,
+-  ): StyleProp<T>;
++    style2: StyleProp<U> | Array<StyleProp<U>>,
++  ): StyleProp<T & U>;
+ 
+   /**
+    * WARNING: EXPERIMENTAL. Breaking changes will probably happen a lot and will
 diff --git a/node_modules/react-native/types/public/ReactNativeTypes.d.ts b/node_modules/react-native/types/public/ReactNativeTypes.d.ts
 index 38e00e1..3acd235 100644
 --- a/node_modules/react-native/types/public/ReactNativeTypes.d.ts


### PR DESCRIPTION
This makes examples in documents starting from Q-S valid for TypeScript. This leaves 9 examples left. Verified these pages locally after the change.
