### PR TITLE
Update Kotlin code snippet for consistency with Java

### DIFF
--- a/docs/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/docs/the-new-architecture/backward-compatibility-turbomodules.md
@@ -416,8 +416,9 @@ class MyModule(reactContext: ReactApplicationContext) : MyModuleSpec(reactContex
 
   override fun getName(): String = MyModuleImpl.NAME
 
-  override fun add(a: Double, b: Double, promise: Promise) {
-    implementation.add(a, b, promise)
+  override fun foo(a: Double, b: Double, promise: Promise) {
+    // Use the implementation instance to execute the function.
+    implementation.foo(a, b, promise)
   }
 }
 ```

--- a/docs/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/docs/the-new-architecture/backward-compatibility-turbomodules.md
@@ -385,7 +385,7 @@ public class MyModule extends MyModuleSpec {
     // declare an instance of the implementation
     private MyModuleImpl implementation;
 
-    CalculatorModule(ReactApplicationContext context) {
+    MyModule(ReactApplicationContext context) {
         super(context);
         // initialize the implementation of the module
         implementation = MyModuleImpl();

--- a/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
@@ -291,7 +291,7 @@ public class MyModule extends ReactContextBaseJavaModule {
     // declare an instance of the implementation
     private MyModuleImpl implementation;
 
-    CalculatorModule(ReactApplicationContext context) {
+    MyModule(ReactApplicationContext context) {
         super(context);
         // initialize the implementation of the module
         implementation = MyModuleImpl();
@@ -318,7 +318,7 @@ public class MyModule extends MyModuleSpec {
     // declare an instance of the implementation
     private MyModuleImpl implementation;
 
-    CalculatorModule(ReactApplicationContext context) {
+    MyModule(ReactApplicationContext context) {
         super(context);
         // initialize the implementation of the module
         implementation = MyModuleImpl();

--- a/website/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-turbomodules.md
@@ -385,7 +385,7 @@ public class MyModule extends MyModuleSpec {
     // declare an instance of the implementation
     private MyModuleImpl implementation;
 
-    CalculatorModule(ReactApplicationContext context) {
+    MyModule(ReactApplicationContext context) {
         super(context);
         // initialize the implementation of the module
         implementation = MyModuleImpl();
@@ -416,8 +416,9 @@ class MyModule(reactContext: ReactApplicationContext) : MyModuleSpec(reactContex
 
   override fun getName(): String = MyModuleImpl.NAME
 
-  override fun add(a: Double, b: Double, promise: Promise) {
-    implementation.add(a, b, promise)
+  override fun foo(a: Double, b: Double, promise: Promise) {
+    // Use the implementation instance to execute the function.
+    implementation.foo(a, b, promise)
   }
 }
 ```


### PR DESCRIPTION
Between the Java and Kotlin code snippets for the Turbo Module example on this [page](https://reactnative.dev/docs/the-new-architecture/backward-compatibility-turbomodules?android-language=kotlin), the method names are different, which can cause some confusion to readers who are trying to compare it with the Native Module example.

Changes:
* Renamed the `add` method to `foo`
* Renamed the `CalculatorModule` class constructor to `MyModule` in the Java sample