### PR TITLE
include `pdf` in list of supported image source formats

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -371,7 +371,7 @@ The image source (either a remote URL or a local file resource).
 
 This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](images#cache-control-ios-only)).
 
-The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
+The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, and for iOS only `psd` and `pdf`. In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 
 | Type                             |
 | -------------------------------- |


### PR DESCRIPTION
PDFs work as an image source on iOS.

Edit: I used pdfs as image source using a `.xcassets` catalog, not sure if using a pdf directly works as well.
