### PR TITLE
fix errors in keyboard.md

### DIFF
--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -270,7 +270,7 @@ Useful for syncing TextInput (or other keyboard accessory view) size of position
 
 ---
 
-### `dismiss()`
+### `isVisible()`
 
 ```tsx
 static isVisible(): boolean;
@@ -280,7 +280,7 @@ Whether the keyboard is last known to be visible.
 
 ---
 
-### `dismiss()`
+### `metrics()`
 
 ```tsx
 static metrics(): KeyboardMetrics | undefined;

--- a/website/versioned_docs/version-0.71/keyboard.md
+++ b/website/versioned_docs/version-0.71/keyboard.md
@@ -270,7 +270,7 @@ Useful for syncing TextInput (or other keyboard accessory view) size of position
 
 ---
 
-### `dismiss()`
+### `isVisible()`
 
 ```tsx
 static isVisible(): boolean;
@@ -280,7 +280,7 @@ Whether the keyboard is last known to be visible.
 
 ---
 
-### `dismiss()`
+### `metrics()`
 
 ```tsx
 static metrics(): KeyboardMetrics | undefined;


### PR DESCRIPTION
Fixes issues in docs/keyboard.md where methods have an incorrect heading (and hence sidebar title).

This is my first contribution. If I made a mistake, please do let me know and I will resolve it ASAP.