### PR TITLE
Add description about onHoverIn/onHoverOut on Pressable

### DIFF
--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -167,7 +167,7 @@ Called when the hover is activated to provide visual feedback.
 
 | Type                                                |
 | --------------------------------------------------- |
-| ({ nativeEvent: MouseEvent }) => void |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
 
 ### `onHoverOut`
 
@@ -175,7 +175,7 @@ Called when the hover is deactivated to undo visual feedback.
 
 | Type                                                |
 | --------------------------------------------------- |
-| ({ nativeEvent: MouseEvent }) => void |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
 
 ### `onLongPress`
 

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -165,16 +165,16 @@ Sets additional distance outside of element in which a press can be detected.
 
 Called when the hover is activated to provide visual feedback.
 
-| Type                                                |
-| --------------------------------------------------- |
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
 | ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
 
 ### `onHoverOut`
 
 Called when the hover is deactivated to undo visual feedback.
 
-| Type                                                |
-| --------------------------------------------------- |
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
 | ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
 
 ### `onLongPress`

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -161,6 +161,22 @@ Sets additional distance outside of element in which a press can be detected.
 | ---------------------- |
 | [Rect](rect) or number |
 
+### `onHoverIn`
+
+Called when the hover is activated to provide visual feedback.
+
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: MouseEvent }) => void |
+
+### `onHoverOut`
+
+Called when the hover is deactivated to undo visual feedback.
+
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: MouseEvent }) => void |
+
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).

--- a/website/versioned_docs/version-0.68/pressable.md
+++ b/website/versioned_docs/version-0.68/pressable.md
@@ -169,16 +169,16 @@ Sets additional distance outside of element in which a press can be detected.
 
 Called when the hover is activated to provide visual feedback.
 
-| Type                                                |
-| --------------------------------------------------- |
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
 | ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
 
 ### `onHoverOut`
 
 Called when the hover is deactivated to undo visual feedback.
 
-| Type                                                |
-| --------------------------------------------------- |
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
 | ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
 
 ### `onLongPress`

--- a/website/versioned_docs/version-0.68/pressable.md
+++ b/website/versioned_docs/version-0.68/pressable.md
@@ -165,6 +165,22 @@ Sets additional distance outside of element in which a press can be detected.
 | ---------------------- |
 | [Rect](rect) or number |
 
+### `onHoverIn`
+
+Called when the hover is activated to provide visual feedback.
+
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
+### `onHoverOut`
+
+Called when the hover is deactivated to undo visual feedback.
+
+| Type                                                |
+| --------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).

--- a/website/versioned_docs/version-0.69/pressable.md
+++ b/website/versioned_docs/version-0.69/pressable.md
@@ -165,6 +165,22 @@ Sets additional distance outside of element in which a press can be detected.
 | ---------------------- |
 | [Rect](rect) or number |
 
+### `onHoverIn`
+
+Called when the hover is activated to provide visual feedback.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
+### `onHoverOut`
+
+Called when the hover is deactivated to undo visual feedback.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).

--- a/website/versioned_docs/version-0.70/pressable.md
+++ b/website/versioned_docs/version-0.70/pressable.md
@@ -165,6 +165,22 @@ Sets additional distance outside of element in which a press can be detected.
 | ---------------------- |
 | [Rect](rect) or number |
 
+### `onHoverIn`
+
+Called when the hover is activated to provide visual feedback.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
+### `onHoverOut`
+
+Called when the hover is deactivated to undo visual feedback.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).

--- a/website/versioned_docs/version-0.71/pressable.md
+++ b/website/versioned_docs/version-0.71/pressable.md
@@ -161,6 +161,22 @@ Sets additional distance outside of element in which a press can be detected.
 | ---------------------- |
 | [Rect](rect) or number |
 
+### `onHoverIn`
+
+Called when the hover is activated to provide visual feedback.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
+### `onHoverOut`
+
+Called when the hover is deactivated to undo visual feedback.
+
+| Type                                                                                                 |
+| ---------------------------------------------------------------------------------------------------- |
+| ({ nativeEvent: [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) }) => void |
+
 ### `onLongPress`
 
 Called if the time after `onPressIn` lasts longer than 500 milliseconds. This time period can be customized with [`delayLongPress`](#delaylongpress).


### PR DESCRIPTION

I found `onHoverIn` and `onHoverOut ` is implemented  in [Presssable component](https://github.com/facebook/react-native/blob/d5e6d9cecd1a8b02d47c4dfaffc550167b093b32/Libraries/Components/Pressable/Pressable.js#L130-L138),
so I added description about those props to docs.

Diff's screenshot: 
<img width="1379" alt="スクリーンショット 2023-01-25 9 07 40" src="https://user-images.githubusercontent.com/15419227/214449131-4e7cd75c-d153-42ce-bada-afdd9d3093e7.png">


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
