### PR TITLE
Simplify "Flex Direction" example

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -113,7 +113,7 @@ const PreviewLayout = ({
         </TouchableOpacity>
       ))}
     </View>
-    <View style={[styles.container, {[label]: selectedValue}]}>{children}</View>
+    <View style={[styles.container, {flexDirection: selectedValue}]}>{children}</View>
   </View>
 );
 


### PR DESCRIPTION
Replace the dynamic `[label]` key with the static `flexDirection` key.

Is there a specific reason to make the key dynamic, if the only relevant value will always be `flexDirection`? It was kinda complicated for me to understand the meaning of it, skimming through the code.