### PR TITLE
docs: fix npm commands on running on specific emulators

### DIFF
--- a/docs/running-on-simulator-ios.md
+++ b/docs/running-on-simulator-ios.md
@@ -36,7 +36,7 @@ You can specify the device the simulator should run with the `--simulator` flag,
 <TabItem value="npm">
 
 ```shell
-npm run ios -- --simulator="iPhone SE (3rd generation)"
+npm run ios --simulator="iPhone SE (3rd generation)"
 ```
 
 </TabItem>
@@ -59,7 +59,7 @@ If you have multiple iOS versions installed, you also need to specify it's appro
 <TabItem value="npm">
 
 ```shell
-npm run ios -- --simulator="iPhone 14 Pro (16.0)"
+npm run ios --simulator="iPhone 14 Pro (16.0)"
 ```
 
 </TabItem>
@@ -80,7 +80,7 @@ You can specify the device UDID returned from `xcrun simctl list devices` comman
 <TabItem value="npm">
 
 ```shell
-npm run ios -- --udid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
+npm run ios --udid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
 ```
 
 </TabItem>


### PR DESCRIPTION
Noticed the `npm` commands are incorrect as they had extra dashes, this commit removes them.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
