### PR TITLE
docs: fix app.js/app.tsx references in quickstart

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -157,7 +157,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
 <h3>That's it!</h3>

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -169,7 +169,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`⌘M`) to see your changes!
 
 <h3>That's it!</h3>

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -171,7 +171,7 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
 
 ### That's it!

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -190,7 +190,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
 <h3>That's it!</h3>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ Install the [Expo Go](https://expo.dev/client) app on your iOS or Android phone 
 
 <h3>Modifying your app</h3>
 
-Now that you have successfully run the app, let's modify it. Open `App.tsx` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
+Now that you have successfully run the app, let's modify it. Open `App.js` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
 
 <h3>That's it!</h3>
 

--- a/website/versioned_docs/version-0.71/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-linux-android.md
@@ -157,7 +157,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
 <h3>That's it!</h3>

--- a/website/versioned_docs/version-0.71/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-android.md
@@ -169,7 +169,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`⌘M`) to see your changes!
 
 <h3>That's it!</h3>

--- a/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
@@ -160,7 +160,7 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
 
 ### That's it!

--- a/website/versioned_docs/version-0.71/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-windows-android.md
@@ -190,7 +190,7 @@ If everything is set up correctly, you should see your new app running in your A
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `App.js` in your text editor of choice and edit some lines.
+- Open `App.tsx` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
 <h3>That's it!</h3>

--- a/website/versioned_docs/version-0.71/getting-started.md
+++ b/website/versioned_docs/version-0.71/getting-started.md
@@ -50,7 +50,7 @@ Install the [Expo Go](https://expo.dev/client) app on your iOS or Android phone 
 
 <h3>Modifying your app</h3>
 
-Now that you have successfully run the app, let's modify it. Open `App.tsx` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
+Now that you have successfully run the app, let's modify it. Open `App.js` in your text editor of choice and edit some lines. The application should reload automatically once you save your changes.
 
 <h3>That's it!</h3>
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
For RN 0.71, similar to previous versions, when creating a new project using `npx create-expo-app` a JavaScript project template is used by default. This includes an **App.js**, not an **App.tsx**.

RN CLI projects though will include an **App.tsx**, so this PR updates those quickstarts to point to the right file as well.

This PR makes sure users are pointed to the correct file.