### PR TITLE
Update _getting-started-windows-android.md

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -9,7 +9,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3 id="jdk">Node, JDK</h3>
 
-We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows.
+We recommend installing Node via [Chocolatey](https://chocolatey.org), a popular package manager for Windows. If you don't have Chocolatey installed in your windows. Here is [installation guide](https://chocolatey.org/install) with couple of simple steps.
 
 It is recommended to use an LTS version of Node. If you want to be able to switch between different versions, you might want to install Node via [nvm-windows](https://github.com/coreybutler/nvm-windows), a Node version manager for Windows.
 


### PR DESCRIPTION
Added linked to install Chocolatey on windows because it's not instaled by default.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
