### PR TITLE
Update guidance on repo build scripts

### DIFF
--- a/website/contributing/how-to-contribute-code.md
+++ b/website/contributing/how-to-contribute-code.md
@@ -22,10 +22,6 @@ Now you are set up to run several commands:
 - `yarn start` starts the Metro packager server.
 - `yarn lint` checks the code style.
 - `yarn format` automatically formats your code.
-- `yarn build` builds all configured packages (also run by `yarn start`).
-  - `yarn watch` watches packages and rebuilds files on change.
-  - `yarn clean` cleans package build directories.
-  - Packages which require a build are configured in [scripts/build/config.js](https://github.com/facebook/react-native/blob/main/scripts/build/config.js).
 - `yarn test` runs the Jest-based JavaScript test suite.
   - `yarn test --watch` runs an interactive JavaScript test watcher.
   - `yarn test <pattern>` runs JavaScript tests with matching filenames.
@@ -34,6 +30,8 @@ Now you are set up to run several commands:
   - `yarn flow-check-ios` does a full Flow check over `*.ios.js` files.
 - `yarn test-typescript` runs the [TypeScript](https://www.typescriptlang.org/) typechecks.
 - `yarn test-ios` runs the iOS test suite (macOS required).
+- `yarn build` builds all configured packages — in general, this command only needs to be run by CI ahead of publishing.
+    - Packages which require a build are configured in [scripts/build/config.js](https://github.com/facebook/react-native/blob/main/scripts/build/config.js).
 
 ## Testing your Changes
 

--- a/website/contributing/how-to-open-a-pull-request.md
+++ b/website/contributing/how-to-open-a-pull-request.md
@@ -48,24 +48,11 @@ We recommend creating a new branch in your fork to keep track of your changes:
 git checkout --branch my_feature_branch --track origin/main
 ```
 
-### 4. Run `yarn` and build packages
-
-This will install all JavaScript dependencies, and build all necessary packages inside the repo. The following should be run from the repo root:
-
-```sh
-yarn
-yarn build
-```
-
-`yarn build` is also run as part of `yarn start`.
-
 ## Chapter II: Implementing your Changes
 
 ### 1. Make changes to the code
 
 You can now make any changes deemed necessary using your code editor of choice. [Visual Studio Code](https://code.visualstudio.com/) is popular with JavaScript developers. If you're mostly making changes to iOS or Android, using Xcode or Android Studio might provide a nicer integrated experience.
-
-If you are making changes inside a package with a JavaScript build, you can use `yarn watch` to continuously rebuild as you make changes.
 
 ### 2. Test your changes
 
@@ -75,7 +62,7 @@ Make sure your changes are correct and do not introduce any test failures. You c
 
 We understand it can take a while to ramp up and get a sense of the style followed for each of the languages in use in the core React Native repository. Developers should not need to worry about minor nits, so whenever possible, we use tools that automate the process of rewriting your code to follow conventions.
 
-For example, we use [Prettier](https://prettier.io/) to format our JavaScript code. This saves you time and energy as you can let Prettier fix up any formatting issues automatically through its editor integrations, or by manually running `yarn run prettier`.
+For example, we use [Prettier](https://prettier.io/) to format our JavaScript code. This saves you time and energy as you can let Prettier fix up any formatting issues automatically through its editor integrations, or by manually running `yarn run prettier`. 
 
 We also use a linter to catch styling issues that may exist in your code. You can check the status of your code styling by running `yarn run lint`.
 


### PR DESCRIPTION
Removes mandatory run of `yarn build/watch` when developing Node.js packages — matching the updated build setup in https://github.com/facebook/react-native/pull/38718 (these packages are now set up to run from source during development).

Partially reverts #3788 "[docs] Add guidance on repo build scripts"

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
