### PR TITLE
Update how-to-build-from-source for 0.72+

### DIFF
--- a/website/contributing/how-to-build-from-source.md
+++ b/website/contributing/how-to-build-from-source.md
@@ -29,13 +29,14 @@ Both with stable releases and nightlies, you will be consuming **precompiled** a
 ```diff
   // ...
   include ':app'
-  includeBuild('../node_modules/react-native-gradle-plugin')
+  includeBuild('../node_modules/@react-native/gradle-plugin')
+  
 + includeBuild('../node_modules/react-native') {
 +     dependencySubstitution {
-+         substitute(module("com.facebook.react:react-android")).using(project(":ReactAndroid"))
-+         substitute(module("com.facebook.react:react-native")).using(project(":ReactAndroid"))
-+         substitute(module("com.facebook.react:hermes-android")).using(project(":ReactAndroid:hermes-engine"))
-+         substitute(module("com.facebook.react:hermes-engine")).using(project(":ReactAndroid:hermes-engine"))
++         substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
++         substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
++         substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
++         substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
 +     }
 + }
 ```


### PR DESCRIPTION
With the monorepo changes, the way how we trigger a build from source had to be adapted.

This change is also pending a change on `react-native` before it can be merged:
- https://github.com/facebook/react-native/pull/36702

As this doc is not versioned, so I think we might want to hold on merging it till 0.72 lands?
On the other hand, the current setup is broken for nightlies and user should use the new instructions.

How do we feel about it?