### PR TITLE
Change instructions due to menu renaming in macOS Ventura and Xcode 14

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -27,13 +27,13 @@ If you have already installed Xcode on your system, make sure it is version 10 o
 
 #### Command Line Tools
 
-You will also need to install the Xcode Command Line Tools. Open Xcode, then choose "Preferences..." from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+You will also need to install the Xcode Command Line Tools. Open Xcode, then choose **Settings... (or Preferences ...)** from the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 ![Xcode Command Line Tools](/docs/assets/GettingStartedXcodeCommandLineTools.png)
 
 #### Installing an iOS Simulator in Xcode
 
-To install a simulator, open <strong>Xcode > Preferences...</strong> and select the <strong>Components</strong> tab. Select a simulator with the corresponding version of iOS you wish to use.
+To install a simulator, open **Xcode > Settings... (or Preferences...)** and select the **Platforms (or Components)** tab. Select a simulator with the corresponding version of iOS you wish to use.
 
 #### CocoaPods
 

--- a/docs/_integration-with-existing-apps-objc.md
+++ b/docs/_integration-with-existing-apps-objc.md
@@ -103,7 +103,7 @@ Assume the [app for integration](https://github.com/JoelMarcey/iOS-2048) is a [2
 
 ### Command Line Tools for Xcode
 
-Install the Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+Install the Command Line Tools. Choose **Settings... (or Preferences...)** in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 ![Xcode Command Line Tools](/docs/assets/GettingStartedXcodeCommandLineTools.png)
 
@@ -184,7 +184,7 @@ Sending stats
 Pod installation complete! There are 3 dependencies from the Podfile and 1 total pod installed.
 ```
 
-> If this fails with errors mentioning `xcrun`, make sure that in Xcode in **Preferences > Locations** the Command Line Tools are assigned.
+> If this fails with errors mentioning `xcrun`, make sure that in Xcode in **Settings... (or Preferences...) > Locations** the Command Line Tools are assigned.
 
 ### Code integration
 

--- a/docs/_integration-with-existing-apps-swift.md
+++ b/docs/_integration-with-existing-apps-swift.md
@@ -75,7 +75,7 @@ Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a 
 
 ### Command Line Tools for Xcode
 
-Install the Command Line Tools. Choose "Preferences..." in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
+Install the Command Line Tools. Choose **Settings... (or Preferences...)** in the Xcode menu. Go to the Locations panel and install the tools by selecting the most recent version in the Command Line Tools dropdown.
 
 ![Xcode Command Line Tools](/docs/assets/GettingStartedXcodeCommandLineTools.png)
 
@@ -117,7 +117,7 @@ Sending stats
 Pod installation complete! There are 3 dependencies from the Podfile and 1 total pod installed.
 ```
 
-> If this fails with errors mentioning `xcrun`, make sure that in Xcode in **Preferences > Locations** the Command Line Tools are assigned.
+> If this fails with errors mentioning `xcrun`, make sure that in Xcode in **Settings.. (or Preferences...) > Locations** the Command Line Tools are assigned.
 
 > If you get a warning such as "_The `swift-2048 [Debug]` target overrides the `FRAMEWORK_SEARCH_PATHS` build setting defined in `Pods/Target Support Files/Pods-swift-2048/Pods-swift-2048.debug.xcconfig`. This can lead to problems with the CocoaPods installation_", then make sure the `Framework Search Paths` in `Build Settings` for both `Debug` and `Release` only contain `$(inherited)`.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -120,7 +120,7 @@ Custom debugger commands executed this way should be short-lived processes, and 
 You can use Safari to debug the iOS version of your app without having to enable "Debug JS Remotely".
 
 - On a physical device go to: `Settings → Safari → Advanced → Make sure "Web Inspector" is turned on` (This step is not needed on the Simulator)
-- On your Mac enable Develop menu in Safari: `Preferences → Advanced → Select "Show Develop menu in menu bar"`
+- On your Mac enable Develop menu in Safari: `Settings (or Preferences) → Advanced → Select "Show Develop menu in menu bar"`
 - Select your app's JSContext: `Develop → Simulator (or other device) → JSContext`
 - Safari's Web Inspector should open which has a Console and a Debugger
 

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -87,7 +87,7 @@ You can now enable Live reloading from the [Dev Menu](debugging.md#accessing-the
 
 You can also connect to the development server over Wi-Fi. You'll first need to install the app on your device using a USB cable, but once that has been done you can debug wirelessly by following these instructions. You'll need your development machine's current IP address before proceeding.
 
-You can find the IP address in **System Preferences** → **Network**.
+You can find the IP address in **System Settings (or System Preferences)** → **Network**.
 
 1. Make sure your laptop and your phone are on the **same** Wi-Fi network.
 2. Open your React Native app on your device.


### PR DESCRIPTION
macOS Ventura and Xcode 14 rename some menus:

- **System Preferences** -> **System Settings** in **Finder**
- **Preferences** -> **Settings** in **Xcode**
- **Components** -> **Platforms** in **Xcode >  Settings**

This PR renames all related references while retaining the old ones (to support the case that older macOS or Xcode versions is used).