### PR TITLE
Missing instruction to compile kotlin and a variable type in CenteredTextManager.kt causing build failure and wrong variable type. #3681

### DIFF
--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -651,6 +651,52 @@ android
                     └── CenteredTextPackage.java
 ```
 
+:::note
+
+If you are going to use **kotlin** then you must update the `build.gradle` file located at `RTNCenteredText/android/build.gradle` so it can compile **kotlin** files.
+
+```diff title="build.gradle update"
+buildscript {
+  ext.safeExtGet = {prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+  repositories {
+    google()
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath("com.android.tools.build:gradle:7.3.1")
++   classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.22")
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'com.facebook.react'
++ apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', 33)
+  namespace "com.rtncenteredtext"
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', 21)
+    targetSdkVersion safeExtGet('targetSdkVersion', 33)
+    buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", "true")
+  }
+}
+
+repositories {
+  mavenCentral()
+  google()
+}
+
+dependencies {
+  implementation 'com.facebook.react:react-native'
+}
+```
+
+:::
+
 ##### CenteredText.java
 
 <Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>

--- a/docs/the-new-architecture/pillars-fabric-components.md
+++ b/docs/the-new-architecture/pillars-fabric-components.md
@@ -849,7 +849,7 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate
 
 @ReactModule(name = CenteredTextManager.NAME)
 class CenteredTextManager(context: ReactApplicationContext) : SimpleViewManager<CenteredText>(), RTNCenteredTextManagerInterface<CenteredText> {
-  private val delegate: RTNCenteredTextManagerDelegate<CenteredText> = RTNCenteredTextManagerDelegate(this)
+  private val delegate: ViewManagerDelegate<CenteredText> = RTNCenteredTextManagerDelegate(this)
 
   override fun getDelegate(): ViewManagerDelegate<CenteredText> = delegate
 

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -651,6 +651,52 @@ android
                     └── CenteredTextPackage.java
 ```
 
+:::note
+
+If you are going to use **kotlin** then you must update the `build.gradle` file located at `RTNCenteredText/android/build.gradle` so it can compile **kotlin** files.
+
+```diff title="build.gradle update"
+buildscript {
+  ext.safeExtGet = {prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+  repositories {
+    google()
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath("com.android.tools.build:gradle:7.3.1")
++   classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.22")
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'com.facebook.react'
++ apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  compileSdkVersion safeExtGet('compileSdkVersion', 33)
+  namespace "com.rtncenteredtext"
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', 21)
+    targetSdkVersion safeExtGet('targetSdkVersion', 33)
+    buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", "true")
+  }
+}
+
+repositories {
+  mavenCentral()
+  google()
+}
+
+dependencies {
+  implementation 'com.facebook.react:react-native'
+}
+```
+
+:::
+
 ##### CenteredText.java
 
 <Tabs groupId="android-language" queryString defaultValue={constants.defaultAndroidLanguage} values={constants.androidLanguages}>

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-fabric-components.md
@@ -849,7 +849,7 @@ import com.facebook.react.viewmanagers.RTNCenteredTextManagerDelegate
 
 @ReactModule(name = CenteredTextManager.NAME)
 class CenteredTextManager(context: ReactApplicationContext) : SimpleViewManager<CenteredText>(), RTNCenteredTextManagerInterface<CenteredText> {
-  private val delegate: RTNCenteredTextManagerDelegate<CenteredText> = RTNCenteredTextManagerDelegate(this)
+  private val delegate: ViewManagerDelegate<CenteredText> = RTNCenteredTextManagerDelegate(this)
 
   override fun getDelegate(): ViewManagerDelegate<CenteredText> = delegate
 


### PR DESCRIPTION
There are no instruction for compiling kotlin files in `RTNCenteredText/android/build.gradle`. After adding those instruction in gradle it compiles the kotlin files.

But now we get error in the file `CenteredTextManager.kt` at line no 14 where the variable `delegate` has type `RTNCenteredTextManagerDelegate<CenteredText>` and this `RTNCenteredTextManagerDelegate` asks for second type.

So i just replaced it with ViewManagerDelegate<CenteredText> and it worked. I have replace RTNCenteredTextManagerDelegate with ViewManagerDelegate in docs.

```
private val delegate: ViewManagerDelegate<CenteredText> = RTNCenteredTextManagerDelegate(this)

```