### PR TITLE
Fix bundle install on M1

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -90,10 +90,16 @@ This is not necessary if you are integrating React Native into an existing appli
 
 If you are having trouble with iOS, try to reinstall the dependencies by running:
 
-1. `cd ios` to navigate to the
+1. `cd ios` to navigate to the ios folder
 2. `bundle install` to install Bundler
    1. If needed: install a [Ruby Version Manager](#ruby) and update the Ruby version
 3. `bundle exec pod install` to install the iOS dependencies.
+
+On M1 chip, if you get ```Multiple Podfiles were found``` error, try this instead:
+
+1. `cd ios` to navigate to the ios folder
+2. `arch -arm64 bundle install` to install Bundler
+3. `arch -arm64 bundle exec pod install` to install the iOS dependencies
 
 :::
 


### PR DESCRIPTION
On M1, bundle install will produce an error that could be mitigated by specifying the architecture (arm64)
The solution was found [here](https://github.com/CocoaPods/CocoaPods/issues/11641#issuecomment-1323173766)

## How to reproduce:

following the tutorial step by step and running `npx react-native init AwesomeProject` (installing with gem or brew produces the same error)

