### PR TITLE
add onPressIn and onPressOut props on text page

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -565,7 +565,27 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Called after `onPressOut`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
 
 | Type                                              |
 | ------------------------------------------------- |

--- a/docs/text.md
+++ b/docs/text.md
@@ -565,7 +565,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-Called after `onPressOut`.
+Function called on user press, triggered after `onPressOut`.
 
 | Type                                              |
 | ------------------------------------------------- |

--- a/website/versioned_docs/version-0.66/text.md
+++ b/website/versioned_docs/version-0.66/text.md
@@ -481,11 +481,31 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Function called on user press, triggered after `onPressOut`.
 
-| Type                                                |
-| --------------------------------------------------- |
-| ({ nativeEvent: [PressEvent](pressevent) }) => void |
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
 
 ---
 

--- a/website/versioned_docs/version-0.67/text.md
+++ b/website/versioned_docs/version-0.67/text.md
@@ -481,11 +481,31 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Function called on user press, triggered after `onPressOut`.
 
-| Type                                                |
-| --------------------------------------------------- |
-| ({ nativeEvent: [PressEvent](pressevent) }) => void |
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
 
 ---
 

--- a/website/versioned_docs/version-0.68/text.md
+++ b/website/versioned_docs/version-0.68/text.md
@@ -481,11 +481,31 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Function called on user press, triggered after `onPressOut`.
 
-| Type                                                |
-| --------------------------------------------------- |
-| ({ nativeEvent: [PressEvent](pressevent) }) => void |
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
 
 ---
 

--- a/website/versioned_docs/version-0.69/text.md
+++ b/website/versioned_docs/version-0.69/text.md
@@ -493,11 +493,31 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Function called on user press, triggered after `onPressOut`.
 
-| Type                                                |
-| --------------------------------------------------- |
-| ({ nativeEvent: [PressEvent](pressevent) }) => void |
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
 
 ---
 

--- a/website/versioned_docs/version-0.70/text.md
+++ b/website/versioned_docs/version-0.70/text.md
@@ -493,11 +493,31 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Function called on user press, triggered after `onPressOut`.
 
-| Type                                                |
-| --------------------------------------------------- |
-| ({ nativeEvent: [PressEvent](pressevent) }) => void |
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
 
 ---
 

--- a/website/versioned_docs/version-0.71/text.md
+++ b/website/versioned_docs/version-0.71/text.md
@@ -555,7 +555,27 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 ### `onPress`
 
-This function is called on press.
+Function called on user press, triggered after `onPressOut`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressIn`
+
+Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
+
+| Type                                              |
+| ------------------------------------------------- |
+| ({nativeEvent: [PressEvent](pressevent)}) => void |
+
+---
+
+### `onPressOut`
+
+Called when a touch is released.
 
 | Type                                              |
 | ------------------------------------------------- |


### PR DESCRIPTION
The [`Text`](https://reactnative.dev/docs/text) page of the documentation doesn't explain that the components embarks also the `onPressIn` and `onPressOut` props. 

Related to the issue [`#3563`](https://github.com/facebook/react-native-website/issues/3563)
