### PR TITLE
Update _getting-started-macos-android.md

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -78,6 +78,7 @@ Add the following lines to your `~/.zprofile` or `~/.zshrc` (if you are using `b
 ```shell
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
+export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 ```
 


### PR DESCRIPTION
Added missing shell configuration PATH for /tools; this was causing issues for me during setup.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
