### PR TITLE
Update getting started Windows documentation to reflect min Node version

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -20,7 +20,7 @@ Open an Administrator Command Prompt (right click Command Prompt and select "Run
 choco install -y nodejs-lts microsoft-openjdk11
 ```
 
-If you have already installed Node on your system, make sure it is Node 14 or newer. If you already have a JDK on your system, we recommend JDK11. You may encounter problems using higher JDK versions.
+If you have already installed Node on your system, make sure it is Node 16 or newer. If you already have a JDK on your system, we recommend JDK11. You may encounter problems using higher JDK versions.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 


### PR DESCRIPTION
React Native is increasing the minimum Node JS requirement from 14 to 16 in facebook/react-native#36217, facebook/react-native-website#3580 for 0.72 onwards. Updating our Windows documentation to reflect the same as macOS.
