### PR TITLE
Fix link to redirect to standalone react-devtools

### DIFF
--- a/website/versioned_docs/version-0.72/debugging.md
+++ b/website/versioned_docs/version-0.72/debugging.md
@@ -66,7 +66,7 @@ From here, select `More Tools → Developer Tools` from the Chrome menu to open 
 - You may want to enable [Pause on Caught Exceptions](https://developer.chrome.com/docs/devtools/javascript/breakpoints/#exceptions) for a better debugging experience.
 
 :::info
-The React Developer Tools Chrome extension does not work with React Native, but you can use its standalone version instead. Read [this section](debugging.md#react-developer-tools) to learn how.
+The React Developer Tools Chrome extension does not work with React Native, but you can use its standalone version instead. Read [this section](react-devtools) to learn how.
 :::
 
 :::note


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
