### PR TITLE
Fix button text alignment on Mobile devices

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -140,7 +140,6 @@ const styles = StyleSheet.create({
     marginHorizontal: '1%',
     marginBottom: 6,
     minWidth: '48%',
-    textAlign: 'center',
   },
   selected: {
     backgroundColor: 'coral',
@@ -150,6 +149,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '500',
     color: 'coral',
+    textAlign: 'center',
   },
   selectedLabel: {
     color: 'white',


### PR DESCRIPTION
Button text were aligned center on web, but were left aligned on Android and iOS

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
