### PR TITLE
docs: update links and init command to 0.71

### DIFF
--- a/docs/the-new-architecture/cxx-cxxturbomodules.md
+++ b/docs/the-new-architecture/cxx-cxxturbomodules.md
@@ -33,7 +33,7 @@ To create a C++ Turbo Native Module, you need to:
 As first step, create a new application:
 
 ```sh
-npx react-native@v0.71.0-rc.3 init CxxTurboModulesGuide --version v0.71.0-rc.3
+npx react-native init CxxTurboModulesGuide
 cd CxxTurboModulesGuide
 yarn install
 ```
@@ -260,7 +260,7 @@ Android apps aren't setup for native code compilation by default.
 
 1.) Create the folder `android/app/src/main/jni`
 
-2.) Copy `CMakeLists.txt` and `Onload.cpp` from [node_modules/react-native/ReactAndroid/cmake-utils/default-app-setup](https://github.com/facebook/react-native/tree/v0.71.0-rc.3/ReactAndroid/cmake-utils/default-app-setup) into the `android/app/src/main/jni` folder.
+2.) Copy `CMakeLists.txt` and `Onload.cpp` from [node_modules/react-native/ReactAndroid/cmake-utils/default-app-setup](https://github.com/facebook/react-native/tree/0.71-stable/ReactAndroid/cmake-utils/default-app-setup) into the `android/app/src/main/jni` folder.
 
 Update `Onload.cpp` with the following entries:
 

--- a/website/versioned_docs/version-0.71/the-new-architecture/cxx-cxxturbomodules.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/cxx-cxxturbomodules.md
@@ -33,7 +33,7 @@ To create a C++ Turbo Native Module, you need to:
 As first step, create a new application:
 
 ```sh
-npx react-native@v0.71.0-rc.3 init CxxTurboModulesGuide --version v0.71.0-rc.3
+npx react-native init CxxTurboModulesGuide
 cd CxxTurboModulesGuide
 yarn install
 ```
@@ -260,7 +260,7 @@ Android apps aren't setup for native code compilation by default.
 
 1.) Create the folder `android/app/src/main/jni`
 
-2.) Copy `CMakeLists.txt` and `Onload.cpp` from [node_modules/react-native/ReactAndroid/cmake-utils/default-app-setup](https://github.com/facebook/react-native/tree/v0.71.0-rc.3/ReactAndroid/cmake-utils/default-app-setup) into the `android/app/src/main/jni` folder.
+2.) Copy `CMakeLists.txt` and `Onload.cpp` from [node_modules/react-native/ReactAndroid/cmake-utils/default-app-setup](https://github.com/facebook/react-native/tree/0.71-stable/ReactAndroid/cmake-utils/default-app-setup) into the `android/app/src/main/jni` folder.
 
 Update `Onload.cpp` with the following entries:
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Hey! 

This PR updates links and init command for turbo modules docs.
