### PR TITLE
Update CellRendererComponent documentation

### DIFF
--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -222,11 +222,11 @@ Takes an item from `data` and renders it into the list
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.md).
+CellRendererComponent allows customizing how cells rendered by `renderItem`/`ListItemComponent` are wrapped when placed into the underlying ScrollView. This component must accept event handlers which notify VirtualizedList of changes within the cell.
 
-| Type                |
-| ------------------- |
-| component, function |
+| Type                                   |
+| -------------------------------------- |
+| React.ComponentType<CellRendererProps> |
 
 ---
 

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -224,9 +224,9 @@ Takes an item from `data` and renders it into the list
 
 CellRendererComponent allows customizing how cells rendered by `renderItem`/`ListItemComponent` are wrapped when placed into the underlying ScrollView. This component must accept event handlers which notify VirtualizedList of changes within the cell.
 
-| Type                                   |
-| -------------------------------------- |
-| React.ComponentType<CellRendererProps> |
+| Type                                     |
+| ---------------------------------------- |
+| `React.ComponentType<CellRendererProps>` |
 
 ---
 


### PR DESCRIPTION
Currently landing a change which adds `CellRendererProps` as a public type, and updates the description for `CellRendererComponent`. This updates the website in line.
