### PR TITLE
add new CLI feature for selecting target device

### DIFF
--- a/docs/running-on-simulator-ios.md
+++ b/docs/running-on-simulator-ios.md
@@ -7,7 +7,11 @@ title: Running On Simulator
 
 Once you have your React Native project initialized, you can run `npx react-native run-ios` inside the newly created project directory. If everything is set up correctly, you should see your new app running in the iOS Simulator shortly.
 
-## Specifying a device
+## Choosing a specific simulator or device
+
+The easiest way to specify a device is by passing the `--list-devices` flag. This will provide an interactive list of all devices and simulators available. For example, if you wish to run on your connected iPhone, you can run `npx react native run-ios --list-devices` and then simply select your iPhone from the list.
+
+## Manually specifying a device
 
 You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone 14"`. If you wish to run your app on an iPhone SE (3rd generation), run `npx react-native run-ios --simulator='iPhone SE (3rd generation)'`.
 

--- a/docs/running-on-simulator-ios.md
+++ b/docs/running-on-simulator-ios.md
@@ -9,7 +9,7 @@ Once you have your React Native project initialized, you can run `npx react-nati
 
 ## Choosing a specific simulator or device
 
-The easiest way to specify a device is by passing the `--list-devices` flag. This will provide an interactive list of all devices and simulators available. For example, if you wish to run on your connected iPhone, you can run `npx react native run-ios --list-devices` and then simply select your iPhone from the list.
+The easiest way to specify a device is by passing the `--list-devices` flag. This will provide an interactive list of all devices and simulators available. For example, if you wish to run on your connected iPhone, you can run `npx react native run-ios --list-devices` and then simply select your iPhone from the list. This works for both simulators and connected physical devices.
 
 ## Manually specifying a device
 


### PR DESCRIPTION

**What**: There is a new `--list-devices` flag being added to the React Native CLI that provides an interactive list of available devices (for both iOS and Android). It's very nice.

**Why**: TL;DR: Convenience & ✨✨ **_Developer Experience_** ✨✨

This interactive approach allows a user to not need to manually run `xcrun simctl list devices` or `adb devices` in order to copy and then paste the exact device name into a `--simulator <simulator_name>` or `--deviceID <device_id>` , for iOS and Android, respectively.

**Status**: Besides approval on this PR, these changes need to land over in [React Native CLI land](https://github.com/react-native-community/cli):
- [x] Android is already merged -- https://github.com/react-native-community/cli/pull/1765  (🥇 @adamTrz )
- [ ] iOS is in review https://github.com/react-native-community/cli/pull/1676

---- 
### Not In Scope
**Consolidating the docs around running on devices and simulators/emulators.**
I noticed that there are at least 3 few places mentioning how to run ([Environment Setup](https://reactnative.dev/docs/environment-setup), [Running on Device](https://reactnative.dev/docs/running-on-device), [Running on iOS Simulator](https://reactnative.dev/docs/running-on-simulator-ios)), but it doesn't feel like there is a definitive place or pattern to the docs. For instance, that third location is a specific iOS guide for running on specific devices/simulators, but there isn't a similar page in the Android guide on the same topic. 

Suggestion:

1. Make an Android "Running on Emulator" (mirroring the iOS "Running on Simulator")
2. Expand these to fully cover running on physical devices, as well. They should become the definitive guides on building to specific iOS and Android dev targets, respectively.
3. Remove explanations in Environment Setup and Running on Device pages, and replace them with a reference to these 2 new "definitive" pages.
4. Drastically simplify the "Running on Device" page to use the automated processes the CLI supports. E.g., for Android, the CLI will try to do the adb reverse for selected device, it will also interactively list devices, etc. You could turn this page for Android dev into "Run `npx react-native run-android --list-devices` and select the connected device or emulator you'd prefer. For more information, check the <Running on Android> Page", which would also have the (old) manual steps.

I may also be hyper-focused on this topic and it's maybe not that big of a deal. 🤷 