### PR TITLE
Update running-on-device.md

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -59,7 +59,7 @@ $ npx react-native run-android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
-> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --mode=release`).
 
 <h2>Connecting to the development server</h2>
 


### PR DESCRIPTION
I believe the latest react-native init for Android uses "mode" instead of "variant."

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
