### PR TITLE
Update getting started in Windows

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -57,10 +57,10 @@ To do that, open Android Studio, click on "More Actions" button and select "SDK 
 
 Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 12 (S)` entry, then make sure the following items are checked:
 
-- `Android SDK Platform 31`
+- `Android SDK Platform 33`
 - `Intel x86 Atom_64 System Image` or `Google APIs Intel x86 Atom System Image`
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the `Android SDK Build-Tools` entry, then make sure that `31.0.0` is selected.
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the `Android SDK Build-Tools` entry, then make sure that `33.0.0` is selected.
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 


### PR DESCRIPTION
Updating Setting up the development environment in Windows documentation to reflect ANDROID_SDK version bump.

React Native is increasing the minimum ANDROID_SDK requirement from Android SDK Platform 31 to Android SDK Platform 33 for 0.72 onwards. Updating our Windows documentation to reflect the same as macOS.