### PR TITLE
Fix fabric native component example

### DIFF
--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -903,6 +903,13 @@ yarn add ../RTNCenteredText
 
 This command adds the `RTNCenteredText` Component to the `node_modules` of your app.
 
+If the package was previously added to your app, you will need to update it:
+
+```sh
+cd MyApp
+yarn upgrade rtn-centered-text
+```
+
 ### iOS
 
 Then, you need to install the new dependencies in your iOS project. To do so, you need to run these commands:

--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -942,7 +942,7 @@ Finally, you can use the component in your JavaScript application.
  */
 import React from 'react';
 import type {Node} from 'react';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
+import RTNCenteredText from 'rtn-centered-text/js/RTNCenteredTextNativeComponent';
 
 const App: () => Node = () => {
   return (
@@ -966,7 +966,7 @@ export default App;
  * @format
  */
 import React from 'react';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
+import RTNCenteredText from 'rtn-centered-text/js/RTNCenteredTextNativeComponent';
 
 const App: () => JSX.Element = () => {
   return (

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
@@ -843,7 +843,7 @@ Finally, you can use the component in your JavaScript application.
  */
 import React from 'react';
 import type {Node} from 'react';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
+import RTNCenteredText from 'rtn-centered-text/js/RTNCenteredTextNativeComponent';
 
 const App: () => Node = () => {
   return (
@@ -867,7 +867,7 @@ export default App;
  * @format
  */
 import React from 'react';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
+import RTNCenteredText from 'rtn-centered-text/js/RTNCenteredTextNativeComponent';
 
 const App: () => JSX.Element = () => {
   return (

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
@@ -804,6 +804,13 @@ yarn add ../RTNCenteredText
 
 This command adds the `RTNCenteredText` Component to the `node_modules` of your app.
 
+If the package was previously added to your app, you will need to update it:
+
+```sh
+cd MyApp
+yarn upgrade rtn-centered-text
+```
+
 ### iOS
 
 Then, you need to install the new dependencies in your iOS project. To do so, you need to run these commands:

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -903,6 +903,13 @@ yarn add ../RTNCenteredText
 
 This command adds the `RTNCenteredText` Component to the `node_modules` of your app.
 
+If the package was previously added to your app, you will need to update it:
+
+```sh
+cd MyApp
+yarn upgrade rtn-centered-text
+```
+
 ### iOS
 
 Then, you need to install the new dependencies in your iOS project. To do so, you need to run these commands:

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -942,7 +942,7 @@ Finally, you can use the component in your JavaScript application.
  */
 import React from 'react';
 import type {Node} from 'react';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
+import RTNCenteredText from 'rtn-centered-text/js/RTNCenteredTextNativeComponent';
 
 const App: () => Node = () => {
   return (
@@ -966,7 +966,7 @@ export default App;
  * @format
  */
 import React from 'react';
-import RTNCalculator from 'rtn-calculator/js/NativeCalculator';
+import RTNCenteredText from 'rtn-centered-text/js/RTNCenteredTextNativeComponent';
 
 const App: () => JSX.Element = () => {
   return (


### PR DESCRIPTION
When following the guide to creating [Fabric Native Components](http://localhost:3000/docs/the-new-architecture/pillars-fabric-components) I ran into an issue where my newly crated native code wasn't synced over correctly.

In the docs,  I was told to `yarn add` in order to test the codegen.
https://github.com/facebook/react-native-website/blob/80ee7b3152a0bac14d13fc6a200c0a3ff9d2aa38/docs/the-new-architecture/pillars-fabric-components.md?plain=1#L359-L368

At the last step "5. Adding the Fabric Native Component To Your App", we tell users to `yarn add` again.
https://github.com/facebook/react-native-website/blob/80ee7b3152a0bac14d13fc6a200c0a3ff9d2aa38/docs/the-new-architecture/pillars-fabric-components.md?plain=1#L895-L902

If the local package is already there, the newly created native code won't get updated unless I run `yarn upgrade`