### PR TITLE
new syntax in native modules android

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -880,7 +880,7 @@ useEffect(() => {
       console.log(event.eventProperty) // "someValue"
     });
 
-    //cut the listening at unmounted
+    // Removes the listener once unmounted
     return () => {
       eventListener.remove();
     };

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -874,19 +874,18 @@ JavaScript modules can then register to receive events by `addListener` on the [
 ```tsx
 import {NativeEventEmitter, NativeModules} from 'react-native';
 ...
+useEffect(() => {
+     const eventEmitter = new NativeEventEmitter(NativeModules.ToastExample);
+    //treat the message return :
+    let eventListener = eventEmitter.addListener('EventReminder', event => {
+      console.log('the bundle:', event); // the bundle sent by module
+    });
 
- componentDidMount() {
-   ...
-   const eventEmitter = new NativeEventEmitter(NativeModules.ToastExample);
-   this.eventListener = eventEmitter.addListener('EventReminder', event => {
-      console.log(event.eventProperty) // "someValue"
-   });
-   ...
- }
-
- componentWillUnmount() {
-   this.eventListener.remove(); //Removes the listener
- }
+    //cut the listening at unmounted
+    return () => {
+      eventListener.remove();
+    };
+  }, []);
 ```
 
 ### Getting Activity Result from startActivityForResult

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -875,10 +875,9 @@ JavaScript modules can then register to receive events by `addListener` on the [
 import {NativeEventEmitter, NativeModules} from 'react-native';
 ...
 useEffect(() => {
-     const eventEmitter = new NativeEventEmitter(NativeModules.ToastExample);
-    //treat the message return :
+    const eventEmitter = new NativeEventEmitter(NativeModules.ToastExample);
     let eventListener = eventEmitter.addListener('EventReminder', event => {
-      console.log('the bundle:', event); // the bundle sent by module
+      console.log(event.eventProperty) // "someValue"
     });
 
     //cut the listening at unmounted


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->the problem was to write and use  NativeEventEmitter in the new syntax (for new developpers) with useEffect
I solved and publish that code version tested
