### PR TITLE
Add Reactiflux to list of communities

### DIFF
--- a/website/community/communities.md
+++ b/website/community/communities.md
@@ -18,6 +18,12 @@ Some companies actively involved in the React Native have also their own communi
 - [Infinite Red's](https://infinite.red/) [Slack Group](https://community.infinite.red/)
 - [Expo's](https://expo.dev/) [Discord server](https://chat.expo.dev/)
 
+### Independent communities
+
+Organic communities of React Native developers, not sponsored by a business with a commercial interest.
+
+- [The Reactiflux community](https://reactiflux.com) on [Discord](https://discord.gg/reactiflux)
+
 ### Content sharing
 
 React Native tagged content can be found on many platforms, such as:


### PR DESCRIPTION
Since it's not either company-based nor explicitly for content sharing, I added a new "Independent communities" header as well. Reactiflux has had a React Native section since its inception! I didn't realize we hadn't requested to be listed before 😄 
