### PR TITLE
Recover debugging native code section

### DIFF
--- a/docs/native-debugging.md
+++ b/docs/native-debugging.md
@@ -32,3 +32,13 @@ If you're using Expo CLI, console logs already appear in the same terminal outpu
 ## Debugging native code
 
 When working with native code, such as when writing native modules, you can launch the app from Android Studio or Xcode and take advantage of the native debugging features (setting up breakpoints, etc.) as you would in case of building a standard native app.
+
+Another option is to run your application using the React Native CLI and attach the native debugger of the native IDE (Android Studio or Xcode) to the process.
+
+### Android Studio
+
+On Android Studio you can do this by going on the "Run" option on the menu bar, clicking on "Attach to Process..." and selecting the running React Native app.
+
+### Xcode
+
+On Xcode click on "Debug" on the top menu bar, select the "Attach to process" option, and select the application in the list of "Likely Targets".

--- a/website/versioned_docs/version-0.72/native-debugging.md
+++ b/website/versioned_docs/version-0.72/native-debugging.md
@@ -32,3 +32,13 @@ If you're using Expo CLI, console logs already appear in the same terminal outpu
 ## Debugging native code
 
 When working with native code, such as when writing native modules, you can launch the app from Android Studio or Xcode and take advantage of the native debugging features (setting up breakpoints, etc.) as you would in case of building a standard native app.
+
+Another option is to run your application using the React Native CLI and attach the native debugger of the native IDE (Android Studio or Xcode) to the process.
+
+### Android Studio
+
+On Android Studio you can do this by going on the "Run" option on the menu bar, clicking on "Attach to Process..." and selecting the running React Native app.
+
+### Xcode
+
+On Xcode click on "Debug" on the top menu bar, select the "Attach to process" option, and select the application in the list of "Likely Targets".


### PR DESCRIPTION
Hi.
I checked the current [native debugging section in docs](https://reactnative.dev/docs/next/native-debugging) and realized that my previous [PR that adds more instructions](https://github.com/facebook/react-native-website/pull/3614) was deleted, I think this is because the file name was changed or something like that. 

[Current doc](https://reactnative.dev/docs/next/native-debugging):
<img width="870" alt="current debugging doc" src="https://github.com/facebook/react-native-website/assets/22357579/5ffbda44-58d6-41a6-9c72-ebb70d7c50b0">

[0.71 doc](https://reactnative.dev/docs/0.71/debugging#debugging-native-code):
<img width="864" alt="old debugging doc" src="https://github.com/facebook/react-native-website/assets/22357579/bc850a07-ba54-4863-a19b-33649cbb8419">
