### PR TITLE
docs: iOS backwards compatibility update

### DIFF
--- a/docs/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/docs/the-new-architecture/backward-compatibility-fabric-components.md
@@ -257,6 +257,8 @@ The same two lines should be added in the implementation file, as first and last
 
 The above snippet uses the same `RCT_NEW_ARCH_ENABLED` flag used in the previous [section](#dependencies-ios). When this flag is not set, Xcode skips the lines within the `#ifdef` during compilation and it does not include them into the compiled binary. The compiled binary will have a the `RNMyComponentView.o` object but it will be an empty object.
 
+After wrapping the above components with a `#ifdef` pragma, you need to replicate the functionality of `RNMyComponentView.mm` inside `RNMyComponentViewManager.mm` to ensure the same functionality between architectures. For more information on how legacy components work, refer to [our documentation](https://reactnative.dev/docs/native-components-ios).
+
 ### Android
 
 As we can't use conditional compilation blocks on Android, we will define two different source sets. This will allow to create a backward compatible TurboModule with the proper source that is loaded and compiled depending on the used architecture.

--- a/docs/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/docs/the-new-architecture/backward-compatibility-fabric-components.md
@@ -257,7 +257,7 @@ The same two lines should be added in the implementation file, as first and last
 
 The above snippet uses the same `RCT_NEW_ARCH_ENABLED` flag used in the previous [section](#dependencies-ios). When this flag is not set, Xcode skips the lines within the `#ifdef` during compilation and it does not include them into the compiled binary. The compiled binary will have a the `RNMyComponentView.o` object but it will be an empty object.
 
-After wrapping the above components with a `#ifdef` pragma, you need to implement the component for the legacy architecture, following [the legacy Native Componente documentation](https://reactnative.dev/docs/native-components-ios). This is needed because the New Renderer works in a different way from the legacy one, and it is not able to follow the new code's paths of the New Renderer. 
+After wrapping the above components with a `#ifdef` pragma, you need to implement the component for the legacy architecture, following [the legacy Native Component documentation](https://reactnative.dev/docs/native-components-ios). This is needed because the New Renderer works in a different way from the legacy one, and it is not able to follow the new code's paths of the New Renderer.
 
 ### Android
 

--- a/docs/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/docs/the-new-architecture/backward-compatibility-fabric-components.md
@@ -257,7 +257,7 @@ The same two lines should be added in the implementation file, as first and last
 
 The above snippet uses the same `RCT_NEW_ARCH_ENABLED` flag used in the previous [section](#dependencies-ios). When this flag is not set, Xcode skips the lines within the `#ifdef` during compilation and it does not include them into the compiled binary. The compiled binary will have a the `RNMyComponentView.o` object but it will be an empty object.
 
-After wrapping the above components with a `#ifdef` pragma, you need to replicate the functionality of `RNMyComponentView.mm` inside `RNMyComponentViewManager.mm` to ensure the same functionality between architectures. For more information on how legacy components work, refer to [our documentation](https://reactnative.dev/docs/native-components-ios).
+After wrapping the above components with a `#ifdef` pragma, you need to implement the component for the legacy architecture, following [the legacy Native Componente documentation](https://reactnative.dev/docs/native-components-ios). This is needed because the New Renderer works in a different way from the legacy one, and it is not able to follow the new code's paths of the New Renderer. 
 
 ### Android
 


### PR DESCRIPTION
## Summary
The [iOS section](https://reactnative.dev/docs/the-new-architecture/backward-compatibility-fabric-components#ios-1) of the Fabric Component Backwards Compatibility docs explicitly mentions the need to update two of the three documents created in the [Fabric Component iOS Native Code section](https://reactnative.dev/docs/the-new-architecture/pillars-fabric-components#ios). 

As someone without experience writing native code, it was unclear that it is necessary to update all three documents. This PR updates the documentation to clarify that point and links back to the relevant section of the Legacy Native Component docs.

[Link to the discussion this PR stems from](https://github.com/reactwg/react-native-new-architecture/discussions/8#discussioncomment-6257033)


## Screenshot
![image](https://github.com/facebook/react-native-website/assets/24562987/217d6d67-1b5b-4ef0-ab54-1afe9227ca7e)