### PR TITLE
Fix Flow/TypeScript Mismatches in New Architecture Library Intro

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -397,12 +397,12 @@ export default RNTMyNativeViewNativeComponent;
 If `requireNativeComponent` is not typed, you can temporarily use the `mixed` type to fix the Flow warning, for example:
 
 ```js
-// @flow strict
+// @flow strict-local
 
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 // ...
 const RCTWebViewNativeComponent: HostComponent<mixed> =
-  requireNativeComponent < mixed > 'RNTMyNativeView';
+  requireNativeComponent<mixed>('RNTMyNativeView');
 ```
 
 #### Later on you can replace `requireNativeComponent`

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -482,7 +482,7 @@ Note:
 #### Using Your Command
 
 ```js
-// @flow strict
+// @flow strict-local
 
 import {Commands, ...} from './MyCustomMapNativeComponent';
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -34,8 +34,8 @@ The following is a basic JavaScript spec template, written using the [Flow](http
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
 
-```ts
-// @flow
+```js
+// @flow strict
 
 import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import {TurboModuleRegistry} from 'react-native';
@@ -47,13 +47,15 @@ export interface Spec extends TurboModule {
   getString(id: string): Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('<MODULE_NAME>'): ?Spec);
+export default (TurboModuleRegistry.get<Spec>(
+  '<MODULE_NAME>',
+): ?Spec);
 ```
 
 </TabItem>
 <TabItem value="TypeScript">
 
-```ts
+```tsx
 import type {TurboModule} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
 
@@ -81,7 +83,7 @@ The following snippet shows a basic JavaScript spec template, written in [Flow](
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
 
-```ts
+```js
 // @flow strict-local
 
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
@@ -94,14 +96,14 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-   '<FABRIC COMPONENT>',
+  '<FABRIC COMPONENT>',
 ): HostComponent<NativeProps>);
 ```
 
 </TabItem>
 <TabItem value="TypeScript">
 
-```ts
+```tsx
 import type {ViewProps} from 'ViewPropTypes';
 import type {HostComponent} from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -225,7 +227,7 @@ Android also requires to have the [React Gradle Plugin properly configured](new-
 
 In the New Architecture, most `UIManager` methods will become available as instance methods on native component instances obtained via `ref`:
 
-```ts
+```tsx
 function MyComponent(props: Props) {
   const viewRef = useRef(null);
 
@@ -260,9 +262,9 @@ We will eventually deprecate `UIManager`. However, we recognize that migrations 
 
 **Example**
 
-```ts
+```tsx
 class MyComponent extends React.Component<Props> {
-  _viewRef: ?React.ElementRef<typeof View>;
+  _viewRef?: React.ElementRef<typeof View>;
 
   render() {
     const {somePropValue} = this.props;
@@ -372,7 +374,7 @@ return <RNTMyNativeView />;
 
 #### New way
 
-```tsx title="RNTMyNativeNativeComponent.tsx"
+```js title="RNTMyNativeNativeComponent.js"
 import RNTMyNativeViewNativeComponent from './RNTMyNativeViewNativeComponent';
 
 [...]
@@ -380,7 +382,7 @@ import RNTMyNativeViewNativeComponent from './RNTMyNativeViewNativeComponent';
 return <RNTMyNativeViewNativeComponent />;
 ```
 
-```tsx title="RNTMyNativeViewNativeComponent.tsx"
+```js title="RNTMyNativeViewNativeComponent.js"
 import {requireNativeComponent} from 'react-native';
 
 const RNTMyNativeViewNativeComponent = requireNativeComponent(
@@ -395,6 +397,8 @@ export default RNTMyNativeViewNativeComponent;
 If `requireNativeComponent` is not typed, you can temporarily use the `mixed` type to fix the Flow warning, for example:
 
 ```js
+// @flow strict
+
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 // ...
 const RCTWebViewNativeComponent: HostComponent<mixed> =
@@ -405,15 +409,19 @@ const RCTWebViewNativeComponent: HostComponent<mixed> =
 
 When you are ready to migrate to Fabric you can replace `requireNativeComponent` with `codegenNativeComponent`:
 
-```ts title="RNTMyNativeViewNativeComponent.ts"
+```js title="RNTMyNativeViewNativeComponent.js"
+// @flow strict
+
 export default (codegenNativeComponent<NativeProps>(
-   'RNTMyNativeView',
+  'RNTMyNativeView',
 ): HostComponent<NativeProps>);
 ```
 
 And update the main file:
 
-```ts title="RNTMyNativeNativeComponent.ts"
+```js title="RNTMyNativeNativeComponent.js"
+// @flow strict
+
 export default require('./RNTMyNativeViewNativeComponent')
   .default;
 ```
@@ -442,7 +450,9 @@ class MyComponent extends React.Component<Props> {
 
 **Creating NativeCommands with `codegenNativeCommands`**
 
-```ts title="MyCustomMapNativeComponent.ts"
+```js title="MyCustomMapNativeComponent.js"
+// @flow strict-local
+
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
@@ -450,15 +460,16 @@ type MyCustomMapNativeComponentType = HostComponent<NativeProps>;
 
 interface NativeCommands {
   +moveToRegion: (
-     viewRef: React.ElementRef<MyCustomMapNativeComponentType>,
-      region: MapRegion,
-      duration: number,
-   ) => void;
- }
+    viewRef: React.ElementRef<MyCustomMapNativeComponentType>,
+    region: MapRegion,
+    duration: number,
+  ) => void;
+}
 
-export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['moveToRegion'],
-});
+export const Commands: NativeCommands =
+  codegenNativeCommands<NativeCommands>({
+    supportedCommands: ['moveToRegion'],
+  });
 ```
 
 Note:
@@ -470,11 +481,13 @@ Note:
 
 #### Using Your Command
 
-```tsx
+```js
+// @flow strict
+
 import {Commands, ...} from './MyCustomMapNativeComponent';
 
 class MyComponent extends React.Component<Props> {
-  _ref?: React.ElementRef<typeof MyCustomMapNativeComponent>;
+  _ref: ?React.ElementRef<typeof MyCustomMapNativeComponent>;
 
   _captureRef: (ref: React.ElementRef<typeof MyCustomMapNativeComponent>) => {
     this._ref = ref;

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -410,7 +410,7 @@ const RCTWebViewNativeComponent: HostComponent<mixed> =
 When you are ready to migrate to Fabric you can replace `requireNativeComponent` with `codegenNativeComponent`:
 
 ```js title="RNTMyNativeViewNativeComponent.js"
-// @flow strict
+// @flow strict-local
 
 export default (codegenNativeComponent<NativeProps>(
   'RNTMyNativeView',
@@ -420,7 +420,7 @@ export default (codegenNativeComponent<NativeProps>(
 And update the main file:
 
 ```js title="RNTMyNativeNativeComponent.js"
-// @flow strict
+// @flow strict-local
 
 export default require('./RNTMyNativeViewNativeComponent')
   .default;

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -397,12 +397,12 @@ export default RNTMyNativeViewNativeComponent;
 If `requireNativeComponent` is not typed, you can temporarily use the `mixed` type to fix the Flow warning, for example:
 
 ```js
-// @flow strict
+// @flow strict-local
 
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 // ...
 const RCTWebViewNativeComponent: HostComponent<mixed> =
-  requireNativeComponent < mixed > 'RNTMyNativeView';
+  requireNativeComponent<mixed>('RNTMyNativeView');
 ```
 
 #### Later on you can replace `requireNativeComponent`

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -482,7 +482,7 @@ Note:
 #### Using Your Command
 
 ```js
-// @flow strict
+// @flow strict-local
 
 import {Commands, ...} from './MyCustomMapNativeComponent';
 

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -34,8 +34,8 @@ The following is a basic JavaScript spec template, written using the [Flow](http
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
 
-```ts
-// @flow
+```js
+// @flow strict
 
 import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import {TurboModuleRegistry} from 'react-native';
@@ -47,13 +47,15 @@ export interface Spec extends TurboModule {
   getString(id: string): Promise<string>;
 }
 
-export default (TurboModuleRegistry.get<Spec>('<MODULE_NAME>'): ?Spec);
+export default (TurboModuleRegistry.get<Spec>(
+  '<MODULE_NAME>',
+): ?Spec);
 ```
 
 </TabItem>
 <TabItem value="TypeScript">
 
-```ts
+```tsx
 import type {TurboModule} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
 
@@ -81,7 +83,7 @@ The following snippet shows a basic JavaScript spec template, written in [Flow](
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
 
-```ts
+```js
 // @flow strict-local
 
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
@@ -94,14 +96,14 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-   '<FABRIC COMPONENT>',
+  '<FABRIC COMPONENT>',
 ): HostComponent<NativeProps>);
 ```
 
 </TabItem>
 <TabItem value="TypeScript">
 
-```ts
+```tsx
 import type {ViewProps} from 'ViewPropTypes';
 import type {HostComponent} from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
@@ -225,7 +227,7 @@ Android also requires to have the [React Gradle Plugin properly configured](new-
 
 In the New Architecture, most `UIManager` methods will become available as instance methods on native component instances obtained via `ref`:
 
-```ts
+```tsx
 function MyComponent(props: Props) {
   const viewRef = useRef(null);
 
@@ -260,9 +262,9 @@ We will eventually deprecate `UIManager`. However, we recognize that migrations 
 
 **Example**
 
-```ts
+```tsx
 class MyComponent extends React.Component<Props> {
-  _viewRef: ?React.ElementRef<typeof View>;
+  _viewRef?: React.ElementRef<typeof View>;
 
   render() {
     const {somePropValue} = this.props;
@@ -372,7 +374,7 @@ return <RNTMyNativeView />;
 
 #### New way
 
-```tsx title="RNTMyNativeNativeComponent.tsx"
+```js title="RNTMyNativeNativeComponent.js"
 import RNTMyNativeViewNativeComponent from './RNTMyNativeViewNativeComponent';
 
 [...]
@@ -380,7 +382,7 @@ import RNTMyNativeViewNativeComponent from './RNTMyNativeViewNativeComponent';
 return <RNTMyNativeViewNativeComponent />;
 ```
 
-```tsx title="RNTMyNativeViewNativeComponent.tsx"
+```js title="RNTMyNativeViewNativeComponent.js"
 import {requireNativeComponent} from 'react-native';
 
 const RNTMyNativeViewNativeComponent = requireNativeComponent(
@@ -395,6 +397,8 @@ export default RNTMyNativeViewNativeComponent;
 If `requireNativeComponent` is not typed, you can temporarily use the `mixed` type to fix the Flow warning, for example:
 
 ```js
+// @flow strict
+
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 // ...
 const RCTWebViewNativeComponent: HostComponent<mixed> =
@@ -405,15 +409,19 @@ const RCTWebViewNativeComponent: HostComponent<mixed> =
 
 When you are ready to migrate to Fabric you can replace `requireNativeComponent` with `codegenNativeComponent`:
 
-```ts title="RNTMyNativeViewNativeComponent.ts"
+```js title="RNTMyNativeViewNativeComponent.js"
+// @flow strict
+
 export default (codegenNativeComponent<NativeProps>(
-   'RNTMyNativeView',
+  'RNTMyNativeView',
 ): HostComponent<NativeProps>);
 ```
 
 And update the main file:
 
-```ts title="RNTMyNativeNativeComponent.ts"
+```js title="RNTMyNativeNativeComponent.js"
+// @flow strict
+
 export default require('./RNTMyNativeViewNativeComponent')
   .default;
 ```
@@ -442,7 +450,9 @@ class MyComponent extends React.Component<Props> {
 
 **Creating NativeCommands with `codegenNativeCommands`**
 
-```ts title="MyCustomMapNativeComponent.ts"
+```js title="MyCustomMapNativeComponent.js"
+// @flow strict-local
+
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
@@ -450,15 +460,16 @@ type MyCustomMapNativeComponentType = HostComponent<NativeProps>;
 
 interface NativeCommands {
   +moveToRegion: (
-     viewRef: React.ElementRef<MyCustomMapNativeComponentType>,
-      region: MapRegion,
-      duration: number,
-   ) => void;
- }
+    viewRef: React.ElementRef<MyCustomMapNativeComponentType>,
+    region: MapRegion,
+    duration: number,
+  ) => void;
+}
 
-export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['moveToRegion'],
-});
+export const Commands: NativeCommands =
+  codegenNativeCommands<NativeCommands>({
+    supportedCommands: ['moveToRegion'],
+  });
 ```
 
 Note:
@@ -470,11 +481,13 @@ Note:
 
 #### Using Your Command
 
-```tsx
+```js
+// @flow strict
+
 import {Commands, ...} from './MyCustomMapNativeComponent';
 
 class MyComponent extends React.Component<Props> {
-  _ref?: React.ElementRef<typeof MyCustomMapNativeComponent>;
+  _ref: ?React.ElementRef<typeof MyCustomMapNativeComponent>;
 
   _captureRef: (ref: React.ElementRef<typeof MyCustomMapNativeComponent>) => {
     this._ref = ref;

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -410,7 +410,7 @@ const RCTWebViewNativeComponent: HostComponent<mixed> =
 When you are ready to migrate to Fabric you can replace `requireNativeComponent` with `codegenNativeComponent`:
 
 ```js title="RNTMyNativeViewNativeComponent.js"
-// @flow strict
+// @flow strict-local
 
 export default (codegenNativeComponent<NativeProps>(
   'RNTMyNativeView',
@@ -420,7 +420,7 @@ export default (codegenNativeComponent<NativeProps>(
 And update the main file:
 
 ```js title="RNTMyNativeNativeComponent.js"
-// @flow strict
+// @flow strict-local
 
 export default require('./RNTMyNativeViewNativeComponent')
   .default;


### PR DESCRIPTION
Fixes #3515

This fixes a few cases where Flow-specific examples are represented as TypeScript. Some of these were present in the original guide, and others I made worse during my mass conversion of inline code examples to TypeScript.

I think some of these were made to be `.ts` to appease syntax highlighting/formatting, but it looks like adding `@flow` is enough to inform both prettier over markdown, and prism syntax highlighting to render correctly. We also change some `.ts` to `.tsx` when components are used.

<img width="844" alt="image" src="https://user-images.githubusercontent.com/835219/219596170-836e51a5-ed07-41fd-8970-9302f39abfc4.png">
