### PR TITLE
Update ATS instructions

### DIFF
--- a/docs/publishing-to-app-store.md
+++ b/docs/publishing-to-app-store.md
@@ -13,7 +13,7 @@ If you are using Expo, read the Expo guide for [Deploying to App Stores](https:/
 
 App Transport Security is a security feature introduced in iOS 9 that rejects all HTTP requests that are not sent over HTTPS. This can result in HTTP traffic being blocked, including the developer React Native server. ATS is disabled for `localhost` by default in React Native projects in order to make development easier.
 
-You should re-enable ATS prior to building your app for production by removing the `localhost` entry from the `NSExceptionDomains` dictionary and setting `NSAllowsArbitraryLoads` to `false` in your `Info.plist` file in the `ios/` folder. You can also re-enable ATS from within Xcode by opening your target properties under the Info pane and editing the App Transport Security Settings entry.
+You should re-enable ATS prior to building your app for production by setting `NSExceptionAllowsInsecureHTTPLoads` to `false` for the `localhost` from the `NSExceptionDomains` in your `Info.plist` file in the `ios/` folder. You can also re-enable ATS from within Xcode by opening your target properties under the Info pane and editing the App Transport Security Settings entry.
 
 :::note
 If your application needs to access HTTP resources on production, learn how to configure ATS on your project.


### PR DESCRIPTION
react-native template already does not use NSAllowsArbitraryLoads.
To guarantee secure communication, I think we can set NSAllowsInsecureHTTPLoads to false, so I have modified the instructions.