### PR TITLE
rename type and method from GreetingsProps to GreetingProps

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -64,11 +64,11 @@ export default LotsOfGreetings;
 import React from 'react';
 import {Text, View} from 'react-native';
 
-type GreetingsProps = {
+type GreetingProps = {
   name: string;
 };
 
-const Greeting = (props: GreetingsProps) => {
+const Greeting = (props: GreetingProps) => {
   return (
     <View style={{alignItems: 'center'}}>
       <Text>Hello {props.name}!</Text>

--- a/website/versioned_docs/version-0.71/props.md
+++ b/website/versioned_docs/version-0.71/props.md
@@ -64,11 +64,11 @@ export default LotsOfGreetings;
 import React from 'react';
 import {Text, View} from 'react-native';
 
-type GreetingsProps = {
+type GreetingProps = {
   name: string;
 };
 
-const Greeting = (props: GreetingsProps) => {
+const Greeting = (props: GreetingProps) => {
   return (
     <View style={{alignItems: 'center'}}>
       <Text>Hello {props.name}!</Text>


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#3519 
-->
