### PR TITLE
feat: Add logical border color props

### DIFF
--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -71,6 +71,30 @@ export default ViewStyleProps;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomColor`
 
 | Type               |
@@ -188,6 +212,30 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 ---
 
 ### `borderStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderInlineColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderInlineEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderInlineStartColor`
 
 | Type               |
 | ------------------ |


### PR DESCRIPTION
This PR updates the View Style Props documentation to include the following new border color logical properties: 

- `borderBlockColor` 
- `borderBlockEndColor` 
- `borderBlockStartColor` 
- `borderInlineColor` 
- `borderInlineEndColor` 
- `borderInlineStartColor` 


Related to https://github.com/facebook/react-native/commit/597a1ff60b3e1844b4794fb4acd40fa073f2e93b  https://github.com/facebook/react-native/pull/36046
