### PR TITLE
correct artifact codegen script name

### DIFF
--- a/docs/new-architecture-library-ios.md
+++ b/docs/new-architecture-library-ios.md
@@ -37,7 +37,7 @@ While this generated native interface code **will not ship as part of your libra
 
 ```sh
 cd <path/to/your/app>
-node node_modules/react-native/scripts/generate-artifacts.js \
+node node_modules/react-native/scripts/generate-codegen-artifacts.js \
     --path <your app>/ \
     --outputPath <an/output/path> \
 ```

--- a/docs/the-new-architecture/pillars-codegen.md
+++ b/docs/the-new-architecture/pillars-codegen.md
@@ -48,12 +48,12 @@ The rest of this guide assumes that you have a `Turbo Native Module` and/or a `F
 
 The **Codegen** for iOS relies on some Node scripts that are invoked during the build process. The scripts are located in the `MyApp/node_modules/react-native/scripts/` folder.
 
-The script that you have to run is the `generate-artifacts.js` script. This searches among all the dependencies of the app, looking for JS files that respects some specific conventions (look at [TurboModules](pillars-turbomodules) and [Fabric Components](pillars-fabric-components) sections for details), and it generates the required code.
+The script that you have to run is the `generate-codegen-artifacts.js` script. This searches among all the dependencies of the app, looking for JS files that respects some specific conventions (look at [TurboModules](pillars-turbomodules) and [Fabric Components](pillars-fabric-components) sections for details), and it generates the required code.
 
 To invoke the script, you can run this command from the root folder of your app:
 
 ```sh
-node node_modules/react-native/scripts/generate-artifacts.js \
+node node_modules/react-native/scripts/generate-codegen-artifacts.js \
     --path SampleApp/ \
     --outputPath <an/output/path> \
 ```

--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -362,12 +362,12 @@ To run Codegen for the iOS platform, open a terminal and run the following comma
 cd MyApp
 yarn add ../RTNCenteredText
 cd ..
-node MyApp/node_modules/react-native/scripts/generate-artifacts.js \
+node MyApp/node_modules/react-native/scripts/generate-codegen-artifacts.js \
   --path MyApp/ \
   --outputPath RTNCenteredText/generated/
 ```
 
-This script first adds the `RTNCenteredText` module to the app with `yarn add`. Then, it invokes **Codegen** via the `generate-artifacts.js` script.
+This script first adds the `RTNCenteredText` module to the app with `yarn add`. Then, it invokes **Codegen** via the `generate-codegen-artifacts.js` script.
 
 The `--path` option specifies the path to the app, while the `--outputPath` option tells the script where to output the generated code.
 

--- a/website/versioned_docs/version-0.71/new-architecture-library-ios.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-ios.md
@@ -37,7 +37,7 @@ While this generated native interface code **will not ship as part of your libra
 
 ```sh
 cd <path/to/your/app>
-node node_modules/react-native/scripts/generate-artifacts.js \
+node node_modules/react-native/scripts/generate-codegen-artifacts.js \
     --path <your app>/ \
     --outputPath <an/output/path> \
 ```

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -362,12 +362,12 @@ To run Codegen for the iOS platform, open a terminal and run the following comma
 cd MyApp
 yarn add ../RTNCenteredText
 cd ..
-node MyApp/node_modules/react-native/scripts/generate-artifacts.js \
+node MyApp/node_modules/react-native/scripts/generate-codegen-artifacts.js \
   --path MyApp/ \
   --outputPath RTNCenteredText/generated/
 ```
 
-This script first adds the `RTNCenteredText` module to the app with `yarn add`. Then, it invokes **Codegen** via the `generate-artifacts.js` script.
+This script first adds the `RTNCenteredText` module to the app with `yarn add`. Then, it invokes **Codegen** via the `generate-codegen-artifacts.js` script.
 
 The `--path` option specifies the path to the app, while the `--outputPath` option tells the script where to output the generated code.
 

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
@@ -347,12 +347,12 @@ To run Codegen for the iOS platform, we need to open a terminal and run the foll
 cd MyApp
 yarn add ../RTNCalculator
 cd ..
-node MyApp/node_modules/react-native/scripts/generate-artifacts.js \
+node MyApp/node_modules/react-native/scripts/generate-codegen-artifacts.js \
   --path MyApp/ \
   --outputPath RTNCalculator/generated/
 ```
 
-This script first adds the `RTNCalculator` module to the app with `yarn add`. Then, it invokes Codegen via the `generate-artifacts.js` script.
+This script first adds the `RTNCalculator` module to the app with `yarn add`. Then, it invokes Codegen via the `generate-codegen-artifacts.js` script.
 
 The `--path` option specifies the path to the app, while the `--outputPath` option tells Codegen where to output the generated code.
 


### PR DESCRIPTION
Follow up to #3526 & #3525.

It looks like we are mentioning the artifact codegen script file in few docs, so I have updated all of the occurrences in unversioned and 0.71 docs.
