### PR TITLE
Naming inconsistency causing build failure in Android Java file.

### DIFF
--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -752,7 +752,7 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate;
 public class CenteredTextManager extends SimpleViewManager<CenteredText>
         implements RTNCenteredTextManagerInterface<CenteredText> {
 
-    private final ViewManagerDelegate<RTNCenteredText> mDelegate;
+    private final ViewManagerDelegate<CenteredText> mDelegate;
 
     static final String NAME = "RTNCenteredText";
 

--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -749,8 +749,8 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerInterface;
 import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate;
 
 @ReactModule(name = CenteredTextManager.NAME)
-public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
-        implements RTNCenteredTextManagerInterface<RTNCenteredText> {
+public class CenteredTextManager extends SimpleViewManager<CenteredText>
+        implements RTNCenteredTextManagerInterface<CenteredText> {
 
     private final ViewManagerDelegate<RTNCenteredText> mDelegate;
 
@@ -762,7 +762,7 @@ public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @Nullable
     @Override
-    protected ViewManagerDelegate<RTNCenteredText> getDelegate() {
+    protected ViewManagerDelegate<CenteredText> getDelegate() {
         return mDelegate;
     }
 
@@ -774,13 +774,13 @@ public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @NonNull
     @Override
-    protected RTNCenteredText createViewInstance(@NonNull ThemedReactContext context) {
-        return new RTNCenteredText(context);
+    protected CenteredText createViewInstance(@NonNull ThemedReactContext context) {
+        return new CenteredText(context);
     }
 
     @Override
     @ReactProp(name = "text")
-    public void setText(RTNCenteredText view, @Nullable String text) {
+    public void setText(CenteredText view, @Nullable String text) {
         view.setText(text);
     }
 }

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
@@ -716,10 +716,10 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate;
 
 
 @ReactModule(name = RTNCenteredTextManager.NAME)
-public class RTNCenteredTextManager extends SimpleViewManager<RTNCenteredText>
-        implements RTNCenteredTextManagerInterface<RTNCenteredText> {
+public class RTNCenteredTextManager extends SimpleViewManager<CenteredText>
+        implements RTNCenteredTextManagerInterface<CenteredText> {
 
-    private final ViewManagerDelegate<RTNCenteredText> mDelegate;
+    private final ViewManagerDelegate<CenteredText> mDelegate;
 
     static final String NAME = "RTNCenteredText";
 
@@ -729,7 +729,7 @@ public class RTNCenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @Nullable
     @Override
-    protected ViewManagerDelegate<RTNCenteredText> getDelegate() {
+    protected ViewManagerDelegate<CenteredText> getDelegate() {
         return mDelegate;
     }
 
@@ -741,13 +741,13 @@ public class RTNCenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @NonNull
     @Override
-    protected RTNCenteredText createViewInstance(@NonNull ThemedReactContext context) {
-        return new RTNCenteredText(context);
+    protected CenteredText createViewInstance(@NonNull ThemedReactContext context) {
+        return new CenteredText(context);
     }
 
     @Override
     @ReactProp(name = "text")
-    public void setText(RTNCenteredText view, @Nullable String text) {
+    public void setText(CenteredText view, @Nullable String text) {
         view.setText(text);
     }
 }

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-fabric-components.md
@@ -716,10 +716,10 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate;
 
 
 @ReactModule(name = RTNCenteredTextManager.NAME)
-public class RTNCenteredTextManager extends SimpleViewManager<CenteredText>
-        implements RTNCenteredTextManagerInterface<CenteredText> {
+public class RTNCenteredTextManager extends SimpleViewManager<RTNCenteredText>
+        implements RTNCenteredTextManagerInterface<RTNCenteredText> {
 
-    private final ViewManagerDelegate<CenteredText> mDelegate;
+    private final ViewManagerDelegate<RTNCenteredText> mDelegate;
 
     static final String NAME = "RTNCenteredText";
 
@@ -729,7 +729,7 @@ public class RTNCenteredTextManager extends SimpleViewManager<CenteredText>
 
     @Nullable
     @Override
-    protected ViewManagerDelegate<CenteredText> getDelegate() {
+    protected ViewManagerDelegate<RTNCenteredText> getDelegate() {
         return mDelegate;
     }
 
@@ -741,13 +741,13 @@ public class RTNCenteredTextManager extends SimpleViewManager<CenteredText>
 
     @NonNull
     @Override
-    protected CenteredText createViewInstance(@NonNull ThemedReactContext context) {
-        return new CenteredText(context);
+    protected RTNCenteredText createViewInstance(@NonNull ThemedReactContext context) {
+        return new RTNCenteredText(context);
     }
 
     @Override
     @ReactProp(name = "text")
-    public void setText(CenteredText view, @Nullable String text) {
+    public void setText(RTNCenteredText view, @Nullable String text) {
         view.setText(text);
     }
 }

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -749,10 +749,10 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerInterface;
 import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate;
 
 @ReactModule(name = CenteredTextManager.NAME)
-public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
-        implements RTNCenteredTextManagerInterface<RTNCenteredText> {
+public class CenteredTextManager extends SimpleViewManager<CenteredText>
+        implements RTNCenteredTextManagerInterface<CenteredText> {
 
-    private final ViewManagerDelegate<RTNCenteredText> mDelegate;
+    private final ViewManagerDelegate<CenteredText> mDelegate;
 
     static final String NAME = "RTNCenteredText";
 
@@ -762,7 +762,7 @@ public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @Nullable
     @Override
-    protected ViewManagerDelegate<RTNCenteredText> getDelegate() {
+    protected ViewManagerDelegate<CenteredText> getDelegate() {
         return mDelegate;
     }
 
@@ -774,13 +774,13 @@ public class CenteredTextManager extends SimpleViewManager<RTNCenteredText>
 
     @NonNull
     @Override
-    protected RTNCenteredText createViewInstance(@NonNull ThemedReactContext context) {
-        return new RTNCenteredText(context);
+    protected CenteredText createViewInstance(@NonNull ThemedReactContext context) {
+        return new CenteredText(context);
     }
 
     @Override
     @ReactProp(name = "text")
-    public void setText(RTNCenteredText view, @Nullable String text) {
+    public void setText(CenteredText view, @Nullable String text) {
         view.setText(text);
     }
 }


### PR DESCRIPTION
file  CenteredText.java in class name is CenteredText. However, in the CenteredTextManager.java file, we used the name RTNCenteredText instead of CenteredText. This is causing issues when trying to create a fabric component, as the build fails when updating the class name to CenteredText. Everything works fine when using the correct class name.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
