### PR TITLE
fix typos: change 'maximum' word to 'minimum' word at aria-valuemin section in react native docs, at six places

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -210,7 +210,7 @@ Represents the maximum value for range-based components, such as sliders and pro
 
 ### `aria-valuemin`
 
-Represents the maximum value for range-based components, such as sliders and progress bars.
+Represents the minimum value for range-based components, such as sliders and progress bars.
 
 ### `aria-valuenow`
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -325,7 +325,7 @@ Represents the maximum value for range-based components, such as sliders and pro
 
 ### `aria-valuemin`
 
-Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
+Represents the minimum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
 
 | Type   |
 | ------ |

--- a/docs/view.md
+++ b/docs/view.md
@@ -335,7 +335,7 @@ Represents the maximum value for range-based components, such as sliders and pro
 
 ### `aria-valuemin`
 
-Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
+Represents the minimum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
 
 | Type   |
 | ------ |

--- a/website/versioned_docs/version-0.71/accessibility.md
+++ b/website/versioned_docs/version-0.71/accessibility.md
@@ -210,7 +210,7 @@ Represents the maximum value for range-based components, such as sliders and pro
 
 ### `aria-valuemin`
 
-Represents the maximum value for range-based components, such as sliders and progress bars.
+Represents the minimum value for range-based components, such as sliders and progress bars.
 
 ### `aria-valuenow`
 

--- a/website/versioned_docs/version-0.71/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.71/touchablewithoutfeedback.md
@@ -325,7 +325,7 @@ Represents the maximum value for range-based components, such as sliders and pro
 
 ### `aria-valuemin`
 
-Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
+Represents the minimum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
 
 | Type   |
 | ------ |

--- a/website/versioned_docs/version-0.71/view.md
+++ b/website/versioned_docs/version-0.71/view.md
@@ -370,7 +370,7 @@ Represents the maximum value for range-based components, such as sliders and pro
 
 ### `aria-valuemin`
 
-Represents the maximum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
+Represents the minimum value for range-based components, such as sliders and progress bars. Has precedence over the `min` value in the `accessibilityValue` prop.
 
 | Type   |
 | ------ |


### PR DESCRIPTION
…on in react-native docs

Corrected the words
``` diff
- maximum
+ minimum
```

![image](https://user-images.githubusercontent.com/85422491/232458878-f87afc5c-ef01-4447-aa71-606ca7923458.png)


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
