### PR TITLE
docs: import TurboModule from react-native directly

### DIFF
--- a/docs/new-architecture-library-intro.md
+++ b/docs/new-architecture-library-intro.md
@@ -56,8 +56,7 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="TypeScript">
 
 ```tsx
-import type {TurboModule} from 'react-native';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {};

--- a/docs/the-new-architecture/cxx-cxxturbomodules.md
+++ b/docs/the-new-architecture/cxx-cxxturbomodules.md
@@ -71,9 +71,7 @@ Create the following spec inside the `tm` folder:
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-// import type {TurboModule} from 'react-native'; in future versions
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly reverseString: (input: string) => string;

--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -82,8 +82,7 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="typescript">
 
 ```typescript title="NativeCalculator.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;

--- a/website/versioned_docs/version-0.70/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.70/new-architecture-library-intro.md
@@ -54,7 +54,8 @@ export default (TurboModuleRegistry.get<Spec>('<MODULE_NAME>'): ?Spec);
 <TabItem value="TypeScript">
 
 ```ts
-import {TurboModule, TurboModuleRegistry} from 'react-native';
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {};

--- a/website/versioned_docs/version-0.70/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.70/new-architecture-library-intro.md
@@ -54,8 +54,7 @@ export default (TurboModuleRegistry.get<Spec>('<MODULE_NAME>'): ?Spec);
 <TabItem value="TypeScript">
 
 ```ts
-import type {TurboModule} from 'react-native';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {};

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
@@ -80,7 +80,8 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="typescript">
 
 ```typescript title="NativeCalculator.ts"
-import {TurboModule, TurboModuleRegistry} from 'react-native';
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;

--- a/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/pillars-turbomodule.md
@@ -80,8 +80,7 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="typescript">
 
 ```typescript title="NativeCalculator.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;

--- a/website/versioned_docs/version-0.71/the-new-architecture/cxx-cxxturbomodules.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/cxx-cxxturbomodules.md
@@ -71,9 +71,7 @@ Create the following spec inside the `tm` folder:
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-// import type {TurboModule} from 'react-native'; in future versions
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly reverseString: (input: string) => string;

--- a/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/pillars-turbomodule.md
@@ -82,8 +82,7 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="typescript">
 
 ```typescript title="NativeCalculator.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;

--- a/website/versioned_docs/version-0.72/new-architecture-library-intro.md
+++ b/website/versioned_docs/version-0.72/new-architecture-library-intro.md
@@ -56,8 +56,7 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="TypeScript">
 
 ```tsx
-import type {TurboModule} from 'react-native';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {};

--- a/website/versioned_docs/version-0.72/the-new-architecture/cxx-cxxturbomodules.md
+++ b/website/versioned_docs/version-0.72/the-new-architecture/cxx-cxxturbomodules.md
@@ -71,9 +71,7 @@ Create the following spec inside the `tm` folder:
 <TabItem value="typescript">
 
 ```typescript title="NativeSampleModule.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-// import type {TurboModule} from 'react-native'; in future versions
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly reverseString: (input: string) => string;

--- a/website/versioned_docs/version-0.72/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.72/the-new-architecture/pillars-turbomodule.md
@@ -82,8 +82,7 @@ export default (TurboModuleRegistry.get<Spec>(
 <TabItem value="typescript">
 
 ```typescript title="NativeCalculator.ts"
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-import {TurboModuleRegistry} from 'react-native';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
