### PR TITLE
Clarify Release Crew role timespan and responsibilities

### DIFF
--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -17,7 +17,7 @@ A Release Crew effort starts with the work on a new minor; meaning, at least one
 
 - 2 people per each release
 
-**Time commitment:** about 4 hours/week of work.
+**Time commitment:** about 4 hours/week of work until the next crew starts working on a new minor release (muti month commitment).
 
 ### Role Responsibilities
 
@@ -38,6 +38,7 @@ A Release Crew effort starts with the work on a new minor; meaning, at least one
   - When a security alert gets raised, communicates it quickly to relevant partners and internally
   - If the security fix commit lands and it’s important, coordinates with the release crew on which stable branches should get the releases and produces the patch releases accordingly
 - Can perform release or delegate release steps
+- Responsible for all active releases in the support window during the duration of the role [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported)
 
 ### Who can fill it
 
@@ -51,7 +52,7 @@ A Release Crew effort starts with the work on a new minor; meaning, at least one
 
 - 2 people per each release
 
-**Time commitment:** flexible but, most likely, a few hours per week.
+**Time commitment:** flexible but, most likely, a few hours per week until next crew starts working on a new minor release (muti month commitment).
 
 ### Role Responsibilities
 
@@ -75,6 +76,7 @@ A Release Crew effort starts with the work on a new minor; meaning, at least one
   - Trigger the rn-diff-purge script to update upgrade-helper (this is automated for 0.68 onwards)
 - Coordinates the [release testing](/contributing/release-testing)
 - Runs a release retrospective after a new minor is released
+- Responsible for all active releases in the support window during the duration of the role [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported)
 
 ### Who can fill it
 

--- a/website/contributing/release-roles-responsibilites.md
+++ b/website/contributing/release-roles-responsibilites.md
@@ -17,7 +17,7 @@ A Release Crew effort starts with the work on a new minor; meaning, at least one
 
 - 2 people per each release
 
-**Time commitment:** about 4 hours/week of work until the next crew starts working on a new minor release (muti month commitment).
+**Time commitment:** about 4 hours/week of work until the next crew starts working on a new minor release (multi month commitment).
 
 ### Role Responsibilities
 
@@ -52,7 +52,7 @@ A Release Crew effort starts with the work on a new minor; meaning, at least one
 
 - 2 people per each release
 
-**Time commitment:** flexible but, most likely, a few hours per week until next crew starts working on a new minor release (muti month commitment).
+**Time commitment:** flexible but, most likely, a few hours per week until next crew starts working on a new minor release (multi month commitment).
 
 ### Role Responsibilities
 


### PR DESCRIPTION
Clarifying that the Release Crew role is a multi month commitment that includes all supported React Native versions until the next minor work starts.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
