### PR TITLE
feat: redirect current version urls

### DIFF
--- a/scripts/update-redirect/index.js
+++ b/scripts/update-redirect/index.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+if (process.argv.length < 4) {
+  console.log(
+    `Usage: update-redirect <path to _redirects> <path to versions.json>`
+  );
+  process.exit(1);
+}
+
+const [redirects, versions] = process.argv.slice(2);
+assert.match(
+  redirects,
+  /_redirects$/,
+  'Expects _redirects path as 2nd argument'
+);
+assert.match(
+  versions,
+  /versions.json$/,
+  'Expects versions.jsoon path as 3nd argument'
+);
+
+const latestPublicVersion = JSON.parse(fs.readFileSync(versions, 'utf8'))[0];
+const VERSION_KEY = '$LATEST_VERSION$';
+
+const before = fs.readFileSync(redirects, 'utf8');
+
+if (!before.includes(VERSION_KEY)) {
+  console.warn(
+    `yarn run update-redirect is expecting to find ${VERSION_KEY} in '${redirects}
+
+This is a problem because any direct linking to ${latestPublicVersion} must be redirected:
+- from: https://reactnative.dev/docs/${latestPublicVersion}/...
+- to:   https://reactnative.dev/docs/...
+
+Someone must have committed the _redirects after build.`
+  );
+  process.exit(1);
+}
+
+fs.writeFileSync(redirects, before.replace(VERSION_KEY, latestPublicVersion));
+console.log(
+  `Successfully added direct for /docs/${latestPublicVersion}/* -> /docs/*`
+);

--- a/scripts/update-redirect/package.json
+++ b/scripts/update-redirect/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@react-native-website/update-redirects",
+  "version": "0.0.0",
+  "private": true,
+  "bin": {
+    "update-redirect": "./index.js"
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && yarn run update-redirect ./build/_redirects ./versions.json",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@docusaurus/types": "^2.3.1",
     "@react-native-website/lint-examples": "0.0.0",
+    "@react-native-website/update-redirects": "0.0.0",
     "alex": "^10.0.0",
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -48,3 +48,6 @@
 
 # Rework of the community
 /help         /community/overview
+
+# Latest version might be linked to directly and should redirect
+/docs/$LATEST_VERSION$/*  /docs/:splat


### PR DESCRIPTION
Allows our CLI tool to user the latest version in the path, and gracefully handles this server side:

https://reactnative.dev/docs/0.71/X -> https://reactnative.dev/docs/X

## Why

Our CLI tooling will generate direct links based on OS, platform and version of React Native.  If you're running the latest version, our current docs don't support a version number infix.  For more details of why see [here](https://github.com/react-native-community/cli/pull/1902#issuecomment-1503094396) where the issue was originally raised.

Options that weren't better (IMHO):
- using the Docusaurus plugin-client-redirects → doesn't like non-existent paths (/0.71/) and would generate a bunch of placeholder html files with client side redirects.
- CLI checks the current version (failing which just default to top-level docs) → a bunch of version checks we shouldn't really need, but this was my fallback if we couldn't find a better way
- some kind of configuration in the `docusaurus.config.js` → I couldn't find anything that was baked in to handle this

## Testing
~~I'd need this to deploy to netlify to confirm, but I've run the `yarn build` locally and confirmed that correct changes are made to the `_redirects` file.~~


https://user-images.githubusercontent.com/49578/231149619-436671ce-dcee-4579-ade6-0e0102311c26.mp4



<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
