### PR TITLE
docs: update correct usage of LayoutAnimation.create

### DIFF
--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -237,12 +237,9 @@ class App extends Component {
   };
 
   toggleBox = () => {
-    LayoutAnimation.configureNext({
-      duration: 500,
-      create: {type: 'linear', property: 'opacity'},
-      update: {type: 'spring', springDamping: 0.4},
-      delete: {type: 'linear', property: 'opacity'},
-    });
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(500, 'linear', 'opacity'),
+    );
     this.setState({
       boxPosition: this.state.boxPosition === 'left' ? 'right' : 'left',
     });

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -167,7 +167,7 @@ const App = () => {
 
   const toggleBox = () => {
     LayoutAnimation.configureNext(
-      LayoutAnimation.create(500, 'linear', 'spring'),
+      LayoutAnimation.create(500, 'linear', 'opacity'),
     );
     setBoxPosition(boxPosition === 'left' ? 'right' : 'left');
   };

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -167,7 +167,7 @@ const App = () => {
 
   const toggleBox = () => {
     LayoutAnimation.configureNext(
-      LayoutAnimation.create(500, 'linear', 'spring')
+      LayoutAnimation.create(500, 'linear', 'spring'),
     );
     setBoxPosition(boxPosition === 'left' ? 'right' : 'left');
   };

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -124,10 +124,20 @@ The config that's passed to `create`, `update`, or `delete` has the following ke
 ### `create()`
 
 ```tsx
-static create(duration, type, creationProp)
+static create(duration, type, property)
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `property` parameter is a [layout property](layoutanimation.md#properties).
+
+#### Parameters:
+
+| Name     | Type                    | Required | Description                    |
+| -------- | ----------------------- | -------- | ------------------------------ |
+| duration | number                  | Yes      | The duration of the animation  |
+| type     | LayoutAnimationType     | Yes      | Animation type to use          |
+| property | LayoutAnimationProperty | Yes      | The layout property to animate |
+
+To check the exact object `create()` returns, see the React Natvie LayoutAnimation API [Source Code](https://github.com/facebook/react-native/blob/main/Libraries/LayoutAnimation/LayoutAnimation.js#L104-L115).
 
 **Example:**
 
@@ -156,12 +166,9 @@ const App = () => {
   const [boxPosition, setBoxPosition] = useState('left');
 
   const toggleBox = () => {
-    LayoutAnimation.configureNext({
-      duration: 500,
-      create: {type: 'linear', property: 'opacity'},
-      update: {type: 'spring', springDamping: 0.4},
-      delete: {type: 'linear', property: 'opacity'},
-    });
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(500, 'linear', 'spring')
+    );
     setBoxPosition(boxPosition === 'left' ? 'right' : 'left');
   };
 

--- a/website/versioned_docs/version-0.71/layoutanimation.md
+++ b/website/versioned_docs/version-0.71/layoutanimation.md
@@ -237,12 +237,9 @@ class App extends Component {
   };
 
   toggleBox = () => {
-    LayoutAnimation.configureNext({
-      duration: 500,
-      create: {type: 'linear', property: 'opacity'},
-      update: {type: 'spring', springDamping: 0.4},
-      delete: {type: 'linear', property: 'opacity'},
-    });
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(500, 'linear', 'opacity'),
+    );
     this.setState({
       boxPosition: this.state.boxPosition === 'left' ? 'right' : 'left',
     });

--- a/website/versioned_docs/version-0.71/layoutanimation.md
+++ b/website/versioned_docs/version-0.71/layoutanimation.md
@@ -167,7 +167,7 @@ const App = () => {
 
   const toggleBox = () => {
     LayoutAnimation.configureNext(
-      LayoutAnimation.create(500, 'linear', 'spring'),
+      LayoutAnimation.create(500, 'linear', 'opacity'),
     );
     setBoxPosition(boxPosition === 'left' ? 'right' : 'left');
   };

--- a/website/versioned_docs/version-0.71/layoutanimation.md
+++ b/website/versioned_docs/version-0.71/layoutanimation.md
@@ -167,7 +167,7 @@ const App = () => {
 
   const toggleBox = () => {
     LayoutAnimation.configureNext(
-      LayoutAnimation.create(500, 'linear', 'spring')
+      LayoutAnimation.create(500, 'linear', 'spring'),
     );
     setBoxPosition(boxPosition === 'left' ? 'right' : 'left');
   };

--- a/website/versioned_docs/version-0.71/layoutanimation.md
+++ b/website/versioned_docs/version-0.71/layoutanimation.md
@@ -124,10 +124,20 @@ The config that's passed to `create`, `update`, or `delete` has the following ke
 ### `create()`
 
 ```tsx
-static create(duration, type, creationProp)
+static create(duration, type, property)
 ```
 
-Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `creationProp` parameter is a [layout property](layoutanimation.md#properties).
+Helper that creates an object (with `create`, `update`, and `delete` fields) to pass into [`configureNext`](layoutanimation.md#configurenext). The `type` parameter is an [animation type](layoutanimation.md#types), and the `property` parameter is a [layout property](layoutanimation.md#properties).
+
+#### Parameters:
+
+| Name     | Type                    | Required | Description                    |
+| -------- | ----------------------- | -------- | ------------------------------ |
+| duration | number                  | Yes      | The duration of the animation  |
+| type     | LayoutAnimationType     | Yes      | Animation type to use          |
+| property | LayoutAnimationProperty | Yes      | The layout property to animate |
+
+To check the exact object `create()` returns, see the React Natvie LayoutAnimation API [Source Code](https://github.com/facebook/react-native/blob/main/Libraries/LayoutAnimation/LayoutAnimation.js#L104-L115).
 
 **Example:**
 
@@ -156,12 +166,9 @@ const App = () => {
   const [boxPosition, setBoxPosition] = useState('left');
 
   const toggleBox = () => {
-    LayoutAnimation.configureNext({
-      duration: 500,
-      create: {type: 'linear', property: 'opacity'},
-      update: {type: 'spring', springDamping: 0.4},
-      delete: {type: 'linear', property: 'opacity'},
-    });
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(500, 'linear', 'spring')
+    );
     setBoxPosition(boxPosition === 'left' ? 'right' : 'left');
   };
 


### PR DESCRIPTION
# Update

A long time ago, I had opened a pull request about a bug in `LayoutAnimation.create()`.
Upon inspecting it a bit more, I found out it was not a bug.
The properties were not set and the documentation had no table to explain the parameters requirements.

https://github.com/facebook/react-native/issues/33740

The issue can be closed now.

# Changes to the documentation

1. Rename `creationProp` to `property`. Since the original function's parameter's name is `property`
2. Add table parameters with all of the parameters set to required w
3. Update Snack Example with updated API Example (both function and dclass example)

The problem was the example and the table which was inaccurate. Not sure why but even without some of the parameters, iOS worked and android didn't. But with all of the parameters defined in the example, it works in both platforms.