### PR TITLE
Remove bad dependencies from useEffect

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -33,7 +33,7 @@ const FadeInView = props => {
       duration: 10000,
       useNativeDriver: true,
     }).start();
-  }, [fadeAnim]);
+  }, []);
 
   return (
     <Animated.View // Special animatable View
@@ -90,7 +90,7 @@ const FadeInView: React.FC<FadeInViewProps> = props => {
       duration: 10000,
       useNativeDriver: true,
     }).start();
-  }, [fadeAnim]);
+  }, []);
 
   return (
     <Animated.View // Special animatable View


### PR DESCRIPTION
Using ref current values in a dependency array is considered a bad practice. You can read more about it here: https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/. If you want to rerun `useEffect` when a new `Animated` object is created you need to use `useState`.
