### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ Install the [Expo Go](https://expo.dev/client) app on your iOS or Android phone 
 
 <h3>Modifying your app</h3>
 
-Now that you have successfully run the app, let's modify it. Open `App.js` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
+Now that you have successfully run the app, let's modify it. Open `App.tsx` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
 
 <h3>That's it!</h3>
 

--- a/website/versioned_docs/version-0.71/getting-started.md
+++ b/website/versioned_docs/version-0.71/getting-started.md
@@ -50,7 +50,7 @@ Install the [Expo Go](https://expo.dev/client) app on your iOS or Android phone 
 
 <h3>Modifying your app</h3>
 
-Now that you have successfully run the app, let's modify it. Open `App.js` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
+Now that you have successfully run the app, let's modify it. Open `App.tsx` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
 
 <h3>That's it!</h3>
 


### PR DESCRIPTION
Starting with 0.71, TypeScript is used by default and instead of an `App.js` file an `App.tsx` file gets created.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
