### PR TITLE
refactor: removed mention of js polyfills that are not used any more

### DIFF
--- a/docs/javascript-environment.md
+++ b/docs/javascript-environment.md
@@ -89,21 +89,6 @@ Many standard functions are also available on all the supported JavaScript runti
 - [`XMLHttpRequest`, `fetch`](network.md#content)
 - [`{set, clear}{Timeout, Interval, Immediate}, {request, cancel}AnimationFrame`](timers.md#content)
 
-#### ECMAScript 2015 (ES6)
-
-- [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from)
-- `md Array.prototype.{[find](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [findIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex)}`
-- [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
-- `md String.prototype.{[startsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith), [endsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith), [repeat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat), [includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes)}`
-
-#### ECMAScript 2016 (ES7)
-
-- `md Array.prototype.[includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes)`
-
-#### ECMAScript 2017 (ES8)
-
-- `md Object.{[entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries), [values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values)}`
-
 #### Specific
 
 - `__DEV__`


### PR DESCRIPTION
### Summary

Both `JSC` and `hermes` implements these methods, so we aren't using a polypill version of them.

- Array.from
- Array.prototype.includes
- Array.prototype.{find, findIndex}
- Object.{entries, values}
- Object.assign
- String.prototype.{startsWith, endsWith, repeat, includes}

See [string-functions](https://github.com/facebook/hermes/blob/main/test/hermes/string-functions.js), [object-functions](https://github.com/facebook/hermes/blob/main/test/hermes/object-functions.js) and [array-functions](https://github.com/facebook/hermes/blob/main/test/hermes/array-functions.js) for reference.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
