### PR TITLE
Update barStyle enum prop description on StatusBar component

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -470,8 +470,8 @@ Status bar style type.
 
 **Constants:**
 
-| Value             | Type   | Description                                                          |
-| ----------------- | ------ | -------------------------------------------------------------------- |
-| `'default'`       | string | Default status bar style (dark for iOS, light for Android)           |
-| `'light-content'` | string | White texts and icons                                                |
-| `'dark-content'`  | string | Dark texts and icons (requires API>=23 on Android)                   |
+| Value             | Type   | Description                                                |
+| ----------------- | ------ | ---------------------------------------------------------- |
+| `'default'`       | string | Default status bar style (dark for iOS, light for Android) |
+| `'light-content'` | string | White texts and icons                                      |
+| `'dark-content'`  | string | Dark texts and icons (requires API>=23 on Android)         |

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -473,5 +473,5 @@ Status bar style type.
 | Value             | Type   | Description                                                          |
 | ----------------- | ------ | -------------------------------------------------------------------- |
 | `'default'`       | string | Default status bar style (dark for iOS, light for Android)           |
-| `'light-content'` | string | Dark background, white texts and icons                               |
-| `'dark-content'`  | string | Light background, dark texts and icons (requires API>=23 on Android) |
+| `'light-content'` | string | White texts and icons                               |
+| `'dark-content'`  | string | Dark texts and icons (requires API>=23 on Android) |

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -473,5 +473,5 @@ Status bar style type.
 | Value             | Type   | Description                                                          |
 | ----------------- | ------ | -------------------------------------------------------------------- |
 | `'default'`       | string | Default status bar style (dark for iOS, light for Android)           |
-| `'light-content'` | string | White texts and icons                               |
-| `'dark-content'`  | string | Dark texts and icons (requires API>=23 on Android) |
+| `'light-content'` | string | White texts and icons                                                |
+| `'dark-content'`  | string | Dark texts and icons (requires API>=23 on Android)                   |


### PR DESCRIPTION
The barStyle description with 'Light/Dark background' confuses, because the prop does not change the background color

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
