### PR TITLE
Fix native module type conversion tables for iOS and Android

### DIFF
--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -445,6 +445,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | double        |               | number     |
 | String        | String        | string     |
 | Callback      | Callback      | Function   |
+| Promise       | Promise       | Promise    |
 | ReadableMap   | ReadableMap   | Object     |
 | ReadableArray | ReadableArray | Array      |
 

--- a/docs/native-modules-ios.md
+++ b/docs/native-modules-ios.md
@@ -269,7 +269,6 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | --------------------------------------------- | ------------------ |
 | NSString                                      | string, ?string    |
 | BOOL                                          | boolean            |
-| NSNumber                                      | ?boolean           |
 | double                                        | number             |
 | NSNumber                                      | ?number            |
 | NSArray                                       | Array, ?Array      |

--- a/website/versioned_docs/version-0.70/native-modules-android.md
+++ b/website/versioned_docs/version-0.70/native-modules-android.md
@@ -432,6 +432,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | double        |               | number     |
 | String        | String        | string     |
 | Callback      | Callback      | Function   |
+| Promise       | Promise       | Promise    |
 | ReadableMap   | ReadableMap   | Object     |
 | ReadableArray | ReadableArray | Array      |
 

--- a/website/versioned_docs/version-0.70/native-modules-ios.md
+++ b/website/versioned_docs/version-0.70/native-modules-ios.md
@@ -255,7 +255,6 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | --------------------------------------------- | ------------------ |
 | NSString                                      | string, ?string    |
 | BOOL                                          | boolean            |
-| NSNumber                                      | ?boolean           |
 | double                                        | number             |
 | NSNumber                                      | ?number            |
 | NSArray                                       | Array, ?Array      |

--- a/website/versioned_docs/version-0.71/native-modules-android.md
+++ b/website/versioned_docs/version-0.71/native-modules-android.md
@@ -432,6 +432,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | double        |               | number     |
 | String        | String        | string     |
 | Callback      | Callback      | Function   |
+| Promise       | Promise       | Promise    |
 | ReadableMap   | ReadableMap   | Object     |
 | ReadableArray | ReadableArray | Array      |
 

--- a/website/versioned_docs/version-0.71/native-modules-ios.md
+++ b/website/versioned_docs/version-0.71/native-modules-ios.md
@@ -255,7 +255,6 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | --------------------------------------------- | ------------------ |
 | NSString                                      | string, ?string    |
 | BOOL                                          | boolean            |
-| NSNumber                                      | ?boolean           |
 | double                                        | number             |
 | NSNumber                                      | ?number            |
 | NSArray                                       | Array, ?Array      |

--- a/website/versioned_docs/version-0.72/native-modules-android.md
+++ b/website/versioned_docs/version-0.72/native-modules-android.md
@@ -445,6 +445,7 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | double        |               | number     |
 | String        | String        | string     |
 | Callback      | Callback      | Function   |
+| Promise       | Promise       | Promise    |
 | ReadableMap   | ReadableMap   | Object     |
 | ReadableArray | ReadableArray | Array      |
 

--- a/website/versioned_docs/version-0.72/native-modules-ios.md
+++ b/website/versioned_docs/version-0.72/native-modules-ios.md
@@ -269,7 +269,6 @@ When a native module method is invoked in JavaScript, React Native converts the 
 | --------------------------------------------- | ------------------ |
 | NSString                                      | string, ?string    |
 | BOOL                                          | boolean            |
-| NSNumber                                      | ?boolean           |
 | double                                        | number             |
 | NSNumber                                      | ?number            |
 | NSArray                                       | Array, ?Array      |


### PR DESCRIPTION
Within the native module documentations there were two errors in the type conversion tables.

For Android the Promise type was missing from the conversion table.

For iOS two NSNumber conversions were present in the type conversion table. One of which stated NSNumber would be converted into a ?boolean. This table entry was removed as this seems to be not true. The other NSNumber entry which states NSNumber is converted to number? was left untouched.