### PR TITLE
Update sourcemaps.md

### DIFF
--- a/docs/sourcemaps.md
+++ b/docs/sourcemaps.md
@@ -63,6 +63,7 @@ At the top of the file near the other export's, add an entry for `SOURCEMAP_FILE
 
 ```
 export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
+export EXTRA_PACKAGER_ARGS="--minify false"
 
 export NODE_BINARY=node
 ../node_modules/react-native/scripts/react-native-xcode.sh


### PR DESCRIPTION
Hi all. I had issue with mapping sourcemap in production (react-native 0.70.5).

After spending few days I have fixed this.
I think it would be useful to update docs.
Basically ../node_modules/react-native/scripts/react-native-xcode.sh requires USE_HERMES=true in IOS to add `--minify false`. Herms is already enabled in accordance with guide(there is no mention of `USE_HERMES=true`). But USE_HERMES=true breaks sourcemap completely.
It might be edge case, but EXTRA_PACKAGER_ARGS does a trick in this particular situation.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
