### PR TITLE
Update More Resources React's Documentation link

### DIFF
--- a/docs/more-resources.md
+++ b/docs/more-resources.md
@@ -16,7 +16,7 @@ There’s always more to learn: developer workflows, shipping to app stores, int
 
 ## Dive deep
 
-- [React’s Documentation](https://reactjs.org/docs/hello-world.html)
+- [React’s Documentation](https://react.dev/reference/react)
 - [MDN’s JavaScript tutorials, reference, and guides](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 - [Android](https://developer.android.com/docs) and [iOS](https://developer.apple.com/documentation/uikit) platform docs
 

--- a/docs/more-resources.md
+++ b/docs/more-resources.md
@@ -16,7 +16,7 @@ There’s always more to learn: developer workflows, shipping to app stores, int
 
 ## Dive deep
 
-- [React’s Documentation](https://react.dev/reference/react)
+- [React’s Documentation](https://react.dev/learn)
 - [MDN’s JavaScript tutorials, reference, and guides](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 - [Android](https://developer.android.com/docs) and [iOS](https://developer.apple.com/documentation/uikit) platform docs
 


### PR DESCRIPTION
Just changed the link to point to the new React documentation at https://react.dev/learn
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
