### PR TITLE
[docs] Remove static config note in Metro guide, adjust formatting

### DIFF
--- a/docs/metro.md
+++ b/docs/metro.md
@@ -16,7 +16,7 @@ Configuration options for Metro can be customized in your project's `metro.confi
 Please see [**Configuring Metro**](https://facebook.github.io/metro/docs/configuration) on the Metro website for documentation on all available config options.
 :::
 
-In React Native, your Metro config should extend either [@react-native/metro-config](https://www.npmjs.com/package/@react-native/metro-config) or [@expo/metro-config](https://www.npmjs.com/package/@expo/metro-config). These packages contain essential defaults necessary to build and run React Native apps.
+In React Native, your Metro config should extend either [`@react-native/metro-config`](https://www.npmjs.com/package/@react-native/metro-config) or [`@expo/metro-config`](https://www.npmjs.com/package/@expo/metro-config). These packages contain essential defaults necessary to build and run React Native apps.
 
 Below is the default `metro.config.js` file in a React Native template project:
 
@@ -35,14 +35,14 @@ const config = {};
 module.exports = mergeConfig(getDefaultConfig(__dirname), config);
 ```
 
-Metro options you wish to customize can be done so within the `config` object. We strongly recommend defining all config values statically within this file.
+Metro options you wish to customize can be done so within the `config` object.
 
 ### Advanced: Using a config function
 
 Exporting a config function is an opt-in to managing the final config yourself — **Metro will not apply any internal defaults**. This pattern can be useful when needing to read the base default config object from Metro or to set options dynamically.
 
 :::info
-**From @react-native/metro-config `0.72.1`**, it is no longer necessary to use a config function to access the complete default config. See the **Tip** section below.
+**From `@react-native/metro-config` 0.72.1**, it is no longer necessary to use a config function to access the complete default config. See the **Tip** section below.
 :::
 
 <!-- prettier-ignore -->
@@ -66,7 +66,7 @@ module.exports = function (baseConfig) {
 ```
 
 :::tip
-Using a config function is for advanced use cases. A simpler method than the above, e.g. for customising `sourceExts`, would be to read these defaults from **@react-native/metro-config**.
+Using a config function is for advanced use cases. A simpler method than the above, e.g. for customising `sourceExts`, would be to read these defaults from `@react-native/metro-config`.
 
 **Alternative**
 

--- a/website/versioned_docs/version-0.72/metro.md
+++ b/website/versioned_docs/version-0.72/metro.md
@@ -16,7 +16,7 @@ Configuration options for Metro can be customized in your project's `metro.confi
 Please see [**Configuring Metro**](https://facebook.github.io/metro/docs/configuration) on the Metro website for documentation on all available config options.
 :::
 
-In React Native, your Metro config should extend either [@react-native/metro-config](https://www.npmjs.com/package/@react-native/metro-config) or [@expo/metro-config](https://www.npmjs.com/package/@expo/metro-config). These packages contain essential defaults necessary to build and run React Native apps.
+In React Native, your Metro config should extend either [`@react-native/metro-config`](https://www.npmjs.com/package/@react-native/metro-config) or [`@expo/metro-config`](https://www.npmjs.com/package/@expo/metro-config). These packages contain essential defaults necessary to build and run React Native apps.
 
 Below is the default `metro.config.js` file in a React Native template project:
 
@@ -35,14 +35,14 @@ const config = {};
 module.exports = mergeConfig(getDefaultConfig(__dirname), config);
 ```
 
-Metro options you wish to customize can be done so within the `config` object. We strongly recommend defining all config values statically within this file.
+Metro options you wish to customize can be done so within the `config` object.
 
 ### Advanced: Using a config function
 
 Exporting a config function is an opt-in to managing the final config yourself — **Metro will not apply any internal defaults**. This pattern can be useful when needing to read the base default config object from Metro or to set options dynamically.
 
 :::info
-**From @react-native/metro-config `0.72.1`**, it is no longer necessary to use a config function to access the complete default config. See the **Tip** section below.
+**From `@react-native/metro-config` 0.72.1**, it is no longer necessary to use a config function to access the complete default config. See the **Tip** section below.
 :::
 
 <!-- prettier-ignore -->
@@ -66,7 +66,7 @@ module.exports = function (baseConfig) {
 ```
 
 :::tip
-Using a config function is for advanced use cases. A simpler method than the above, e.g. for customising `sourceExts`, would be to read these defaults from **@react-native/metro-config**.
+Using a config function is for advanced use cases. A simpler method than the above, e.g. for customising `sourceExts`, would be to read these defaults from `@react-native/metro-config`.
 
 **Alternative**
 


### PR DESCRIPTION
Small follow-up to #3772.

On **bold** vs `code` for package names:
- **pkg-name** (generally with a link) is used by npm, [Rollup](https://rollupjs.org/introduction/), [Vue](https://vuejs.org/guide/quick-start.html#using-vue-from-cdn), [Relay](https://relay.dev/docs/getting-started/prerequisites/) — I like this, but it's overwhelmed by the below 😅⬇️.
- `pkg-name` (generally with a link) is used by Expo, [react-native-windows](https://microsoft.github.io/react-native-windows/docs/getting-started), Node.js and [across this website](http://localhost:3000/docs/upgrading).

⬆️ cc @Simek Feels worth adding a brief style guide to this repo, I'd also like to align our use of keyboard shortcuts in a future PR (`<kbd>` and with key names, e.g.: <kbd>Cmd ⌘</kbd> + <kbd>K</kbd>).