### PR TITLE
docs: update Codegen types description

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -138,8 +138,8 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Int32`
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
-- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent up to the root (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`) and don't bubble.
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -136,9 +136,10 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Double`
 - `Float`
 - `Int32`
+- `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For bubbling events (eg: `onChange`).
-- `DirectEventHandler<T>` - For direct events (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.68/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.68/new-architecture-library-intro.md
@@ -88,7 +88,7 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Int32`
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent up to the root (eg: `onStartShouldSetResponder`).
 - `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`) and don't bubble.
 
 Later on those types are compiled to coresponding equivalents on target platforms.

--- a/website/versioned_docs/version-0.68/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.68/new-architecture-library-intro.md
@@ -86,9 +86,10 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Double`
 - `Float`
 - `Int32`
+- `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For bubbling events (eg: `onChange`).
-- `DirectEventHandler<T>` - For direct events (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.68/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.68/new-architecture-library-intro.md
@@ -88,7 +88,7 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Int32`
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent (eg: `onStartShouldSetResponder`).
 - `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
 
 Later on those types are compiled to coresponding equivalents on target platforms.

--- a/website/versioned_docs/version-0.68/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.68/new-architecture-library-intro.md
@@ -89,7 +89,7 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
 - `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent (eg: `onStartShouldSetResponder`).
-- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`) and don't bubble.
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.69/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.69/new-architecture-library-intro.md
@@ -137,8 +137,8 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Int32`
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
-- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent up to the root (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`) and don't bubble.
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.69/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.69/new-architecture-library-intro.md
@@ -135,9 +135,10 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Double`
 - `Float`
 - `Int32`
+- `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For bubbling events (eg: `onChange`).
-- `DirectEventHandler<T>` - For direct events (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.70/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.70/new-architecture-library-intro.md
@@ -138,8 +138,8 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Int32`
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
-- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent up to the root (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`) and don't bubble.
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.70/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.70/new-architecture-library-intro.md
@@ -136,9 +136,10 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Double`
 - `Float`
 - `Int32`
+- `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For bubbling events (eg: `onChange`).
-- `DirectEventHandler<T>` - For direct events (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -138,8 +138,8 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Int32`
 - `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
-- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated (bubbled) up the component tree from child to parent up to the root (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`) and don't bubble.
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -136,9 +136,10 @@ You can use predefined types for your JavaScript spec, here is a list of them:
 - `Double`
 - `Float`
 - `Int32`
+- `UnsafeObject`
 - `WithDefault<Type, Value>` - Sets default value for type
-- `BubblingEventHandler<T>` - For bubbling events (eg: `onChange`).
-- `DirectEventHandler<T>` - For direct events (eg: `onClick`).
+- `BubblingEventHandler<T>` - For events that are propagated up the component tree from child to parent (eg: `onStartShouldSetResponder`).
+- `DirectEventHandler<T>` - For events that are called only on element recieving the event (eg: `onClick`).
 
 Later on those types are compiled to coresponding equivalents on target platforms.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Hey, 

This PR updates misleading codegen types event description and also adds `UnsafeObject` helper type to the list.
