### PR TITLE
Feat ids for deeplinks

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -18,7 +18,7 @@ React Native currently recommends version 11 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -32,7 +32,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 13 (Tiramisu)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -36,7 +36,7 @@ If you have already installed JDK on your system, we recommend JDK 11. You may e
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -50,7 +50,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 13 (Tiramisu)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -30,7 +30,7 @@ If you have already installed Node on your system, make sure it is Node 16 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -6,7 +6,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 13 (Tiramisu)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.60/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.60/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.60/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.60/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-macos-android.md
@@ -46,7 +46,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.60/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-windows-android.md
@@ -26,7 +26,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.60/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-windows-android.md
@@ -41,7 +41,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.60/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.60/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, Python2, a JDK, and
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, Python2, JDK</h3>
+<h3 id="jdk">Node, Python2, JDK</h3>
 
 We recommend installing Node and Python2 via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.61/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.61/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.61/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.61/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-macos-android.md
@@ -46,7 +46,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.61/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-windows-android.md
@@ -26,7 +26,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.61/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-windows-android.md
@@ -41,7 +41,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.61/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.61/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, Python2, a JDK, and
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, Python2, JDK</h3>
+<h3 id="jdk">Node, Python2, JDK</h3>
 
 We recommend installing Node and Python2 via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.62/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.62/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.62/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.62/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-macos-android.md
@@ -46,7 +46,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.62/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-windows-android.md
@@ -26,7 +26,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.62/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-windows-android.md
@@ -41,7 +41,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.62/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.62/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, Python2, a JDK, and
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, Python2, JDK</h3>
+<h3 id="jdk">Node, Python2, JDK</h3>
 
 We recommend installing Node and Python2 via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.63/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.63/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.63/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.63/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-macos-android.md
@@ -46,7 +46,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 10 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.63/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.63/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.64/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.64/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.64/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.64/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-macos-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.64/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 10 (Q)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.64/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.64/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.64/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.65/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.65/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.65/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.65/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-macos-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.65/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.65/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.65/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.65/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.66/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.66/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.66/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 8 or newer
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.66/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-macos-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.66/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.66/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.66/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.66/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.67/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.67/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.67/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-macos-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.67/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-macos-android.md
@@ -31,7 +31,7 @@ If you have already installed JDK on your system, make sure it is JDK 11 or newe
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.67/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 11 (R)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.67/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 12 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.67/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.67/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.68/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.68/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.68/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-macos-android.md
@@ -34,7 +34,7 @@ If you have already installed JDK on your system, make sure it is JDK 11 or newe
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.68/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-macos-android.md
@@ -48,7 +48,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.68/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.68/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.68/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.68/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.69/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-linux-android.md
@@ -30,7 +30,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.69/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-linux-android.md
@@ -16,7 +16,7 @@ React Native requires at least the version 8 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.69/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-macos-android.md
@@ -34,7 +34,7 @@ If you have already installed JDK on your system, make sure it is JDK 11 or newe
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.69/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-macos-android.md
@@ -48,7 +48,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.69/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-windows-android.md
@@ -28,7 +28,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.69/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-windows-android.md
@@ -43,7 +43,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.69/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.69/_getting-started-windows-android.md
@@ -4,7 +4,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.70/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-linux-android.md
@@ -18,7 +18,7 @@ React Native currently recommends version 11 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.70/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-linux-android.md
@@ -32,7 +32,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.70/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-macos-android.md
@@ -36,7 +36,7 @@ If you have already installed JDK on your system, we recommend JDK 11. You may e
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.70/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-macos-android.md
@@ -50,7 +50,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.70/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-windows-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.70/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-windows-android.md
@@ -6,7 +6,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.70/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-windows-android.md
@@ -30,7 +30,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.71/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-linux-android.md
@@ -18,7 +18,7 @@ React Native currently recommends version 11 of the Java SE Development Kit (JDK
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.71/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-linux-android.md
@@ -32,7 +32,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.71/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-android.md
@@ -36,7 +36,7 @@ If you have already installed JDK on your system, we recommend JDK 11. You may e
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 

--- a/website/versioned_docs/version-0.71/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-android.md
@@ -50,7 +50,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.71/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-windows-android.md
@@ -45,7 +45,7 @@ Then, click "Next" to install all of these components.
 
 Once setup has finalized and you're presented with the Welcome screen, proceed to the next step.
 
-<h4>2. Install the Android SDK</h4>
+<h4 id="android-sdk">2. Install the Android SDK</h4>
 
 Android Studio installs the latest Android SDK by default. Building a React Native app with native code, however, requires the `Android 12 (S)` SDK in particular. Additional Android SDKs can be installed through the SDK Manager in Android Studio.
 

--- a/website/versioned_docs/version-0.71/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-windows-android.md
@@ -6,7 +6,7 @@ You will need Node, the React Native command line interface, a JDK, and Android 
 
 While you can use any editor of your choice to develop your app, you will need to install Android Studio in order to set up the necessary tooling to build your React Native app for Android.
 
-<h3>Node, JDK</h3>
+<h3 id="jdk">Node, JDK</h3>
 
 We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
 

--- a/website/versioned_docs/version-0.71/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-windows-android.md
@@ -30,7 +30,7 @@ If you have already installed Node on your system, make sure it is Node 14 or ne
 
 Setting up your development environment can be somewhat tedious if you're new to Android development. If you're already familiar with Android development, there are a few things you may need to configure. In either case, please make sure to carefully follow the next few steps.
 
-<h4>1. Install Android Studio</h4>
+<h4 id="android-studio">1. Install Android Studio</h4>
 
 [Download and install Android Studio](https://developer.android.com/studio/index.html). While on Android Studio installation wizard, make sure the boxes next to all of the following items are checked:
 


### PR DESCRIPTION
Add deeplink support for: JDK, Android Studio and the Android SDK:

```bash
# JDK (it's in there 😀)
gg -l '<h3>Node,' | gsed -i 's/<h3>Node,/<h3 id="jdk">Node,/g'

# Android Studio
gg -l '<h4>1. Install Android ' | xargs gsed -i 's/<h4>1. Install Android/<h4 id="android-studio">1. Install Android/g'

# Android SDK
gg -l '<h4>2. Install the An' | xargs gsed -i 's/<h4>2. Install the An/<h4 id="android-sdk">2. Install the An/g'
```

These are all deep links used by the CLI on error.