### PR TITLE
feature: set fixed device types for Snack

### DIFF
--- a/plugins/remark-snackplayer/README.md
+++ b/plugins/remark-snackplayer/README.md
@@ -31,16 +31,18 @@ The above code snippet would look like this:
 
 ### Parameters
 
-| Name               | Description                                               | Default             |
-| ------------------ | --------------------------------------------------------- | ------------------- |
-| name               | SnackPlayer name                                          | `"Example"`         |
-| description        | Description of the example                                | `"Example usage"`   |
-| dependencies       | Additional dependencies, eg. `"expo-constant"`            | `""`                |
-| platform           | Example platform                                          | `"web"`             |
-| supportedPlatforms | Supported platforms                                       | `"ios,android,web"` |
-| theme              | SnackPlayer theme, `"light"` or `"dark"`                  | `"light"`           |
-| preview            | Preview visible, `"true"` or `"false"`                    | `"true"`            |
-| loading            | iFrame loading attribute, `"auto"`, `"lazy"` or `"eager"` | `"lazy"`            |
+| Name               | Description                                                                                                     | Default             |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------- |
+| name               | SnackPlayer name                                                                                                | `"Example"`         |
+| description        | Description of the example                                                                                      | `"Example usage"`   |
+| dependencies       | Additional dependencies, eg. `"expo-constant"`                                                                  | `""`                |
+| platform           | Example platform                                                                                                | `"web"`             |
+| supportedPlatforms | Supported platforms                                                                                             | `"ios,android,web"` |
+| theme              | SnackPlayer theme, `"light"` or `"dark"`                                                                        | `"light"`           |
+| preview            | Preview visible, `"true"` or `"false"`                                                                          | `"true"`            |
+| loading            | iFrame loading attribute, `"auto"`, `"lazy"` or `"eager"`                                                       | `"lazy"`            |
+| deviceAndroid      | Emulator type used for Android, [see Appetize options](https://docs.appetize.io/core-features/playback-options) | `pixel4`            |
+| deviceIos          | Simulator type used for iOS, [see Appetize options](https://docs.appetize.io/core-features/playback-options)    | `iphone12`          |
 
 ## Styling
 

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -48,6 +48,8 @@ const processNode = (node, parent) => {
       const theme = params.theme || 'light';
       const preview = params.preview || 'true';
       const loading = params.loading || 'lazy';
+      const deviceAndroid = params.deviceAndroid || 'pixel4';
+      const deviceIos = params.deviceIos || 'iphone12';
 
       // Generate Node for SnackPlayer
       // See https://github.com/expo/snack/blob/main/docs/embedding-snacks.md
@@ -64,6 +66,8 @@ const processNode = (node, parent) => {
             data-snack-theme="${theme}"
             data-snack-preview="${preview}"
             data-snack-loading="${loading}"
+            data-snack-device-android="${deviceAndroid}"
+            data-snack-device-ios="${deviceIos}"
           ></div>
           `,
       });

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,7 +42,7 @@ module.exports = {
       src: 'https://widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd8ryO5qrZo8Exadq9qmt1wtm4_2FdZGEAKHDFEt_2BBlwwM4.js',
       defer: true,
     },
-    {src: 'https://snack.expo.dev/embed.js', defer: true},
+    {src: 'https://snack.expo.dev/embed.js?version=20230517', defer: true},
   ],
   favicon: 'img/favicon.ico',
   titleDelimiter: '·',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,7 +42,7 @@ module.exports = {
       src: 'https://widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd8ryO5qrZo8Exadq9qmt1wtm4_2FdZGEAKHDFEt_2BBlwwM4.js',
       defer: true,
     },
-    {src: 'https://snack.expo.dev/embed.js?version=20230517', defer: true},
+    {src: 'https://snack.expo.dev/embed.js', defer: true},
   ],
   favicon: 'img/favicon.ico',
   titleDelimiter: '·',


### PR DESCRIPTION
This feature, added in https://github.com/expo/snack/pull/425 helps us avoid the issue reported by @NickGerleman in https://github.com/expo/snack/issues/422.

With this, we (Expo) can update the devices without affecting the React Native docs. We may do this due to outdated visual appearances or OS versions. Only when updated here, and validated that it doesn't cut anything off, the React Native docs can be updated too.

The cutoff is caused by the height changes in the device preview, and can be controlled here: https://github.com/facebook/react-native-website/blob/d67805884a7c0920dcefc1af5894580984918239/website/src/css/customTheme.scss#L1717