### PR TITLE
Add @latest when creating library to ensure up-to-date template

### DIFF
--- a/docs/native-modules-setup.md
+++ b/docs/native-modules-setup.md
@@ -12,7 +12,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.64/native-modules-setup.md
+++ b/website/versioned_docs/version-0.64/native-modules-setup.md
@@ -8,7 +8,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.65/native-modules-setup.md
+++ b/website/versioned_docs/version-0.65/native-modules-setup.md
@@ -8,7 +8,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.66/native-modules-setup.md
+++ b/website/versioned_docs/version-0.66/native-modules-setup.md
@@ -8,7 +8,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.67/native-modules-setup.md
+++ b/website/versioned_docs/version-0.67/native-modules-setup.md
@@ -8,7 +8,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.68/native-modules-setup.md
+++ b/website/versioned_docs/version-0.68/native-modules-setup.md
@@ -8,7 +8,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.69/native-modules-setup.md
+++ b/website/versioned_docs/version-0.69/native-modules-setup.md
@@ -8,7 +8,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:

--- a/website/versioned_docs/version-0.70/native-modules-setup.md
+++ b/website/versioned_docs/version-0.70/native-modules-setup.md
@@ -12,7 +12,7 @@ Native modules are usually distributed as npm packages, except that on top of th
 To get set up with the basic project structure for a native module we will use the community tool called [create-react-native-library](https://github.com/callstack/react-native-builder-bob). You can go ahead further and dive deep into how that library works, but for our needs we will only execute the basic script:
 
 ```shell
-npx create-react-native-library react-native-awesome-module
+npx create-react-native-library@latest react-native-awesome-module
 ```
 
 Where `react-native-awesome-module` is the name you would like for the new module. After doing this you will navigate into `react-native-awesome-module` folder and bootstrap the example project by running:


### PR DESCRIPTION
When running a command with `npx`, there's no guarantee that it'll use the latest version of the package. If the package is already cached, it will use the cached version instead (see https://github.com/npm/cli/issues/4108). This can result in users getting a project based on an outdated template which might be missing any fixes.

This change adds `@latest` to the command to ensure that the latest version is always used. We already do this in Bob's documentation: https://github.com/callstack/react-native-builder-bob
