### PR TITLE
Update headless-js documentation

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -55,7 +55,7 @@ public class MyTaskService extends HeadlessJsTaskService {
       return new HeadlessJsTaskConfig(
           "SomeTaskName",
           Arguments.fromBundle(extras),
-          5000, // timeout for the task
+          5000, // timeout in milliseconds for the task
           false // optional: defines whether or not the task is allowed in foreground. Default is false
         );
     }


### PR DESCRIPTION
Mention that the timeout is in milliseconds.

Time units are important and may cause confusion!

Source: https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/jstasks/HeadlessJsTaskConfig.java#L43

