### PR TITLE
chore: add react-native-keys in security section to secure keys in react native

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -13,7 +13,7 @@ In this guide, you will learn about best practices for storing sensitive informa
 
 ## Storing Sensitive Info
 
-Never store sensitive API keys in your app code. Anything included in your code could be accessed in plain text by anyone inspecting the app bundle. Tools like [react-native-dotenv](https://github.com/goatandsheep/react-native-dotenv) and [react-native-config](https://github.com/luggit/react-native-config/) are great for adding environment-specific variables like API endpoints, but they should not be confused with server-side environment variables, which can often contain secrets and API keys.
+Never store sensitive API keys in your app code. One way is to use a package like [react-native-keys](https://github.com/numandev1/react-native-keys), which stores keys in C++ and uses encryption to better secure them that than other solutions. Anything included in your code could be accessed in plain text by anyone inspecting the app bundle. Tools like [react-native-dotenv](https://github.com/goatandsheep/react-native-dotenv) and [react-native-config](https://github.com/luggit/react-native-config/) are great for adding environment-specific variables like API endpoints, but they should not be confused with server-side environment variables, which can often contain secrets and API keys.
 
 If you must have an API key or a secret to access some resource from your app, the most secure way to handle this would be to build an orchestration layer between your app and the resource. This could be a serverless function (e.g. using AWS Lambda or Google Cloud Functions) which can forward the request with the required API key or secret. Secrets in server side code cannot be accessed by the API consumers the same way secrets in your app code can.
 


### PR DESCRIPTION
Just added a [react-native-keys](https://github.com/numandev1/react-native-keys) package in the security section because this package can secure and manage ENVs than all other available solutions

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
