### PR TITLE
[Text] refactor: useSelect listed under text props instead of text style props

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -929,3 +929,13 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 | Type                             | Default  |
 | -------------------------------- | -------- |
 | enum(`'auto'`, `'ltr'`, `'rtl'`) | `'auto'` |
+
+---
+
+### `userSelect`
+
+It allows the user to select text and to use the native copy and paste functionality. Has precedence over the `selectable` prop.
+
+| Type                                                     | Default |
+| -------------------------------------------------------- | ------- |
+| enum(`'auto'`, `'text'`, `'none'`, `'contain'`, `'all'`) | `none`  |

--- a/docs/text.md
+++ b/docs/text.md
@@ -691,16 +691,6 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `userSelect`
-
-It allows the user to select text and to use the native copy and paste functionality. Has precedence over the `selectable` prop.
-
-| Type                                                     | Default |
-| -------------------------------------------------------- | ------- |
-| enum(`'auto'`, `'text'`, `'none'`, `'contain'`, `'all'`) | `none`  |
-
----
-
 ### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.

--- a/website/versioned_docs/version-0.71/text-style-props.md
+++ b/website/versioned_docs/version-0.71/text-style-props.md
@@ -929,3 +929,13 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 | Type                             | Default  |
 | -------------------------------- | -------- |
 | enum(`'auto'`, `'ltr'`, `'rtl'`) | `'auto'` |
+
+---
+
+### `userSelect`
+
+It allows the user to select text and to use the native copy and paste functionality. Has precedence over the `selectable` prop.
+
+| Type                                                     | Default |
+| -------------------------------------------------------- | ------- |
+| enum(`'auto'`, `'text'`, `'none'`, `'contain'`, `'all'`) | `none`  |

--- a/website/versioned_docs/version-0.71/text.md
+++ b/website/versioned_docs/version-0.71/text.md
@@ -733,16 +733,6 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `userSelect`
-
-It allows the user to select text and to use the native copy and paste functionality. Has precedence over the `selectable` prop.
-
-| Type                                                     | Default |
-| -------------------------------------------------------- | ------- |
-| enum(`'auto'`, `'text'`, `'none'`, `'contain'`, `'all'`) | `none`  |
-
----
-
 ### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.

--- a/website/versioned_docs/version-0.72/text-style-props.md
+++ b/website/versioned_docs/version-0.72/text-style-props.md
@@ -929,3 +929,13 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 | Type                             | Default  |
 | -------------------------------- | -------- |
 | enum(`'auto'`, `'ltr'`, `'rtl'`) | `'auto'` |
+
+---
+
+### `userSelect`
+
+It allows the user to select text and to use the native copy and paste functionality. Has precedence over the `selectable` prop.
+
+| Type                                                     | Default |
+| -------------------------------------------------------- | ------- |
+| enum(`'auto'`, `'text'`, `'none'`, `'contain'`, `'all'`) | `none`  |

--- a/website/versioned_docs/version-0.72/text.md
+++ b/website/versioned_docs/version-0.72/text.md
@@ -691,16 +691,6 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `userSelect`
-
-It allows the user to select text and to use the native copy and paste functionality. Has precedence over the `selectable` prop.
-
-| Type                                                     | Default |
-| -------------------------------------------------------- | ------- |
-| enum(`'auto'`, `'text'`, `'none'`, `'contain'`, `'all'`) | `none`  |
-
----
-
 ### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
`userSelect` is text style prop but it is listed under text props. 