### PR TITLE
feat: tabs now support deep-linking

### DIFF
--- a/docs/_integration-with-existing-apps-objc.md
+++ b/docs/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios
@@ -76,7 +76,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=AccessibilityInfo%20Class%20Component%20Example&supportedPlatforms=android,ios&ext=js

--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -17,7 +17,7 @@ The [`Animated`](animated) API is designed to concisely express a wide variety o
 
 For example, a container view that fades in when it is mounted may look like this:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer ext=js
@@ -310,7 +310,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -441,7 +441,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android&ext=js
@@ -774,7 +774,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example
@@ -77,7 +77,7 @@ If you don't want to see the AppState update from `active` to `inactive` on iOS 
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=AppState%20Class%20Component%20Example&ext=js

--- a/docs/backhandler.md
+++ b/docs/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -99,7 +99,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android&ext=js

--- a/docs/building-for-tv.md
+++ b/docs/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/docs/communication-android.md
+++ b/docs/communication-android.md
@@ -21,7 +21,7 @@ Properties are the most straightforward way of cross-component communication. So
 
 You can pass properties down to the React Native app by providing a custom implementation of `ReactActivityDelegate` in your main activity. This implementation should override `getLaunchOptions` to return a `Bundle` with the desired properties.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 
@@ -82,7 +82,7 @@ export default class ImageBrowserApp extends React.Component {
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/docs/custom-webview-android.md
+++ b/docs/custom-webview-android.md
@@ -26,7 +26,7 @@ To get started, you'll need to create a subclass of `RNCWebViewManager`, `RNCWeb
 - `getName`
 - `addEventEmitters`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -94,7 +94,7 @@ You'll need to follow the usual steps to [register the module](native-modules-an
 
 To add a new property, you'll need to add it to `CustomWebView`, and then expose it in `CustomWebViewManager`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -149,7 +149,7 @@ class CustomWebViewManager : RNCWebViewManager() {
 
 For events, you'll first need to make create event subclass.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -198,7 +198,7 @@ You can trigger the event in your web view client. You can hook existing handler
 
 You should refer to [RNCWebViewManager.java](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java) in the React Native WebView codebase to see what handlers are available and how they are implemented. You can extend any methods here to provide extra functionality.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -274,7 +274,7 @@ protected class CustomWebViewClient : RNCWebViewClient() {
 
 Finally, you'll need to expose the events in `CustomWebViewManager` through `getExportedCustomDirectEventTypeConstants`. Note that currently, the default implementation returns `null`, but this may change in the future.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/docs/datepickerios.md
+++ b/docs/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -90,7 +90,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions
@@ -86,7 +86,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Dimensions&ext=js

--- a/docs/direct-manipulation.md
+++ b/docs/direct-manipulation.md
@@ -63,7 +63,7 @@ If you look at the implementation of `setNativeProps` in [NativeMethodsMixin](ht
 
 Composite components are not backed by a native view, so you cannot call `setNativeProps` on them. Consider this example:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=setNativeProps%20with%20Composite%20Components&ext=js
@@ -116,7 +116,7 @@ If you run this you will immediately see this error: `Touchable child must eithe
 
 Since the `setNativeProps` method exists on any ref to a `View` component, it is enough to forward a ref on your custom component to one of the `<View />` components that it renders. This means that a call to `setNativeProps` on the custom component will have the same effect as if you called `setNativeProps` on the wrapped `View` component itself.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Forwarding%20setNativeProps&ext=js
@@ -171,7 +171,7 @@ You may have noticed that we passed all of the props down to the child view usin
 
 Another very common use case of `setNativeProps` is to edit the value of the TextInput. The `controlled` prop of TextInput can sometimes drop characters when the `bufferDelay` is low and the user types very quickly. Some developers prefer to skip this prop entirely and instead use `setNativeProps` to directly manipulate the TextInput value when necessary. For example, the following code demonstrates editing the input when you tap a button:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Clear%20text&ext=js
@@ -316,7 +316,7 @@ Like `measure()`, but measures the view relative to an ancestor, specified with 
 This method can also be called with a `relativeToNativeNode` handler (instead of reference), but this variant is deprecated.
 :::
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=measureLayout%20example&supportedPlatforms=android,ios&ext=js

--- a/docs/drawerlayoutandroid.md
+++ b/docs/drawerlayoutandroid.md
@@ -9,7 +9,7 @@ React component that wraps the platform `DrawerLayout` (Android only). The Drawe
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=DrawerLayoutAndroid%20Component%20Example&supportedPlatforms=android&ext=js

--- a/docs/dynamiccolorios.md
+++ b/docs/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -45,7 +45,7 @@ The following helpers are used to modify other easing functions.
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Easing%20Demo&ext=js

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -22,7 +22,7 @@ If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=flatlist-simple&ext=js
@@ -166,7 +166,7 @@ More complex, selectable example below.
 - By passing `extraData={selectedId}` to `FlatList` we make sure `FlatList` itself will re-render when the state changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is a `PureComponent` and the prop comparison will not show any changes.
 - `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
 
-<Tabs groupId="language" defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=flatlist-selectable&ext=js

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -65,7 +65,7 @@ export default Flex;
 
 You can learn more [here](https://yogalayout.com/docs/flex-direction).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Direction&ext=js
@@ -282,7 +282,7 @@ Layout [`direction`](layout-props#direction) specifies the direction in which ch
 
 - `RTL` Text and children are laid out from right to left. Margin and padding applied to the start of an element are applied on the right side.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Direction&ext=js
@@ -509,7 +509,7 @@ export default DirectionLayout;
 
 You can learn more [here](https://yogalayout.com/docs/justify-content).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Justify%20Content&ext=js
@@ -752,7 +752,7 @@ For `stretch` to have an effect, children must not have a fixed dimension along 
 
 You can learn more [here](https://yogalayout.com/docs/align-items).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Align%20Items&ext=js
@@ -985,7 +985,7 @@ export default AlignItemsLayout;
 
 [`alignSelf`](layout-props#alignself) has the same options and effect as `alignItems` but instead of affecting the children within a container, you can apply this property to a single child to change its alignment within its parent. `alignSelf` overrides any option set by the parent with `alignItems`.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Align%20Self&ext=js
@@ -1235,7 +1235,7 @@ export default AlignSelfLayout;
 
 You can learn more [here](https://yogalayout.com/docs/align-content).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Align%20Content&ext=js
@@ -1476,7 +1476,7 @@ The [`flexWrap`](layout-props#flexwrap) property is set on containers and it con
 
 When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Wrap&ext=js
@@ -1707,7 +1707,7 @@ export default FlexWrapLayout;
 
 You can learn more [here](https://yogalayout.com/docs/flex).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Basis%2C%20Grow%2C%20and%20Shrink&ext=js
@@ -2080,7 +2080,7 @@ export default App;
 
 You can use `flexWrap` and `alignContent` alongwith `gap` to add consistent spacing between items.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Row%20Gap%20and%20Column%20Gap&ext=js
@@ -2307,7 +2307,7 @@ Both `width` and `height` can take the following values:
 
 - `percentage` Defines the width or height in percentage of its parent's width or height, respectively.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Width%20and%20Height&ext=js
@@ -2588,7 +2588,7 @@ The `position` type of an element defines how it is positioned within its parent
 
 - `absolute` When positioned absolutely, an element doesn't take part in the normal layout flow. It is instead laid out independent of its siblings. The position is determined based on the `top`, `right`, `bottom`, and `left` values.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Absolute%20%26%20Relative%20Layout&ext=js

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Run the following command to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -91,12 +91,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -118,7 +118,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -33,7 +33,7 @@ You can do anything in your task such as network requests, timers and so on, as 
 
 Yes, this does still require some native code, but it's pretty thin. You need to extend `HeadlessJsTaskService` and override `getTaskConfig`, e.g.:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -104,7 +104,7 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
 
 Example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ By default, the headless JS task will not perform any retries. In order to do so
 
 `LinearCountingRetryPolicy` is an implementation of `HeadlessJsRetryPolicy` that allows you to specify a maximum number of retries with a fixed delay between each attempt. If that does not suit your needs then you can implement your own `HeadlessJsRetryPolicy`. These policies can be passed as an extra argument to the `HeadlessJsTaskConfig` constructor, e.g.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -213,7 +213,7 @@ Following lines shows part of Android manifest file for registering broadcast re
 
 Broadcast receiver then handles intent that was broadcasted in onReceive function. This is a great place to check whether your app is on foreground or not. If app is not on foreground we can prepare our intent to be started, with no information or additional information bundled using `putExtra` (keep in mind bundle can handle only parcelable values). In the end service is started and wakelock is acquired.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/docs/image-style-props.md
+++ b/docs/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/docs/image.md
+++ b/docs/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/docs/improvingux.md
+++ b/docs/improvingux.md
@@ -17,7 +17,7 @@ Entering text on touch phone is a challenge - small screen, software keyboard. B
 
 Check out [`TextInput` docs](textinput.md) for more configuration options.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=TextInput%20form%20example&ext=js
@@ -212,7 +212,7 @@ export default App;
 
 Software keyboard takes almost half of the screen. If you have interactive elements that can get covered by the keyboard, make sure they are still accessible by using the [`KeyboardAvoidingView` component](keyboardavoidingview.md).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=KeyboardAvoidingView%20example&ext=js

--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -19,7 +19,7 @@ You will need to implement the `ReactApplication` interface in your main Applica
 
 Ensure your main Application class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -38,7 +38,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -96,7 +96,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -165,7 +165,7 @@ Now in your Activity class (e.g. `MainActivity.java` or `MainActivity.kt`) you n
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -184,7 +184,7 @@ private Button mButton;
 
 Update your Activity's `onCreate` method as follows:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -241,7 +241,7 @@ If you are using a starter kit for React Native, replace the "HelloWorld" string
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -267,7 +267,7 @@ private Bundle getLaunchOptions(String message) {
 
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/docs/integration-with-existing-apps.md
+++ b/docs/integration-with-existing-apps.md
@@ -13,7 +13,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="kotlin">
 

--- a/docs/interactionmanager.md
+++ b/docs/interactionmanager.md
@@ -43,7 +43,7 @@ By default, queued tasks are executed together in a loop in one `setImmediate` b
 
 ### Basic
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=InteractionManager%20Function%20Component%20Basic%20Example&supportedPlatforms=ios,android&ext=js
@@ -210,7 +210,7 @@ export default App;
 
 ### Advanced
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=InteractionManager%20Function%20Component%20Advanced%20Example&supportedPlatforms=ios,android&ext=js

--- a/docs/intro-react.md
+++ b/docs/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -145,7 +145,7 @@ export default Cat;
 
 Any JavaScript expression will work between curly braces, including function calls like `{getFullName("Rum", "Tum", "Tugger")}`:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Curly%20Braces&ext=js
@@ -223,7 +223,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -273,7 +273,7 @@ You can put as many cats in your cafe as you like. Each `<Cat>` renders a unique
 
 **Props** is short for “properties”. Props let you customize React components. For example, here you pass each `<Cat>` a different `name` for `Cat` to render:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Multiple%20Props&ext=js
@@ -373,12 +373,12 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=State&ext=js
@@ -526,7 +526,7 @@ const Cafe = () => {
 
 The older class components approach is a little different when it comes to state.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=State%20and%20Class%20Components&ext=js

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -59,7 +59,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -116,7 +116,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android
@@ -69,7 +69,7 @@ export default Example;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Keyboard%20Class%20Component%20Example&supportedPlatforms=ios,android&ext=js

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The following example shows how different properties can affect or shape a React Native layout. You can try for example to add or remove squares from the UI while changing the values of the property `flexWrap`.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=LayoutProps%20Example&ext=js

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -131,7 +131,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -347,7 +347,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).
@@ -114,7 +114,7 @@ You can handle these events with `Linking.getInitialURL()` - it returns a Promis
 
 ### Open Links and Deep Links (Universal Links)
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -220,7 +220,7 @@ export default App;
 
 ### Open Custom Settings
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -299,7 +299,7 @@ export default App;
 
 ### Get the Deep Link
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -412,7 +412,7 @@ export default App;
 
 ### Send Intents (Android)
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=android&ext=js

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -32,7 +32,7 @@ To send a view:
 
 In this example we create view manager class `ReactImageManager` that extends `SimpleViewManager` of type `ReactImageView`. `ReactImageView` is the type of object managed by the manager, this will be the custom native view. Name returned by `getName` is used to reference the native view type from JavaScript.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -75,7 +75,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
 Views are created in the `createViewInstance` method, the view should initialize itself in its default state, any properties will be set via a follow up call to `updateView.`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -106,7 +106,7 @@ Except from `name`, `@ReactProp` annotation may take following optional argument
 
 Setter declaration requirements for methods annotated with `@ReactPropGroup` are different than for `@ReactProp`, please refer to the `@ReactPropGroup` annotation class docs for more information about it. **IMPORTANT!** in ReactJS updating the property value will result in setter method call. Note that one of the ways we can update component is by removing properties that have been set before. In that case setter method will be called as well to notify view manager that property has changed. In that case "default" value will be provided (for primitive types "default" value can be specified using `defaultBoolean`, `defaultFloat`, etc. arguments of `@ReactProp` annotation, for complex types setter will be called with value set to `null`).
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -153,7 +153,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
 
 The final step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.md), via the applications package member function `createViewManagers`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -201,7 +201,7 @@ The `requireNativeComponent` function takes the name of the native view. Note th
 
 So now we know how to expose native view components that we can control freely from JS, but how do we deal with events from the user, like pinch-zooms or panning? When a native event occurs the native code should issue an event to the JavaScript representation of the View, and the two views are linked with the value returned from the `getId()` method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -241,7 +241,7 @@ class MyCustomView extends View {
 
 To map the `topChange` event name to the `onChange` callback prop in JavaScript, register it by overriding the `getExportedCustomBubblingEventTypeConstants` method in your `ViewManager`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -317,7 +317,7 @@ In order to integrate existing Native UI elements to your React Native app, you 
 
 First, let's create a `CustomView` class which extends `FrameLayout` (the content of this view can be any view that you'd like to render)
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="CustomView.kt"
@@ -378,7 +378,7 @@ public class CustomView extends FrameLayout {
 
 ### 2. Create a `Fragment`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyFragment.kt"
@@ -490,7 +490,7 @@ public class MyFragment extends Fragment {
 
 ### 3. Create the `ViewManager` subclass
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyViewManager.kt"
@@ -736,7 +736,7 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
 ### 4. Register the `ViewManager`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyPackage.kt"
@@ -786,7 +786,7 @@ public class MyPackage implements ReactPackage {
 
 ### 5. Register the `Package`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -38,7 +38,7 @@ The first step is to create the (`CalendarModule.java` or `CalendarModule.kt`) J
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -85,7 +85,7 @@ As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaMod
 
 All Java/Kotlin native modules in Android need to implement the `getName()` method. This method returns a string, which represents the name of the native module. The native module can then be accessed in JavaScript using its name. For example, in the below code snippet, `getName()` returns `"CalendarModule"`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -119,7 +119,7 @@ Next you will need to add a method to your native module that will create calend
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ public void createCalendarEvent(String name, String location) {
 
 Add a debug log in the method to confirm it has been invoked when you call it from your application. Below is an example of how you can import and use the [Log](https://developer.android.com/reference/android/util/Log) class from the Android util package:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -174,7 +174,7 @@ Once you finish implementing the native module and hook it up in JavaScript, you
 
 You can pass `isBlockingSynchronousMethod = true` to a native method to mark it as a synchronous method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -203,7 +203,7 @@ To add your Native Module to `ReactPackage`, first create a new Java/Kotlin Clas
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -273,7 +273,7 @@ To register the `CalendarModule` package, you must add `MyAppPackage` to the lis
 
 Locate ReactNativeHost’s `getPackages()` method and add your package to the packages list `getPackages()` returns:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -444,7 +444,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 
 For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, `Date` conversion is not supported out of the box. You can handle the conversion to the `Date` type within the native method yourself like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -478,7 +478,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -518,7 +518,7 @@ Native modules also support a unique kind of argument: a callback. Callbacks are
 
 In order to create a native module method with a callback, first import the `Callback` interface, and then add a new parameter to your native module method of type `Callback`. There are a couple of nuances with callback arguments that will soon be lifted with TurboModules. First off, you can only have two callbacks in your function arguments- a successCallback and a failureCallback. In addition, the last argument to a native module method call, if it's a function, is treated as the successCallback, and the second to last argument to a native module method call, if it's a function, is treated as the failure callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -543,7 +543,7 @@ import com.facebook.react.bridge.Callback
 
 You can invoke the callback in your Java/Kotlin method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -586,7 +586,7 @@ Another important detail to note is that a native module method can only invoke 
 
 There are two approaches to error handling with callbacks. The first is to follow Node’s convention and treat the first argument passed to the callback as an error object.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -630,7 +630,7 @@ const onPress = () => {
 
 Another option is to use an onSuccess and onFailure callback:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -678,7 +678,7 @@ Native modules can also fulfill a [Promise](https://developer.mozilla.org/en-US/
 
 Refactoring the above code to use a promise instead of callbacks looks like this:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -733,7 +733,7 @@ const onSubmit = async () => {
 
 The reject method takes different combinations of the following arguments:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -754,7 +754,7 @@ For more detail, you can find the `Promise.java` interface [here](https://github
 
 Java/Kotlin reject call:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -782,7 +782,7 @@ Error message in React Native App when promise is rejected:
 
 Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -891,7 +891,7 @@ useEffect(() => {
 
 You'll need to listen to `onActivityResult` if you want to get results from an activity you started with `startActivityForResult`. To do this, you must extend `BaseActivityEventListener` or implement `ActivityEventListener`. The former is preferred as it is more resilient to API changes. Then, you need to register the listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -910,7 +910,7 @@ reactContext.addActivityEventListener(mActivityResultListener);
 
 Now you can listen to `onActivityResult` by implementing the following method:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -943,7 +943,7 @@ override fun onActivityResult(
 
 Let's implement a basic image picker to demonstrate this. The image picker will expose the method `pickImage` to JavaScript, which will return the path of the image when called.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```kotlin
@@ -1103,7 +1103,7 @@ class ImagePickerModule(reactContext: ReactApplicationContext) :
 
 Listening to the activity's LifeCycle events such as `onResume`, `onPause` etc. is very similar to how `ActivityEventListener` was implemented. The module must implement `LifecycleEventListener`. Then, you need to register a listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -1122,7 +1122,7 @@ reactContext.addLifecycleEventListener(this)
 
 Now you can listen to the activity's LifeCycle events by implementing the following methods:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/docs/network.md
+++ b/docs/network.md
@@ -74,10 +74,10 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Fetch%20Example&ext=js
@@ -187,7 +187,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Fetch%20Example&ext=js

--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -57,7 +57,7 @@ Update your native module or component to ensure it **extends the abstract class
 
 Following the example set forth in the previous section, your library might import `NativeAwesomeManagerSpec`, implement the relevant native interface and the necessary methods for it:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -29,7 +29,7 @@ JavaScript spec files **must** be named `Native<MODULE_NAME>.js`, and they expor
 
 The following is a basic JavaScript spec template, written using the [Flow](https://flow.org/) and [TypeScript](https://www.typescriptlang.org/) syntax.
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
@@ -78,7 +78,7 @@ JavaScript spec files **must** be named `<FABRIC COMPONENT>NativeComponent.js` (
 
 The following snippet shows a basic JavaScript spec template, written in [Flow](https://flow.org/) as well as [TypeScript](https://www.typescriptlang.org/).
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
@@ -524,7 +524,7 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
 
 **Android**
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -127,7 +127,7 @@ For functional components, move the `renderItem` function outside of the returne
 
 For class componenents, move the `renderItem` function outside of the render function, so it won't recreate itself each time the render function is called.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">
 
 ```tsx

--- a/docs/panresponder.md
+++ b/docs/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/docs/props.md
+++ b/docs/props.md
@@ -29,7 +29,7 @@ Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX.
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place by referring to `props` in your `render` function. Here's an example:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Props&ext=js

--- a/docs/react-18-and-react-native.md
+++ b/docs/react-18-and-react-native.md
@@ -45,7 +45,7 @@ However, if you do hit any issues, we provide an option to opt-out of the new ro
 
 On Android, you will be able to override the `isConcurrentRootEnabled` in your ActivityDelegate (in the `MainActivity` file), and enable/disable Concurrent React.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -12,14 +12,14 @@ It's always a good idea to test your app on an actual device before releasing it
 If you used `create-expo-app` to set up your project, you can run your app on a device in Expo Go by scanning the QR code that is displayed when you run `npm start`. Refer to the Expo guide for [running your project on your device](https://docs.expo.dev/workflow/run-on-device/) for more information.
 :::
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -316,7 +316,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/docs/security.md
+++ b/docs/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -5,7 +5,7 @@ title: Shadow Props
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios&ext=js

--- a/docs/share.md
+++ b/docs/share.md
@@ -7,10 +7,10 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -90,7 +90,7 @@ export default ShareExample;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Class%20Component%20Example&supportedPlatforms=ios,android&ext=js

--- a/docs/state.md
+++ b/docs/state.md
@@ -11,7 +11,7 @@ In general, you should initialize `state` in the constructor, and then call `set
 
 For example, let's say we want to make text that blinks all the time. The text itself gets set once when the blinking component gets created, so the text itself is a `prop`. The "whether the text is currently on or off" changes over time, so that should be kept in `state`.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=State&ext=js

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -11,7 +11,7 @@ Component to control the app's status bar. The status bar is the zone, typically
 
 It is possible to have multiple `StatusBar` components mounted at the same time. The props will be merged in the order the `StatusBar` components were mounted.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=StatusBar%20Component%20Example&supportedPlatforms=android,ios&ext=js

--- a/docs/systrace.md
+++ b/docs/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -7,7 +7,7 @@ title: Text Style Props
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=TextStyleProps&supportedPlatforms=ios,android&ext=js

--- a/docs/text.md
+++ b/docs/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/docs/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/docs/the-new-architecture/backward-compatibility-fabric-components.md
@@ -304,7 +304,7 @@ my-component
 
 The code that should go in the `MyComponentViewManagerImpl.java` and that can be shared between the Native Component and the Fabric Native Component is, for example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="example of MyComponentViewManager.java"
@@ -352,7 +352,7 @@ Then, the Native Component and the Fabric Native Component can be updated using 
 
 For example, for a Native Component:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="Native Component using the ViewManagerImpl"
@@ -410,7 +410,7 @@ class MyComponentViewManager(var context: ReactApplicationContext) : SimpleViewM
 
 And, for a Fabric Native Component:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="Fabric Component using the ViewManagerImpl"
@@ -499,7 +499,7 @@ import MyComponent from 'your-component/src/index';
 
 Since `codegenNativeComponent` is calling the `requireNativeComponent` under the hood, we need to re-export our component, to avoid registering it multiple times.
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">

--- a/docs/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/docs/the-new-architecture/backward-compatibility-turbomodules.md
@@ -272,7 +272,7 @@ my-module
 
 The code that should go in the `MyModuleImpl.java`, and that can be shared by the Legacy Native Module and the Turbo Native Module is, for example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="example of MyModuleImpl.java"
@@ -325,7 +325,7 @@ Then, the Legacy Native Module and the Turbo Native Module can be updated with t
 
 For example, for a Legacy Native Module:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="Native Module using the Impl module"
@@ -377,7 +377,7 @@ class MyModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(co
 
 And, for a Turbo Native Module:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="TurboModule using the Impl module"
@@ -441,7 +441,7 @@ import MyModule from 'your-module/src/index';
 
 Since `TurboModuleRegistry.get` taps into the old Native Modules API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
-<Tabs groupId="turbomodule-backward-compatibility"
+<Tabs groupId="turbomodule-backward-compatibility" queryString
       defaultValue={constants.defaultTurboModuleSpecLanguage}
       values={constants.turboModuleSpecLanguages}>
 <TabItem value="Flow">

--- a/docs/the-new-architecture/cxx-custom-types.md
+++ b/docs/the-new-architecture/cxx-custom-types.md
@@ -63,7 +63,7 @@ Omitting either `fromJS` or `toJS` would make you `bridging` header either _read
 
 Now you can add the following function to your JavaScript spec:
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"
@@ -157,7 +157,7 @@ export type CustomType = {
 
 which can be exposed to your C++ Turbo Native Module via
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"

--- a/docs/the-new-architecture/cxx-cxxturbomodules.md
+++ b/docs/the-new-architecture/cxx-cxxturbomodules.md
@@ -67,7 +67,7 @@ CxxTurboModulesGuide
 
 Create the following spec inside the `tm` folder:
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"

--- a/docs/the-new-architecture/pillars-codegen.md
+++ b/docs/the-new-architecture/pillars-codegen.md
@@ -151,7 +151,7 @@ These tasks invoke the `generateCodegenArtifactsFromSchema` on all the the impor
 
 Once the Gradle task completes, you can see different structures for a Turbo Native Module or for a Fabric Native Component. The following tab shows how they appear:
 
-<Tabs groupId="android-codegen" defaultValue={constants.defaultNewArchFeature} values={constants.newArchFeatures}>
+<Tabs groupId="android-codegen" queryString defaultValue={constants.defaultNewArchFeature} values={constants.newArchFeatures}>
 <TabItem value="turbomodules">
 
 ```sh

--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -66,7 +66,7 @@ There are two requirements the file containing this specification must meet:
 
 Below are specifications of the `RTNCenteredText` component in both Flow and TypeScript. Create a `RTNCenteredTextNativeComponent` file with the proper extension in the `js` folder.
 
-<Tabs groupId="fabric-component-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="fabric-component-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value='flow'>
 
 ```typescript
@@ -283,7 +283,7 @@ Then, you need a class that implements the `ReactPackage` interface. To run the 
 
 Create an `android/src/main/java/com/rtncenteredtext` folder and, inside that folder, create a `CenteredTextPackage.java` file.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CenteredTextPackage.java"
@@ -653,7 +653,7 @@ android
 
 ##### CenteredText.java
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CenteredText.java"
@@ -730,7 +730,7 @@ This class represents the actual view Android is going to represent on screen. I
 
 ##### CenteredTextManager.java
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CenteredTextManager.java"
@@ -833,7 +833,7 @@ It is also responsible for exporting all the constructs required by React Native
 
 Finally, open the `CenteredTextPackage.java` file in the `android/src/main/java/com/rtncenteredtext` folder and update it with the following lines
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```diff title="CenteredTextPackage.java update"
@@ -929,7 +929,7 @@ Android configuration requires to enable the **New Architecture**.
 
 Finally, you can use the component in your JavaScript application.
 
-<Tabs groupId="final-app" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="final-app" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="App.js"

--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -62,7 +62,7 @@ There are two requirements the file containing this specification must meet:
 1. The file **must** be named `Native<MODULE_NAME>`, with a `.js` or `.jsx` extension when using Flow, or a `.ts`, or `.tsx` extension when using TypeScript. Codegen will only look for files matching this pattern.
 2. The file must export a `TurboModuleRegistrySpec` object.
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="NativeCalculator.js"
@@ -269,7 +269,7 @@ Then, you need a class that extends the `TurboReactPackage` interface. To run th
 
 Create an `android/src/main/java/com/rtncalculator` folder and, inside that folder, create a `CalculatorPackage.java` file.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CalculatorPackage.java"
@@ -528,7 +528,7 @@ android
 
 ##### Creating the `CalculatorModule.java`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CalculatorModule.java"
@@ -597,7 +597,7 @@ This class implements the module itself, which extends the `NativeCalculatorSpec
 
 ##### Updating the `CalculatorPackage.java`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```diff title="CalculatorPackage.java"
@@ -763,7 +763,7 @@ Now you can use your Turbo Native Module calculator in your app!
 
 Here's an example App.js file using the `add` method:
 
-<Tabs groupId="final-app" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="final-app" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="App.js"

--- a/docs/the-new-architecture/use-app-template.md
+++ b/docs/the-new-architecture/use-app-template.md
@@ -49,7 +49,7 @@ Please [follow the instructions on the React Native website](hermes.md) to enabl
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="ios">
 
 Navigate to the `ios` directory and run the following:

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props: MyComponentProps) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -63,7 +63,7 @@ Most components can be customized when they are created, with different paramete
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place. Refer to `props.YOUR_PROP_NAME` in your functional components or `this.props.YOUR_PROP_NAME` in your class components. Here's an example:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Hello%20Props&ext=js

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -21,7 +21,7 @@ npx create-expo-app --template
 
 1. Add TypeScript, types, and ESLint plugins to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -166,7 +166,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/docs/view.md
+++ b/docs/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -11,7 +11,7 @@ Virtualization massively improves memory consumption and performance of large li
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=VirtualizedListExample&ext=js

--- a/website/versioned_docs/version-0.60/building-for-tv.md
+++ b/website/versioned_docs/version-0.60/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.60/dimensions.md
+++ b/website/versioned_docs/version-0.60/dimensions.md
@@ -22,7 +22,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.60/getting-started.md
+++ b/website/versioned_docs/version-0.60/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.60/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.60/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.60/intro-react.md
+++ b/website/versioned_docs/version-0.60/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.60/introduction.md
+++ b/website/versioned_docs/version-0.60/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.60/running-on-device.md
+++ b/website/versioned_docs/version-0.60/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](/docs/environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.61/building-for-tv.md
+++ b/website/versioned_docs/version-0.61/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.61/dimensions.md
+++ b/website/versioned_docs/version-0.61/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.61/getting-started.md
+++ b/website/versioned_docs/version-0.61/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.61/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.61/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.61/intro-react.md
+++ b/website/versioned_docs/version-0.61/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.61/introduction.md
+++ b/website/versioned_docs/version-0.61/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.61/running-on-device.md
+++ b/website/versioned_docs/version-0.61/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](/docs/environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.62/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.62/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/activityindicator.md
+++ b/website/versioned_docs/version-0.62/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/alert.md
+++ b/website/versioned_docs/version-0.62/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. To
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.62/animated.md
+++ b/website/versioned_docs/version-0.62/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 <block class="functional syntax" />
@@ -28,7 +28,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.62/animations.md
+++ b/website/versioned_docs/version-0.62/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -545,7 +545,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.62/appearance.md
+++ b/website/versioned_docs/version-0.62/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.62/appstate.md
+++ b/website/versioned_docs/version-0.62/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/backhandler.md
+++ b/website/versioned_docs/version-0.62/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.62/building-for-tv.md
+++ b/website/versioned_docs/version-0.62/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.62/datepickerios.md
+++ b/website/versioned_docs/version-0.62/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.62/dimensions.md
+++ b/website/versioned_docs/version-0.62/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.62/getting-started.md
+++ b/website/versioned_docs/version-0.62/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.62/image-style-props.md
+++ b/website/versioned_docs/version-0.62/image-style-props.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Style%20Props%20Function%20Component%20Example
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
 </TabItem>
 </Tabs>
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -322,7 +322,7 @@ const styles = StyleSheet.create({
 </TabItem>
 </Tabs>
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -401,7 +401,7 @@ const styles = StyleSheet.create({
 </TabItem>
 </Tabs>
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.62/image.md
+++ b/website/versioned_docs/version-0.62/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default class DisplayAnImage extends Component {
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.62/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.62/intro-react.md
+++ b/website/versioned_docs/version-0.62/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -191,7 +191,7 @@ export default function Cat() {
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -295,7 +295,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.62/introduction.md
+++ b/website/versioned_docs/version-0.62/introduction.md
@@ -54,7 +54,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -106,7 +106,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.62/keyboard.md
+++ b/website/versioned_docs/version-0.62/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.62/layoutanimation.md
+++ b/website/versioned_docs/version-0.62/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 Example usage:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -334,7 +334,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 Example usage:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.62/linking.md
+++ b/website/versioned_docs/version-0.62/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.62/modal.md
+++ b/website/versioned_docs/version-0.62/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.62/network.md
+++ b/website/versioned_docs/version-0.62/network.md
@@ -74,7 +74,7 @@ async function getMoviesFromApiAsync() {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.62/panresponder.md
+++ b/website/versioned_docs/version-0.62/panresponder.md
@@ -91,7 +91,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.62/permissionsandroid.md
+++ b/website/versioned_docs/version-0.62/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.62/running-on-device.md
+++ b/website/versioned_docs/version-0.62/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.62/sectionlist.md
+++ b/website/versioned_docs/version-0.62/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.62/security.md
+++ b/website/versioned_docs/version-0.62/security.md
@@ -32,7 +32,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.62/share.md
+++ b/website/versioned_docs/version-0.62/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.62/systrace.md
+++ b/website/versioned_docs/version-0.62/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/text.md
+++ b/website/versioned_docs/version-0.62/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.62/touchablehighlight.md
+++ b/website/versioned_docs/version-0.62/touchablehighlight.md
@@ -30,7 +30,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/touchableopacity.md
+++ b/website/versioned_docs/version-0.62/touchableopacity.md
@@ -11,7 +11,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.62/transforms.md
+++ b/website/versioned_docs/version-0.62/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.62/vibration.md
+++ b/website/versioned_docs/version-0.62/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.62/view.md
+++ b/website/versioned_docs/version-0.62/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.63/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.63/activityindicator.md
+++ b/website/versioned_docs/version-0.63/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/alert.md
+++ b/website/versioned_docs/version-0.63/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. To
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.63/animated.md
+++ b/website/versioned_docs/version-0.63/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 <block class="functional syntax" />
@@ -28,7 +28,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.63/animations.md
+++ b/website/versioned_docs/version-0.63/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -533,7 +533,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.63/appearance.md
+++ b/website/versioned_docs/version-0.63/appearance.md
@@ -13,7 +13,7 @@ import {Appearance} from 'react-native';
 
 The `Appearance` module exposes information about the user's appearance preferences, such as their preferred color scheme (light or dark).
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.63/appstate.md
+++ b/website/versioned_docs/version-0.63/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/backhandler.md
+++ b/website/versioned_docs/version-0.63/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.63/building-for-tv.md
+++ b/website/versioned_docs/version-0.63/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.63/datepickerios.md
+++ b/website/versioned_docs/version-0.63/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.63/dimensions.md
+++ b/website/versioned_docs/version-0.63/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.63/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.63/dynamiccolorios.md
@@ -19,7 +19,7 @@ At runtime, the system will choose which of the two colors to display depending 
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.63/getting-started.md
+++ b/website/versioned_docs/version-0.63/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.63/image-style-props.md
+++ b/website/versioned_docs/version-0.63/image-style-props.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Style%20Props%20Function%20Component%20Example
@@ -178,7 +178,7 @@ export default DisplayAnImageWithStyle;
 </TabItem>
 </Tabs>
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -327,7 +327,7 @@ export default DisplayAnImageWithStyle;
 </TabItem>
 </Tabs>
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -410,7 +410,7 @@ export default DisplayAnImageWithStyle;
 </TabItem>
 </Tabs>
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.63/image.md
+++ b/website/versioned_docs/version-0.63/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -113,7 +113,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.63/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.63/intro-react.md
+++ b/website/versioned_docs/version-0.63/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ const Cat = () => {
 export default Cat;
 ```
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.63/introduction.md
+++ b/website/versioned_docs/version-0.63/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.63/keyboard.md
+++ b/website/versioned_docs/version-0.63/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.63/layoutanimation.md
+++ b/website/versioned_docs/version-0.63/layoutanimation.md
@@ -119,7 +119,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 Example usage:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -337,7 +337,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 Example usage:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.63/linking.md
+++ b/website/versioned_docs/version-0.63/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.63/modal.md
+++ b/website/versioned_docs/version-0.63/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.63/network.md
+++ b/website/versioned_docs/version-0.63/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.63/panresponder.md
+++ b/website/versioned_docs/version-0.63/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.63/permissionsandroid.md
+++ b/website/versioned_docs/version-0.63/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.63/platformcolor.md
+++ b/website/versioned_docs/version-0.63/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.63/running-on-device.md
+++ b/website/versioned_docs/version-0.63/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.63/sectionlist.md
+++ b/website/versioned_docs/version-0.63/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.63/security.md
+++ b/website/versioned_docs/version-0.63/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.63/share.md
+++ b/website/versioned_docs/version-0.63/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.63/systrace.md
+++ b/website/versioned_docs/version-0.63/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/text.md
+++ b/website/versioned_docs/version-0.63/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.63/touchablehighlight.md
+++ b/website/versioned_docs/version-0.63/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/touchableopacity.md
+++ b/website/versioned_docs/version-0.63/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.63/transforms.md
+++ b/website/versioned_docs/version-0.63/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.63/typescript.md
+++ b/website/versioned_docs/version-0.63/typescript.md
@@ -25,7 +25,7 @@ npx react-native init MyApp --template react-native-template-typescript
 
 You can use [Expo][expo] which has two TypeScript templates:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -46,7 +46,7 @@ expo init MyTSProject
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -69,7 +69,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -242,7 +242,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.63/vibration.md
+++ b/website/versioned_docs/version-0.63/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.63/view.md
+++ b/website/versioned_docs/version-0.63/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.64/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.64/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.64/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.64/activityindicator.md
+++ b/website/versioned_docs/version-0.64/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/alert.md
+++ b/website/versioned_docs/version-0.64/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.64/animated.md
+++ b/website/versioned_docs/version-0.64/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.64/animations.md
+++ b/website/versioned_docs/version-0.64/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -533,7 +533,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.64/appearance.md
+++ b/website/versioned_docs/version-0.64/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.64/appstate.md
+++ b/website/versioned_docs/version-0.64/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/backhandler.md
+++ b/website/versioned_docs/version-0.64/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.64/building-for-tv.md
+++ b/website/versioned_docs/version-0.64/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.64/datepickerios.md
+++ b/website/versioned_docs/version-0.64/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.64/debugging.md
+++ b/website/versioned_docs/version-0.64/debugging.md
@@ -89,7 +89,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.64/dimensions.md
+++ b/website/versioned_docs/version-0.64/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.64/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.64/dynamiccolorios.md
@@ -19,7 +19,7 @@ At runtime, the system will choose which of the two colors to display depending 
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.64/getting-started.md
+++ b/website/versioned_docs/version-0.64/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.64/image-style-props.md
+++ b/website/versioned_docs/version-0.64/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.64/image.md
+++ b/website/versioned_docs/version-0.64/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.64/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.64/intro-react.md
+++ b/website/versioned_docs/version-0.64/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.64/introduction.md
+++ b/website/versioned_docs/version-0.64/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.64/keyboard.md
+++ b/website/versioned_docs/version-0.64/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.64/layoutanimation.md
+++ b/website/versioned_docs/version-0.64/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -338,7 +338,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.64/libraries.md
+++ b/website/versioned_docs/version-0.64/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.64/linking.md
+++ b/website/versioned_docs/version-0.64/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.64/modal.md
+++ b/website/versioned_docs/version-0.64/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.64/network.md
+++ b/website/versioned_docs/version-0.64/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.64/panresponder.md
+++ b/website/versioned_docs/version-0.64/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.64/permissionsandroid.md
+++ b/website/versioned_docs/version-0.64/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.64/platformcolor.md
+++ b/website/versioned_docs/version-0.64/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.64/running-on-device.md
+++ b/website/versioned_docs/version-0.64/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.64/sectionlist.md
+++ b/website/versioned_docs/version-0.64/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.64/security.md
+++ b/website/versioned_docs/version-0.64/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.64/share.md
+++ b/website/versioned_docs/version-0.64/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.64/systrace.md
+++ b/website/versioned_docs/version-0.64/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/text.md
+++ b/website/versioned_docs/version-0.64/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.64/touchablehighlight.md
+++ b/website/versioned_docs/version-0.64/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/touchableopacity.md
+++ b/website/versioned_docs/version-0.64/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.64/transforms.md
+++ b/website/versioned_docs/version-0.64/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.64/typescript.md
+++ b/website/versioned_docs/version-0.64/typescript.md
@@ -25,7 +25,7 @@ npx react-native init MyApp --template react-native-template-typescript
 
 You can use [Expo][expo] which has two TypeScript templates:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -46,7 +46,7 @@ expo init MyTSProject
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -69,7 +69,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -235,7 +235,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.64/vibration.md
+++ b/website/versioned_docs/version-0.64/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.64/view.md
+++ b/website/versioned_docs/version-0.64/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.65/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.65/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.65/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.65/activityindicator.md
+++ b/website/versioned_docs/version-0.65/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/alert.md
+++ b/website/versioned_docs/version-0.65/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.65/animated.md
+++ b/website/versioned_docs/version-0.65/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.65/animations.md
+++ b/website/versioned_docs/version-0.65/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -533,7 +533,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.65/appearance.md
+++ b/website/versioned_docs/version-0.65/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.65/appstate.md
+++ b/website/versioned_docs/version-0.65/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/backhandler.md
+++ b/website/versioned_docs/version-0.65/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.65/building-for-tv.md
+++ b/website/versioned_docs/version-0.65/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.65/datepickerios.md
+++ b/website/versioned_docs/version-0.65/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.65/debugging.md
+++ b/website/versioned_docs/version-0.65/debugging.md
@@ -89,7 +89,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.65/dimensions.md
+++ b/website/versioned_docs/version-0.65/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.65/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.65/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.65/getting-started.md
+++ b/website/versioned_docs/version-0.65/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.65/image-style-props.md
+++ b/website/versioned_docs/version-0.65/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.65/image.md
+++ b/website/versioned_docs/version-0.65/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.65/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.65/intro-react.md
+++ b/website/versioned_docs/version-0.65/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.65/introduction.md
+++ b/website/versioned_docs/version-0.65/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.65/keyboard.md
+++ b/website/versioned_docs/version-0.65/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.65/layoutanimation.md
+++ b/website/versioned_docs/version-0.65/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -338,7 +338,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.65/libraries.md
+++ b/website/versioned_docs/version-0.65/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.65/linking.md
+++ b/website/versioned_docs/version-0.65/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.65/modal.md
+++ b/website/versioned_docs/version-0.65/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.65/network.md
+++ b/website/versioned_docs/version-0.65/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.65/panresponder.md
+++ b/website/versioned_docs/version-0.65/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.65/permissionsandroid.md
+++ b/website/versioned_docs/version-0.65/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.65/platformcolor.md
+++ b/website/versioned_docs/version-0.65/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.65/running-on-device.md
+++ b/website/versioned_docs/version-0.65/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.65/sectionlist.md
+++ b/website/versioned_docs/version-0.65/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.65/security.md
+++ b/website/versioned_docs/version-0.65/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.65/share.md
+++ b/website/versioned_docs/version-0.65/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.65/systrace.md
+++ b/website/versioned_docs/version-0.65/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/text.md
+++ b/website/versioned_docs/version-0.65/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.65/touchablehighlight.md
+++ b/website/versioned_docs/version-0.65/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/touchableopacity.md
+++ b/website/versioned_docs/version-0.65/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.65/transforms.md
+++ b/website/versioned_docs/version-0.65/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.65/typescript.md
+++ b/website/versioned_docs/version-0.65/typescript.md
@@ -25,7 +25,7 @@ npx react-native init MyApp --template react-native-template-typescript
 
 You can use [Expo][expo] which has two TypeScript templates:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -46,7 +46,7 @@ expo init MyTSProject
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -69,7 +69,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -235,7 +235,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.65/vibration.md
+++ b/website/versioned_docs/version-0.65/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.65/view.md
+++ b/website/versioned_docs/version-0.65/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.66/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.66/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.66/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.66/activityindicator.md
+++ b/website/versioned_docs/version-0.66/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/alert.md
+++ b/website/versioned_docs/version-0.66/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.66/animated.md
+++ b/website/versioned_docs/version-0.66/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.66/animations.md
+++ b/website/versioned_docs/version-0.66/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -531,7 +531,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.66/appearance.md
+++ b/website/versioned_docs/version-0.66/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.66/appstate.md
+++ b/website/versioned_docs/version-0.66/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/backhandler.md
+++ b/website/versioned_docs/version-0.66/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.66/building-for-tv.md
+++ b/website/versioned_docs/version-0.66/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.66/datepickerios.md
+++ b/website/versioned_docs/version-0.66/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.66/debugging.md
+++ b/website/versioned_docs/version-0.66/debugging.md
@@ -89,7 +89,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.66/dimensions.md
+++ b/website/versioned_docs/version-0.66/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.66/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.66/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.66/getting-started.md
+++ b/website/versioned_docs/version-0.66/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.66/image-style-props.md
+++ b/website/versioned_docs/version-0.66/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.66/image.md
+++ b/website/versioned_docs/version-0.66/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.66/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.66/intro-react.md
+++ b/website/versioned_docs/version-0.66/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.66/introduction.md
+++ b/website/versioned_docs/version-0.66/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.66/keyboard.md
+++ b/website/versioned_docs/version-0.66/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.66/layoutanimation.md
+++ b/website/versioned_docs/version-0.66/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -338,7 +338,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.66/libraries.md
+++ b/website/versioned_docs/version-0.66/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.66/linking.md
+++ b/website/versioned_docs/version-0.66/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.66/modal.md
+++ b/website/versioned_docs/version-0.66/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.66/network.md
+++ b/website/versioned_docs/version-0.66/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.66/panresponder.md
+++ b/website/versioned_docs/version-0.66/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.66/permissionsandroid.md
+++ b/website/versioned_docs/version-0.66/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.66/platformcolor.md
+++ b/website/versioned_docs/version-0.66/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.66/running-on-device.md
+++ b/website/versioned_docs/version-0.66/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.66/sectionlist.md
+++ b/website/versioned_docs/version-0.66/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.66/security.md
+++ b/website/versioned_docs/version-0.66/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.66/share.md
+++ b/website/versioned_docs/version-0.66/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.66/systrace.md
+++ b/website/versioned_docs/version-0.66/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/text.md
+++ b/website/versioned_docs/version-0.66/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.66/touchablehighlight.md
+++ b/website/versioned_docs/version-0.66/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/touchableopacity.md
+++ b/website/versioned_docs/version-0.66/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.66/transforms.md
+++ b/website/versioned_docs/version-0.66/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.66/typescript.md
+++ b/website/versioned_docs/version-0.66/typescript.md
@@ -25,7 +25,7 @@ npx react-native init MyApp --template react-native-template-typescript
 
 You can use [Expo][expo] which has two TypeScript templates:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -46,7 +46,7 @@ expo init MyTSProject
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -69,7 +69,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -235,7 +235,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.66/vibration.md
+++ b/website/versioned_docs/version-0.66/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.66/view.md
+++ b/website/versioned_docs/version-0.66/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.67/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.67/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.67/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.67/activityindicator.md
+++ b/website/versioned_docs/version-0.67/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/alert.md
+++ b/website/versioned_docs/version-0.67/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.67/animated.md
+++ b/website/versioned_docs/version-0.67/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.67/animations.md
+++ b/website/versioned_docs/version-0.67/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -531,7 +531,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.67/appearance.md
+++ b/website/versioned_docs/version-0.67/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.67/appstate.md
+++ b/website/versioned_docs/version-0.67/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/backhandler.md
+++ b/website/versioned_docs/version-0.67/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.67/building-for-tv.md
+++ b/website/versioned_docs/version-0.67/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.67/datepickerios.md
+++ b/website/versioned_docs/version-0.67/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.67/debugging.md
+++ b/website/versioned_docs/version-0.67/debugging.md
@@ -89,7 +89,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.67/dimensions.md
+++ b/website/versioned_docs/version-0.67/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.67/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.67/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.67/getting-started.md
+++ b/website/versioned_docs/version-0.67/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 12 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.67/image-style-props.md
+++ b/website/versioned_docs/version-0.67/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.67/image.md
+++ b/website/versioned_docs/version-0.67/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.67/integration-with-android-fragment.md
@@ -19,7 +19,7 @@ You will need to implement the `ReactApplication` interface in your main Applica
 
 Ensure your main Application class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -38,7 +38,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -96,7 +96,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -163,7 +163,7 @@ Now in your Activity class (e.g. `MainActivity.java` or `MainActivity.kt`) you n
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -182,7 +182,7 @@ private Button mButton;
 
 Update your Activity's `onCreate` method as follows:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -241,7 +241,7 @@ If you are using a starter kit for React Native, replace the "HelloWorld" string
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -267,7 +267,7 @@ private Bundle getLaunchOptions(String message) {
 
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.67/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.67/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.67/intro-react.md
+++ b/website/versioned_docs/version-0.67/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.67/introduction.md
+++ b/website/versioned_docs/version-0.67/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.67/keyboard.md
+++ b/website/versioned_docs/version-0.67/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.67/layoutanimation.md
+++ b/website/versioned_docs/version-0.67/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -338,7 +338,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.67/libraries.md
+++ b/website/versioned_docs/version-0.67/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.67/linking.md
+++ b/website/versioned_docs/version-0.67/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.67/modal.md
+++ b/website/versioned_docs/version-0.67/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.67/network.md
+++ b/website/versioned_docs/version-0.67/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.67/panresponder.md
+++ b/website/versioned_docs/version-0.67/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.67/permissionsandroid.md
+++ b/website/versioned_docs/version-0.67/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.67/platformcolor.md
+++ b/website/versioned_docs/version-0.67/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.67/running-on-device.md
+++ b/website/versioned_docs/version-0.67/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -310,7 +310,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.67/sectionlist.md
+++ b/website/versioned_docs/version-0.67/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.67/security.md
+++ b/website/versioned_docs/version-0.67/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.67/share.md
+++ b/website/versioned_docs/version-0.67/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.67/systrace.md
+++ b/website/versioned_docs/version-0.67/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/text.md
+++ b/website/versioned_docs/version-0.67/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.67/touchablehighlight.md
+++ b/website/versioned_docs/version-0.67/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/touchableopacity.md
+++ b/website/versioned_docs/version-0.67/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.67/transforms.md
+++ b/website/versioned_docs/version-0.67/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.67/typescript.md
+++ b/website/versioned_docs/version-0.67/typescript.md
@@ -25,7 +25,7 @@ npx react-native init MyApp --template react-native-template-typescript
 
 You can use [Expo][expo] which has two TypeScript templates:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -46,7 +46,7 @@ expo init MyTSProject
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -69,7 +69,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -235,7 +235,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.67/vibration.md
+++ b/website/versioned_docs/version-0.67/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.67/view.md
+++ b/website/versioned_docs/version-0.67/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.68/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.68/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.68/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.68/activityindicator.md
+++ b/website/versioned_docs/version-0.68/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/alert.md
+++ b/website/versioned_docs/version-0.68/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.68/animated.md
+++ b/website/versioned_docs/version-0.68/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.68/animations.md
+++ b/website/versioned_docs/version-0.68/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -531,7 +531,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.68/appearance.md
+++ b/website/versioned_docs/version-0.68/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.68/appstate.md
+++ b/website/versioned_docs/version-0.68/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/backhandler.md
+++ b/website/versioned_docs/version-0.68/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.68/building-for-tv.md
+++ b/website/versioned_docs/version-0.68/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.68/datepickerios.md
+++ b/website/versioned_docs/version-0.68/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.68/debugging.md
+++ b/website/versioned_docs/version-0.68/debugging.md
@@ -89,7 +89,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.68/dimensions.md
+++ b/website/versioned_docs/version-0.68/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.68/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.68/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.68/getting-started.md
+++ b/website/versioned_docs/version-0.68/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Assuming that you have [Node 14 LTS](https://nodejs.org/en/download/) or greater installed, you can use npm to install the Expo CLI command line utility:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -38,7 +38,7 @@ yarn global add expo-cli
 
 Then run the following commands to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -115,12 +115,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -166,7 +166,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.68/headless-js-android.md
+++ b/website/versioned_docs/version-0.68/headless-js-android.md
@@ -33,7 +33,7 @@ You can do anything in your task such as network requests, timers and so on, as 
 
 Yes, this does still require some native code, but it's pretty thin. You need to extend `HeadlessJsTaskService` and override `getTaskConfig`, e.g.:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -104,7 +104,7 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
 
 Example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ By default, the headless JS task will not perform any retries. In order to do so
 
 `LinearCountingRetryPolicy` is an implementation of `HeadlessJsRetryPolicy` that allows you to specify a maximum number of retries with a fixed delay between each attempt. If that does not suit your needs then you can implement your own `HeadlessJsRetryPolicy`. These policies can be passed as an extra argument to the `HeadlessJsTaskConfig` constructor, e.g.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -213,7 +213,7 @@ Following lines shows part of Android manifest file for registering broadcast re
 
 Broadcast receiver then handles intent that was broadcasted in onReceive function. This is a great place to check whether your app is on foreground or not. If app is not on foreground we can prepare our intent to be started, with no information or additional information bundled using `putExtra` (keep in mind bundle can handle only parcelable values). In the end service is started and wakelock is acquired.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.68/image-style-props.md
+++ b/website/versioned_docs/version-0.68/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.68/image.md
+++ b/website/versioned_docs/version-0.68/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.68/integration-with-android-fragment.md
@@ -19,7 +19,7 @@ You will need to implement the `ReactApplication` interface in your main Applica
 
 Ensure your main Application class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -38,7 +38,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -96,7 +96,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -163,7 +163,7 @@ Now in your Activity class (e.g. `MainActivity.java` or `MainActivity.kt`) you n
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -182,7 +182,7 @@ private Button mButton;
 
 Update your Activity's `onCreate` method as follows:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -239,7 +239,7 @@ If you are using a starter kit for React Native, replace the "HelloWorld" string
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -265,7 +265,7 @@ private Bundle getLaunchOptions(String message) {
 
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.68/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.68/integration-with-existing-apps.md
@@ -12,7 +12,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.68/intro-react.md
+++ b/website/versioned_docs/version-0.68/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.68/introduction.md
+++ b/website/versioned_docs/version-0.68/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.68/keyboard.md
+++ b/website/versioned_docs/version-0.68/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.68/layoutanimation.md
+++ b/website/versioned_docs/version-0.68/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -338,7 +338,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.68/libraries.md
+++ b/website/versioned_docs/version-0.68/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.68/linking.md
+++ b/website/versioned_docs/version-0.68/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.68/modal.md
+++ b/website/versioned_docs/version-0.68/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.68/native-modules-android.md
+++ b/website/versioned_docs/version-0.68/native-modules-android.md
@@ -37,7 +37,7 @@ The first step is to create the (`CalendarModule.java` or `CalendarModule.kt`) J
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -84,7 +84,7 @@ As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaMod
 
 All Java/Kotlin native modules in Android need to implement the `getName()` method. This method returns a string, which represents the name of the native module. The native module can then be accessed in JavaScript using its name. For example, in the below code snippet, `getName()` returns `"CalendarModule"`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -118,7 +118,7 @@ Next you will need to add a method to your native module that will create calend
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -139,7 +139,7 @@ public void createCalendarEvent(String name, String location) {
 
 Add a debug log in the method to confirm it has been invoked when you call it from your application. Below is an example of how you can import and use the [Log](https://developer.android.com/reference/android/util/Log) class from the Android util package:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -173,7 +173,7 @@ Once you finish implementing the native module and hook it up in JavaScript, you
 
 You can pass `isBlockingSynchronousMethod = true` to a native method to mark it as a synchronous method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -202,7 +202,7 @@ To add your Native Module to `ReactPackage`, first create a new Java/Kotlin Clas
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -272,7 +272,7 @@ To register the `CalendarModule` package, you must add `MyAppPackage` to the lis
 
 Locate ReactNativeHost’s `getPackages()` method and add your package to the packages list `getPackages()` returns:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -443,7 +443,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 
 For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, `Date` conversion is not supported out of the box. You can handle the conversion to the `Date` type within the native method yourself like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -477,7 +477,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -517,7 +517,7 @@ Native modules also support a unique kind of argument: a callback. Callbacks are
 
 In order to create a native module method with a callback, first import the `Callback` interface, and then add a new parameter to your native module method of type `Callback`. There are a couple of nuances with callback arguments that will soon be lifted with TurboModules. First off, you can only have two callbacks in your function arguments- a successCallback and a failureCallback. In addition, the last argument to a native module method call, if it's a function, is treated as the successCallback, and the second to last argument to a native module method call, if it's a function, is treated as the failure callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -542,7 +542,7 @@ import com.facebook.react.bridge.Callback
 
 You can invoke the callback in your Java/Kotlin method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -585,7 +585,7 @@ Another important detail to note is that a native module method can only invoke 
 
 There are two approaches to error handling with callbacks. The first is to follow Node’s convention and treat the first argument passed to the callback as an error object.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -629,7 +629,7 @@ const onPress = () => {
 
 Another option is to use an onSuccess and onFailure callback:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -677,7 +677,7 @@ Native modules can also fulfill a [Promise](https://developer.mozilla.org/en-US/
 
 Refactoring the above code to use a promise instead of callbacks looks like this:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -732,7 +732,7 @@ const onSubmit = async () => {
 
 The reject method takes different combinations of the following arguments:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -753,7 +753,7 @@ For more detail, you can find the `Promise.java` interface [here](https://github
 
 Java/Kotlin reject call:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -781,7 +781,7 @@ Error message in React Native App when promise is rejected:
 
 Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -892,7 +892,7 @@ import { NativeEventEmitter, NativeModules } from 'react-native';
 
 You'll need to listen to `onActivityResult` if you want to get results from an activity you started with `startActivityForResult`. To do this, you must extend `BaseActivityEventListener` or implement `ActivityEventListener`. The former is preferred as it is more resilient to API changes. Then, you need to register the listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -911,7 +911,7 @@ reactContext.addActivityEventListener(mActivityResultListener);
 
 Now you can listen to `onActivityResult` by implementing the following method:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -944,7 +944,7 @@ override fun onActivityResult(
 
 Let's implement a basic image picker to demonstrate this. The image picker will expose the method `pickImage` to JavaScript, which will return the path of the image when called.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```jsx
@@ -1104,7 +1104,7 @@ class ImagePickerModule(reactContext: ReactApplicationContext) :
 
 Listening to the activity's LifeCycle events such as `onResume`, `onPause` etc. is very similar to how `ActivityEventListener` was implemented. The module must implement `LifecycleEventListener`. Then, you need to register a listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -1123,7 +1123,7 @@ reactContext.addLifecycleEventListener(this)
 
 Now you can listen to the activity's LifeCycle events by implementing the following methods:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.68/network.md
+++ b/website/versioned_docs/version-0.68/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.68/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.68/optimizing-flatlist-configuration.md
@@ -125,7 +125,7 @@ You can also use a `key` prop in your item component.
 
 Move out the `renderItem` function to the outside of render function, so it won't recreate itself each time render function called.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">
 
 ```jsx

--- a/website/versioned_docs/version-0.68/panresponder.md
+++ b/website/versioned_docs/version-0.68/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.68/permissionsandroid.md
+++ b/website/versioned_docs/version-0.68/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.68/platformcolor.md
+++ b/website/versioned_docs/version-0.68/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.68/running-on-device.md
+++ b/website/versioned_docs/version-0.68/running-on-device.md
@@ -10,14 +10,14 @@ It's always a good idea to test your app on an actual device before releasing it
 
 If you used Expo CLI or Create React Native App to set up your project, you can preview your app on a device by scanning the QR code with the Expo app—but in order to build and run your app on a device, you will need to eject and install the native code dependencies from the [environment setup guide](environment-setup).
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -310,7 +310,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.68/sectionlist.md
+++ b/website/versioned_docs/version-0.68/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.68/security.md
+++ b/website/versioned_docs/version-0.68/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.68/share.md
+++ b/website/versioned_docs/version-0.68/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.68/systrace.md
+++ b/website/versioned_docs/version-0.68/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/text.md
+++ b/website/versioned_docs/version-0.68/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.68/touchablehighlight.md
+++ b/website/versioned_docs/version-0.68/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/touchableopacity.md
+++ b/website/versioned_docs/version-0.68/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.68/transforms.md
+++ b/website/versioned_docs/version-0.68/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.68/typescript.md
+++ b/website/versioned_docs/version-0.68/typescript.md
@@ -32,7 +32,7 @@ Optionally, you can also use the command given below to get started with your te
 
 You can use [Expo][expo] which has two TypeScript templates:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -53,7 +53,7 @@ expo init MyTSProject
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -76,7 +76,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -242,7 +242,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.68/vibration.md
+++ b/website/versioned_docs/version-0.68/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.68/view.md
+++ b/website/versioned_docs/version-0.68/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.69/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.69/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.69/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.69/activityindicator.md
+++ b/website/versioned_docs/version-0.69/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/alert.md
+++ b/website/versioned_docs/version-0.69/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.69/animated.md
+++ b/website/versioned_docs/version-0.69/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.69/animations.md
+++ b/website/versioned_docs/version-0.69/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -531,7 +531,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.69/appearance.md
+++ b/website/versioned_docs/version-0.69/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.69/appstate.md
+++ b/website/versioned_docs/version-0.69/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/backhandler.md
+++ b/website/versioned_docs/version-0.69/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.69/building-for-tv.md
+++ b/website/versioned_docs/version-0.69/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.69/communication-android.md
+++ b/website/versioned_docs/version-0.69/communication-android.md
@@ -21,7 +21,7 @@ Properties are the most straightforward way of cross-component communication. So
 
 You can pass properties down to the React Native app by providing a custom implementation of `ReactActivityDelegate` in your main activity. This implementation should override `getLaunchOptions` to return a `Bundle` with the desired properties.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 
@@ -82,7 +82,7 @@ export default class ImageBrowserApp extends React.Component {
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.69/custom-webview-android.md
+++ b/website/versioned_docs/version-0.69/custom-webview-android.md
@@ -26,7 +26,7 @@ To get started, you'll need to create a subclass of `RNCWebViewManager`, `RNCWeb
 - `getName`
 - `addEventEmitters`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -94,7 +94,7 @@ You'll need to follow the usual steps to [register the module](native-modules-an
 
 To add a new property, you'll need to add it to `CustomWebView`, and then expose it in `CustomWebViewManager`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -149,7 +149,7 @@ class CustomWebViewManager : RNCWebViewManager() {
 
 For events, you'll first need to make create event subclass.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -198,7 +198,7 @@ You can trigger the event in your web view client. You can hook existing handler
 
 You should refer to [RNCWebViewManager.java](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java) in the React Native WebView codebase to see what handlers are available and how they are implemented. You can extend any methods here to provide extra functionality.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -274,7 +274,7 @@ protected class CustomWebViewClient : RNCWebViewClient() {
 
 Finally, you'll need to expose the events in `CustomWebViewManager` through `getExportedCustomDirectEventTypeConstants`. Note that currently, the default implementation returns `null`, but this may change in the future.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.69/datepickerios.md
+++ b/website/versioned_docs/version-0.69/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.69/debugging.md
+++ b/website/versioned_docs/version-0.69/debugging.md
@@ -89,7 +89,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.69/dimensions.md
+++ b/website/versioned_docs/version-0.69/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.69/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.69/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.69/getting-started.md
+++ b/website/versioned_docs/version-0.69/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Run the following command to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -91,12 +91,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -118,7 +118,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.69/headless-js-android.md
+++ b/website/versioned_docs/version-0.69/headless-js-android.md
@@ -33,7 +33,7 @@ You can do anything in your task such as network requests, timers and so on, as 
 
 Yes, this does still require some native code, but it's pretty thin. You need to extend `HeadlessJsTaskService` and override `getTaskConfig`, e.g.:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -104,7 +104,7 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
 
 Example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ By default, the headless JS task will not perform any retries. In order to do so
 
 `LinearCountingRetryPolicy` is an implementation of `HeadlessJsRetryPolicy` that allows you to specify a maximum number of retries with a fixed delay between each attempt. If that does not suit your needs then you can implement your own `HeadlessJsRetryPolicy`. These policies can be passed as an extra argument to the `HeadlessJsTaskConfig` constructor, e.g.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -213,7 +213,7 @@ Following lines shows part of Android manifest file for registering broadcast re
 
 Broadcast receiver then handles intent that was broadcasted in onReceive function. This is a great place to check whether your app is on foreground or not. If app is not on foreground we can prepare our intent to be started, with no information or additional information bundled using `putExtra` (keep in mind bundle can handle only parcelable values). In the end service is started and wakelock is acquired.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.69/image-style-props.md
+++ b/website/versioned_docs/version-0.69/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.69/image.md
+++ b/website/versioned_docs/version-0.69/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.69/integration-with-android-fragment.md
@@ -19,7 +19,7 @@ You will need to implement the `ReactApplication` interface in your main Applica
 
 Ensure your main Application class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -38,7 +38,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -96,7 +96,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -163,7 +163,7 @@ Now in your Activity class (e.g. `MainActivity.java` or `MainActivity.kt`) you n
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -182,7 +182,7 @@ private Button mButton;
 
 Update your Activity's `onCreate` method as follows:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -239,7 +239,7 @@ If you are using a starter kit for React Native, replace the "HelloWorld" string
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -265,7 +265,7 @@ private Bundle getLaunchOptions(String message) {
 
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.69/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.69/integration-with-existing-apps.md
@@ -13,7 +13,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="kotlin">
 

--- a/website/versioned_docs/version-0.69/intro-react.md
+++ b/website/versioned_docs/version-0.69/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.69/introduction.md
+++ b/website/versioned_docs/version-0.69/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.69/keyboard.md
+++ b/website/versioned_docs/version-0.69/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.69/layoutanimation.md
+++ b/website/versioned_docs/version-0.69/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -338,7 +338,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.69/libraries.md
+++ b/website/versioned_docs/version-0.69/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.69/linking.md
+++ b/website/versioned_docs/version-0.69/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.69/modal.md
+++ b/website/versioned_docs/version-0.69/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.69/native-components-android.md
+++ b/website/versioned_docs/version-0.69/native-components-android.md
@@ -29,7 +29,7 @@ To send a view:
 
 In this example we create view manager class `ReactImageManager` that extends `SimpleViewManager` of type `ReactImageView`. `ReactImageView` is the type of object managed by the manager, this will be the custom native view. Name returned by `getName` is used to reference the native view type from JavaScript.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -72,7 +72,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
 Views are created in the `createViewInstance` method, the view should initialize itself in its default state, any properties will be set via a follow up call to `updateView.`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -107,7 +107,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
 
 <!-- alex enable primitive -->
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -154,7 +154,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
 
 The final step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.md), via the applications package member function `createViewManagers`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -202,7 +202,7 @@ The `requireNativeComponent` function takes the name of the native view. Note th
 
 So now we know how to expose native view components that we can control freely from JS, but how do we deal with events from the user, like pinch-zooms or panning? When a native event occurs the native code should issue an event to the JavaScript representation of the View, and the two views are linked with the value returned from the `getId()` method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -242,7 +242,7 @@ class MyCustomView extends View {
 
 To map the `topChange` event name to the `onChange` callback prop in JavaScript, register it by overriding the `getExportedCustomBubblingEventTypeConstants` method in your `ViewManager`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -318,7 +318,7 @@ In order to integrate existing Native UI elements to your React Native app, you 
 
 First, let's create a `CustomView` class which extends `FrameLayout` (the content of this view can be any view that you'd like to render)
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="CustomView.kt"
@@ -379,7 +379,7 @@ public class CustomView extends FrameLayout {
 
 ### 2. Create a `Fragment`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyFragment.kt"
@@ -491,7 +491,7 @@ public class MyFragment extends Fragment {
 
 ### 3. Create the `ViewManager` subclass
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyViewManager.kt"
@@ -737,7 +737,7 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
 ### 4. Register the `ViewManager`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyPackage.kt"
@@ -787,7 +787,7 @@ public class MyPackage implements ReactPackage {
 
 ### 5. Register the `Package`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"

--- a/website/versioned_docs/version-0.69/native-modules-android.md
+++ b/website/versioned_docs/version-0.69/native-modules-android.md
@@ -37,7 +37,7 @@ The first step is to create the (`CalendarModule.java` or `CalendarModule.kt`) J
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -84,7 +84,7 @@ As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaMod
 
 All Java/Kotlin native modules in Android need to implement the `getName()` method. This method returns a string, which represents the name of the native module. The native module can then be accessed in JavaScript using its name. For example, in the below code snippet, `getName()` returns `"CalendarModule"`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -118,7 +118,7 @@ Next you will need to add a method to your native module that will create calend
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -139,7 +139,7 @@ public void createCalendarEvent(String name, String location) {
 
 Add a debug log in the method to confirm it has been invoked when you call it from your application. Below is an example of how you can import and use the [Log](https://developer.android.com/reference/android/util/Log) class from the Android util package:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -173,7 +173,7 @@ Once you finish implementing the native module and hook it up in JavaScript, you
 
 You can pass `isBlockingSynchronousMethod = true` to a native method to mark it as a synchronous method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -202,7 +202,7 @@ To add your Native Module to `ReactPackage`, first create a new Java/Kotlin Clas
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -272,7 +272,7 @@ To register the `CalendarModule` package, you must add `MyAppPackage` to the lis
 
 Locate ReactNativeHost’s `getPackages()` method and add your package to the packages list `getPackages()` returns:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -443,7 +443,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 
 For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, `Date` conversion is not supported out of the box. You can handle the conversion to the `Date` type within the native method yourself like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -477,7 +477,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -517,7 +517,7 @@ Native modules also support a unique kind of argument: a callback. Callbacks are
 
 In order to create a native module method with a callback, first import the `Callback` interface, and then add a new parameter to your native module method of type `Callback`. There are a couple of nuances with callback arguments that will soon be lifted with TurboModules. First off, you can only have two callbacks in your function arguments- a successCallback and a failureCallback. In addition, the last argument to a native module method call, if it's a function, is treated as the successCallback, and the second to last argument to a native module method call, if it's a function, is treated as the failure callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -542,7 +542,7 @@ import com.facebook.react.bridge.Callback
 
 You can invoke the callback in your Java/Kotlin method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -585,7 +585,7 @@ Another important detail to note is that a native module method can only invoke 
 
 There are two approaches to error handling with callbacks. The first is to follow Node’s convention and treat the first argument passed to the callback as an error object.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -629,7 +629,7 @@ const onPress = () => {
 
 Another option is to use an onSuccess and onFailure callback:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -677,7 +677,7 @@ Native modules can also fulfill a [Promise](https://developer.mozilla.org/en-US/
 
 Refactoring the above code to use a promise instead of callbacks looks like this:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -732,7 +732,7 @@ const onSubmit = async () => {
 
 The reject method takes different combinations of the following arguments:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -753,7 +753,7 @@ For more detail, you can find the `Promise.java` interface [here](https://github
 
 Java/Kotlin reject call:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -781,7 +781,7 @@ Error message in React Native App when promise is rejected:
 
 Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -892,7 +892,7 @@ import { NativeEventEmitter, NativeModules } from 'react-native';
 
 You'll need to listen to `onActivityResult` if you want to get results from an activity you started with `startActivityForResult`. To do this, you must extend `BaseActivityEventListener` or implement `ActivityEventListener`. The former is preferred as it is more resilient to API changes. Then, you need to register the listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -911,7 +911,7 @@ reactContext.addActivityEventListener(mActivityResultListener);
 
 Now you can listen to `onActivityResult` by implementing the following method:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -944,7 +944,7 @@ override fun onActivityResult(
 
 Let's implement a basic image picker to demonstrate this. The image picker will expose the method `pickImage` to JavaScript, which will return the path of the image when called.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```jsx
@@ -1104,7 +1104,7 @@ class ImagePickerModule(reactContext: ReactApplicationContext) :
 
 Listening to the activity's LifeCycle events such as `onResume`, `onPause` etc. is very similar to how `ActivityEventListener` was implemented. The module must implement `LifecycleEventListener`. Then, you need to register a listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -1123,7 +1123,7 @@ reactContext.addLifecycleEventListener(this)
 
 Now you can listen to the activity's LifeCycle events by implementing the following methods:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.69/network.md
+++ b/website/versioned_docs/version-0.69/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.69/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.69/new-architecture-library-intro.md
@@ -35,7 +35,7 @@ JavaScript spec files **must** be named `Native<MODULE_NAME>.js` (for TypeScript
 
 The following snippets show a basic spec template, written in [Flow](https://flow.org/) as well as [TypeScript](https://www.typescriptlang.org/).
 
-<Tabs groupId="turbo-module-spec-language" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbo-module-spec-language" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```ts
@@ -80,7 +80,7 @@ JavaScript spec files **must** be named `<FABRIC COMPONENT>NativeComponent.js` (
 
 The following snippet shows a basic JavaScript spec template, written in [Flow](https://flow.org/) as well as [TypeScript](https://www.typescriptlang.org/).
 
-<Tabs groupId="turbo-module-spec-language" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbo-module-spec-language" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```ts
@@ -574,7 +574,7 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
 
 **Android**
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.69/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.69/optimizing-flatlist-configuration.md
@@ -125,7 +125,7 @@ You can also use a `key` prop in your item component.
 
 Move out the `renderItem` function to the outside of render function, so it won't recreate itself each time render function called.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">
 
 ```jsx

--- a/website/versioned_docs/version-0.69/panresponder.md
+++ b/website/versioned_docs/version-0.69/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.69/permissionsandroid.md
+++ b/website/versioned_docs/version-0.69/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.69/platformcolor.md
+++ b/website/versioned_docs/version-0.69/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.69/react-18-and-react-native.md
+++ b/website/versioned_docs/version-0.69/react-18-and-react-native.md
@@ -42,7 +42,7 @@ However, if you do hit any issues, we provide an option to opt-out of the new ro
 
 On Android, you will be able to override the `isConcurrentRootEnabled` in your ActivityDelegate (in the `MainActivity` file), and enable/disable Concurrent React.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.69/running-on-device.md
+++ b/website/versioned_docs/version-0.69/running-on-device.md
@@ -12,14 +12,14 @@ It's always a good idea to test your app on an actual device before releasing it
 If you used `create-expo-app` to set up your project, you can run your app on a device in Expo Go by scanning the QR code that is displayed when you run `npm start`. Refer to the Expo guide for [running your project on your device](https://docs.expo.dev/workflow/run-on-device/) for more information.
 :::
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -312,7 +312,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.69/sectionlist.md
+++ b/website/versioned_docs/version-0.69/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.69/security.md
+++ b/website/versioned_docs/version-0.69/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.69/share.md
+++ b/website/versioned_docs/version-0.69/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.69/systrace.md
+++ b/website/versioned_docs/version-0.69/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/text.md
+++ b/website/versioned_docs/version-0.69/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.69/touchablehighlight.md
+++ b/website/versioned_docs/version-0.69/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/touchableopacity.md
+++ b/website/versioned_docs/version-0.69/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.69/transforms.md
+++ b/website/versioned_docs/version-0.69/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.69/typescript.md
+++ b/website/versioned_docs/version-0.69/typescript.md
@@ -32,7 +32,7 @@ Optionally, you can also use the command given below to get started with your te
 
 You can use [Expo][expo], which maintains TypeScript templates, or will prompt you to automatically install and configure TypeScript when a `.ts` or `.tsx` file is added to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -51,7 +51,7 @@ yarn create expo-app --template
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -74,7 +74,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -223,7 +223,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.69/vibration.md
+++ b/website/versioned_docs/version-0.69/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.69/view.md
+++ b/website/versioned_docs/version-0.69/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.70/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.70/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.70/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.70/activityindicator.md
+++ b/website/versioned_docs/version-0.70/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/alert.md
+++ b/website/versioned_docs/version-0.70/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.70/animated.md
+++ b/website/versioned_docs/version-0.70/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.70/animations.md
+++ b/website/versioned_docs/version-0.70/animations.md
@@ -232,7 +232,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -531,7 +531,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.70/appearance.md
+++ b/website/versioned_docs/version-0.70/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.70/appstate.md
+++ b/website/versioned_docs/version-0.70/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/backhandler.md
+++ b/website/versioned_docs/version-0.70/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -158,7 +158,7 @@ export default App;
 
 Additionally `BackHandler.removeEventListener` can also be used to clear the event listener. Ensure the callback has the reference to the same function used in the `addEventListener` call as shown the following example ﹣
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android

--- a/website/versioned_docs/version-0.70/building-for-tv.md
+++ b/website/versioned_docs/version-0.70/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.70/communication-android.md
+++ b/website/versioned_docs/version-0.70/communication-android.md
@@ -21,7 +21,7 @@ Properties are the most straightforward way of cross-component communication. So
 
 You can pass properties down to the React Native app by providing a custom implementation of `ReactActivityDelegate` in your main activity. This implementation should override `getLaunchOptions` to return a `Bundle` with the desired properties.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 
@@ -82,7 +82,7 @@ export default class ImageBrowserApp extends React.Component {
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.70/custom-webview-android.md
+++ b/website/versioned_docs/version-0.70/custom-webview-android.md
@@ -26,7 +26,7 @@ To get started, you'll need to create a subclass of `RNCWebViewManager`, `RNCWeb
 - `getName`
 - `addEventEmitters`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -94,7 +94,7 @@ You'll need to follow the usual steps to [register the module](native-modules-an
 
 To add a new property, you'll need to add it to `CustomWebView`, and then expose it in `CustomWebViewManager`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -149,7 +149,7 @@ class CustomWebViewManager : RNCWebViewManager() {
 
 For events, you'll first need to make create event subclass.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -198,7 +198,7 @@ You can trigger the event in your web view client. You can hook existing handler
 
 You should refer to [RNCWebViewManager.java](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java) in the React Native WebView codebase to see what handlers are available and how they are implemented. You can extend any methods here to provide extra functionality.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -274,7 +274,7 @@ protected class CustomWebViewClient : RNCWebViewClient() {
 
 Finally, you'll need to expose the events in `CustomWebViewManager` through `getExportedCustomDirectEventTypeConstants`. Note that currently, the default implementation returns `null`, but this may change in the future.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.70/datepickerios.md
+++ b/website/versioned_docs/version-0.70/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.70/debugging.md
+++ b/website/versioned_docs/version-0.70/debugging.md
@@ -90,7 +90,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.70/dimensions.md
+++ b/website/versioned_docs/version-0.70/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions

--- a/website/versioned_docs/version-0.70/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.70/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.70/getting-started.md
+++ b/website/versioned_docs/version-0.70/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Run the following command to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -91,12 +91,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -118,7 +118,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.70/headless-js-android.md
+++ b/website/versioned_docs/version-0.70/headless-js-android.md
@@ -33,7 +33,7 @@ You can do anything in your task such as network requests, timers and so on, as 
 
 Yes, this does still require some native code, but it's pretty thin. You need to extend `HeadlessJsTaskService` and override `getTaskConfig`, e.g.:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -104,7 +104,7 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
 
 Example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ By default, the headless JS task will not perform any retries. In order to do so
 
 `LinearCountingRetryPolicy` is an implementation of `HeadlessJsRetryPolicy` that allows you to specify a maximum number of retries with a fixed delay between each attempt. If that does not suit your needs then you can implement your own `HeadlessJsRetryPolicy`. These policies can be passed as an extra argument to the `HeadlessJsTaskConfig` constructor, e.g.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -213,7 +213,7 @@ Following lines shows part of Android manifest file for registering broadcast re
 
 Broadcast receiver then handles intent that was broadcasted in onReceive function. This is a great place to check whether your app is on foreground or not. If app is not on foreground we can prepare our intent to be started, with no information or additional information bundled using `putExtra` (keep in mind bundle can handle only parcelable values). In the end service is started and wakelock is acquired.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.70/image-style-props.md
+++ b/website/versioned_docs/version-0.70/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.70/image.md
+++ b/website/versioned_docs/version-0.70/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.70/integration-with-android-fragment.md
@@ -19,7 +19,7 @@ You will need to implement the `ReactApplication` interface in your main Applica
 
 Ensure your main Application class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -38,7 +38,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -96,7 +96,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -163,7 +163,7 @@ Now in your Activity class (e.g. `MainActivity.java` or `MainActivity.kt`) you n
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -182,7 +182,7 @@ private Button mButton;
 
 Update your Activity's `onCreate` method as follows:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -239,7 +239,7 @@ If you are using a starter kit for React Native, replace the "HelloWorld" string
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -265,7 +265,7 @@ private Bundle getLaunchOptions(String message) {
 
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.70/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.70/integration-with-existing-apps.md
@@ -13,7 +13,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="kotlin">
 

--- a/website/versioned_docs/version-0.70/intro-react.md
+++ b/website/versioned_docs/version-0.70/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -205,7 +205,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -315,7 +315,7 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)

--- a/website/versioned_docs/version-0.70/introduction.md
+++ b/website/versioned_docs/version-0.70/introduction.md
@@ -56,7 +56,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -111,7 +111,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.70/keyboard.md
+++ b/website/versioned_docs/version-0.70/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.70/layoutanimation.md
+++ b/website/versioned_docs/version-0.70/layoutanimation.md
@@ -120,7 +120,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -336,7 +336,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.70/libraries.md
+++ b/website/versioned_docs/version-0.70/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.70/linking.md
+++ b/website/versioned_docs/version-0.70/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).

--- a/website/versioned_docs/version-0.70/modal.md
+++ b/website/versioned_docs/version-0.70/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.70/native-components-android.md
+++ b/website/versioned_docs/version-0.70/native-components-android.md
@@ -32,7 +32,7 @@ To send a view:
 
 In this example we create view manager class `ReactImageManager` that extends `SimpleViewManager` of type `ReactImageView`. `ReactImageView` is the type of object managed by the manager, this will be the custom native view. Name returned by `getName` is used to reference the native view type from JavaScript.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -75,7 +75,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
 Views are created in the `createViewInstance` method, the view should initialize itself in its default state, any properties will be set via a follow up call to `updateView.`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -106,7 +106,7 @@ Except from `name`, `@ReactProp` annotation may take following optional argument
 
 Setter declaration requirements for methods annotated with `@ReactPropGroup` are different than for `@ReactProp`, please refer to the `@ReactPropGroup` annotation class docs for more information about it. **IMPORTANT!** in ReactJS updating the property value will result in setter method call. Note that one of the ways we can update component is by removing properties that have been set before. In that case setter method will be called as well to notify view manager that property has changed. In that case "default" value will be provided (for primitive types "default" value can be specified using `defaultBoolean`, `defaultFloat`, etc. arguments of `@ReactProp` annotation, for complex types setter will be called with value set to `null`).
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -153,7 +153,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
 
 The final step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.md), via the applications package member function `createViewManagers`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -201,7 +201,7 @@ The `requireNativeComponent` function takes the name of the native view. Note th
 
 So now we know how to expose native view components that we can control freely from JS, but how do we deal with events from the user, like pinch-zooms or panning? When a native event occurs the native code should issue an event to the JavaScript representation of the View, and the two views are linked with the value returned from the `getId()` method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -241,7 +241,7 @@ class MyCustomView extends View {
 
 To map the `topChange` event name to the `onChange` callback prop in JavaScript, register it by overriding the `getExportedCustomBubblingEventTypeConstants` method in your `ViewManager`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -317,7 +317,7 @@ In order to integrate existing Native UI elements to your React Native app, you 
 
 First, let's create a `CustomView` class which extends `FrameLayout` (the content of this view can be any view that you'd like to render)
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="CustomView.kt"
@@ -378,7 +378,7 @@ public class CustomView extends FrameLayout {
 
 ### 2. Create a `Fragment`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyFragment.kt"
@@ -490,7 +490,7 @@ public class MyFragment extends Fragment {
 
 ### 3. Create the `ViewManager` subclass
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyViewManager.kt"
@@ -736,7 +736,7 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
 ### 4. Register the `ViewManager`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyPackage.kt"
@@ -786,7 +786,7 @@ public class MyPackage implements ReactPackage {
 
 ### 5. Register the `Package`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"

--- a/website/versioned_docs/version-0.70/native-modules-android.md
+++ b/website/versioned_docs/version-0.70/native-modules-android.md
@@ -38,7 +38,7 @@ The first step is to create the (`CalendarModule.java` or `CalendarModule.kt`) J
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -85,7 +85,7 @@ As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaMod
 
 All Java/Kotlin native modules in Android need to implement the `getName()` method. This method returns a string, which represents the name of the native module. The native module can then be accessed in JavaScript using its name. For example, in the below code snippet, `getName()` returns `"CalendarModule"`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -119,7 +119,7 @@ Next you will need to add a method to your native module that will create calend
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ public void createCalendarEvent(String name, String location) {
 
 Add a debug log in the method to confirm it has been invoked when you call it from your application. Below is an example of how you can import and use the [Log](https://developer.android.com/reference/android/util/Log) class from the Android util package:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -174,7 +174,7 @@ Once you finish implementing the native module and hook it up in JavaScript, you
 
 You can pass `isBlockingSynchronousMethod = true` to a native method to mark it as a synchronous method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -203,7 +203,7 @@ To add your Native Module to `ReactPackage`, first create a new Java/Kotlin Clas
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -273,7 +273,7 @@ To register the `CalendarModule` package, you must add `MyAppPackage` to the lis
 
 Locate ReactNativeHost’s `getPackages()` method and add your package to the packages list `getPackages()` returns:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -444,7 +444,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 
 For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, `Date` conversion is not supported out of the box. You can handle the conversion to the `Date` type within the native method yourself like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -478,7 +478,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -518,7 +518,7 @@ Native modules also support a unique kind of argument: a callback. Callbacks are
 
 In order to create a native module method with a callback, first import the `Callback` interface, and then add a new parameter to your native module method of type `Callback`. There are a couple of nuances with callback arguments that will soon be lifted with TurboModules. First off, you can only have two callbacks in your function arguments- a successCallback and a failureCallback. In addition, the last argument to a native module method call, if it's a function, is treated as the successCallback, and the second to last argument to a native module method call, if it's a function, is treated as the failure callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -543,7 +543,7 @@ import com.facebook.react.bridge.Callback
 
 You can invoke the callback in your Java/Kotlin method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -586,7 +586,7 @@ Another important detail to note is that a native module method can only invoke 
 
 There are two approaches to error handling with callbacks. The first is to follow Node’s convention and treat the first argument passed to the callback as an error object.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -630,7 +630,7 @@ const onPress = () => {
 
 Another option is to use an onSuccess and onFailure callback:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -678,7 +678,7 @@ Native modules can also fulfill a [Promise](https://developer.mozilla.org/en-US/
 
 Refactoring the above code to use a promise instead of callbacks looks like this:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -733,7 +733,7 @@ const onSubmit = async () => {
 
 The reject method takes different combinations of the following arguments:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -754,7 +754,7 @@ For more detail, you can find the `Promise.java` interface [here](https://github
 
 Java/Kotlin reject call:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -782,7 +782,7 @@ Error message in React Native App when promise is rejected:
 
 Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -893,7 +893,7 @@ import { NativeEventEmitter, NativeModules } from 'react-native';
 
 You'll need to listen to `onActivityResult` if you want to get results from an activity you started with `startActivityForResult`. To do this, you must extend `BaseActivityEventListener` or implement `ActivityEventListener`. The former is preferred as it is more resilient to API changes. Then, you need to register the listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -912,7 +912,7 @@ reactContext.addActivityEventListener(mActivityResultListener);
 
 Now you can listen to `onActivityResult` by implementing the following method:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -945,7 +945,7 @@ override fun onActivityResult(
 
 Let's implement a basic image picker to demonstrate this. The image picker will expose the method `pickImage` to JavaScript, which will return the path of the image when called.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```jsx
@@ -1105,7 +1105,7 @@ class ImagePickerModule(reactContext: ReactApplicationContext) :
 
 Listening to the activity's LifeCycle events such as `onResume`, `onPause` etc. is very similar to how `ActivityEventListener` was implemented. The module must implement `LifecycleEventListener`. Then, you need to register a listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -1124,7 +1124,7 @@ reactContext.addLifecycleEventListener(this)
 
 Now you can listen to the activity's LifeCycle events by implementing the following methods:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.70/network.md
+++ b/website/versioned_docs/version-0.70/network.md
@@ -74,7 +74,7 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Fetch%20Example

--- a/website/versioned_docs/version-0.70/new-architecture-app-modules-android.md
+++ b/website/versioned_docs/version-0.70/new-architecture-app-modules-android.md
@@ -103,7 +103,7 @@ yarn react-native run-android
 Now is time to actually use the Turbo Native Module.
 First, we will need to create a `ReactPackageTurboModuleManagerDelegate` subclass, like the following:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -201,7 +201,7 @@ Then, you can provide the class you created to your `ReactNativeHost`. You can l
 
 Once you located it, you need to add the `getReactPackageTurboModuleManagerDelegateBuilder` method as from the snippet below:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -261,7 +261,7 @@ class MyApplication : Application(), ReactApplication {
 
 Still on the `ReactNativeHost` , we need to extend the the `getPackages()` method to include the newly created Turbo Native Module. Update the method to include the following:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -534,7 +534,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
 
 Now you can finally enable the `Turbo Native Module` support in your Application. To do so, you need to turn on the `useTurboModule` flag inside your Application `onCreate` method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.70/new-architecture-library-android.md
+++ b/website/versioned_docs/version-0.70/new-architecture-library-android.md
@@ -57,7 +57,7 @@ Update your native module or component to ensure it **extends the abstract class
 
 Following the example set forth in the previous section, your library might import `NativeAwesomeManagerSpec`, implement the relevant native interface and the necessary methods for it:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.70/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.70/new-architecture-library-intro.md
@@ -29,7 +29,7 @@ JavaScript spec files **must** be named `Native<MODULE_NAME>.js` and they export
 
 The following is a basic JavaScript spec template, written using the [Flow](https://flow.org/) syntax as well as [TypeScript](https://www.typescriptlang.org/).
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
@@ -76,7 +76,7 @@ JavaScript spec files **must** be named `<FABRIC COMPONENT>NativeComponent.js` (
 
 The following snippet shows a basic JavaScript spec template, written in [Flow](https://flow.org/) as well as [TypeScript](https://www.typescriptlang.org/).
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
@@ -632,7 +632,7 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
 
 **Android**
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.70/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.70/optimizing-flatlist-configuration.md
@@ -125,7 +125,7 @@ You can also use a `key` prop in your item component.
 
 Move out the `renderItem` function to the outside of render function, so it won't recreate itself each time render function called.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">
 
 ```jsx

--- a/website/versioned_docs/version-0.70/panresponder.md
+++ b/website/versioned_docs/version-0.70/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.70/permissionsandroid.md
+++ b/website/versioned_docs/version-0.70/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.70/platformcolor.md
+++ b/website/versioned_docs/version-0.70/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.70/react-18-and-react-native.md
+++ b/website/versioned_docs/version-0.70/react-18-and-react-native.md
@@ -45,7 +45,7 @@ However, if you do hit any issues, we provide an option to opt-out of the new ro
 
 On Android, you will be able to override the `isConcurrentRootEnabled` in your ActivityDelegate (in the `MainActivity` file), and enable/disable Concurrent React.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.70/running-on-device.md
+++ b/website/versioned_docs/version-0.70/running-on-device.md
@@ -12,14 +12,14 @@ It's always a good idea to test your app on an actual device before releasing it
 If you used `create-expo-app` to set up your project, you can run your app on a device in Expo Go by scanning the QR code that is displayed when you run `npm start`. Refer to the Expo guide for [running your project on your device](https://docs.expo.dev/workflow/run-on-device/) for more information.
 :::
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -316,7 +316,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.70/sectionlist.md
+++ b/website/versioned_docs/version-0.70/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.70/security.md
+++ b/website/versioned_docs/version-0.70/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.70/share.md
+++ b/website/versioned_docs/version-0.70/share.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.70/systrace.md
+++ b/website/versioned_docs/version-0.70/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/text.md
+++ b/website/versioned_docs/version-0.70/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
@@ -395,7 +395,7 @@ import MyComponent from 'your-component/src/index';
 
 Since `codegenNativeComponent` is calling the `requireNativeComponent` under the hood, we need to re-export our component, to avoid registering it multiple times.
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
@@ -355,7 +355,7 @@ import MyModule from 'your-module/src/index';
 
 Since `TurboModuleRegistry.get` taps into the old Native Modules API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
-<Tabs groupId="turbomodule-backward-compatibility"
+<Tabs groupId="turbomodule-backward-compatibility" queryString
       defaultValue={constants.defaultTurboModuleSpecLanguage}
       values={constants.turboModuleSpecLanguages}>
 <TabItem value="Flow">

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-codegen.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-codegen.md
@@ -151,7 +151,7 @@ This tasks invokes the `generateCodegenArtifactsFromSchema` on all the the impor
 
 Once the Gradle task completes, you can see different structures for a Turbo Native Module or for a Fabric Native Component. The following tab shows how they appear:
 
-<Tabs groupId="android-codegen" defaultValue={constants.defaultNewArchFeature} values={constants.newArchFeatures}>
+<Tabs groupId="android-codegen" queryString defaultValue={constants.defaultNewArchFeature} values={constants.newArchFeatures}>
 <TabItem value="turbomodules">
 
 ```sh

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
@@ -66,7 +66,7 @@ There are two requirements the file containing this specification must meet:
 
 Below are specifications of the `RTNCenteredText` component in both Flow and TypeScript. Create a `RTNCenteredText` file with the proper extension in the `js` folder.
 
-<Tabs groupId="fabric-component-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="fabric-component-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value='flow'>
 
 ```typescript
@@ -830,7 +830,7 @@ Android configuration requires to enable the **New Architecture**.
 
 Finally, you can use the component in your JavaScript application.
 
-<Tabs groupId="final-app" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="final-app" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="App.js"

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
@@ -60,7 +60,7 @@ There are two requirements the file containing this specification must meet:
 1. The file **must** be named `Native<MODULE_NAME>`, with a `.js` or `.jsx` extension when using Flow, or a `.ts`, or `.tsx` extension when using TypeScript. Codegen will only look for files matching this pattern.
 2. The file must export a `TurboModuleRegistrySpec` object.
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="NativeCalculator.js"
@@ -666,7 +666,7 @@ Now you can use your Turbo Native Module calculator in your app!
 
 Here's an example App.js file using the `add` method:
 
-<Tabs groupId="final-app" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="final-app" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="App.js"

--- a/website/versioned_docs/version-0.70/the-new-architecture/use-app-template.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/use-app-template.md
@@ -49,7 +49,7 @@ Please [follow the instructions on the React Native website](hermes.md) in order
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="ios">
 
 Navigate to the `ios` directory and run the following:

--- a/website/versioned_docs/version-0.70/touchablehighlight.md
+++ b/website/versioned_docs/version-0.70/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/touchableopacity.md
+++ b/website/versioned_docs/version-0.70/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.70/transforms.md
+++ b/website/versioned_docs/version-0.70/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.70/typescript.md
+++ b/website/versioned_docs/version-0.70/typescript.md
@@ -32,7 +32,7 @@ Optionally, you can also use the command given below to get started with your te
 
 You can use [Expo][expo], which maintains TypeScript templates, or will prompt you to automatically install and configure TypeScript when a `.ts` or `.tsx` file is added to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -51,7 +51,7 @@ yarn create expo-app --template
 
 Or you could use [Ignite][ignite], which also has a TypeScript template:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -74,7 +74,7 @@ ignite new MyTSProject
 
 1. Add TypeScript and the types for React Native and Jest to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -223,7 +223,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.70/vibration.md
+++ b/website/versioned_docs/version-0.70/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.70/view.md
+++ b/website/versioned_docs/version-0.70/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.71/_integration-with-existing-apps-objc.md
@@ -39,7 +39,7 @@ Next, make sure you have [installed the yarn package manager](https://yarnpkg.co
 
 Install the `react` and `react-native` packages. Open a terminal or command prompt, then navigate to the directory with your `package.json` file and run:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -62,7 +62,7 @@ This will print a message similar to the following (scroll up in the yarn output
 
 This is OK, it means we also need to install React:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -346,7 +346,7 @@ Apple has blocked implicit cleartext HTTP resource loading. So we need to add th
 
 To run your app, you need to first start the development server. To do this, run the following command in the root directory of your React Native project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.71/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.71/accessibilityinfo.md
@@ -9,7 +9,7 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AccessibilityInfo%20Function%20Component%20Example&supportedPlatforms=android,ios
@@ -76,7 +76,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=AccessibilityInfo%20Class%20Component%20Example&supportedPlatforms=android,ios&ext=js

--- a/website/versioned_docs/version-0.71/activityindicator.md
+++ b/website/versioned_docs/version-0.71/activityindicator.md
@@ -9,7 +9,7 @@ Displays a circular loading indicator.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=ActivityIndicator%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/alert.md
+++ b/website/versioned_docs/version-0.71/alert.md
@@ -13,7 +13,7 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Alert%20Function%20Component%20Example&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.71/animated.md
+++ b/website/versioned_docs/version-0.71/animated.md
@@ -9,7 +9,7 @@ The `Animated` library is designed to make animations fluid, powerful, and painl
 
 The core workflow for creating an animation is to create an `Animated.Value`, hook it up to one or more style attributes of an animated component, and then drive updates via animations using `Animated.timing()`.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 > Don't modify the animated value directly. You can use the [`useRef` Hook](https://reactjs.org/docs/hooks-reference.html#useref) to return a mutable ref object. This ref object's `current` property is initialized as the given argument and persists throughout the component lifecycle.
@@ -26,7 +26,7 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.71/animations.md
+++ b/website/versioned_docs/version-0.71/animations.md
@@ -17,7 +17,7 @@ The [`Animated`](animated) API is designed to concisely express a wide variety o
 
 For example, a container view that fades in when it is mounted may look like this:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer ext=js
@@ -310,7 +310,7 @@ The following example implements a horizontal scrolling carousel where the scrol
 
 #### ScrollView with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
@@ -441,7 +441,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android&ext=js
@@ -774,7 +774,7 @@ onPanResponderMove={Animated.event(
 
 #### PanResponder with Animated Event Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Animated

--- a/website/versioned_docs/version-0.71/appearance.md
+++ b/website/versioned_docs/version-0.71/appearance.md
@@ -13,7 +13,7 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.71/appstate.md
+++ b/website/versioned_docs/version-0.71/appstate.md
@@ -24,7 +24,7 @@ For more information, see [Apple's documentation](https://developer.apple.com/do
 
 To see the current state, you can check `AppState.currentState`, which will be kept up-to-date. However, `currentState` will be null at launch while `AppState` retrieves it over the bridge.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=AppState%20Function%20Component%20Example
@@ -77,7 +77,7 @@ If you don't want to see the AppState update from `active` to `inactive` on iOS 
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=AppState%20Class%20Component%20Example&ext=js

--- a/website/versioned_docs/version-0.71/backhandler.md
+++ b/website/versioned_docs/version-0.71/backhandler.md
@@ -45,7 +45,7 @@ BackHandler.addEventListener('hardwareBackPress', function () {
 
 The following example implements a scenario where you confirm if the user wants to exit the app:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
@@ -99,7 +99,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android&ext=js

--- a/website/versioned_docs/version-0.71/building-for-tv.md
+++ b/website/versioned_docs/version-0.71/building-for-tv.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-<Tabs groupId="tv" defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
+<Tabs groupId="tv" queryString defaultValue="androidtv" values={[ {label: 'Android TV', value: 'androidtv'}, {label: '🚧 tvOS', value: 'tvos'}, ]}>
 
 <TabItem value="androidtv">
 

--- a/website/versioned_docs/version-0.71/communication-android.md
+++ b/website/versioned_docs/version-0.71/communication-android.md
@@ -21,7 +21,7 @@ Properties are the most straightforward way of cross-component communication. So
 
 You can pass properties down to the React Native app by providing a custom implementation of `ReactActivityDelegate` in your main activity. This implementation should override `getLaunchOptions` to return a `Bundle` with the desired properties.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 
@@ -82,7 +82,7 @@ export default class ImageBrowserApp extends React.Component {
 
 `ReactRootView` provides a read-write property `appProperties`. After `appProperties` is set, the React Native app is re-rendered with new properties. The update is only performed when the new updated properties differ from the previous ones.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.71/custom-webview-android.md
+++ b/website/versioned_docs/version-0.71/custom-webview-android.md
@@ -26,7 +26,7 @@ To get started, you'll need to create a subclass of `RNCWebViewManager`, `RNCWeb
 - `getName`
 - `addEventEmitters`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -94,7 +94,7 @@ You'll need to follow the usual steps to [register the module](native-modules-an
 
 To add a new property, you'll need to add it to `CustomWebView`, and then expose it in `CustomWebViewManager`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -149,7 +149,7 @@ class CustomWebViewManager : RNCWebViewManager() {
 
 For events, you'll first need to make create event subclass.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -198,7 +198,7 @@ You can trigger the event in your web view client. You can hook existing handler
 
 You should refer to [RNCWebViewManager.java](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java) in the React Native WebView codebase to see what handlers are available and how they are implemented. You can extend any methods here to provide extra functionality.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -274,7 +274,7 @@ protected class CustomWebViewClient : RNCWebViewClient() {
 
 Finally, you'll need to expose the events in `CustomWebViewManager` through `getExportedCustomDirectEventTypeConstants`. Note that currently, the default implementation returns `null`, but this may change in the future.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.71/datepickerios.md
+++ b/website/versioned_docs/version-0.71/datepickerios.md
@@ -11,7 +11,7 @@ Use `DatePickerIOS` to render a date/time picker (selector) on iOS. This is a co
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=DatePickerIOS&supportedPlatforms=ios

--- a/website/versioned_docs/version-0.71/debugging.md
+++ b/website/versioned_docs/version-0.71/debugging.md
@@ -90,7 +90,7 @@ You can use [the standalone version of React Developer Tools](https://github.com
 
 > Note: Version 4 of `react-devtools` requires `react-native` version 0.62 or higher to work properly.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.71/dimensions.md
+++ b/website/versioned_docs/version-0.71/dimensions.md
@@ -24,7 +24,7 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Dimensions
@@ -86,7 +86,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Dimensions&ext=js

--- a/website/versioned_docs/version-0.71/direct-manipulation.md
+++ b/website/versioned_docs/version-0.71/direct-manipulation.md
@@ -63,7 +63,7 @@ If you look at the implementation of `setNativeProps` in [NativeMethodsMixin](ht
 
 Composite components are not backed by a native view, so you cannot call `setNativeProps` on them. Consider this example:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=setNativeProps%20with%20Composite%20Components&ext=js
@@ -116,7 +116,7 @@ If you run this you will immediately see this error: `Touchable child must eithe
 
 Since the `setNativeProps` method exists on any ref to a `View` component, it is enough to forward a ref on your custom component to one of the `<View />` components that it renders. This means that a call to `setNativeProps` on the custom component will have the same effect as if you called `setNativeProps` on the wrapped `View` component itself.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Forwarding%20setNativeProps&ext=js
@@ -171,7 +171,7 @@ You may have noticed that we passed all of the props down to the child view usin
 
 Another very common use case of `setNativeProps` is to edit the value of the TextInput. The `controlled` prop of TextInput can sometimes drop characters when the `bufferDelay` is low and the user types very quickly. Some developers prefer to skip this prop entirely and instead use `setNativeProps` to directly manipulate the TextInput value when necessary. For example, the following code demonstrates editing the input when you tap a button:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Clear%20text&ext=js
@@ -316,7 +316,7 @@ Like `measure()`, but measures the view relative to an ancestor, specified with 
 This method can also be called with a `relativeToNativeNode` handler (instead of reference), but this variant is deprecated.
 :::
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=measureLayout%20example&supportedPlatforms=android,ios&ext=js

--- a/website/versioned_docs/version-0.71/drawerlayoutandroid.md
+++ b/website/versioned_docs/version-0.71/drawerlayoutandroid.md
@@ -9,7 +9,7 @@ React component that wraps the platform `DrawerLayout` (Android only). The Drawe
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=DrawerLayoutAndroid%20Component%20Example&supportedPlatforms=android&ext=js

--- a/website/versioned_docs/version-0.71/dynamiccolorios.md
+++ b/website/versioned_docs/version-0.71/dynamiccolorios.md
@@ -22,7 +22,7 @@ At runtime, the system will choose which of the colors to display depending on t
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["ios", "web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.71/easing.md
+++ b/website/versioned_docs/version-0.71/easing.md
@@ -45,7 +45,7 @@ The following helpers are used to modify other easing functions.
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Easing%20Demo&ext=js

--- a/website/versioned_docs/version-0.71/flatlist.md
+++ b/website/versioned_docs/version-0.71/flatlist.md
@@ -22,7 +22,7 @@ If you need section support, use [`<SectionList>`](sectionlist.md).
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=flatlist-simple&ext=js
@@ -166,7 +166,7 @@ More complex, selectable example below.
 - By passing `extraData={selectedId}` to `FlatList` we make sure `FlatList` itself will re-render when the state changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is a `PureComponent` and the prop comparison will not show any changes.
 - `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
 
-<Tabs groupId="language" defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.dewfaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=flatlist-selectable&ext=js

--- a/website/versioned_docs/version-0.71/flexbox.md
+++ b/website/versioned_docs/version-0.71/flexbox.md
@@ -65,7 +65,7 @@ export default Flex;
 
 You can learn more [here](https://yogalayout.com/docs/flex-direction).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Direction&ext=js
@@ -282,7 +282,7 @@ Layout [`direction`](layout-props#direction) specifies the direction in which ch
 
 - `RTL` Text and children are laid out from right to left. Margin and padding applied to the start of an element are applied on the right side.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Direction&ext=js
@@ -509,7 +509,7 @@ export default DirectionLayout;
 
 You can learn more [here](https://yogalayout.com/docs/justify-content).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Justify%20Content&ext=js
@@ -752,7 +752,7 @@ For `stretch` to have an effect, children must not have a fixed dimension along 
 
 You can learn more [here](https://yogalayout.com/docs/align-items).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Align%20Items&ext=js
@@ -985,7 +985,7 @@ export default AlignItemsLayout;
 
 [`alignSelf`](layout-props#alignself) has the same options and effect as `alignItems` but instead of affecting the children within a container, you can apply this property to a single child to change its alignment within its parent. `alignSelf` overrides any option set by the parent with `alignItems`.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Align%20Self&ext=js
@@ -1235,7 +1235,7 @@ export default AlignSelfLayout;
 
 You can learn more [here](https://yogalayout.com/docs/align-content).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Align%20Content&ext=js
@@ -1476,7 +1476,7 @@ The [`flexWrap`](layout-props#flexwrap) property is set on containers and it con
 
 When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Wrap&ext=js
@@ -1707,7 +1707,7 @@ export default FlexWrapLayout;
 
 You can learn more [here](https://yogalayout.com/docs/flex).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Flex%20Basis%2C%20Grow%2C%20and%20Shrink&ext=js
@@ -2080,7 +2080,7 @@ export default App;
 
 You can use `flexWrap` and `alignContent` alongwith `gap` to add consistent spacing between items.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Row%20Gap%20and%20Column%20Gap&ext=js
@@ -2307,7 +2307,7 @@ Both `width` and `height` can take the following values:
 
 - `percentage` Defines the width or height in percentage of its parent's width or height, respectively.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Width%20and%20Height&ext=js
@@ -2588,7 +2588,7 @@ The `position` type of an element defines how it is positioned within its parent
 
 - `absolute` When positioned absolutely, an element doesn't take part in the normal layout flow. It is instead laid out independent of its siblings. The position is determined based on the `top`, `right`, `bottom`, and `left` values.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Absolute%20%26%20Relative%20Layout&ext=js

--- a/website/versioned_docs/version-0.71/getting-started.md
+++ b/website/versioned_docs/version-0.71/getting-started.md
@@ -14,12 +14,12 @@ This page will help you install and build your first React Native app.
 
 **If you are already familiar with mobile development**, you may want to use React Native CLI. It requires Xcode or Android Studio to get started. If you already have one of these tools installed, you should be able to get up and running within a few minutes. If they are not installed, you should expect to spend about an hour installing and configuring them.
 
-<Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<Tabs groupId="guide" queryString defaultValue={constants.defaultGuide} values={constants.guides}>
 <TabItem value="quickstart">
 
 Run the following command to create a new React Native project called "AwesomeProject":
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -91,12 +91,12 @@ The instructions are a bit different depending on your development operating sys
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'macOS, Android'
@@ -118,7 +118,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Windows, Android'
@@ -142,7 +142,7 @@ The instructions are a bit different depending on your development operating sys
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 [//]: # 'Linux, Android'

--- a/website/versioned_docs/version-0.71/headless-js-android.md
+++ b/website/versioned_docs/version-0.71/headless-js-android.md
@@ -33,7 +33,7 @@ You can do anything in your task such as network requests, timers and so on, as 
 
 Yes, this does still require some native code, but it's pretty thin. You need to extend `HeadlessJsTaskService` and override `getTaskConfig`, e.g.:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -104,7 +104,7 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
 
 Example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ By default, the headless JS task will not perform any retries. In order to do so
 
 `LinearCountingRetryPolicy` is an implementation of `HeadlessJsRetryPolicy` that allows you to specify a maximum number of retries with a fixed delay between each attempt. If that does not suit your needs then you can implement your own `HeadlessJsRetryPolicy`. These policies can be passed as an extra argument to the `HeadlessJsTaskConfig` constructor, e.g.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -213,7 +213,7 @@ Following lines shows part of Android manifest file for registering broadcast re
 
 Broadcast receiver then handles intent that was broadcasted in onReceive function. This is a great place to check whether your app is on foreground or not. If app is not on foreground we can prepare our intent to be started, with no information or additional information bundled using `putExtra` (keep in mind bundle can handle only parcelable values). In the end service is started and wakelock is acquired.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.71/image-style-props.md
+++ b/website/versioned_docs/version-0.71/image-style-props.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ### Image Resize Mode
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Function%20Component%20Example
@@ -182,7 +182,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Function%20Component%20Example
@@ -265,7 +265,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Border Radius
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20Border%20Radius%20Function%20Component%20Example
@@ -416,7 +416,7 @@ export default DisplayAnImageWithStyle;
 
 ### Image Tint
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component

--- a/website/versioned_docs/version-0.71/image.md
+++ b/website/versioned_docs/version-0.71/image.md
@@ -13,7 +13,7 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example
@@ -112,7 +112,7 @@ export default DisplayAnImage;
 
 You can also add `style` to an image:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/improvingux.md
+++ b/website/versioned_docs/version-0.71/improvingux.md
@@ -17,7 +17,7 @@ Entering text on touch phone is a challenge - small screen, software keyboard. B
 
 Check out [`TextInput` docs](textinput.md) for more configuration options.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=TextInput%20form%20example&ext=js
@@ -212,7 +212,7 @@ export default App;
 
 Software keyboard takes almost half of the screen. If you have interactive elements that can get covered by the keyboard, make sure they are still accessible by using the [`KeyboardAvoidingView` component](keyboardavoidingview.md).
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=KeyboardAvoidingView%20example&ext=js

--- a/website/versioned_docs/version-0.71/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.71/integration-with-android-fragment.md
@@ -19,7 +19,7 @@ You will need to implement the `ReactApplication` interface in your main Applica
 
 Ensure your main Application class implements ReactApplication:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -38,7 +38,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 Override the required methods `getUseDeveloperSupport`, `getPackages` and `getReactNativeHost`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -96,7 +96,7 @@ public class MyReactApplication extends Application implements ReactApplication 
 
 If you are using Android Studio, use Alt + Enter to add all missing imports in your class. Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -165,7 +165,7 @@ Now in your Activity class (e.g. `MainActivity.java` or `MainActivity.kt`) you n
 
 Add the button field to the top of your Activity:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -184,7 +184,7 @@ private Button mButton;
 
 Update your Activity's `onCreate` method as follows:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -241,7 +241,7 @@ If you are using a starter kit for React Native, replace the "HelloWorld" string
 
 Add the `getLaunchOptions` method which will allow you to pass props through to your component. This is optional and you can remove `setLaunchOptions` if you don't need to pass any props.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -267,7 +267,7 @@ private Bundle getLaunchOptions(String message) {
 
 Add all missing imports in your Activity class. Be careful to use your package’s BuildConfig and not the one from the facebook package! Alternatively these are the required imports to include manually:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.71/integration-with-existing-apps.md
+++ b/website/versioned_docs/version-0.71/integration-with-existing-apps.md
@@ -13,7 +13,7 @@ React Native is great when you are starting a new mobile app from scratch. Howev
 
 The specific steps are different depending on what platform you're targeting.
 
-<Tabs groupId="language" defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
+<Tabs groupId="language" queryString defaultValue="java" values={[ {label: 'Android (Kotlin)', value: 'kotlin'}, {label: 'Android (Java)', value: 'java'}, {label: 'iOS (Objective-C)', value: 'objc'}, {label: 'iOS (Swift)', value: 'swift'}, ]}>
 
 <TabItem value="kotlin">
 

--- a/website/versioned_docs/version-0.71/interactionmanager.md
+++ b/website/versioned_docs/version-0.71/interactionmanager.md
@@ -43,7 +43,7 @@ By default, queued tasks are executed together in a loop in one `setImmediate` b
 
 ### Basic
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=InteractionManager%20Function%20Component%20Basic%20Example&supportedPlatforms=ios,android&ext=js
@@ -210,7 +210,7 @@ export default App;
 
 ### Advanced
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=InteractionManager%20Function%20Component%20Advanced%20Example&supportedPlatforms=ios,android&ext=js

--- a/website/versioned_docs/version-0.71/intro-react.md
+++ b/website/versioned_docs/version-0.71/intro-react.md
@@ -21,7 +21,7 @@ If you want to dig deeper, we encourage you to check out [React’s official doc
 
 The rest of this introduction to React uses cats in its examples: friendly, approachable creatures that need names and a cafe to work in. Here is your very first Cat component:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Your%20Cat
@@ -145,7 +145,7 @@ export default Cat;
 
 Any JavaScript expression will work between curly braces, including function calls like `{getFullName("Rum", "Tum", "Tugger")}`:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Curly%20Braces&ext=js
@@ -223,7 +223,7 @@ export default Cat;
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android", "web"])}>
 
 <TabItem value="web">
 
@@ -273,7 +273,7 @@ You can put as many cats in your cafe as you like. Each `<Cat>` renders a unique
 
 **Props** is short for “properties”. Props let you customize React components. For example, here you pass each `<Cat>` a different `name` for `Cat` to render:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Multiple%20Props&ext=js
@@ -373,12 +373,12 @@ While you can think of props as arguments you use to configure how components re
 
 The following example takes place in a cat cafe where two hungry cats are waiting to be fed. Their hunger, which we expect to change over time (unlike their names), is stored as state. To feed the cats, press their buttons—which will update their state.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 You can add state to a component by calling [React’s `useState` Hook](https://reactjs.org/docs/hooks-state.html). A Hook is a kind of function that lets you “hook into” React features. For example, `useState` is a Hook that lets you add state to function components. You can learn more about [other kinds of Hooks in the React documentation.](https://reactjs.org/docs/hooks-intro.html)
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=State&ext=js
@@ -526,7 +526,7 @@ const Cafe = () => {
 
 The older class components approach is a little different when it comes to state.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=State%20and%20Class%20Components&ext=js

--- a/website/versioned_docs/version-0.71/introduction.md
+++ b/website/versioned_docs/version-0.71/introduction.md
@@ -59,7 +59,7 @@ With React, you can make components using either classes or functions. Originall
 
 [Hooks were introduced in React Native 0.59.](/blog/2019/03/12/releasing-react-native-059), and because Hooks are the future-facing way to write your React components, we wrote this introduction using function component examples. Where useful, we also cover class components under a toggle like so:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Hello%20World%20Function%20Component
@@ -116,7 +116,7 @@ You can find more examples of class components in [previous versions of this doc
 
 People from many different development backgrounds are learning React Native. You may have experience with a range of technologies, from web to Android to iOS and more. We try to write for developers from all backgrounds. Sometimes we provide explanations specific to one platform or another like so:
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["android","ios","web"])}>
 
 <TabItem value="android">
 

--- a/website/versioned_docs/version-0.71/keyboard.md
+++ b/website/versioned_docs/version-0.71/keyboard.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The Keyboard module allows you to listen for native events and react to them, as well as make changes to the keyboard, like dismissing it.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Keyboard%20Function%20Component%20Example&supportedPlatforms=ios,android
@@ -69,7 +69,7 @@ export default Example;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Keyboard%20Class%20Component%20Example&supportedPlatforms=ios,android&ext=js

--- a/website/versioned_docs/version-0.71/layout-props.md
+++ b/website/versioned_docs/version-0.71/layout-props.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 The following example shows how different properties can affect or shape a React Native layout. You can try for example to add or remove squares from the UI while changing the values of the property `flexWrap`.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=LayoutProps%20Example&ext=js

--- a/website/versioned_docs/version-0.71/layoutanimation.md
+++ b/website/versioned_docs/version-0.71/layoutanimation.md
@@ -131,7 +131,7 @@ Helper that creates an object (with `create`, `update`, and `delete` fields) to 
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
@@ -347,7 +347,7 @@ Calls `configureNext()` with `Presets.spring`.
 
 **Example:**
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.71/libraries.md
+++ b/website/versioned_docs/version-0.71/libraries.md
@@ -22,7 +22,7 @@ If you have Node.js installed on your computer then you already have the npm CLI
 
 To install a library in your project, navigate to your project directory in your terminal and run the installation command. Let's try this with `react-native-webview`:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.71/linking.md
+++ b/website/versioned_docs/version-0.71/linking.md
@@ -37,7 +37,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 If you want to enable deep links in your app, please read the below guide:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultPlatform} values={constants.platforms}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultPlatform} values={constants.platforms}>
 <TabItem value="android">
 
 > For instructions on how to add support for deep linking on Android, refer to [Enabling Deep Links for App Content - Add Intent Filters for Your Deep Links](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters).
@@ -114,7 +114,7 @@ You can handle these events with `Linking.getInitialURL()` - it returns a Promis
 
 ### Open Links and Deep Links (Universal Links)
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -220,7 +220,7 @@ export default App;
 
 ### Open Custom Settings
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -299,7 +299,7 @@ export default App;
 
 ### Get the Deep Link
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -412,7 +412,7 @@ export default App;
 
 ### Send Intents (Android)
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Linking%20Function%20Component%20Example&supportedPlatforms=android&ext=js

--- a/website/versioned_docs/version-0.71/modal.md
+++ b/website/versioned_docs/version-0.71/modal.md
@@ -9,7 +9,7 @@ The Modal component is a basic way to present content above an enclosing view.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios

--- a/website/versioned_docs/version-0.71/native-components-android.md
+++ b/website/versioned_docs/version-0.71/native-components-android.md
@@ -32,7 +32,7 @@ To send a view:
 
 In this example we create view manager class `ReactImageManager` that extends `SimpleViewManager` of type `ReactImageView`. `ReactImageView` is the type of object managed by the manager, this will be the custom native view. Name returned by `getName` is used to reference the native view type from JavaScript.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -75,7 +75,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
 Views are created in the `createViewInstance` method, the view should initialize itself in its default state, any properties will be set via a follow up call to `updateView.`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -106,7 +106,7 @@ Except from `name`, `@ReactProp` annotation may take following optional argument
 
 Setter declaration requirements for methods annotated with `@ReactPropGroup` are different than for `@ReactProp`, please refer to the `@ReactPropGroup` annotation class docs for more information about it. **IMPORTANT!** in ReactJS updating the property value will result in setter method call. Note that one of the ways we can update component is by removing properties that have been set before. In that case setter method will be called as well to notify view manager that property has changed. In that case "default" value will be provided (for primitive types "default" value can be specified using `defaultBoolean`, `defaultFloat`, etc. arguments of `@ReactProp` annotation, for complex types setter will be called with value set to `null`).
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -153,7 +153,7 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
 
 The final step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.md), via the applications package member function `createViewManagers`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -201,7 +201,7 @@ The `requireNativeComponent` function takes the name of the native view. Note th
 
 So now we know how to expose native view components that we can control freely from JS, but how do we deal with events from the user, like pinch-zooms or panning? When a native event occurs the native code should issue an event to the JavaScript representation of the View, and the two views are linked with the value returned from the `getId()` method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -241,7 +241,7 @@ class MyCustomView extends View {
 
 To map the `topChange` event name to the `onChange` callback prop in JavaScript, register it by overriding the `getExportedCustomBubblingEventTypeConstants` method in your `ViewManager`:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin
@@ -317,7 +317,7 @@ In order to integrate existing Native UI elements to your React Native app, you 
 
 First, let's create a `CustomView` class which extends `FrameLayout` (the content of this view can be any view that you'd like to render)
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="CustomView.kt"
@@ -378,7 +378,7 @@ public class CustomView extends FrameLayout {
 
 ### 2. Create a `Fragment`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyFragment.kt"
@@ -490,7 +490,7 @@ public class MyFragment extends Fragment {
 
 ### 3. Create the `ViewManager` subclass
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyViewManager.kt"
@@ -736,7 +736,7 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
 
 ### 4. Register the `ViewManager`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MyPackage.kt"
@@ -786,7 +786,7 @@ public class MyPackage implements ReactPackage {
 
 ### 5. Register the `Package`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"

--- a/website/versioned_docs/version-0.71/native-modules-android.md
+++ b/website/versioned_docs/version-0.71/native-modules-android.md
@@ -38,7 +38,7 @@ The first step is to create the (`CalendarModule.java` or `CalendarModule.kt`) J
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -85,7 +85,7 @@ As you can see, your `CalendarModule` class extends the `ReactContextBaseJavaMod
 
 All Java/Kotlin native modules in Android need to implement the `getName()` method. This method returns a string, which represents the name of the native module. The native module can then be accessed in JavaScript using its name. For example, in the below code snippet, `getName()` returns `"CalendarModule"`.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -119,7 +119,7 @@ Next you will need to add a method to your native module that will create calend
 
 Set up a method `createCalendarEvent()` for `CalendarModule` that can be invoked in JS through `CalendarModule.createCalendarEvent()`. For now, the method will take in a name and location as strings. Argument type options will be covered shortly.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -140,7 +140,7 @@ public void createCalendarEvent(String name, String location) {
 
 Add a debug log in the method to confirm it has been invoked when you call it from your application. Below is an example of how you can import and use the [Log](https://developer.android.com/reference/android/util/Log) class from the Android util package:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -174,7 +174,7 @@ Once you finish implementing the native module and hook it up in JavaScript, you
 
 You can pass `isBlockingSynchronousMethod = true` to a native method to mark it as a synchronous method.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -203,7 +203,7 @@ To add your Native Module to `ReactPackage`, first create a new Java/Kotlin Clas
 
 Then add the following content:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -273,7 +273,7 @@ To register the `CalendarModule` package, you must add `MyAppPackage` to the lis
 
 Locate ReactNativeHost’s `getPackages()` method and add your package to the packages list `getPackages()` returns:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -444,7 +444,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 
 For argument types not listed above, you will need to handle the conversion yourself. For example, in Android, `Date` conversion is not supported out of the box. You can handle the conversion to the `Date` type within the native method yourself like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -478,7 +478,7 @@ For argument types not listed above, you will need to handle the conversion your
 
 A native module can export constants by implementing the native method `getConstants()`, which is available in JS. Below you will implement `getConstants()` and return a Map that contains a `DEFAULT_EVENT_NAME` constant you can access in JavaScript:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -518,7 +518,7 @@ Native modules also support a unique kind of argument: a callback. Callbacks are
 
 In order to create a native module method with a callback, first import the `Callback` interface, and then add a new parameter to your native module method of type `Callback`. There are a couple of nuances with callback arguments that will soon be lifted with TurboModules. First off, you can only have two callbacks in your function arguments- a successCallback and a failureCallback. In addition, the last argument to a native module method call, if it's a function, is treated as the successCallback, and the second to last argument to a native module method call, if it's a function, is treated as the failure callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -543,7 +543,7 @@ import com.facebook.react.bridge.Callback
 
 You can invoke the callback in your Java/Kotlin method, providing whatever data you want to pass to JavaScript. Please note that you can only pass serializable data from native code to JavaScript. If you need to pass back a native object you can use `WriteableMaps`, if you need to use a collection use `WritableArrays`. It is also important to highlight that the callback is not invoked immediately after the native function completes. Below the ID of an event created in an earlier call is passed to the callback.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -586,7 +586,7 @@ Another important detail to note is that a native module method can only invoke 
 
 There are two approaches to error handling with callbacks. The first is to follow Node’s convention and treat the first argument passed to the callback as an error object.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -630,7 +630,7 @@ const onPress = () => {
 
 Another option is to use an onSuccess and onFailure callback:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -678,7 +678,7 @@ Native modules can also fulfill a [Promise](https://developer.mozilla.org/en-US/
 
 Refactoring the above code to use a promise instead of callbacks looks like this:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -733,7 +733,7 @@ const onSubmit = async () => {
 
 The reject method takes different combinations of the following arguments:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -754,7 +754,7 @@ For more detail, you can find the `Promise.java` interface [here](https://github
 
 Java/Kotlin reject call:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -782,7 +782,7 @@ Error message in React Native App when promise is rejected:
 
 Native modules can signal events to JavaScript without being invoked directly. For example, you might want to signal to JavaScript a reminder that a calendar event from the native Android calendar app will occur soon. The easiest way to do this is to use the `RCTDeviceEventEmitter` which can be obtained from the `ReactContext` as in the code snippet below.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -893,7 +893,7 @@ import {NativeEventEmitter, NativeModules} from 'react-native';
 
 You'll need to listen to `onActivityResult` if you want to get results from an activity you started with `startActivityForResult`. To do this, you must extend `BaseActivityEventListener` or implement `ActivityEventListener`. The former is preferred as it is more resilient to API changes. Then, you need to register the listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -912,7 +912,7 @@ reactContext.addActivityEventListener(mActivityResultListener);
 
 Now you can listen to `onActivityResult` by implementing the following method:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -945,7 +945,7 @@ override fun onActivityResult(
 
 Let's implement a basic image picker to demonstrate this. The image picker will expose the method `pickImage` to JavaScript, which will return the path of the image when called.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```kotlin
@@ -1105,7 +1105,7 @@ class ImagePickerModule(reactContext: ReactApplicationContext) :
 
 Listening to the activity's LifeCycle events such as `onResume`, `onPause` etc. is very similar to how `ActivityEventListener` was implemented. The module must implement `LifecycleEventListener`. Then, you need to register a listener in the module's constructor like so:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java
@@ -1124,7 +1124,7 @@ reactContext.addLifecycleEventListener(this)
 
 Now you can listen to the activity's LifeCycle events by implementing the following methods:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java

--- a/website/versioned_docs/version-0.71/network.md
+++ b/website/versioned_docs/version-0.71/network.md
@@ -74,10 +74,10 @@ const getMoviesFromApiAsync = async () => {
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Fetch%20Example&ext=js
@@ -187,7 +187,7 @@ export default App;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Fetch%20Example&ext=js

--- a/website/versioned_docs/version-0.71/new-architecture-library-android.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-android.md
@@ -57,7 +57,7 @@ Update your native module or component to ensure it **extends the abstract class
 
 Following the example set forth in the previous section, your library might import `NativeAwesomeManagerSpec`, implement the relevant native interface and the necessary methods for it:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -29,7 +29,7 @@ JavaScript spec files **must** be named `Native<MODULE_NAME>.js`, and they expor
 
 The following is a basic JavaScript spec template, written using the [Flow](https://flow.org/) and [TypeScript](https://www.typescriptlang.org/) syntax.
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
@@ -78,7 +78,7 @@ JavaScript spec files **must** be named `<FABRIC COMPONENT>NativeComponent.js` (
 
 The following snippet shows a basic JavaScript spec template, written in [Flow](https://flow.org/) as well as [TypeScript](https://www.typescriptlang.org/).
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">
@@ -524,7 +524,7 @@ RCT_EXPORT_METHOD(moveToRegion:(nonnull NSNumber *)reactTag
 
 **Android**
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="kotlin">
 
 ```kotlin

--- a/website/versioned_docs/version-0.71/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.71/optimizing-flatlist-configuration.md
@@ -125,7 +125,7 @@ You can also use a `key` prop in your item component.
 
 Move out the `renderItem` function to the outside of render function, so it won't recreate itself each time render function called.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="classical">
 
 ```tsx

--- a/website/versioned_docs/version-0.71/panresponder.md
+++ b/website/versioned_docs/version-0.71/panresponder.md
@@ -80,7 +80,7 @@ const ExampleComponent = () => {
 
 `PanResponder` works with `Animated` API to help build complex gestures in the UI. The following example contains an animated `View` component which can be dragged freely across the screen
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PanResponder

--- a/website/versioned_docs/version-0.71/permissionsandroid.md
+++ b/website/versioned_docs/version-0.71/permissionsandroid.md
@@ -20,7 +20,7 @@ If a user has previously turned off a permission that you prompt for, the OS wil
 
 ### Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=PermissionsAndroid%20Example&supportedPlatforms=android

--- a/website/versioned_docs/version-0.71/platformcolor.md
+++ b/website/versioned_docs/version-0.71/platformcolor.md
@@ -32,7 +32,7 @@ For a full list of the types of system colors supported, see:
 
 #### Developer notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.71/props.md
+++ b/website/versioned_docs/version-0.71/props.md
@@ -29,7 +29,7 @@ Notice the braces surrounding `{pic}` - these embed the variable `pic` into JSX.
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place by referring to `props` in your `render` function. Here's an example:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Props&ext=js

--- a/website/versioned_docs/version-0.71/react-18-and-react-native.md
+++ b/website/versioned_docs/version-0.71/react-18-and-react-native.md
@@ -45,7 +45,7 @@ However, if you do hit any issues, we provide an option to opt-out of the new ro
 
 On Android, you will be able to override the `isConcurrentRootEnabled` in your ActivityDelegate (in the `MainActivity` file), and enable/disable Concurrent React.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 
 <TabItem value="java">
 

--- a/website/versioned_docs/version-0.71/running-on-device.md
+++ b/website/versioned_docs/version-0.71/running-on-device.md
@@ -12,14 +12,14 @@ It's always a good idea to test your app on an actual device before releasing it
 If you used `create-expo-app` to set up your project, you can run your app on a device in Expo Go by scanning the QR code that is displayed when you run `npm start`. Refer to the Expo guide for [running your project on your device](https://docs.expo.dev/workflow/run-on-device/) for more information.
 :::
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="android">
 
 ## Running your app on Android devices
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, Android'
@@ -316,7 +316,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 #### Development OS
 
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<Tabs groupId="os" queryString defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
 <TabItem value="macos">
 
 [//]: # 'macOS, iOS'

--- a/website/versioned_docs/version-0.71/sectionlist.md
+++ b/website/versioned_docs/version-0.71/sectionlist.md
@@ -22,7 +22,7 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=SectionList%20Example

--- a/website/versioned_docs/version-0.71/security.md
+++ b/website/versioned_docs/version-0.71/security.md
@@ -34,7 +34,7 @@ If you must have an API key or a secret to access some resource from your app, t
 
 #### Developer Notes
 
-<Tabs groupId="guide" defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
+<Tabs groupId="guide" queryString defaultValue="web" values={constants.getDevNotesTabs(["web"])}>
 
 <TabItem value="web">
 

--- a/website/versioned_docs/version-0.71/shadow-props.md
+++ b/website/versioned_docs/version-0.71/shadow-props.md
@@ -5,7 +5,7 @@ title: Shadow Props
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios&ext=js

--- a/website/versioned_docs/version-0.71/share.md
+++ b/website/versioned_docs/version-0.71/share.md
@@ -7,10 +7,10 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Function%20Component%20Example&supportedPlatforms=ios,android&ext=js
@@ -90,7 +90,7 @@ export default ShareExample;
 </TabItem>
 <TabItem value="classical">
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Class%20Component%20Example&supportedPlatforms=ios,android&ext=js

--- a/website/versioned_docs/version-0.71/state.md
+++ b/website/versioned_docs/version-0.71/state.md
@@ -11,7 +11,7 @@ In general, you should initialize `state` in the constructor, and then call `set
 
 For example, let's say we want to make text that blinks all the time. The text itself gets set once when the blinking component gets created, so the text itself is a `prop`. The "whether the text is currently on or off" changes over time, so that should be kept in `state`.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=State&ext=js

--- a/website/versioned_docs/version-0.71/statusbar.md
+++ b/website/versioned_docs/version-0.71/statusbar.md
@@ -11,7 +11,7 @@ Component to control the app's status bar. The status bar is the zone, typically
 
 It is possible to have multiple `StatusBar` components mounted at the same time. The props will be merged in the order the `StatusBar` components were mounted.
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=StatusBar%20Component%20Example&supportedPlatforms=android,ios&ext=js

--- a/website/versioned_docs/version-0.71/systrace.md
+++ b/website/versioned_docs/version-0.71/systrace.md
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 `Systrace` allows you to mark JavaScript (JS) events with a tag and an integer value. Capture the non-Timed JS events in EasyProfiler.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Systrace%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/text-style-props.md
+++ b/website/versioned_docs/version-0.71/text-style-props.md
@@ -7,7 +7,7 @@ title: Text Style Props
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=TextStyleProps&supportedPlatforms=ios,android&ext=js

--- a/website/versioned_docs/version-0.71/text.md
+++ b/website/versioned_docs/version-0.71/text.md
@@ -11,7 +11,7 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Text%20Functional%20Component%20Example

--- a/website/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-fabric-components.md
@@ -304,7 +304,7 @@ my-component
 
 The code that should go in the `MyComponentViewManagerImpl.java` and that can be shared between the Native Component and the Fabric Native Component is, for example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="example of MyComponentViewManager.java"
@@ -352,7 +352,7 @@ Then, the Native Component and the Fabric Native Component can be updated using 
 
 For example, for a Native Component:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="Native Component using the ViewManagerImpl"
@@ -410,7 +410,7 @@ class MyComponentViewManager(var context: ReactApplicationContext) : SimpleViewM
 
 And, for a Fabric Native Component:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="Fabric Component using the ViewManagerImpl"
@@ -499,7 +499,7 @@ import MyComponent from 'your-component/src/index';
 
 Since `codegenNativeComponent` is calling the `requireNativeComponent` under the hood, we need to re-export our component, to avoid registering it multiple times.
 
-<Tabs groupId="fabric-component-backward-compatibility"
+<Tabs groupId="fabric-component-backward-compatibility" queryString
       defaultValue={constants.defaultFabricComponentSpecLanguage}
       values={constants.fabricComponentSpecLanguages}>
 <TabItem value="Flow">

--- a/website/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-turbomodules.md
@@ -272,7 +272,7 @@ my-module
 
 The code that should go in the `MyModuleImpl.java`, and that can be shared by the Legacy Native Module and the Turbo Native Module is, for example:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="example of MyModuleImpl.java"
@@ -325,7 +325,7 @@ Then, the Legacy Native Module and the Turbo Native Module can be updated with t
 
 For example, for a Legacy Native Module:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="Native Module using the Impl module"
@@ -377,7 +377,7 @@ class MyModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(co
 
 And, for a Turbo Native Module:
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="TurboModule using the Impl module"
@@ -441,7 +441,7 @@ import MyModule from 'your-module/src/index';
 
 Since `TurboModuleRegistry.get` taps into the old Native Modules API under the hood, we need to re-export our module, to avoid registering it multiple times.
 
-<Tabs groupId="turbomodule-backward-compatibility"
+<Tabs groupId="turbomodule-backward-compatibility" queryString
       defaultValue={constants.defaultTurboModuleSpecLanguage}
       values={constants.turboModuleSpecLanguages}>
 <TabItem value="Flow">

--- a/website/versioned_docs/version-0.71/the-new-architecture/cxx-custom-types.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/cxx-custom-types.md
@@ -63,7 +63,7 @@ Omitting either `fromJS` or `toJS` would make you `bridging` header either _read
 
 Now you can add the following function to your JavaScript spec:
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"
@@ -157,7 +157,7 @@ export type CustomType = {
 
 which can be exposed to your C++ Turbo Native Module via
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"

--- a/website/versioned_docs/version-0.71/the-new-architecture/cxx-cxxturbomodules.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/cxx-cxxturbomodules.md
@@ -67,7 +67,7 @@ CxxTurboModulesGuide
 
 Create the following spec inside the `tm` folder:
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-codegen.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-codegen.md
@@ -151,7 +151,7 @@ These tasks invoke the `generateCodegenArtifactsFromSchema` on all the the impor
 
 Once the Gradle task completes, you can see different structures for a Turbo Native Module or for a Fabric Native Component. The following tab shows how they appear:
 
-<Tabs groupId="android-codegen" defaultValue={constants.defaultNewArchFeature} values={constants.newArchFeatures}>
+<Tabs groupId="android-codegen" queryString defaultValue={constants.defaultNewArchFeature} values={constants.newArchFeatures}>
 <TabItem value="turbomodules">
 
 ```sh

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -66,7 +66,7 @@ There are two requirements the file containing this specification must meet:
 
 Below are specifications of the `RTNCenteredText` component in both Flow and TypeScript. Create a `RTNCenteredTextNativeComponent` file with the proper extension in the `js` folder.
 
-<Tabs groupId="fabric-component-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="fabric-component-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value='flow'>
 
 ```typescript
@@ -283,7 +283,7 @@ Then, you need a class that implements the `ReactPackage` interface. To run the 
 
 Create an `android/src/main/java/com/rtncenteredtext` folder and, inside that folder, create a `CenteredTextPackage.java` file.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CenteredTextPackage.java"
@@ -653,7 +653,7 @@ android
 
 ##### CenteredText.java
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CenteredText.java"
@@ -730,7 +730,7 @@ This class represents the actual view Android is going to represent on screen. I
 
 ##### CenteredTextManager.java
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CenteredTextManager.java"
@@ -833,7 +833,7 @@ It is also responsible for exporting all the constructs required by React Native
 
 Finally, open the `CenteredTextPackage.java` file in the `android/src/main/java/com/rtncenteredtext` folder and update it with the following lines
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```diff title="CenteredTextPackage.java update"
@@ -929,7 +929,7 @@ Android configuration requires to enable the **New Architecture**.
 
 Finally, you can use the component in your JavaScript application.
 
-<Tabs groupId="final-app" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="final-app" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="App.js"

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
@@ -62,7 +62,7 @@ There are two requirements the file containing this specification must meet:
 1. The file **must** be named `Native<MODULE_NAME>`, with a `.js` or `.jsx` extension when using Flow, or a `.ts`, or `.tsx` extension when using TypeScript. Codegen will only look for files matching this pattern.
 2. The file must export a `TurboModuleRegistrySpec` object.
 
-<Tabs groupId="turbomodule-specs" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="turbomodule-specs" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="NativeCalculator.js"
@@ -269,7 +269,7 @@ Then, you need a class that extends the `TurboReactPackage` interface. To run th
 
 Create an `android/src/main/java/com/rtncalculator` folder and, inside that folder, create a `CalculatorPackage.java` file.
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CalculatorPackage.java"
@@ -528,7 +528,7 @@ android
 
 ##### Creating the `CalculatorModule.java`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```java title="CalculatorModule.java"
@@ -597,7 +597,7 @@ This class implements the module itself, which extends the `NativeCalculatorSpec
 
 ##### Updating the `CalculatorPackage.java`
 
-<Tabs groupId="android-language" defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
+<Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>
 <TabItem value="java">
 
 ```diff title="CalculatorPackage.java"
@@ -763,7 +763,7 @@ Now you can use your Turbo Native Module calculator in your app!
 
 Here's an example App.js file using the `add` method:
 
-<Tabs groupId="final-app" defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
+<Tabs groupId="final-app" queryString defaultValue={constants.defaultJavaScriptSpecLanguages} values={constants.javaScriptSpecLanguages}>
 <TabItem value="flow">
 
 ```typescript title="App.js"

--- a/website/versioned_docs/version-0.71/the-new-architecture/use-app-template.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/use-app-template.md
@@ -49,7 +49,7 @@ Please [follow the instructions on the React Native website](hermes.md) to enabl
 
 #### Target OS
 
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<Tabs groupId="platform" queryString defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
 <TabItem value="ios">
 
 Navigate to the `ios` directory and run the following:

--- a/website/versioned_docs/version-0.71/touchablehighlight.md
+++ b/website/versioned_docs/version-0.71/touchablehighlight.md
@@ -32,7 +32,7 @@ function MyComponent(props: MyComponentProps) {
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableHighlight%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/touchableopacity.md
+++ b/website/versioned_docs/version-0.71/touchableopacity.md
@@ -13,7 +13,7 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=TouchableOpacity%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/transforms.md
+++ b/website/versioned_docs/version-0.71/transforms.md
@@ -9,7 +9,7 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Transforms

--- a/website/versioned_docs/version-0.71/tutorial.md
+++ b/website/versioned_docs/version-0.71/tutorial.md
@@ -63,7 +63,7 @@ Most components can be customized when they are created, with different paramete
 
 Your own components can also use `props`. This lets you make a single component that is used in many different places in your app, with slightly different properties in each place. Refer to `props.YOUR_PROP_NAME` in your functional components or `this.props.YOUR_PROP_NAME` in your class components. Here's an example:
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=Hello%20Props&ext=js

--- a/website/versioned_docs/version-0.71/typescript.md
+++ b/website/versioned_docs/version-0.71/typescript.md
@@ -21,7 +21,7 @@ npx create-expo-app --template
 
 1. Add TypeScript, types, and ESLint plugins to your project.
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell
@@ -164,7 +164,7 @@ To use custom path aliases with TypeScript, you need to set the path aliases to 
 
 2. Add [`babel-plugin-module-resolver`][bpmr] as a development package to your project:
 
-<Tabs groupId="package-manager" defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">
 
 ```shell

--- a/website/versioned_docs/version-0.71/vibration.md
+++ b/website/versioned_docs/version-0.71/vibration.md
@@ -9,7 +9,7 @@ Vibrates the device.
 
 ## Example
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=Vibration&supportedPlatforms=ios,android

--- a/website/versioned_docs/version-0.71/view.md
+++ b/website/versioned_docs/version-0.71/view.md
@@ -11,7 +11,7 @@ The most fundamental component for building a UI, `View` is a container that sup
 
 This example creates a `View` that wraps two boxes with color and a text component in a row with padding.
 
-<Tabs groupId="syntax" defaultValue={constants.defaultSyntax} values={constants.syntax}>
+<Tabs groupId="syntax" queryString defaultValue={constants.defaultSyntax} values={constants.syntax}>
 <TabItem value="functional">
 
 ```SnackPlayer name=View%20Function%20Component%20Example

--- a/website/versioned_docs/version-0.71/virtualizedlist.md
+++ b/website/versioned_docs/version-0.71/virtualizedlist.md
@@ -11,7 +11,7 @@ Virtualization massively improves memory consumption and performance of large li
 
 ## Example
 
-<Tabs groupId="language" defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
+<Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
 ```SnackPlayer name=VirtualizedListExample&ext=js


### PR DESCRIPTION
Adds support for deep-linking in tabs.  This will only work *after* #3618 goes it (note: it won't break anything if it does land before).

I updated all of these using this:
```bash
git grep -lE '<Tabs .*groupId' | xargs -J echo gsed -ri 's/<Tabs(.*)groupId="([^\"]*)"/<Tabs\1groupId="\2" queryString/'
```

https://user-images.githubusercontent.com/49578/224362123-8126614d-71e5-4a6f-a219-511d0ed73160.mp4


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
