### PR TITLE
Clarify documentation for turbomodules

### DIFF
--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -151,14 +151,16 @@ The shared configuration is a `package.json` file used by yarn when installing y
     "react": "*",
     "react-native": "*"
   },
-  "codegenConfig": [{
-    "name": "RTNCalculatorSpec",
-    "type": "modules",
-    "jsSrcsDir": "js",
-    "android": {
-      "javaPackageName": "com.rtncalculator"
+  "codegenConfig": [
+    {
+      "name": "RTNCalculatorSpec",
+      "type": "modules",
+      "jsSrcsDir": "js",
+      "android": {
+        "javaPackageName": "com.rtncalculator"
+      }
     }
-  }]
+  ]
 }
 ```
 

--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -151,14 +151,14 @@ The shared configuration is a `package.json` file used by yarn when installing y
     "react": "*",
     "react-native": "*"
   },
-  "codegenConfig": {
+  "codegenConfig": [{
     "name": "RTNCalculatorSpec",
     "type": "modules",
     "jsSrcsDir": "js",
     "android": {
       "javaPackageName": "com.rtncalculator"
     }
-  }
+  }]
 }
 ```
 

--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -151,16 +151,14 @@ The shared configuration is a `package.json` file used by yarn when installing y
     "react": "*",
     "react-native": "*"
   },
-  "codegenConfig": [
-    {
-      "name": "RTNCalculatorSpec",
-      "type": "modules",
-      "jsSrcsDir": "js",
-      "android": {
-        "javaPackageName": "com.rtncalculator"
-      }
+  "codegenConfig": {
+    "name": "RTNCalculatorSpec",
+    "type": "modules",
+    "jsSrcsDir": "js",
+    "android": {
+      "javaPackageName": "com.rtncalculator"
     }
-  ]
+  }
 }
 ```
 
@@ -168,7 +166,7 @@ The upper part of the file contains some descriptive information like the name o
 
 Then there are the dependencies for this package. For this guide, you need `react` and `react-native`.
 
-Finally, the **Codegen** configuration is specified by the `codegenConfig` field. It contains an array of libraries, each of which is defined by three other fields:
+Finally, the **Codegen** configuration is specified by the `codegenConfig` field. It contains an object that defines the module through four fields:
 
 - `name`: The name of the library. By convention, you should add the `Spec` suffix.
 - `type`: The type of module contained by this package. In this case, it is a Turbo Native Module; thus, the value to use is `modules`.


### PR DESCRIPTION
Documentation clarification for this page:
https://reactnative.dev/docs/next/the-new-architecture/pillars-turbomodules#shared

`codegenConfig` is stated in text that it's an array, but in code example it's an object. See highlighted text-selection in the attached screenshot.

Either the text or the code example should change. **This PR changes the code example**, if this assumption is wrong I can open another PR changing the text.

---

<img width="827" alt="Screenshot 2023-07-07 at 07 57 51" src="https://github.com/facebook/react-native-website/assets/457653/369608ae-4f78-4197-b4d1-a8fe1aef0610">

---

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
