### PR TITLE
consistent wording for the direction of data flow

### DIFF
--- a/docs/animatedvalue.md
+++ b/docs/animatedvalue.md
@@ -51,7 +51,7 @@ Sets an offset that is applied on top of whatever value is set, whether via `set
 flattenOffset();
 ```
 
-Merges the offset value into the base value and resets the offset to zero. The final output of the value is unchanged.
+Merges the offset value into the base, and resets the offset to zero. The final output of the value is unchanged.
 
 ---
 
@@ -61,7 +61,7 @@ Merges the offset value into the base value and resets the offset to zero. The f
 extractOffset();
 ```
 
-Sets the offset value to the base value, and resets the base value to zero. The final output of the value is unchanged.
+Sets the base value into the offset, and resets the base value to zero. The final output of the value is unchanged.
 
 ---
 


### PR DESCRIPTION
> Sets the offset value to the base value

If not looked carefully it might confuse something into thinking it is to "set the offset value to the base", which means "base = offset", but it actually wants to say "offset = base".

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
