### PR TITLE
Remove out dated caveat about using setTimeout from a headless js task

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -193,7 +193,6 @@ If you wish all errors to cause a retry attempt, you will need to catch them and
 
 ## Caveats
 
-- The function passed to `setTimeout` does not always behave as expected. Instead the function is called only when the application is launched again. If you only need to wait, use the retry functionality.
 - By default, your app will crash if you try to run a task while the app is in the foreground. This is to prevent developers from shooting themselves in the foot by doing a lot of work in a task and slowing the UI. You can pass a fourth `boolean` argument to control this behaviour.
 - If you start your service from a `BroadcastReceiver`, make sure to call `HeadlessJsTaskService.acquireWakeLockNow()` before returning from `onReceive()`.
 

--- a/website/versioned_docs/version-0.70/headless-js-android.md
+++ b/website/versioned_docs/version-0.70/headless-js-android.md
@@ -193,7 +193,6 @@ If you wish all errors to cause a retry attempt, you will need to catch them and
 
 ## Caveats
 
-- The function passed to `setTimeout` does not always behave as expected. Instead the function is called only when the application is launched again. If you only need to wait, use the retry functionality.
 - By default, your app will crash if you try to run a task while the app is in the foreground. This is to prevent developers from shooting themselves in the foot by doing a lot of work in a task and slowing the UI. You can pass a fourth `boolean` argument to control this behaviour.
 - If you start your service from a `BroadcastReceiver`, make sure to call `HeadlessJsTaskService.acquireWakeLockNow()` before returning from `onReceive()`.
 

--- a/website/versioned_docs/version-0.71/headless-js-android.md
+++ b/website/versioned_docs/version-0.71/headless-js-android.md
@@ -193,7 +193,6 @@ If you wish all errors to cause a retry attempt, you will need to catch them and
 
 ## Caveats
 
-- The function passed to `setTimeout` does not always behave as expected. Instead the function is called only when the application is launched again. If you only need to wait, use the retry functionality.
 - By default, your app will crash if you try to run a task while the app is in the foreground. This is to prevent developers from shooting themselves in the foot by doing a lot of work in a task and slowing the UI. You can pass a fourth `boolean` argument to control this behaviour.
 - If you start your service from a `BroadcastReceiver`, make sure to call `HeadlessJsTaskService.acquireWakeLockNow()` before returning from `onReceive()`.
 

--- a/website/versioned_docs/version-0.72/headless-js-android.md
+++ b/website/versioned_docs/version-0.72/headless-js-android.md
@@ -193,7 +193,6 @@ If you wish all errors to cause a retry attempt, you will need to catch them and
 
 ## Caveats
 
-- The function passed to `setTimeout` does not always behave as expected. Instead the function is called only when the application is launched again. If you only need to wait, use the retry functionality.
 - By default, your app will crash if you try to run a task while the app is in the foreground. This is to prevent developers from shooting themselves in the foot by doing a lot of work in a task and slowing the UI. You can pass a fourth `boolean` argument to control this behaviour.
 - If you start your service from a `BroadcastReceiver`, make sure to call `HeadlessJsTaskService.acquireWakeLockNow()` before returning from `onReceive()`.
 


### PR DESCRIPTION
Hey Team,

I think this caveat is outdated.

This was fixed in https://github.com/facebook/react-native/pull/33044 and it's now possible to use setTimeout from a HeadlessJsTask.

See:
https://github.com/facebook/react-native/pull/33043
https://github.com/facebook/react-native/pull/33044

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
