### PR TITLE
Out of boundsfix

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1714,7 +1714,7 @@ html[data-theme="dark"] .docsRating {
 /* Snack Player */
 
 .snack-player {
-  height: 544px;
+  height: 740px;
   width: 100%;
   overflow: hidden;
   margin-bottom: 24px;

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1714,7 +1714,7 @@ html[data-theme="dark"] .docsRating {
 /* Snack Player */
 
 .snack-player {
-  height: 740px;
+  height: 711px;
   width: 100%;
   overflow: hidden;
   margin-bottom: 24px;


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#3751
-->

Fixed out-of-bounds issue #3751, for embedded snack player cutting off android, and ios devices. Changed snack players height so view is no longer cutoff and there is sufficient space surrounding it.

![1](https://github.com/facebook/react-native-website/assets/86215539/b48d77e7-b857-4efc-9f48-55a462a858b5)

![2](https://github.com/facebook/react-native-website/assets/86215539/80114fd8-2847-448a-a909-a2d7e5ed171e)

