### PR TITLE
feature: Move to GA4, UA stops working 1 July 2023

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -102,11 +102,12 @@ module.exports = {
             require.resolve('./src/css/versions.scss'),
           ],
         },
+        // TODO: GA is deprecated, remove once we're sure data is streaming in GA4 via gtag.
         googleAnalytics: {
           trackingID: 'UA-41298772-2',
         },
         gtag: {
-          trackingID: 'UA-41298772-2',
+          trackingID: 'G-58L13S6BDP',
         },
       }),
     ],


### PR DESCRIPTION
Google's Universal Analytics pipeline will [no longer process data from 1 July 2023](https://support.google.com/analytics/answer/11583528?sjid=12523431476709424134-EU). To continue gather web analytics we need to move over to Google Analytics 4 (GA4).

There are a couple of steps:
- [x] Link our current UA properties → GA4 properties (Google side).  I think because we've already setup gtag for our UA container ID, data should already be flowing.  This is being done as part of #3142:
![CleanShot 2023-05-24 at 12 22 53@2x](https://github.com/facebook/react-native-website/assets/49578/9f2c988b-4ca6-47fe-a9c9-c26dabbab358)

- [ ] Confirm data is flowing after this is deployed.
- [x] ~Remove old [`googleAnalytics`](https://github.com/facebook/react-native-website/blob/cb1de5dba397ac1c334cf0da489fa4763a5e7ea6/website/docusaurus.config.js#L105-L107) UA from our Docusaurus config.~ The guidance is we can run these [side-by-side](https://github.com/facebook/docusaurus/issues/7221).

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
