### PR TITLE
Adding an info box on NVM and zsh to MacOS + iOS

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -118,6 +118,17 @@ This is the **suggested approach** to decouple the build infrastructure from the
 
 On top of this, it's possible to add any other environment variable and to source the `.xcode.env` file in your build script phases. If you need to run script that requires some specific environment, this is the **suggested approach**: it allows to decouple the build phases from a specific environment.
 
+:::info
+If you are already using [NVM](http://nvm.sh/) (a command which helps you install and switch between versions of Node.js) and [zsh](https://ohmyz.sh/), you might want to move the code that initialize NVM from your `~/.zshrc` into a `~/.zshenv` file to help Xcode find your Node executable:
+
+```
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+```
+
+You might also want to ensure that all "shell script build phase" of your Xcode project, is using `/bin/zsh` as its shell.
+:::
+
 ## Running your React Native application
 
 ### Step 1: Start Metro


### PR DESCRIPTION
For users of NVM ([a very popular Node.js version manager](https://2022.stateofjs.com/en-US/other-tools/#utilities)) and zsh (which is now the default shell on macOS), I want to add an info box to help workaround a common issue of the current React Native template, to help Xcode resolve the correct path for Node.js when invoking shell scripts.

![Screenshot 2023-01-25 at 14 21 17](https://user-images.githubusercontent.com/1243959/214578103-dfd1246d-60b4-4730-b8c2-3097744c2ce4.png)

On a related note, I've commented on an issue in the NVM repository to update the install.sh script to have this happen automatically for new users: https://github.com/nvm-sh/nvm/issues/338#issuecomment-1403559575