### PR TITLE
Delist unmaintained Out-of-Tree Platforms

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -12,10 +12,8 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 **From Community**
 
-- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
-- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 - [React Native Skia](https://github.com/react-native-skia/react-native-skia) - React Native using [Skia](https://skia.org/) as a renderer. Currently supports Linux and macOS.
 
 ## Creating your own React Native platform

--- a/website/versioned_docs/version-0.71/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.71/out-of-tree-platforms.md
@@ -12,10 +12,8 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 **From Community**
 
-- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
-- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 
 ## Creating your own React Native platform
 

--- a/website/versioned_docs/version-0.72/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.72/out-of-tree-platforms.md
@@ -12,10 +12,8 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 **From Community**
 
-- [alita](https://github.com/areslabs/alita) - An experimental, comprehensive port of React Native to mini-program (微信小程序).
 - [React Native tvOS](https://github.com/react-native-tvos/react-native-tvos) - React Native for Apple TV and Android TV devices.
 - [React Native Web](https://github.com/necolas/react-native-web) - React Native on the web using React DOM.
-- [Valence Native](https://github.com/valence-native/valence-native) - A wrapper for React Native, using Qt to target Linux, macOS, and Windows. Forked from [Proton Native](https://github.com/kusti8/proton-native) which is no longer maintained.
 - [React Native Skia](https://github.com/react-native-skia/react-native-skia) - React Native using [Skia](https://skia.org/) as a renderer. Currently supports Linux and macOS.
 
 ## Creating your own React Native platform


### PR DESCRIPTION
This PR updates the Out-of-Tree Platforms doc removing [Alita](https://github.com/areslabs/alita) and [Valence Native](https://github.com/valence-native/valence-native) from the list. These projects have remained dormant for the past few years and are no longer actively maintained.