### PR TITLE
Remove `NativeDeprecated` from "Direct Manipulation" page

### DIFF
--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -3,9 +3,7 @@ id: direct-manipulation
 title: Direct Manipulation
 ---
 
-import NativeDeprecated from './the-new-architecture/\_markdown_native_deprecation.mdx'; import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
-
-<NativeDeprecated />
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 It is sometimes necessary to make changes directly to a component without using state/props to trigger a re-render of the entire subtree. When using React in the browser for example, you sometimes need to directly modify a DOM node, and the same is true for views in mobile apps. `setNativeProps` is the React Native equivalent to setting properties directly on a DOM node.
 


### PR DESCRIPTION
This removes the deprecation notice at the top of "Direct Manipulation".

For the foreseeable future, `setNativeProps` will continue providing value in high frequency, performance-sensitive scenarios such as animations. Until we have a reasonable alternative, there is no reason for the deprecation notice to be displayed on this page.

This is additionally influenced by our ongoing work to implement `setNativeProps` in the New Architecture.

![Screenshot of the "Direct Manipulation" documentation page without the deprecation notice](https://user-images.githubusercontent.com/55161/209215566-b254eadc-741d-43e4-8795-ef5e45400996.png)
