### PR TITLE
Touchups: Use `<kbd>` for specifying Keyboard Keys and Shortcuts

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -158,7 +158,7 @@ If everything is set up correctly, you should see your new app running in your A
 Now that you have successfully run the app, let's modify it.
 
 - Open `App.tsx` in your text editor of choice and edit some lines.
-- Press the `R` key twice or select `Reload` from the Dev Menu (`Ctrl + M`) to see your changes!
+- Press the <kbd>R</kbd> key twice or select `Reload` from the Dev Menu (<kbd>Ctrl</kbd> + <kbd>M</kbd>) to see your changes!
 
 <h3>That's it!</h3>
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -175,7 +175,7 @@ If everything is set up correctly, you should see your new app running in your A
 Now that you have successfully run the app, let's modify it.
 
 - Open `App.tsx` in your text editor of choice and edit some lines.
-- Press the `R` key twice or select `Reload` from the Dev Menu (`⌘M`) to see your changes!
+- Press the <kbd>R</kbd> key twice or select `Reload` from the Dev Menu (<kbd>Cmd ⌘</kbd> + <kbd>M</kbd>) to see your changes!
 
 <h3>That's it!</h3>
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -142,7 +142,7 @@ The above command will automatically run your app on the iOS Simulator by defaul
 Now that you have successfully run the app, let's modify it.
 
 - Open `App.tsx` in your text editor of choice and edit some lines.
-- Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
+- Hit <kbd>Cmd ⌘</kbd> + <kbd>R</kbd> in your iOS Simulator to reload the app and see your changes!
 
 ### That's it!
 

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -191,7 +191,7 @@ If everything is set up correctly, you should see your new app running in your A
 Now that you have successfully run the app, let's modify it.
 
 - Open `App.tsx` in your text editor of choice and edit some lines.
-- Press the `R` key twice or select `Reload` from the Dev Menu (`Ctrl + M`) to see your changes!
+- Press the <kbd>R</kbd> key twice or select `Reload` from the Dev Menu (<kbd>Ctrl</kbd> + <kbd>M</kbd>) to see your changes!
 
 <h3>That's it!</h3>
 

--- a/docs/_integration-with-existing-apps-java.md
+++ b/docs/_integration-with-existing-apps-java.md
@@ -342,7 +342,7 @@ We also need to pass back button events to React Native:
 
 This allows JavaScript to control what happens when the user presses the hardware back button (e.g. to implement navigation). When JavaScript doesn't handle the back button press, your `invokeDefaultOnBackPressed` method will be called. By default this finishes your `Activity`.
 
-Finally, we need to hook up the dev menu. By default, this is activated by (rage) shaking the device, but this is not very useful in emulators. So we make it show when you press the hardware menu button (use `Ctrl + M` if you're using Android Studio emulator):
+Finally, we need to hook up the dev menu. By default, this is activated by (rage) shaking the device, but this is not very useful in emulators. So we make it show when you press the hardware menu button (use <kbd>Ctrl</kbd> + <kbd>M</kbd> if you're using Android Studio emulator):
 
 ```java
 @Override

--- a/docs/_integration-with-existing-apps-kotlin.md
+++ b/docs/_integration-with-existing-apps-kotlin.md
@@ -319,7 +319,7 @@ override fun onBackPressed() {
 
 This allows JavaScript to control what happens when the user presses the hardware back button (e.g. to implement navigation). When JavaScript doesn't handle the back button press, your `invokeDefaultOnBackPressed` method will be called. By default this finishes your `Activity`.
 
-Finally, we need to hook up the dev menu. By default, this is activated by (rage) shaking the device, but this is not very useful in emulators. So we make it show when you press the hardware menu button (use `Ctrl + M` if you're using Android Studio emulator):
+Finally, we need to hook up the dev menu. By default, this is activated by (rage) shaking the device, but this is not very useful in emulators. So we make it show when you press the hardware menu button (use <kbd>Ctrl</kbd> + <kbd>M</kbd> if you're using Android Studio emulator):
 
 ```kotlin
 override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {

--- a/docs/publishing-to-app-store.md
+++ b/docs/publishing-to-app-store.md
@@ -48,7 +48,7 @@ The static bundle is built every time you target a physical device, even in Debu
 
 ### 3. Build app for release
 
-You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
+You can now build your app for release by tapping <kbd>Cmd ⌘</kbd> + <kbd>B</kbd> or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
 :::info
 You can also use the `React Native CLI` to perform this operation using the option `--mode` with the value `Release` (e.g. `npx react-native run-ios --mode Release`).

--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -339,7 +339,7 @@ Select your project in the Xcode Project Navigator, then select your main target
 
 ### 3. Build and Run your app
 
-If everything is set up correctly, your device will be listed as the build target in the Xcode toolbar, and it will also appear in the Devices pane (`⇧⌘2`). You can now press the **Build and run** button (`⌘R`) or select **Run** from the **Product** menu. Your app will launch on your device shortly.
+If everything is set up correctly, your device will be listed as the build target in the Xcode toolbar, and it will also appear in the Devices pane (<kbd>Shift ⇧</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>2</kbd>). You can now press the **Build and run** button (<kbd>Cmd ⌘</kbd> + <kbd>R</kbd>) or select **Run** from the **Product** menu. Your app will launch on your device shortly.
 
 ![](/docs/assets/RunningOnDeviceReady.png)
 


### PR DESCRIPTION
### Summary

Currently, some docs are diverged from using `<kbd>` and rather use \` for formatting Keyboard Keys and Shortcuts. 

This diff updates docs to use the `<kbd>` HTML tag for formatting the same and of course, adds some formatting touchups.

### Changelog

[UI] Touchups: Use `<kbd>` for specifying Keyboard Keys and Shortcuts.

---

P.S.: I came across these occurrences when working on #3732 😇
