### PR TITLE
Update optimizing-flatlist-configuration.md

### DIFF
--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -27,7 +27,7 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 | Type    | Default |
 | ------- | ------- |
-| Boolean | False   |
+| Boolean | False (iOS), True (Android)   |
 
 If `true`, views that are outside of the viewport are detached from the native view hierarchy.
 

--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -27,7 +27,7 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 | Type    | Default |
 | ------- | ------- |
-| Boolean | False (iOS), True (Android)   |
+| Boolean | false (iOS), true (Android)|
 
 If `true`, views that are outside of the viewport are detached from the native view hierarchy.
 


### PR DESCRIPTION
default for removeClippedSubviews is True on Android and False on iOS. The documentation did not reflect that (it said the default is always false)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
