### PR TITLE
Move objectFit property explanation from Image page to Image Style Props one

### DIFF
--- a/docs/image-style-props.md
+++ b/docs/image-style-props.md
@@ -618,6 +618,16 @@ For details of how this works under the hood, see [Fresco documentation](https:/
 
 ---
 
+### `objectFit`
+
+Determines how to resize the image when the frame doesn't match the raw image dimensions.
+
+| Type                                                   | Default   |
+| ------------------------------------------------------ | --------- |
+| enum(`'cover'`, `'contain'`, `'fill'`, `'scale-down'`) | `'cover'` |
+
+---
+
 ### `tintColor`
 
 Changes the color of all the non-transparent pixels to the tintColor.

--- a/docs/image.md
+++ b/docs/image.md
@@ -322,16 +322,6 @@ Similarly to `source`, this property represents the resource used to render the 
 
 ---
 
-### `objectFit`
-
-Determines how to resize the image when the frame doesn't match the raw image dimensions.
-
-| Type                                                   | Default   |
-| ------------------------------------------------------ | --------- |
-| enum(`'cover'`, `'contain'`, `'fill'`, `'scale-down'`) | `'cover'` |
-
----
-
 ### `onError`
 
 Invoked on load error.

--- a/website/versioned_docs/version-0.71/image-style-props.md
+++ b/website/versioned_docs/version-0.71/image-style-props.md
@@ -618,6 +618,16 @@ For details of how this works under the hood, see [Fresco documentation](https:/
 
 ---
 
+### `objectFit`
+
+Determines how to resize the image when the frame doesn't match the raw image dimensions.
+
+| Type                                                   | Default   |
+| ------------------------------------------------------ | --------- |
+| enum(`'cover'`, `'contain'`, `'fill'`, `'scale-down'`) | `'cover'` |
+
+---
+
 ### `tintColor`
 
 Changes the color of all the non-transparent pixels to the tintColor.

--- a/website/versioned_docs/version-0.71/image.md
+++ b/website/versioned_docs/version-0.71/image.md
@@ -322,16 +322,6 @@ Similarly to `source`, this property represents the resource used to render the 
 
 ---
 
-### `objectFit`
-
-Determines how to resize the image when the frame doesn't match the raw image dimensions.
-
-| Type                                                   | Default   |
-| ------------------------------------------------------ | --------- |
-| enum(`'cover'`, `'contain'`, `'fill'`, `'scale-down'`) | `'cover'` |
-
----
-
 ### `onError`
 
 Invoked on load error.


### PR DESCRIPTION
PR related to the Issue [`#3579`](https://github.com/facebook/react-native-website/issues/3579).

As the commit has been released on the 0.71 version, so I did the changes on the _next_ and _0.71_ versions 
