### PR TITLE
showcase: add info link for the PUMA app

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -131,6 +131,7 @@
       "icon": "puma.png",
       "linkAppStore": "https://apps.apple.com/us/app/puma/id1563024677",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.puma.ecom.app",
+      "infoLink": "https://formidable.com/work/puma-scaling-across-the-globe/",
       "pinned": true
     },
     {


### PR DESCRIPTION
Adds a link to the Formidable blog post about the PUMA case study.
