### PR TITLE
Replace deprecated `--variant` with `--mode`

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -116,10 +116,10 @@ In order for Google Play to accept AAB format the App Signing by Google Play nee
 Before uploading the release build to the Play Store, make sure you test it thoroughly. First uninstall any previous version of the app you already have installed. Install it on the device using the following command in the project root:
 
 ```shell
-npx react-native run-android --variant=release
+npx react-native run-android --mode=release
 ```
 
-Note that `--variant release` is only available if you've set up signing as described above.
+Note that `--mode release` is only available if you've set up signing as described above.
 
 You can terminate any running bundler instances, since all your framework and JavaScript code is bundled in the APK's assets.
 


### PR DESCRIPTION
CLI v10 compatible with v0.71 deprecated `--variant`

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
