### PR TITLE
Update _getting-started-macos-android.md

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -25,10 +25,10 @@ We recommend installing the OpenJDK distribution called Azul **Zulu** using [Hom
 
 ```shell
 brew tap homebrew/cask-versions
-brew install --cask zulu11
+brew install --cask zulu
 
 # Get path to where cask was installed to double-click installer
-brew info --cask zulu11
+brew info --cask zulu
 ```
 
 After you install the JDK, update your `JAVA_HOME` environment variable. If you used above steps, JDK will likely be at `/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home`


### PR DESCRIPTION
zulu11 isn't the name anymore, looks like the cask is just called zulu now

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
