### PR TITLE
Update Flatlist to Allow ArrayLike data

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -426,11 +426,11 @@ Example usage:
 
 ### <div class="label required basic">Required</div> **`data`**
 
-For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
+An array (or array-like list) of items to render. Other data types can be used by targetting [`VirtualizedList`](virtualizedlist.md) directly.
 
 | Type  |
 | ----- |
-| array |
+| ArrayLike |
 
 ---
 


### PR DESCRIPTION
Committed with https://github.com/facebook/react-native/commit/c03de97fb44f0aecbec8f930bd99fe26f37f9648.

This is technically probably going to be backported to 0.71 as well, but there is a breaking bit of the change coming in 0.72, and not all 0.71 versions will permit this, so it probably doesn't make sense in 0.71 versioned docs.