### PR TITLE
fix: add vertical line in project structure

### DIFF
--- a/docs/the-new-architecture/cxx-cxxturbomodules.md
+++ b/docs/the-new-architecture/cxx-cxxturbomodules.md
@@ -413,7 +413,7 @@ CxxTurboModulesGuide
 │       └── build.gradle (updated)
 ├── ios
 │   └── CxxTurboModulesGuide
-│       └── AppDelegate.mm (updated)│
+│       └── AppDelegate.mm (updated)
 ├── js
 │   └── App.tsx|jsx (updated)
 └── tm

--- a/docs/the-new-architecture/cxx-cxxturbomodules.md
+++ b/docs/the-new-architecture/cxx-cxxturbomodules.md
@@ -413,9 +413,9 @@ CxxTurboModulesGuide
 │       └── build.gradle (updated)
 ├── ios
 │   └── CxxTurboModulesGuide
-│       └── AppDelegate.mm (updated)
+│       └── AppDelegate.mm (updated)│
 ├── js
-    └── App.tsx|jsx (updated)
+│   └── App.tsx|jsx (updated)
 └── tm
     ├── CMakeLists.txt
     ├── NativeSampleModule.h


### PR DESCRIPTION
For me, there is no clear reason to not keep the same style for the complete example project structure
Therefore, I added the missing vertical line
