### PR TITLE
Replace deprecated `--variant` and `--configuration` with `--mode`

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -46,7 +46,7 @@ $ npx react-native run-android --mode release
 or for iOS:
 
 ```shell
-$ npx react-native run-ios --configuration Release
+$ npx react-native run-ios --mode Release
 ```
 
 This will compile JavaScript to bytecode during build time which will improve your app's startup speed on device.

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -40,7 +40,7 @@ Confirm that you are using the `.hbc` file and also benchmark the before/after a
 To see the benefits of Hermes, try making a release build/deployment of your app to compare. For example:
 
 ```shell
-$ npx react-native run-android --variant release
+$ npx react-native run-android --mode release
 ```
 
 or for iOS:

--- a/docs/publishing-to-app-store.md
+++ b/docs/publishing-to-app-store.md
@@ -51,7 +51,7 @@ The static bundle is built every time you target a physical device, even in Debu
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
 :::info
-You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
+You can also use the `React Native CLI` to perform this operation using the option `--mode` with the value `Release` (e.g. `npx react-native run-ios --mode Release`).
 :::
 
 Once you are done with the testing and ready to publish to App Store, follow along with this guide.

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -137,7 +137,7 @@ Type the following in your command prompt to install and launch your app on the 
 $ npx react-native run-android
 ```
 
-> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --mode=release`).
 
 <h2>Connecting to the development server</h2>
 
@@ -262,7 +262,7 @@ $ npx react-native run-android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
-> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --mode=release`).
 
 <h2>Connecting to the development server</h2>
 

--- a/website/versioned_docs/version-0.71/hermes.md
+++ b/website/versioned_docs/version-0.71/hermes.md
@@ -46,7 +46,7 @@ $ npx react-native run-android --mode release
 or for iOS:
 
 ```shell
-$ npx react-native run-ios --configuration Release
+$ npx react-native run-ios --mode Release
 ```
 
 This will compile JavaScript to bytecode during build time which will improve your app's startup speed on device.

--- a/website/versioned_docs/version-0.71/hermes.md
+++ b/website/versioned_docs/version-0.71/hermes.md
@@ -40,7 +40,7 @@ Confirm that you are using the `.hbc` file and also benchmark the before/after a
 To see the benefits of Hermes, try making a release build/deployment of your app to compare. For example:
 
 ```shell
-$ npx react-native run-android --variant release
+$ npx react-native run-android --mode release
 ```
 
 or for iOS:

--- a/website/versioned_docs/version-0.71/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.71/publishing-to-app-store.md
@@ -51,7 +51,7 @@ The static bundle is built every time you target a physical device, even in Debu
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
 :::info
-You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
+You can also use the `React Native CLI` to perform this operation using the option `--mode` with the value `Release` (e.g. `npx react-native run-ios --mode Release`).
 :::
 
 Once you are done with the testing and ready to publish to App Store, follow along with this guide.

--- a/website/versioned_docs/version-0.71/running-on-device.md
+++ b/website/versioned_docs/version-0.71/running-on-device.md
@@ -59,7 +59,7 @@ $ npx react-native run-android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
-> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --mode=release`).
 
 <h2>Connecting to the development server</h2>
 
@@ -137,7 +137,7 @@ Type the following in your command prompt to install and launch your app on the 
 $ npx react-native run-android
 ```
 
-> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --mode=release`).
 
 <h2>Connecting to the development server</h2>
 
@@ -262,7 +262,7 @@ $ npx react-native run-android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
-> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --variant=release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `npx react-native run-android --mode=release`).
 
 <h2>Connecting to the development server</h2>
 


### PR DESCRIPTION
i recently updated to react-native 0.71 and started receiving these console errors:

android:
`warn "variant" flag is deprecated and will be removed in future release. Please switch to "mode" flag.`

ios:
```
warn --configuration has been deprecated. Use --mode instead.
warn Parameters were automatically reassigned to --mode on this run.
```

i found this pr which updates the docs in a single file: https://github.com/facebook/react-native-website/pull/3522

i checked and there were a few more places using the `--variant` and `--configuration` flags, this pr changes those too. there are a few fixes for the versioned_docs/0.71, and also updates to the /docs folder so future versions are also correct.