### PR TITLE
Make C++ TM example work with C++17

### DIFF
--- a/docs/the-new-architecture/cxx-custom-types.md
+++ b/docs/the-new-architecture/cxx-custom-types.md
@@ -196,11 +196,11 @@ struct Bridging<CustomType> {
       const jsi::Object &value,
       const std::shared_ptr<CallInvoker> &jsInvoker) {
     return CustomType{
-        .key = bridging::fromJs<std::string>(
+        bridging::fromJs<std::string>(
             rt, value.getProperty(rt, "key"), jsInvoker),
-        .enabled = bridging::fromJs<bool>(
+        bridging::fromJs<bool>(
             rt, value.getProperty(rt, "enabled"), jsInvoker),
-        .time = bridging::fromJs<std::optional<int32_t>>(
+        bridging::fromJs<std::optional<int32_t>>(
             rt, value.getProperty(rt, "time"), jsInvoker)};
   }
 


### PR DESCRIPTION
The example given uses C++20 syntax which MSVC does not support yet.
It works in clang with some special compiler flags. 
Updated sample also works in C++17 with MSVC.
Verified that example compiles in Xcode