### PR TITLE
fix: default value of textBreakStrategy prop of TextInput component

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -960,7 +960,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 ### `textBreakStrategy` <div class="label android">Android</div>
 
-Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `simple`.
+Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
 | Type                                      |
 | ----------------------------------------- |

--- a/website/versioned_docs/version-0.70/textinput.md
+++ b/website/versioned_docs/version-0.70/textinput.md
@@ -854,7 +854,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 ### `textBreakStrategy` <div class="label android">Android</div>
 
-Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `simple`.
+Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
 | Type                                      |
 | ----------------------------------------- |

--- a/website/versioned_docs/version-0.71/textinput.md
+++ b/website/versioned_docs/version-0.71/textinput.md
@@ -946,7 +946,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 ### `textBreakStrategy` <div class="label android">Android</div>
 
-Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `simple`.
+Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
 | Type                                      |
 | ----------------------------------------- |

--- a/website/versioned_docs/version-0.72/textinput.md
+++ b/website/versioned_docs/version-0.72/textinput.md
@@ -942,7 +942,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 ### `textBreakStrategy` <div class="label android">Android</div>
 
-Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `simple`.
+Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
 | Type                                      |
 | ----------------------------------------- |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This PR updates the default value of `textBreakStrategy` prop of `TextInput` component to 'highQuality' instead of 'simple'. This has been the default behaviour for quite some time now and it is tripping off developers. More details regarding this mismatch is available at https://github.com/facebook/react-native/issues/38244
