### PR TITLE
Fix import in Turbo Native Modules sample code

### DIFF
--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -780,7 +780,7 @@ import {
   Text,
   Button,
 } from 'react-native';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator.js';
+import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
 
 const App: () => Node = () => {
   const [result, setResult] = useState<number | null>(null);

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
@@ -683,7 +683,7 @@ import {
   Text,
   Button,
 } from 'react-native';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator.js';
+import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
 
 const App: () => Node = () => {
   const [result, setResult] = useState<number | null>(null);

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
@@ -780,7 +780,7 @@ import {
   Text,
   Button,
 } from 'react-native';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator.js';
+import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
 
 const App: () => Node = () => {
   const [result, setResult] = useState<number | null>(null);


### PR DESCRIPTION
See https://github.com/facebook/react-native/issues/35832#issuecomment-1397125019.

This also aligns with existing code examples which use extensionless imports (more portable).