### PR TITLE
docs: changed FlatList props inheritance

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -358,9 +358,9 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
-### [ScrollView Props](scrollview.md#props)
+### [VirtualizedList Props](virtualizedlist.md#props)
 
-Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
+Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 

--- a/website/versioned_docs/version-0.70/flatlist.md
+++ b/website/versioned_docs/version-0.70/flatlist.md
@@ -172,9 +172,9 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
-### [ScrollView Props](scrollview.md#props)
+### [VirtualizedList Props](virtualizedlist.md#props)
 
-Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
+Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 

--- a/website/versioned_docs/version-0.71/flatlist.md
+++ b/website/versioned_docs/version-0.71/flatlist.md
@@ -358,9 +358,9 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
-### [ScrollView Props](scrollview.md#props)
+### [VirtualizedList Props](virtualizedlist.md#props)
 
-Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
+Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 

--- a/website/versioned_docs/version-0.72/flatlist.md
+++ b/website/versioned_docs/version-0.72/flatlist.md
@@ -358,9 +358,9 @@ This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), 
 
 ## Props
 
-### [ScrollView Props](scrollview.md#props)
+### [VirtualizedList Props](virtualizedlist.md#props)
 
-Inherits [ScrollView Props](scrollview.md#props), unless it is nested in another FlatList of same orientation.
+Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

[FlatList extends its props from VirtualizedList](https://github.com/facebook/react-native/blob/97647d11841c9c97632617fe770439e3acb689ea/packages/react-native/Libraries/Lists/FlatList.d.ts#L22), so their docs should point to `VirtualizedList Props` instead of `ScrollView Props`.

