### PR TITLE
Correct default of nestedScrollEnabled

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -405,7 +405,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.64/scrollview.md
+++ b/website/versioned_docs/version-0.64/scrollview.md
@@ -379,7 +379,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.65/scrollview.md
+++ b/website/versioned_docs/version-0.65/scrollview.md
@@ -379,7 +379,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.66/scrollview.md
+++ b/website/versioned_docs/version-0.66/scrollview.md
@@ -389,7 +389,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.67/scrollview.md
+++ b/website/versioned_docs/version-0.67/scrollview.md
@@ -389,7 +389,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.68/scrollview.md
+++ b/website/versioned_docs/version-0.68/scrollview.md
@@ -399,7 +399,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.69/scrollview.md
+++ b/website/versioned_docs/version-0.69/scrollview.md
@@ -399,7 +399,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.70/scrollview.md
+++ b/website/versioned_docs/version-0.70/scrollview.md
@@ -399,7 +399,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 

--- a/website/versioned_docs/version-0.71/scrollview.md
+++ b/website/versioned_docs/version-0.71/scrollview.md
@@ -405,7 +405,7 @@ Enables nested scrolling for Android API level 21+.
 
 | Type | Default |
 | ---- | ------- |
-| bool | `true`  |
+| bool | `false` |
 
 ---
 


### PR DESCRIPTION
This defaults to `false`, see https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java#L188
