### PR TITLE
docs(android): recommend JDK 17 as supported version

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -12,7 +12,7 @@ Follow the [installation instructions for your Linux distribution](https://nodej
 
 <h3>Java Development Kit</h3>
 
-React Native currently recommends version 11 of the Java SE Development Kit (JDK). You may encounter problems using higher JDK versions. You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager.
+React Native currently recommends version 17 of the Java SE Development Kit (JDK). You may encounter problems using higher JDK versions. You may download and install [OpenJDK](http://openjdk.java.net) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager.
 
 <h3>Android development environment</h3>
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -25,12 +25,12 @@ We recommend installing the OpenJDK distribution called Azul **Zulu** using [Hom
 
 ```shell
 brew tap homebrew/cask-versions
-brew install --cask zulu11
+brew install --cask zulu17
 ```
 
 The Zulu OpenJDK distribution offers JDKs for **both Intel and M1 Macs**. This will make sure your builds are faster on M1 Macs compared to using an Intel-based JDK.
 
-If you have already installed JDK on your system, we recommend JDK 11. You may encounter problems using higher JDK versions.
+If you have already installed JDK on your system, we recommend JDK 17. You may encounter problems using higher JDK versions.
 
 <h3>Android development environment</h3>
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -12,15 +12,15 @@ We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular
 
 It is recommended to use an LTS version of Node. If you want to be able to switch between different versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 
-React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk/11/), which can be installed using Chocolatey as well.
+React Native also requires [Java SE Development Kit (JDK)](https://openjdk.java.net/projects/jdk/17/), which can be installed using Chocolatey as well.
 
 Open an Administrator Command Prompt (right click Command Prompt and select "Run as Administrator"), then run the following command:
 
 ```powershell
-choco install -y nodejs-lts microsoft-openjdk11
+choco install -y nodejs-lts microsoft-openjdk17
 ```
 
-If you have already installed Node on your system, make sure it is Node 14 or newer. If you already have a JDK on your system, we recommend JDK11. You may encounter problems using higher JDK versions.
+If you have already installed Node on your system, make sure it is Node 14 or newer. If you already have a JDK on your system, we recommend JDK17. You may encounter problems using higher JDK versions.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

JDK 11 is outdated.

I'd like to propose updating the guidance here to suggest using JDK 17 instead (latest LTS).

### Prev. Discussions:-

1. JDK 17 may not work for < 0.68 (see [prev. discussion](https://github.com/facebook/react-native-website/pull/3178))
2. JDK 18 _should now work_ for 0.70+ now that Gradle 7.5 support has landed (see [this issue](https://github.com/facebook/react-native/issues/34103))
    - **but** on macOS `zulu18` is not available on Brew at time of writing
    - `zulu17` is available
    - I figured suggesting JDK 17 everywhere might be simplest + best (?)