### PR TITLE
 change mode option with configuration in 0.71 version

### DIFF
--- a/website/versioned_docs/version-0.71/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.71/publishing-to-app-store.md
@@ -51,7 +51,7 @@ The static bundle is built every time you target a physical device, even in Debu
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
 :::info
-You can also use the `React Native CLI` to perform this operation using the option `--mode` with the value `Release` (e.g. `npx react-native run-ios --mode Release`).
+You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `npx react-native run-ios --configuration Release`).
 :::
 
 Once you are done with the testing and ready to publish to App Store, follow along with this guide.


### PR DESCRIPTION
In the documentation's "Publishing to App Store" section, there is a mistake in the "Build app for release" step. The error lies in mentioning the "--mode" option in the "run-ios" command, which should instead be "--configuration".

<img width="928" alt="image" src="https://github.com/facebook/react-native-website/assets/104450977/3d3dc561-c3d3-44a1-a3af-a67d2faa19a0">
