### PR TITLE
Updating dead link for label-action workflow

### DIFF
--- a/website/contributing/bots-reference.md
+++ b/website/contributing/bots-reference.md
@@ -12,7 +12,7 @@ The code analysis bot collects feedback from tools such as Prettier, eslint, and
 
 ## label-actions
 
-A bot that acts on an issue or pull request based on a label. Configured in [`.github/respond-to-issue-based-on-label.yml`](https://github.com/facebook/react-native/blob/main/.github/respond-to-issue-based-on-label.yml).
+A bot that acts on an issue or pull request based on a label. Configured in [`.github/workflows/on-issue-labeled.yml`](https://github.com/facebook/react-native/blob/main/.github/workflows/on-issue-labeled.yml).
 
 ## github-actions
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This fixes a dead link on `/contributing/bots-reference` in the `label-actions` section. 
