### PR TITLE
Added missing xmlns to FrameLayout

### DIFF
--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -141,6 +141,7 @@ Add a `<FrameLayout>` with an id, width and height. This is the layout you will 
 
 ```xml
 <FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/reactNativeFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/website/versioned_docs/version-0.70/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.70/integration-with-android-fragment.md
@@ -139,6 +139,7 @@ Add a `<FrameLayout>` with an id, width and height. This is the layout you will 
 
 ```xml
 <FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/reactNativeFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/website/versioned_docs/version-0.71/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.71/integration-with-android-fragment.md
@@ -141,6 +141,7 @@ Add a `<FrameLayout>` with an id, width and height. This is the layout you will 
 
 ```xml
 <FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/reactNativeFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/website/versioned_docs/version-0.72/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.72/integration-with-android-fragment.md
@@ -141,6 +141,7 @@ Add a `<FrameLayout>` with an id, width and height. This is the layout you will 
 
 ```xml
 <FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/reactNativeFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />


### PR DESCRIPTION
Added missing `xmlns:...` to `<FrameLayout ...` on the guide for adding RN to Fragments instead of activities.
Without specifying xmlns in newer versions:

![image](https://github.com/facebook/react-native-website/assets/895369/637dde6b-69d6-4396-aa59-04b5806c0866)

