### PR TITLE
Update debugger types in release test cases

### DIFF
--- a/website/contributing/release-testing.md
+++ b/website/contributing/release-testing.md
@@ -129,16 +129,16 @@ To help provide the relevant information, we have prepared this template they ca
 | Debug/dev build on Simulator | ✅/🚨/🙅‍♂️                |
 | Debug/dev build on Device    | ✅/🚨/🙅‍♂️                |
 | Production build             | ✅/🚨/🙅‍♂️                |
-| Chrome remote debugger       | ✅/🚨/🙅‍♂️                |
-| Hermes debugger              | ✅/🚨/🙅‍♂️                |
-| Flipper debugger             | ✅/🚨/🙅‍♂️                |
+| Debugger (Hermes) | ✅/🚨/🙅‍♂️ |
+| Chrome remote debugger (deprecated) | ✅/🚨/🙅‍♂️ |
+| Flipper debugger (deprecated) | ✅/🚨/🙅‍♂️ |
 | Deploy to TestFlight         | ✅/🚨/🙅‍♂️                |
 | **Tested - Android**         |                         |
 | Fast Refresh                 | ✅/🚨/🙅‍♂️                |
 | Debug/dev build on Emulator  | ✅/🚨/🙅‍♂️                |
 | Debug/dev build on Device    | ✅/🚨/🙅‍♂️                |
 | Production build             | ✅/🚨/🙅‍♂️                |
-| Chrome remote debugger       | ✅/🚨/🙅‍♂️                |
-| Hermes debugger              | ✅/🚨/🙅‍♂️                |
-| Flipper debugger             | ✅/🚨/🙅‍♂️                |
+| Debugger (Hermes) | ✅/🚨/🙅‍♂️ |
+| Chrome remote debugger (deprecated) | ✅/🚨/🙅‍♂️ |
+| Flipper debugger (deprecated) | ✅/🚨/🙅‍♂️ |
 ```


### PR DESCRIPTION
Marks "Chrome remote debugger" and "Flipper debugger" items in the Release Testing docs page as deprecated.