### PR TITLE
`textContentType` breaking change clarification

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -854,7 +854,7 @@ Possible values for `textAlign` are:
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
 :::note
-[`autoComplete`](#autocomplete), provides the same functionality and is available for both platforms. You can use [`Platform.select`](/docs/next/platform#select) for differing platform behaviors.
+[`autoComplete`](#autocomplete), provides the same functionality and is available for all platforms. You can use [`Platform.select`](/docs/next/platform#select) for differing platform behaviors.
 
 Avoid using both `textContentType` and `autoComplete`. For backwards compatibility, `textContentType` takes precedence when both properties are set.
 :::

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -853,6 +853,12 @@ Possible values for `textAlign` are:
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
+:::note
+[`autoComplete`](#autocomplete), provides the same functionality and is available for both platforms. You can use [`Platform.select`](/docs/next/platform#select) for differing platform behaviors.
+
+Avoid using both `textContentType` and `autoComplete`. For backwards compatibility, when both are set, `textContentType` takes precedence.
+:::
+
 For iOS 11+ you can set `textContentType` to `username` or `password` to enable autofill of login details from the device keychain.
 
 For iOS 12+ `newPassword` can be used to indicate a new password input the user may want to save in the keychain, and `oneTimeCode` can be used to indicate that a field can be autofilled by a code arriving in an SMS.

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -856,7 +856,7 @@ Give the keyboard and the system information about the expected semantic meaning
 :::note
 [`autoComplete`](#autocomplete), provides the same functionality and is available for both platforms. You can use [`Platform.select`](/docs/next/platform#select) for differing platform behaviors.
 
-Avoid using both `textContentType` and `autoComplete`. For backwards compatibility, when both are set, `textContentType` takes precedence.
+Avoid using both `textContentType` and `autoComplete`. For backwards compatibility, `textContentType` takes precedence when both properties are set.
 :::
 
 For iOS 11+ you can set `textContentType` to `username` or `password` to enable autofill of login details from the device keychain.

--- a/website/versioned_docs/version-0.71/textinput.md
+++ b/website/versioned_docs/version-0.71/textinput.md
@@ -860,7 +860,7 @@ Avoid using both `textContentType` and `autoComplete`.
 :::
 
 :::caution
-In 0.71 a breaking change was introduced where the property `autoComplete` overrides `textContentType` on iOS when both are set. In 0.71.5, this was addressed so that `textContentType` takes precedence.
+A breaking change was introduced in 0.71 where `autoComplete` overrides `textContentType` on iOS when both properties are set. >=0.71.5 reverts the breaking change such that `textContentType` takes precedence.
 :::
 
 For iOS 11+ you can set `textContentType` to `username` or `password` to enable autofill of login details from the device keychain.

--- a/website/versioned_docs/version-0.71/textinput.md
+++ b/website/versioned_docs/version-0.71/textinput.md
@@ -853,6 +853,16 @@ Possible values for `textAlign` are:
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
+:::note
+[`autoComplete`](#autocomplete), introduced to iOS in 0.71, provides the same functionality and is available for both platforms. You can use [`Platform.select`](/docs/platform#select) for differing platform behaviors.
+
+Avoid using both `textContentType` and `autoComplete`.
+:::
+
+:::caution
+In 0.71 a breaking change was introduced where the property `autoComplete` overrides `textContentType` on iOS when both are set. In 0.71.5, this was addressed so that `textContentType` takes precedence.
+:::
+
 For iOS 11+ you can set `textContentType` to `username` or `password` to enable autofill of login details from the device keychain.
 
 For iOS 12+ `newPassword` can be used to indicate a new password input the user may want to save in the keychain, and `oneTimeCode` can be used to indicate that a field can be autofilled by a code arriving in an SMS.

--- a/website/versioned_docs/version-0.71/textinput.md
+++ b/website/versioned_docs/version-0.71/textinput.md
@@ -854,7 +854,7 @@ Possible values for `textAlign` are:
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
 :::note
-[`autoComplete`](#autocomplete), introduced to iOS in 0.71, provides the same functionality and is available for both platforms. You can use [`Platform.select`](/docs/platform#select) for differing platform behaviors.
+[`autoComplete`](#autocomplete), introduced to iOS in 0.71, provides the same functionality and is available for all platforms. You can use [`Platform.select`](/docs/platform#select) for differing platform behaviors.
 
 Avoid using both `textContentType` and `autoComplete`.
 :::


### PR DESCRIPTION
This PR clarifies a breaking change with `textContentType` from changes in 0.71 as discussed here: https://github.com/facebook/react-native/issues/36229 and specifically acts on plan from this [comment](https://github.com/facebook/react-native/issues/36229#issuecomment-1470468374)

This can only be landed after we release 0.71.5