### PR TITLE
fix: reference CenteredText in java example for fabric component

### DIFF
--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -749,10 +749,10 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerInterface;
 import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate;
 
 @ReactModule(name = CenteredTextManager.NAME)
-public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
-        implements RTNCenteredTextManagerInterface<RTNCenteredText> {
+public class CenteredTextManager extends SimpleViewManager<CenteredText>
+        implements RTNCenteredTextManagerInterface<CenteredText> {
 
-    private final ViewManagerDelegate<RTNCenteredText> mDelegate;
+    private final ViewManagerDelegate<CenteredText> mDelegate;
 
     static final String NAME = "RTNCenteredText";
 
@@ -762,7 +762,7 @@ public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @Nullable
     @Override
-    protected ViewManagerDelegate<RTNCenteredText> getDelegate() {
+    protected ViewManagerDelegate<CenteredText> getDelegate() {
         return mDelegate;
     }
 
@@ -774,13 +774,13 @@ public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @NonNull
     @Override
-    protected RTNCenteredText createViewInstance(@NonNull ThemedReactContext context) {
-        return new RTNCenteredText(context);
+    protected CenteredText createViewInstance(@NonNull ThemedReactContext context) {
+        return new CenteredText(context);
     }
 
     @Override
     @ReactProp(name = "text")
-    public void setText(RTNCenteredText view, @Nullable String text) {
+    public void setText(CenteredText view, @Nullable String text) {
         view.setText(text);
     }
 }


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
[`CenteredTextManager.java`](https://reactnative.dev/docs/next/the-new-architecture/pillars-fabric-components?android-language=kotlin#centeredtextmanagerjava) in the guide of creating fabric components is referencing `RTNCenteredText` which is non existent and not the correct class. 

Following this code will lead to an error. It is meant to reference `CenteredText`. You can also check it in the kotlin example how it is done correctly.