### PR TITLE
default for removeClippedSubviews is True on Android and False on iOS…

### DIFF
--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -25,9 +25,9 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 ### removeClippedSubviews
 
-| Type    | Default |
-| ------- | ------- |
-| Boolean | False   |
+| Type    | Default                     |
+| ------- |-----------------------------|
+| Boolean | False (iOS), True (Android) |
 
 If `true`, views that are outside of the viewport are detached from the native view hierarchy.
 


### PR DESCRIPTION
…. The documentation did not reflect that (it said the default is always false)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
