### PR TITLE
Add documentation on XCode Accessibilty Inspector

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -476,7 +476,7 @@ adb shell settings put secure enabled_accessibility_services com.google.android.
 
 ## Testing VoiceOver Support <div class="label ios">iOS</div>
 
-To test and debug accessibility on the iOS Simulator, open up XCode, then go to the XCode menu, Open Developer Menu, then Accessibility Inspector. The Accessibility Inspector allows you to select items, iterate through them, and have MacOS' screen reader to pronounce the accessibility labels. In addition, it displays the view hierarchy and lists available Actions, allowing developers to test out specific actions like Magic Touch.
+To test and debug accessibility on the iOS Simulator, open up XCode, then go to the XCode menu, Open Developer Tool, then Accessibility Inspector. The Accessibility Inspector allows you to select items, iterate through them, and have MacOS' screen reader to pronounce the accessibility labels. In addition, it displays the view hierarchy and lists available Actions, allowing developers to test out specific actions like Magic Touch.
 
 To enable VoiceOver on your device, go to the Settings app on your iOS device. Tap General, then Accessibility. There you will find many tools that people use to make their devices more usable, such as bolder text, increased contrast, and VoiceOver.
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -476,7 +476,9 @@ adb shell settings put secure enabled_accessibility_services com.google.android.
 
 ## Testing VoiceOver Support <div class="label ios">iOS</div>
 
-To enable VoiceOver, go to the Settings app on your iOS device (it's not available for simulator). Tap General, then Accessibility. There you will find many tools that people use to make their devices more usable, such as bolder text, increased contrast, and VoiceOver.
+To test and debug accessibility on the iOS Simulator, open up XCode, then go to the XCode menu, Open Developer Menu, then Accessibility Inspector. The Accessibility Inspector allows you to select items, iterate through them, and have MacOS' screen reader to pronounce the accessibility labels. In addition, it displays the view hierarchy and lists available Actions, allowing developers to test out specific actions like Magic Touch.
+
+To enable VoiceOver on your device, go to the Settings app on your iOS device. Tap General, then Accessibility. There you will find many tools that people use to make their devices more usable, such as bolder text, increased contrast, and VoiceOver.
 
 To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 


### PR DESCRIPTION
The existing documentation states that a developer cannot test a11y or VoiceOver on the simulator, but this is not correct. The Accessibility Inspector tool in XCode is the ideal debug tool for developers to use to test a11y on iOS devices.
