### PR TITLE
Update the way for Expo projects to enable New Architecture

### DIFF
--- a/docs/the-new-architecture/use-app-template.md
+++ b/docs/the-new-architecture/use-app-template.md
@@ -18,7 +18,7 @@ Before continuing, make sure you've followed all the steps in the [Setting up th
 If following the setup guide, stop when you reach the section **Running your React Native Application**, and resume following this guide.
 
 :::info Note for Expo projects
-If you're using Expo, you can enable the New Architecture at by the [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) plugin.
+If you're using Expo, you can enable the New Architecture by the [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) plugin.
 :::
 
 ## Creating a New Application

--- a/docs/the-new-architecture/use-app-template.md
+++ b/docs/the-new-architecture/use-app-template.md
@@ -17,8 +17,8 @@ Before continuing, make sure you've followed all the steps in the [Setting up th
 
 If following the setup guide, stop when you reach the section **Running your React Native Application**, and resume following this guide.
 
-:::caution
-If you're using Expo, you can't enable the New Architecture at the moment and will have to wait for a future release of the Expo SDK.
+:::info Note for Expo projects
+If you're using Expo, you can enable the New Architecture at by the [expo-build-properties](https://docs.expo.dev/versions/latest/sdk/build-properties/) plugin.
 :::
 
 ## Creating a New Application


### PR DESCRIPTION
# Why

Follow up https://github.com/reactwg/react-native-new-architecture/discussions/127#discussioncomment-5688489

# How

Given that we are now support New Architecture in most cases, only exceptions in some expo-modules like expo-dev-client. We may able to support more all in Expo SDK 49. I am revising the wording as "How to enable New Architecture in Expo projects".