### PR TITLE
[docs] Reorganise docs sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,28 +22,13 @@
       "running-on-device",
       "fast-refresh",
       "metro",
-      {
-        "type": "category",
-        "label": "Debugging",
-        "collapsible": false,
-        "collapsed": false,
-        "items": ["debugging", "react-devtools", "native-debugging"]
-      },
       "symbolication",
       "sourcemaps",
-      "testing-overview",
       "libraries",
       "typescript",
-      "upgrading",
-      {
-        "type": "category",
-        "label": "Connectivity",
-        "collapsible": false,
-        "collapsed": false,
-        "items": ["network", "security"]
-      }
+      "upgrading"
     ],
-    "Design": [
+    "UI & Interaction": [
       "style",
       "height-and-width",
       "flexbox",
@@ -63,11 +48,26 @@
       },
       {
         "type": "category",
+        "label": "Connectivity",
+        "collapsible": false,
+        "collapsed": false,
+        "items": ["network", "security"]
+      },
+      {
+        "type": "category",
         "label": "Inclusion",
         "collapsible": false,
         "collapsed": false,
         "items": ["accessibility"]
       }
+    ],
+    "Debugging": [
+      "debugging",
+      "react-devtools",
+      "native-debugging"
+    ],
+    "Testing": [
+      "testing-overview"
     ],
     "Performance": [
       "performance",

--- a/website/versioned_sidebars/version-0.70-sidebars.json
+++ b/website/versioned_sidebars/version-0.70-sidebars.json
@@ -21,21 +21,12 @@
     "Workflow": [
       "running-on-device",
       "fast-refresh",
-      "debugging",
       "symbolication",
-      "testing-overview",
       "libraries",
       "typescript",
-      "upgrading",
-      {
-        "type": "category",
-        "label": "Connectivity",
-        "collapsible": false,
-        "collapsed": false,
-        "items": ["network", "security"]
-      }
+      "upgrading"
     ],
-    "Design": [
+    "UI & Interaction": [
       "style",
       "height-and-width",
       "flexbox",
@@ -55,11 +46,24 @@
       },
       {
         "type": "category",
+        "label": "Connectivity",
+        "collapsible": false,
+        "collapsed": false,
+        "items": ["network", "security"]
+      },
+      {
+        "type": "category",
         "label": "Inclusion",
         "collapsible": false,
         "collapsed": false,
         "items": ["accessibility"]
       }
+    ],
+    "Debugging": [
+      "debugging"
+    ],
+    "Testing": [
+      "testing-overview"
     ],
     "Performance": [
       "performance",

--- a/website/versioned_sidebars/version-0.71-sidebars.json
+++ b/website/versioned_sidebars/version-0.71-sidebars.json
@@ -21,22 +21,13 @@
     "Workflow": [
       "running-on-device",
       "fast-refresh",
-      "debugging",
       "symbolication",
       "sourcemaps",
-      "testing-overview",
       "libraries",
       "typescript",
-      "upgrading",
-      {
-        "type": "category",
-        "label": "Connectivity",
-        "collapsible": false,
-        "collapsed": false,
-        "items": ["network", "security"]
-      }
+      "upgrading"
     ],
-    "Design": [
+    "UI & Interaction": [
       "style",
       "height-and-width",
       "flexbox",
@@ -56,11 +47,24 @@
       },
       {
         "type": "category",
+        "label": "Connectivity",
+        "collapsible": false,
+        "collapsed": false,
+        "items": ["network", "security"]
+      },
+      {
+        "type": "category",
         "label": "Inclusion",
         "collapsible": false,
         "collapsed": false,
         "items": ["accessibility"]
       }
+    ],
+    "Debugging": [
+      "debugging"
+    ],
+    "Testing": [
+      "testing-overview"
     ],
     "Performance": [
       "performance",

--- a/website/versioned_sidebars/version-0.72-sidebars.json
+++ b/website/versioned_sidebars/version-0.72-sidebars.json
@@ -22,28 +22,13 @@
       "running-on-device",
       "fast-refresh",
       "metro",
-      {
-        "type": "category",
-        "label": "Debugging",
-        "collapsible": false,
-        "collapsed": false,
-        "items": ["debugging", "react-devtools", "native-debugging"]
-      },
       "symbolication",
       "sourcemaps",
-      "testing-overview",
       "libraries",
       "typescript",
-      "upgrading",
-      {
-        "type": "category",
-        "label": "Connectivity",
-        "collapsible": false,
-        "collapsed": false,
-        "items": ["network", "security"]
-      }
+      "upgrading"
     ],
-    "Design": [
+    "UI & Interaction": [
       "style",
       "height-and-width",
       "flexbox",
@@ -63,11 +48,26 @@
       },
       {
         "type": "category",
+        "label": "Connectivity",
+        "collapsible": false,
+        "collapsed": false,
+        "items": ["network", "security"]
+      },
+      {
+        "type": "category",
         "label": "Inclusion",
         "collapsible": false,
         "collapsed": false,
         "items": ["accessibility"]
       }
+    ],
+    "Debugging": [
+      "debugging",
+      "react-devtools",
+      "native-debugging"
+    ],
+    "Testing": [
+      "testing-overview"
     ],
     "Performance": [
       "performance",


### PR DESCRIPTION
## Summary

This is an opinionated restructure of top level categories in the docs sidebar, with the aims of:

- Making items more navigable (ungrouping some of the concepts previously under "Workflow").
- Exposing "Debugging" as a top level item — ahead of incoming additions / a refresh to this section.

This affects the sidebar structure only — all page URLs are unchanged.

## Test plan

| Before | After |
| - | - |
| <img width="150" alt="Screenshot 2023-10-10 at 15 15 30" src="https://github.com/facebook/react-native-website/assets/2547783/c4c408a8-372b-4c04-8377-6c992fb23c10"> | <img width="150" alt="Screenshot 2023-10-10 at 15 17 14" src="https://github.com/facebook/react-native-website/assets/2547783/e6af5268-0fee-4564-bd94-4e1db09ef5f7"> |
