### PR TITLE
Update optimizing-flatlist-configuration.md

### DIFF
--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -123,7 +123,9 @@ You can also use a `key` prop in your item component.
 
 ### Avoid anonymous function on renderItem
 
-Move out the `renderItem` function to the outside of render function, so it won't recreate itself each time render function called.
+For functional components, move the `renderItem` function outside of the returned JSX. Also, ensure that it is wrapped in a `useCallback` to prevent it from being recreated each render.
+
+For class componenents, move the `renderItem` function outside of the render function, so it won't recreate itself each time the render function called.
 
 <Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">

--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -125,7 +125,7 @@ You can also use a `key` prop in your item component.
 
 For functional components, move the `renderItem` function outside of the returned JSX. Also, ensure that it is wrapped in a `useCallback` hook to prevent it from being recreated each render.
 
-For class componenents, move the `renderItem` function outside of the render function, so it won't recreate itself each time the render function called.
+For class componenents, move the `renderItem` function outside of the render function, so it won't recreate itself each time the render function is called.
 
 <Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">

--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -123,7 +123,7 @@ You can also use a `key` prop in your item component.
 
 ### Avoid anonymous function on renderItem
 
-For functional components, move the `renderItem` function outside of the returned JSX. Also, ensure that it is wrapped in a `useCallback` to prevent it from being recreated each render.
+For functional components, move the `renderItem` function outside of the returned JSX. Also, ensure that it is wrapped in a `useCallback` hook to prevent it from being recreated each render.
 
 For class componenents, move the `renderItem` function outside of the render function, so it won't recreate itself each time the render function called.
 


### PR DESCRIPTION
Based on my understanding, to gain the benefit of not having the `renderItem` function not recreate/rerun, it should be wrapped in a `useCallback` in functional components. The code snippet already demonstrates this. However, the docs do not explain this nor explain why this should be done.

Minor clarity adjustments as well. Let me know if my understanding is incorrect or if I should make further changes.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
