### PR TITLE
Add react-native-skia to out-of-tree platform list

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -16,7 +16,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
-- [React Native Skia](https://github.com/react-native-skia/react-native-skia) - React Native with [Skia](https://skia.org/) renderer, currently support Linux and macOS.
+- [React Native Skia](https://github.com/react-native-skia/react-native-skia) - React Native using [Skia](https://skia.org/) as a renderer.  Currently supports Linux and macOS.
 
 ## Creating your own React Native platform
 

--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -16,6 +16,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
 - [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
+- [React Native Skia](https://github.com/react-native-skia/react-native-skia) - React Native with [Skia](https://skia.org/) renderer, currently support Linux and macOS.
 
 ## Creating your own React Native platform
 


### PR DESCRIPTION
# Why

according to the old discussion at https://github.com/react-native-community/discussions-and-proposals/discussions/487#discussioncomment-2987986 and after the app.js conf talk, it's a good time to add react-native-skia to the website.