### PR TITLE
change file extension to ts in turbo modules creation guide

### DIFF
--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -759,7 +759,7 @@ TurboModulesGuide
     │   ├── RTNCalculator.h
     │   └── RTNCalculator.mm
     ├── js
-    │   └── NativeCalculator.js
+    │   └── NativeCalculator.ts
     ├── package.json
     └── rtn-calculator.podspec
 ```

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
@@ -759,7 +759,7 @@ TurboModulesGuide
     │   ├── RTNCalculator.h
     │   └── RTNCalculator.mm
     ├── js
-    │   └── NativeCalculator.js
+    │   └── NativeCalculator.ts
     ├── package.json
     └── rtn-calculator.podspec
 ```

--- a/website/versioned_docs/version-0.72/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.72/the-new-architecture/pillars-turbomodule.md
@@ -759,7 +759,7 @@ TurboModulesGuide
     │   ├── RTNCalculator.h
     │   └── RTNCalculator.mm
     ├── js
-    │   └── NativeCalculator.js
+    │   └── NativeCalculator.ts
     ├── package.json
     └── rtn-calculator.podspec
 ```


### PR DESCRIPTION
Minor fix of file extension cause for someone it can be confusing to have .js file in final result when typescript code was used at the beginning 
