### PR TITLE
docs: update contributing overview

### DIFF
--- a/website/contributing/contributing-overview.md
+++ b/website/contributing/contributing-overview.md
@@ -103,17 +103,18 @@ Directly in the repo, there is the [`rn-tester` app](https://github.com/facebook
 The process of proposing a change to React Native can be summarized as follows:
 
 1. Fork the React Native repository and create your branch from `main`.
-2. Make the desired changes to React Native sources. Use the `packages/rn-tester` app to test them out.
-3. If you've added code that should be tested, add tests.
-4. If you've changed APIs, update the documentation, which lives in [separate repo](https://github.com/facebook/react-native-website/).
-5. Ensure the test suite passes, either locally or on CI once you opened a pull request.
-6. Make sure your code lints (for example via `yarn lint --fix`).
-7. Push the changes to your fork.
-8. Create a pull request to the React Native repository.
-9. Review and address comments on your pull request.
-10. A bot may comment with suggestions. Generally we ask you to resolve these first before a maintainer will review your code.
-11. If changes are requested and addressed, please [request review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify reviewers to take another look.
-12. If you haven't already, please complete the [Contributor License Agreement](/contributing/contribution-license-agreement) ("CLA"). **[Complete your CLA here.](https://code.facebook.com/cla)**
+2. For editing files in Android Studio, open the root react-native folder.
+3. Make the desired changes to React Native sources. Use the `packages/rn-tester` app to test them out.
+4. If you've added code that should be tested, add tests.
+5. If you've changed APIs, update the documentation, which lives in [separate repo](https://github.com/facebook/react-native-website/).
+6. Ensure the test suite passes, either locally or on CI once you opened a pull request.
+7. Make sure your code lints (for example via `yarn lint --fix`).
+8. Push the changes to your fork.
+9. Create a pull request to the React Native repository.
+10. Review and address comments on your pull request.
+11. A bot may comment with suggestions. Generally we ask you to resolve these first before a maintainer will review your code.
+12. If changes are requested and addressed, please [request review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify reviewers to take another look.
+13. If you haven't already, please complete the [Contributor License Agreement](/contributing/contribution-license-agreement) ("CLA"). **[Complete your CLA here.](https://code.facebook.com/cla)**
 
 If all goes well, your pull request will be merged. If it is not merged, maintainers will do their best to explain the reason why.
 


### PR DESCRIPTION
## Description:

After the migration of react-native to mono-repo, the docs weren't updated for the contribution guide. Previously, we could open the `packages/rn-tester/android` in Android Studio and make the changes to the native files easily. Now opening `packages/rn-tester/android` doesn't work. We have to open the root react-native folder in Android Studio in order to edit the native files easily.

Note: I didn't intend to edit other bullet points but since I had to add the updated information as point 2, so I had to edit the subsequent numbers for bullets.

## Test Plan:

Running `yarn prettier` and `yarn language:lint` gives 🟢 light.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
