### PR TITLE
Remove new architecture warning

### DIFF
--- a/docs/the-new-architecture/use-app-template.md
+++ b/docs/the-new-architecture/use-app-template.md
@@ -17,10 +17,6 @@ Before continuing, make sure you've followed all the steps in the [Setting up th
 
 If following the setup guide, stop when you reach the section **Running your React Native Application**, and resume following this guide.
 
-:::caution
-If you're using Expo, you can't enable the New Architecture at the moment and will have to wait for a future release of the Expo SDK.
-:::
-
 ## Creating a New Application
 
 <RemoveGlobalCLI />


### PR DESCRIPTION
This was possible in Expo SDK 47 and is supported by all Expo modules in SDK 48, and [developers can use the Expo Modules API to create modules that work with the new architecture by default](https://docs.expo.dev/modules/overview/#react-native-new-architecture). You can also enable the new architecture when using prebuild with the [newArchEnabled property in expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties). You can create an app that uses the new architecture out of the box with `npx create-expo-app@latest -e with-new-arch`