### PR TITLE
chore: prepare docs for Docusaurus v3 upgrade - 2nd iteration

### DIFF
--- a/docs/native-components-ios.md
+++ b/docs/native-components-ios.md
@@ -286,7 +286,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRegionChange, RCTBubblingEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, MKMapView)
 {
-	[view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
+  [view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
 }
 
 - (UIView *)view

--- a/docs/profile-hermes.md
+++ b/docs/profile-hermes.md
@@ -71,7 +71,7 @@ To open the profile in Chrome DevTools:
 2. Select the **Performance** tab.
 3. Right click and choose **Load profile...**
 
- <img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
+<img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
 
 ## How does the Hermes Profile Transformer work?
 

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -402,9 +402,9 @@ See what push permissions are currently enabled.
 
 `callback` will be invoked with a `permissions` object:
 
-- `alert` :boolean
-- `badge` :boolean
-- `sound` :boolean
+- `alert: boolean`
+- `badge: boolean`
+- `sound: boolean`
 
 ---
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -751,7 +751,7 @@ Displays the scroll indicators momentarily.
 scrollTo(
   options?: {x?: number, y?: number, animated?: boolean} | number,
   deprecatedX?: number,
-	deprecatedAnimated?: boolean,
+  deprecatedAnimated?: boolean,
 );
 ```
 

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -168,7 +168,7 @@ static SelectableBackground(
 ): ThemeAttributeBackgroundPropType;
 ```
 
-Creates an object that represents android theme's default background for selectable elements (?android:attr/selectableItemBackground). `rippleRadius` parameter controls the radius of the ripple effect.
+Creates an object that represents android theme's default background for selectable elements (`?android:attr/selectableItemBackground`). `rippleRadius` parameter controls the radius of the ripple effect.
 
 ---
 

--- a/website/architecture/render-pipeline.md
+++ b/website/architecture/render-pipeline.md
@@ -160,7 +160,7 @@ React Native renderer leverages structural sharing to minimize the overhead of i
 
 In the above example, React creates the new tree using these operations:
 
-1. CloneNode(**Node 3**, {backgroundColor: 'yellow'}) → **Node 3'**
+1. CloneNode(**Node 3**, `{backgroundColor: 'yellow'}`) → **Node 3'**
 2. CloneNode(**Node 2**) → **Node 2'**
 3. AppendChild(**Node 2'**, **Node 3'**)
 4. AppendChild(**Node 2'**, **Node 4**)

--- a/website/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
+++ b/website/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
@@ -15,9 +15,10 @@ This involved changing [css-layout](https://github.com/facebook/css-layout), the
 
 To battle test the RTL support in production, the latest version of the **Facebook Ads Manager** app (the first cross-platform 100% RN app) is now available in Arabic and Hebrew with RTL layouts for both [iOS](https://itunes.apple.com/app/id964397083) and [Android](https://play.google.com/store/apps/details?id=com.facebook.adsmanager). Here is how it looks like in those RTL languages:
 
+<>
 <img src="/blog/assets/rtl-ama-ios-arabic.png" width={280} style={{ margin: 10 }} />
-
 <img src="/blog/assets/rtl-ama-android-hebrew.png" width={280} style={{ margin: 10 }} />
+</>
 
 ## Overview Changes in RN for RTL support
 

--- a/website/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
+++ b/website/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
@@ -53,15 +53,15 @@ With this update, when you allow RTL layout for your app:
 
    ```objc
    // in AppDelegate.m
-   		[[RCTI18nUtil sharedInstance] allowRTL:YES];
+     [[RCTI18nUtil sharedInstance] allowRTL:YES];
    ```
 
    Android:
 
    ```java
    // in MainActivity.java
-   		I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
-   		sharedI18nUtilInstance.allowRTL(context, true);
+     I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
+     sharedI18nUtilInstance.allowRTL(context, true);
    ```
 
 3. For Android, you need add `android:supportsRtl="true"` to the [`<application>`](https://developer.android.com/guide/topics/manifest/application-element.html) element in `AndroidManifest.xml` file.

--- a/website/blog/2016-12-05-easier-upgrades.md
+++ b/website/blog/2016-12-05-easier-upgrades.md
@@ -79,26 +79,26 @@ index e98ebb0..2fb6a11 100644
 All we need now is to apply this patch to your source files. While the old `react-native upgrade` process would have prompted you for any small difference, Git is able to merge most of the changes automatically using its 3-way merge algorithm and eventually leave us with familiar conflict delimiters:
 
 ```
-		13B07F951A680F5B00A75B9A /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+    13B07F951A680F5B00A75B9A /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+        ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 <<<<<<< ours
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/HockeySDK.embeddedframework",
-					"$(PROJECT_DIR)/HockeySDK-iOS/HockeySDK.embeddedframework",
-				);
+        CODE_SIGN_IDENTITY = "iPhone Developer";
+        FRAMEWORK_SEARCH_PATHS = (
+          "$(inherited)",
+          "$(PROJECT_DIR)/HockeySDK.embeddedframework",
+          "$(PROJECT_DIR)/HockeySDK-iOS/HockeySDK.embeddedframework",
+        );
 =======
-				CURRENT_PROJECT_VERSION = 1;
+        CURRENT_PROJECT_VERSION = 1;
 >>>>>>> theirs
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
-				);
+        HEADER_SEARCH_PATHS = (
+          "$(inherited)",
+          /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+          "$(SRCROOT)/../node_modules/react-native/React/**",
+          "$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
+        );
 ```
 
 These conflicts are generally easy to reason about. The delimiter **ours** stands for "your team" whereas **theirs** could be seen as "the React Native team".

--- a/website/blog/2016-12-05-easier-upgrades.md
+++ b/website/blog/2016-12-05-easier-upgrades.md
@@ -65,14 +65,14 @@ index e98ebb0..2fb6a11 100644
 --- a/ios/MyAwesomeApp/Info.plist
 +++ b/ios/MyAwesomeApp/Info.plist
 @@ -45,7 +45,7 @@
- 		<dict>
- 			<key>localhost</key>
- 			<dict>
--				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
- 				<true/>
- 			</dict>
- 		</dict>
+        <dict>
+            <key>localhost</key>
+            <dict>
+-               <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
++               <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
 [...]
 ```
 

--- a/website/blog/2021-09-01-preparing-your-app-for-iOS-15-and-android-12.md
+++ b/website/blog/2021-09-01-preparing-your-app-for-iOS-15-and-android-12.md
@@ -65,7 +65,7 @@ Android 12 introduces new [overscroll effect](https://developer.android.com/abou
 
 #### Permission Updates
 
-Android 12 allows users of your app to only provide access to the approximate location if you request it with **`ACCESS_FINE_LOCATION`** permission**.** Learn more about it [here](https://developer.android.com/about/versions/12/approximate-location).
+Android 12 allows users of your app to only provide access to the approximate location if you request it with **`ACCESS_FINE_LOCATION`** permission. Learn more about it [here](https://developer.android.com/about/versions/12/approximate-location).
 
 Check out Google’s [detailed behavior changes](https://developer.android.com/about/versions/12/behavior-changes-all) for all apps running on Android 12.
 

--- a/website/versioned_docs/version-0.70/native-components-ios.md
+++ b/website/versioned_docs/version-0.70/native-components-ios.md
@@ -286,7 +286,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRegionChange, RCTBubblingEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, MKMapView)
 {
-	[view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
+  [view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
 }
 
 - (UIView *)view

--- a/website/versioned_docs/version-0.70/profile-hermes.md
+++ b/website/versioned_docs/version-0.70/profile-hermes.md
@@ -93,7 +93,7 @@ To open the profile in Chrome DevTools:
 2. Select the **Performance** tab.
 3. Right click and choose **Load profile...**
 
- <img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
+<img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
 
 ## How does the Hermes Profile Transformer work?
 

--- a/website/versioned_docs/version-0.70/pushnotificationios.md
+++ b/website/versioned_docs/version-0.70/pushnotificationios.md
@@ -386,9 +386,9 @@ See what push permissions are currently enabled.
 
 `callback` will be invoked with a `permissions` object:
 
-- `alert` :boolean
-- `badge` :boolean
-- `sound` :boolean
+- `alert: boolean`
+- `badge: boolean`
+- `sound: boolean`
 
 ---
 

--- a/website/versioned_docs/version-0.70/scrollview.md
+++ b/website/versioned_docs/version-0.70/scrollview.md
@@ -745,7 +745,7 @@ Displays the scroll indicators momentarily.
 scrollTo(
   options?: { x?: number, y?: number, animated?: boolean } | number,
   deprecatedX?: number,
-	deprecatedAnimated?: boolean,
+  deprecatedAnimated?: boolean,
 );
 ```
 

--- a/website/versioned_docs/version-0.70/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.70/touchablenativefeedback.md
@@ -158,7 +158,7 @@ TV next focus up (see documentation for the View component).
 static SelectableBackground(rippleRadius: ?number)
 ```
 
-Creates an object that represents android theme's default background for selectable elements (?android:attr/selectableItemBackground). `rippleRadius` parameter controls the radius of the ripple effect.
+Creates an object that represents android theme's default background for selectable elements (`?android:attr/selectableItemBackground`). `rippleRadius` parameter controls the radius of the ripple effect.
 
 ---
 

--- a/website/versioned_docs/version-0.71/native-components-ios.md
+++ b/website/versioned_docs/version-0.71/native-components-ios.md
@@ -286,7 +286,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRegionChange, RCTBubblingEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, MKMapView)
 {
-	[view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
+  [view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
 }
 
 - (UIView *)view

--- a/website/versioned_docs/version-0.71/profile-hermes.md
+++ b/website/versioned_docs/version-0.71/profile-hermes.md
@@ -71,7 +71,7 @@ To open the profile in Chrome DevTools:
 2. Select the **Performance** tab.
 3. Right click and choose **Load profile...**
 
- <img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
+<img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
 
 ## How does the Hermes Profile Transformer work?
 

--- a/website/versioned_docs/version-0.71/pushnotificationios.md
+++ b/website/versioned_docs/version-0.71/pushnotificationios.md
@@ -402,9 +402,9 @@ See what push permissions are currently enabled.
 
 `callback` will be invoked with a `permissions` object:
 
-- `alert` :boolean
-- `badge` :boolean
-- `sound` :boolean
+- `alert: boolean`
+- `badge: boolean`
+- `sound: boolean`
 
 ---
 

--- a/website/versioned_docs/version-0.71/scrollview.md
+++ b/website/versioned_docs/version-0.71/scrollview.md
@@ -751,7 +751,7 @@ Displays the scroll indicators momentarily.
 scrollTo(
   options?: {x?: number, y?: number, animated?: boolean} | number,
   deprecatedX?: number,
-	deprecatedAnimated?: boolean,
+  deprecatedAnimated?: boolean,
 );
 ```
 

--- a/website/versioned_docs/version-0.71/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.71/touchablenativefeedback.md
@@ -168,7 +168,7 @@ static SelectableBackground(
 ): ThemeAttributeBackgroundPropType;
 ```
 
-Creates an object that represents android theme's default background for selectable elements (?android:attr/selectableItemBackground). `rippleRadius` parameter controls the radius of the ripple effect.
+Creates an object that represents android theme's default background for selectable elements (`?android:attr/selectableItemBackground`). `rippleRadius` parameter controls the radius of the ripple effect.
 
 ---
 

--- a/website/versioned_docs/version-0.72/native-components-ios.md
+++ b/website/versioned_docs/version-0.72/native-components-ios.md
@@ -286,7 +286,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRegionChange, RCTBubblingEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, MKMapView)
 {
-	[view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
+  [view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
 }
 
 - (UIView *)view

--- a/website/versioned_docs/version-0.72/profile-hermes.md
+++ b/website/versioned_docs/version-0.72/profile-hermes.md
@@ -71,7 +71,7 @@ To open the profile in Chrome DevTools:
 2. Select the **Performance** tab.
 3. Right click and choose **Load profile...**
 
- <img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
+<img src="/docs/assets/openChromeProfile.png" alt="Loading a performance profile on Chrome DevTools" />
 
 ## How does the Hermes Profile Transformer work?
 

--- a/website/versioned_docs/version-0.72/pushnotificationios.md
+++ b/website/versioned_docs/version-0.72/pushnotificationios.md
@@ -402,9 +402,9 @@ See what push permissions are currently enabled.
 
 `callback` will be invoked with a `permissions` object:
 
-- `alert` :boolean
-- `badge` :boolean
-- `sound` :boolean
+- `alert: boolean`
+- `badge: boolean`
+- `sound: boolean`
 
 ---
 

--- a/website/versioned_docs/version-0.72/scrollview.md
+++ b/website/versioned_docs/version-0.72/scrollview.md
@@ -751,7 +751,7 @@ Displays the scroll indicators momentarily.
 scrollTo(
   options?: {x?: number, y?: number, animated?: boolean} | number,
   deprecatedX?: number,
-	deprecatedAnimated?: boolean,
+  deprecatedAnimated?: boolean,
 );
 ```
 

--- a/website/versioned_docs/version-0.72/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.72/touchablenativefeedback.md
@@ -168,7 +168,7 @@ static SelectableBackground(
 ): ThemeAttributeBackgroundPropType;
 ```
 
-Creates an object that represents android theme's default background for selectable elements (?android:attr/selectableItemBackground). `rippleRadius` parameter controls the radius of the ripple effect.
+Creates an object that represents android theme's default background for selectable elements (`?android:attr/selectableItemBackground`). `rippleRadius` parameter controls the radius of the ripple effect.
 
 ---
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10997,9 +10997,9 @@ prism-react-renderer@^1.3.5:
   integrity sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==
 
 prismjs@^1.28.0:
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.28.0.tgz#0d8f561fa0f7cf6ebca901747828b149147044b6"
-  integrity sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
 
 proc-log@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This is a follow-up of https://github.com/facebook/react-native-website/pull/3807

The goal is to adjust docs so that they render exactly the same on MDX v1 and MDX v2.
This permits my visual regression tests to avoid reporting false positives due to MDX behavior changes.

This also permitted to catch a few typos and inconsistencies.

Preview: https://deploy-preview-3830--react-native.netlify.app/

