### PR TITLE
Specify Explicit React Native Version For Init

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -84,7 +84,7 @@ React Native has a built-in command line interface. Rather than install and mana
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -94,7 +94,7 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -96,7 +96,7 @@ React Native has a built-in command line interface. Rather than install and mana
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -106,7 +106,7 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -81,7 +81,7 @@ React Native has a built-in command line interface. Rather than install and mana
 You can use React Native's built-in command line interface to generate a new project. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -102,7 +102,7 @@ If you are having trouble with iOS, try to reinstall the dependencies by running
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -115,7 +115,7 @@ React Native has a built-in command line interface. Rather than install and mana
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -125,7 +125,7 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/docs/the-new-architecture/use-app-template.md
+++ b/docs/the-new-architecture/use-app-template.md
@@ -28,7 +28,7 @@ If you're using Expo, you can't enable the New Architecture at the moment and wi
 If you already have your development environment set up, create a new React Native project from the template:
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 :::caution

--- a/website/versioned_docs/version-0.71/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-linux-android.md
@@ -84,7 +84,7 @@ React Native has a built-in command line interface. Rather than install and mana
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -94,7 +94,7 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/website/versioned_docs/version-0.71/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-android.md
@@ -96,7 +96,7 @@ React Native has a built-in command line interface. Rather than install and mana
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -106,7 +106,7 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
@@ -81,7 +81,7 @@ React Native has a built-in command line interface. Rather than install and mana
 You can use React Native's built-in command line interface to generate a new project. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding iOS support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -102,7 +102,7 @@ If you are having trouble with iOS, try to reinstall the dependencies by running
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/website/versioned_docs/version-0.71/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-windows-android.md
@@ -115,7 +115,7 @@ React Native has a built-in command line interface. Rather than install and mana
 React Native has a built-in command line interface, which you can use to generate a new project. You can access it without installing anything globally using `npx`, which ships with Node.js. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, if you "ejected" from Expo, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to init your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -125,7 +125,7 @@ This is not necessary if you are integrating React Native into an existing appli
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native init AwesomeProject --version X.XX.X
+npx react-native@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument.

--- a/website/versioned_docs/version-0.71/the-new-architecture/use-app-template.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/use-app-template.md
@@ -28,7 +28,7 @@ If you're using Expo, you can't enable the New Architecture at the moment and wi
 If you already have your development environment set up, create a new React Native project from the template:
 
 ```shell
-npx react-native init AwesomeProject
+npx react-native@latest init AwesomeProject
 ```
 
 :::caution


### PR DESCRIPTION
`npx react-native init` [is not guaranteed](https://github.com/npm/cli/issues/4108) to pull in `react-native@latest`. When the bootstrapping CLI is mismatched from the react-native version it tries to install, it may not work correctly.

Currently, this means if you previously installed RN 0.70, you may end up using `react-native init` from RN 0.70, using CLI `9.2.1`, to bootstrap your React Native 0.71 app. This seems to lead to the CLI not correctly generating the template app. Most visibly, files like `_rbenv` are not converted to `.rbenv`.

This seems like a CLI bug. `--version` exists to allow CLI to bootstrap different RN version, so it should support this scenario. But we can change the example to one that prevents users from hitting it.
