### PR TITLE
docs(gradle-plugin): fix typo for codegen example

### DIFF
--- a/docs/react-native-gradle-plugin.md
+++ b/docs/react-native-gradle-plugin.md
@@ -60,7 +60,7 @@ If you're in a monorepo or using a different package manager, you can adjust `co
 You can customize it as follows:
 
 ```groovy
-reactNativeDir = file("../node_modules/@react-native/codegen")
+codegenDir = file("../node_modules/@react-native/codegen")
 ```
 
 ### `cliFile`


### PR DESCRIPTION
codegenDir uses reactNativeDir in example.

p.s.: spotted it by reading source code of the gradle-plugin 😉.
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
