### PR TITLE
Clarify where to register headless services in the Android Manifest

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -94,7 +94,7 @@ class MyTaskService : HeadlessJsTaskService() {
 </TabItem>
 </Tabs>
 
-Then add the service to your `AndroidManifest.xml` file:
+Then add the service to your `AndroidManifest.xml` file inside the `application` tag:
 
 ```
 <service android:name="com.example.MyTaskService" />


### PR DESCRIPTION
The current docs are ambiguous if the `service` should be declared inside or outside of the `application` tag. 

HeadlessJS services need to be declared [inside the `application` tag](https://developer.android.com/guide/components/services#Declaring). This updates makes that requirement clearer.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
