### PR TITLE
chore: fix objective-c syntax highlighting on fabric guide

### DIFF
--- a/docs/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/docs/the-new-architecture/backward-compatibility-fabric-components.md
@@ -179,7 +179,7 @@ A Fabric Native Component requires an header file and an implementation file to 
 
 For example, the `RNMyComponentView.h` header file could look like this:
 
-```objective-c
+```objectivec title='RNMyComponentView.h'
 #import <React/RCTViewComponentView.h>
 #import <UIKit/UIKit.h>
 
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_END
 
 The implementation `RNMyComponentView.mm` file, instead, could look like this:
 
-```objective-c
+```objectivec title='RNMyComponentView.mm'
 #import "RNMyComponentView.h"
 
 // <react/renderer imports>

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
@@ -158,7 +158,7 @@ A Fabric Native Component requires an header file and an implementation file to 
 
 For example, the `RNMyComponentView.h` header file could look like this:
 
-```objective-c
+```objectivec title='RNMyComponentView.h'
 #import <React/RCTViewComponentView.h>
 #import <UIKit/UIKit.h>
 
@@ -177,7 +177,7 @@ NS_ASSUME_NONNULL_END
 
 The implementation `RNMyComponentView.mm` file, instead, could look like this:
 
-```objective-c
+```objectivec title='RNMyComponentView.mm'
 #import "RNMyComponentView.h"
 
 // <react/renderer imports>


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Hey, 

This PR fixes the syntax highlighting of objective-c files for fabric guide.

### Before 

<img width="844" alt="CleanShot 2022-12-15 at 17 18 27@2x" src="https://user-images.githubusercontent.com/52801365/207914081-23bbf170-6b69-4196-89ab-7a4c815106bf.png">

### After

<img width="844" alt="CleanShot 2022-12-15 at 17 21 02@2x" src="https://user-images.githubusercontent.com/52801365/207914133-85784196-0ca0-4d63-8938-dd6c3e6c7515.png">

