### PR TITLE
add logical border radius props

### DIFF
--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -111,6 +111,38 @@ export default ViewStyleProps;
 
 ---
 
+### `borderStartEndRadius`
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `borderStartStartRadius`
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `borderEndEndRadius`
+
+| Type   |
+| ------ |
+| number |
+
+---
+
+### `borderEndStartRadius`
+
+| Type   |
+| ------ |
+| number |
+
+---
+
 ### `borderBottomWidth`
 
 | Type   |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Update View Style docs to include new logical border radius props

`borderEndEndRadius`
`borderEndStartRadius`
`borderStartEndRadius`
`borderStartStartRadius`

Related: https://github.com/facebook/react-native/pull/35572
