### PR TITLE
Update shadow-props.md for Sets the drop shadow zIndex for Android.

### DIFF
--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -130,6 +130,7 @@ const App = () => {
   const [shadowOffsetHeight, setShadowOffsetHeight] = useState(0);
   const [shadowRadius, setShadowRadius] = useState(0);
   const [shadowOpacity, setShadowOpacity] = useState(0.1);
+  const [zIndex, setZIndex] = useState(0);
 
   return (
     <View style={styles.container}>
@@ -143,6 +144,7 @@ const App = () => {
             },
             shadowOpacity,
             shadowRadius,
+            zIndex,
           },
         ]}
       />
@@ -175,6 +177,13 @@ const App = () => {
           step={0.05}
           value={shadowOpacity}
           onValueChange={val => setShadowOpacity(val)}
+        />
+        <ShadowPropSlider
+          label="zIndex"
+          minimumValue={0}
+          maximumValue={1000}
+          value={zIndex}
+          onValueChange={setZIndex}
         />
       </View>
     </View>
@@ -246,6 +255,16 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 ### `shadowRadius` <div class="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `zIndex` <div class="label ios">iOS</div>
+
+Sets the drop shadow zIndex.
 
 | Type   |
 | ------ |


### PR DESCRIPTION
Sets the drop shadow zIndex for Android.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
