### PR TITLE
chore: replace manual command with CLI command

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -94,14 +94,13 @@ android {
 
 ## Generating the release AAB
 
-Run the following in a terminal:
+Run the following command in a terminal:
 
 ```shell
-cd android
-./gradlew bundleRelease
+npx react-native build-android --mode=release
 ```
 
-Gradle's `bundleRelease` will bundle all the JavaScript needed to run your app into the AAB ([Android App Bundle](https://developer.android.com/guide/app-bundle)). If you need to change the way the JavaScript bundle and/or drawable resources are bundled (e.g. if you changed the default file/folder names or the general structure of the project), have a look at `android/app/build.gradle` to see how you can update it to reflect these changes.
+This command uses Gradle's `bundleRelease` under the hood that bundles all the JavaScript needed to run your app into the AAB ([Android App Bundle](https://developer.android.com/guide/app-bundle)). If you need to change the way the JavaScript bundle and/or drawable resources are bundled (e.g. if you changed the default file/folder names or the general structure of the project), have a look at `android/app/build.gradle` to see how you can update it to reflect these changes.
 
 :::note
 Make sure `gradle.properties` does not include `org.gradle.configureondemand=true` as that will make the release build skip bundling JS and assets into the app binary.


### PR DESCRIPTION
Hey! 👋
In this PR I changed manual command with CLI command `build-android`, which was [introduced](https://github.com/react-native-community/cli/pull/1739) some time ago.