### PR TITLE
fix: improve examples for Android Native Modules addListener/removeListeners

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -798,14 +798,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();
@@ -830,14 +840,23 @@ private fun sendEvent(reactContext: ReactContext, eventName: String, params: Wri
       .emit(eventName, params)
 }
 
+private var listenerCount = 0
+
 @ReactMethod
 fun addListener(eventName: String) {
+  if (listenerCount == 0) {
     // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1
 }
 
 @ReactMethod
 fun removeListeners(count: Int) {
+  listenerCount -= count
+  if (listenerCount == 0) {
     // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 val params = Arguments.createMap().apply {

--- a/website/versioned_docs/version-0.65/native-modules-android.md
+++ b/website/versioned_docs/version-0.65/native-modules-android.md
@@ -516,14 +516,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();

--- a/website/versioned_docs/version-0.66/native-modules-android.md
+++ b/website/versioned_docs/version-0.66/native-modules-android.md
@@ -516,14 +516,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();

--- a/website/versioned_docs/version-0.67/native-modules-android.md
+++ b/website/versioned_docs/version-0.67/native-modules-android.md
@@ -516,14 +516,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();

--- a/website/versioned_docs/version-0.68/native-modules-android.md
+++ b/website/versioned_docs/version-0.68/native-modules-android.md
@@ -797,14 +797,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();
@@ -829,14 +839,23 @@ private fun sendEvent(reactContext: ReactContext, eventName: String, params: Wri
       .emit(eventName, params)
 }
 
+private var listenerCount = 0
+
 @ReactMethod
 fun addListener(eventName: String) {
+  if (listenerCount == 0) {
     // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1
 }
 
 @ReactMethod
 fun removeListeners(count: Int) {
+  listenerCount -= count
+  if (listenerCount == 0) {
     // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 val params = Arguments.createMap().apply {

--- a/website/versioned_docs/version-0.69/native-modules-android.md
+++ b/website/versioned_docs/version-0.69/native-modules-android.md
@@ -797,14 +797,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();
@@ -829,14 +839,23 @@ private fun sendEvent(reactContext: ReactContext, eventName: String, params: Wri
       .emit(eventName, params)
 }
 
+private var listenerCount = 0
+
 @ReactMethod
 fun addListener(eventName: String) {
+  if (listenerCount == 0) {
     // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1
 }
 
 @ReactMethod
 fun removeListeners(count: Int) {
+  listenerCount -= count
+  if (listenerCount == 0) {
     // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 val params = Arguments.createMap().apply {

--- a/website/versioned_docs/version-0.70/native-modules-android.md
+++ b/website/versioned_docs/version-0.70/native-modules-android.md
@@ -798,14 +798,24 @@ private void sendEvent(ReactContext reactContext,
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
      .emit(eventName, params);
 }
+
+private int listenerCount = 0;
+
 @ReactMethod
 public void addListener(String eventName) {
-  // Set up any upstream listeners or background tasks as necessary
+  if (listenerCount == 0) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1;
 }
 
 @ReactMethod
 public void removeListeners(Integer count) {
-  // Remove upstream listeners, stop unnecessary background tasks
+  listenerCount -= count;
+  if (listenerCount == 0) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 WritableMap params = Arguments.createMap();
@@ -830,14 +840,23 @@ private fun sendEvent(reactContext: ReactContext, eventName: String, params: Wri
       .emit(eventName, params)
 }
 
+private var listenerCount = 0
+
 @ReactMethod
 fun addListener(eventName: String) {
+  if (listenerCount == 0) {
     // Set up any upstream listeners or background tasks as necessary
+  }
+
+  listenerCount += 1
 }
 
 @ReactMethod
 fun removeListeners(count: Int) {
+  listenerCount -= count
+  if (listenerCount == 0) {
     // Remove upstream listeners, stop unnecessary background tasks
+  }
 }
 ...
 val params = Arguments.createMap().apply {


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Improve Android Native Module examples for using `addListener`  and `removeListeners` with pattern that mimics the one in RCTEventEmitter on iOS. The current examples are not self explanatory, as `removeListeners` is called with not-obvious `count` parameter. I've sent 1 hr figuring out how all of these should work and want to save other readers from having to do the same research.
