### PR TITLE
Update all Metro links to metrobundler.dev

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -126,7 +126,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-[**Metro**](https://facebook.github.io/metro/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
+[**Metro**](https://metrobundler.dev/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
 
 <Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -141,7 +141,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-[**Metro**](https://facebook.github.io/metro/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
+[**Metro**](https://metrobundler.dev/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
 
 <Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -106,7 +106,7 @@ You might also want to ensure that all "shell script build phase" of your Xcode 
 
 ### Step 1: Start Metro
 
-[**Metro**](https://facebook.github.io/metro/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
+[**Metro**](https://metrobundler.dev/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
 
 <Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">

--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -157,7 +157,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-[**Metro**](https://facebook.github.io/metro/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
+[**Metro**](https://metrobundler.dev/) is the JavaScript build tool for React Native. To start the Metro development server, run the following from your project folder:
 
 <Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
 <TabItem value="npm">

--- a/docs/_integration-with-existing-apps-java.md
+++ b/docs/_integration-with-existing-apps-java.md
@@ -440,4 +440,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/docs/_integration-with-existing-apps-kotlin.md
+++ b/docs/_integration-with-existing-apps-kotlin.md
@@ -416,4 +416,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/docs/_integration-with-existing-apps-objc.md
+++ b/docs/_integration-with-existing-apps-objc.md
@@ -400,4 +400,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/docs/_integration-with-existing-apps-swift.md
+++ b/docs/_integration-with-existing-apps-swift.md
@@ -378,4 +378,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -98,7 +98,7 @@ Hermes supports the Chrome debugger by implementing the Chrome inspector protoco
 Note that this is very different with the deprecated "Remote JS Debugging" from the In-App Dev Menu documented in the [Debugging](debugging#remote-debugging) section, which actually runs the JS code on Chrome's V8 on your development machine (laptop or desktop) instead of connecting to the JS engine running the app on your device.
 :::
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://metrobundler.dev/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -69,7 +69,7 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [bundler defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/configuration#resolver-options) in your [Metro configuration](https://facebook.github.io/metro/docs/configuration).
+You can add support for other types by adding an [`assetExts` resolver option](https://metrobundler.dev/docs/configuration#resolver-options) in your [Metro configuration](https://metrobundler.dev/docs/configuration).
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/docs/metro.md
+++ b/docs/metro.md
@@ -3,7 +3,7 @@ id: metro
 title: Metro
 ---
 
-React Native uses [Metro](https://facebook.github.io/metro/) to build your JavaScript code and assets.
+React Native uses [Metro](https://metrobundler.dev/) to build your JavaScript code and assets.
 
 ## Configuring Metro
 
@@ -13,7 +13,7 @@ Configuration options for Metro can be customized in your project's `metro.confi
 - [**A function**](#advanced-using-a-config-function) that will be called with Metro's internal config defaults and should return a final config object.
 
 :::tip
-Please see [**Configuring Metro**](https://facebook.github.io/metro/docs/configuration) on the Metro website for documentation on all available config options.
+Please see [**Configuring Metro**](https://metrobundler.dev/docs/configuration) on the Metro website for documentation on all available config options.
 :::
 
 In React Native, your Metro config should extend either [`@react-native/metro-config`](https://www.npmjs.com/package/@react-native/metro-config) or [`@expo/metro-config`](https://www.npmjs.com/package/@expo/metro-config). These packages contain essential defaults necessary to build and run React Native apps.
@@ -26,7 +26,7 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
 /**
  * Metro configuration
- * https://facebook.github.io/metro/docs/configuration
+ * https://metrobundler.dev/docs/configuration
  *
  * @type {import('metro-config').MetroConfig}
  */
@@ -100,5 +100,5 @@ const config = {
 
 ## Learn more about Metro
 
-- [Metro website](https://facebook.github.io/metro/)
+- [Metro website](https://metrobundler.dev/)
 - [Video: "Metro & React Native DevX" talk at App.js 2023](https://www.youtube.com/watch?v=c9D4pg0y9cI)

--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -22,7 +22,7 @@ Right now the process of creating a React Native platform from scratch is not ve
 
 ### Bundling
 
-As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
+As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://metrobundler.dev/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
 
 To register your platform with RNPM, your module's name must match one of these patterns:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,4 +149,4 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 If you run into issue where executing `npm run android` or `yarn android` on macOS throws the above error, try to run `sudo chmod +x android/gradlew` command to make `gradlew` files into executable.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/blog/2023-06-21-package-exports-support.md
+++ b/website/blog/2023-06-21-package-exports-support.md
@@ -84,7 +84,7 @@ Enabling Package Exports brings a few [edge-case breaking changes](#breaking-cha
 
 ### Enabling Package Exports (beta)
 
-Package Exports can be enabled in your app's [**metro.config.js**](https://github.com/facebook/react-native/blob/0.72-stable/packages/react-native/template/metro.config.js) file via the [`resolver.unstable_enablePackageExports`](https://facebook.github.io/metro/docs/configuration/#unstable_enablepackageexports-experimental) option.
+Package Exports can be enabled in your app's [**metro.config.js**](https://github.com/facebook/react-native/blob/0.72-stable/packages/react-native/template/metro.config.js) file via the [`resolver.unstable_enablePackageExports`](https://metrobundler.dev/docs/configuration/#unstable_enablepackageexports-experimental) option.
 
 ```js
 const config = {
@@ -97,8 +97,8 @@ const config = {
 
 Metro exposes two further resolver options which configure how conditional exports behave:
 
-- [`unstable_conditionNames`](https://facebook.github.io/metro/docs/configuration/#unstable_conditionnames-experimental) — The set of [condition names](https://nodejs.org/docs/latest-v19.x/api/packages.html#community-conditions-definitions) to assert when resolving conditional exports. By default, we match `['require', 'import', 'react-native']`.
-- [`unstable_conditionsByPlatform`](https://facebook.github.io/metro/docs/configuration/#unstable_conditionsbyplatform-experimental) — The additional condition names to assert when resolving for a given platform target. By default, this matches `'browser'` when the platform is `'web'`.
+- [`unstable_conditionNames`](https://metrobundler.dev/docs/configuration/#unstable_conditionnames-experimental) — The set of [condition names](https://nodejs.org/docs/latest-v19.x/api/packages.html#community-conditions-definitions) to assert when resolving conditional exports. By default, we match `['require', 'import', 'react-native']`.
+- [`unstable_conditionsByPlatform`](https://metrobundler.dev/docs/configuration/#unstable_conditionsbyplatform-experimental) — The additional condition names to assert when resolving for a given platform target. By default, this matches `'browser'` when the platform is `'web'`.
 
 :::tip
 **Remember to use the React Native [Jest preset](https://github.com/facebook/react-native/blob/main/template/jest.config.js#L2)!** Jest includes support for Package Exports by default. In tests, you can override which `customExportConditions` are resolved using the [`testEnvironmentOptions`](https://jestjs.io/docs/configuration#testenvironmentoptions-object) option.
@@ -148,10 +148,10 @@ We decided on an implementation of Package Exports in Metro that is spec-complia
 
 The key breaking change is that when `"exports"` is provided by a package, it will be consulted first (before any other `package.json` fields) — and a matched subpath target will be used directly.
 
-- Metro will not expand [`sourceExts`](https://facebook.github.io/metro/docs/configuration/#sourceexts) against the import specifier.
+- Metro will not expand [`sourceExts`](https://metrobundler.dev/docs/configuration/#sourceexts) against the import specifier.
 - Metro will not resolve [platform-specific extensions](/docs/platform-specific-code) against the target file.
 
-For more details, please see all [**breaking changes**](https://facebook.github.io/metro/docs/package-exports#summary-of-breaking-changes) in the Metro docs.
+For more details, please see all [**breaking changes**](https://metrobundler.dev/docs/package-exports#summary-of-breaking-changes) in the Metro docs.
 
 ### Package encapsulation is lenient
 
@@ -194,7 +194,7 @@ We believe that the new features of `"exports"` provide a compelling feature set
 - **Tighten your package API**: This is a great time to review the module API of your package, which can now be formally defined via exported subpath aliases. This prevents users from accessing internal APIs, reducing surface area for bugs.
 - **Conditional exports**: If your package targets React Native for Web (i.e. `"react-native"` and `"browser"`), we now give packages control of the resolution order of these conditions (see next heading).
 
-If you decide to introduce `"exports"`, **we recommend making this as a breaking change**. We've prepared a [**migration guide**](https://facebook.github.io/metro/docs/package-exports#migration-guide-for-package-maintainers) in the Metro docs which includes how to replace features such as platform-specific extensions.
+If you decide to introduce `"exports"`, **we recommend making this as a breaking change**. We've prepared a [**migration guide**](https://metrobundler.dev/docs/package-exports#migration-guide-for-package-maintainers) in the Metro docs which includes how to replace features such as platform-specific extensions.
 
 :::note
 **Please do not rely on the lenient behaviours of Metro's implementation.** While Metro is backwards-compatible, packages should follow how `"exports"` is documented in the spec and strictly implemented by other tools.

--- a/website/versioned_docs/version-0.70/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-linux-android.md
@@ -129,7 +129,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.70/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-macos-android.md
@@ -146,7 +146,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.70/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.70/_getting-started-macos-ios.md
@@ -122,7 +122,7 @@ On top of this, it's possible to add any other environment variable and to sourc
 
 ### Step 1: Start Metro
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.70/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.70/_getting-started-windows-android.md
@@ -160,7 +160,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.70/_integration-with-existing-apps-java.md
+++ b/website/versioned_docs/version-0.70/_integration-with-existing-apps-java.md
@@ -380,4 +380,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.70/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.70/_integration-with-existing-apps-kotlin.md
@@ -373,4 +373,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.70/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.70/_integration-with-existing-apps-objc.md
@@ -388,4 +388,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.70/_integration-with-existing-apps-swift.md
+++ b/website/versioned_docs/version-0.70/_integration-with-existing-apps-swift.md
@@ -336,4 +336,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.70/hermes.md
+++ b/website/versioned_docs/version-0.70/hermes.md
@@ -59,7 +59,7 @@ Hermes supports the Chrome debugger by implementing the Chrome inspector protoco
 Note that this is very different with the "Remote JS Debugging" from the In-App Developer Menu documented in the [Debugging](debugging#debugging-using-a-custom-javascript-debugger) section, which actually runs the JS code on Chrome's V8 on your development machine (laptop or desktop).
 :::
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://metrobundler.dev/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/website/versioned_docs/version-0.70/images.md
+++ b/website/versioned_docs/version-0.70/images.md
@@ -69,7 +69,7 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [bundler defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/configuration#resolver-options) in your [Metro configuration](https://facebook.github.io/metro/docs/configuration).
+You can add support for other types by adding an [`assetExts` resolver option](https://metrobundler.dev/docs/configuration#resolver-options) in your [Metro configuration](https://metrobundler.dev/docs/configuration).
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/website/versioned_docs/version-0.70/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.70/out-of-tree-platforms.md
@@ -23,7 +23,7 @@ Right now the process of creating a React Native platform from scratch is not ve
 
 ### Bundling
 
-As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
+As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://metrobundler.dev/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
 
 To register your platform with RNPM, your module's name must match one of these patterns:
 

--- a/website/versioned_docs/version-0.70/troubleshooting.md
+++ b/website/versioned_docs/version-0.70/troubleshooting.md
@@ -121,4 +121,4 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 If you run into issue where executing `npm run android` on macOS throws the above error, try to run `sudo chmod +x android/gradlew` command to make `gradlew` files into executable.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.71/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-linux-android.md
@@ -125,7 +125,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.71/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-android.md
@@ -140,7 +140,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
@@ -124,7 +124,7 @@ On top of this, it's possible to add any other environment variable and to sourc
 
 ### Step 1: Start Metro
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.71/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.71/_getting-started-windows-android.md
@@ -156,7 +156,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run `npx react-native start` inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.71/_integration-with-existing-apps-java.md
+++ b/website/versioned_docs/version-0.71/_integration-with-existing-apps-java.md
@@ -397,4 +397,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.71/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.71/_integration-with-existing-apps-kotlin.md
@@ -373,4 +373,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.71/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.71/_integration-with-existing-apps-objc.md
@@ -388,4 +388,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.71/_integration-with-existing-apps-swift.md
+++ b/website/versioned_docs/version-0.71/_integration-with-existing-apps-swift.md
@@ -327,4 +327,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.71/hermes.md
+++ b/website/versioned_docs/version-0.71/hermes.md
@@ -59,7 +59,7 @@ Hermes supports the Chrome debugger by implementing the Chrome inspector protoco
 Note that this is very different with the "Remote JS Debugging" from the In-App Developer Menu documented in the [Debugging](debugging#debugging-using-a-custom-javascript-debugger) section, which actually runs the JS code on Chrome's V8 on your development machine (laptop or desktop).
 :::
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://metrobundler.dev/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/website/versioned_docs/version-0.71/images.md
+++ b/website/versioned_docs/version-0.71/images.md
@@ -69,7 +69,7 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [bundler defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/configuration#resolver-options) in your [Metro configuration](https://facebook.github.io/metro/docs/configuration).
+You can add support for other types by adding an [`assetExts` resolver option](https://metrobundler.dev/docs/configuration#resolver-options) in your [Metro configuration](https://metrobundler.dev/docs/configuration).
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/website/versioned_docs/version-0.71/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.71/out-of-tree-platforms.md
@@ -21,7 +21,7 @@ Right now the process of creating a React Native platform from scratch is not ve
 
 ### Bundling
 
-As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
+As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://metrobundler.dev/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
 
 To register your platform with RNPM, your module's name must match one of these patterns:
 

--- a/website/versioned_docs/version-0.71/troubleshooting.md
+++ b/website/versioned_docs/version-0.71/troubleshooting.md
@@ -121,4 +121,4 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 If you run into issue where executing `npm run android` on macOS throws the above error, try to run `sudo chmod +x android/gradlew` command to make `gradlew` files into executable.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.72/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.72/_getting-started-linux-android.md
@@ -126,7 +126,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run following command inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.72/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.72/_getting-started-macos-android.md
@@ -141,7 +141,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run following command inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.72/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.72/_getting-started-macos-ios.md
@@ -104,7 +104,7 @@ You might also want to ensure that all "shell script build phase" of your Xcode 
 
 ### Step 1: Start Metro
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run following command inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.72/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.72/_getting-started-windows-android.md
@@ -157,7 +157,7 @@ Click "Next" then "Finish" to create your AVD. At this point you should be able 
 
 <h3>Step 1: Start Metro</h3>
 
-First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://facebook.github.io/metro/docs/concepts)
+First, you will need to start Metro, the JavaScript bundler that ships with React Native. Metro "takes in an entry file and various options, and returns a single JavaScript file that includes all your code and its dependencies."—[Metro Docs](https://metrobundler.dev/docs/concepts)
 
 To start Metro, run following command inside your React Native project folder:
 

--- a/website/versioned_docs/version-0.72/_integration-with-existing-apps-java.md
+++ b/website/versioned_docs/version-0.72/_integration-with-existing-apps-java.md
@@ -440,4 +440,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.72/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.72/_integration-with-existing-apps-kotlin.md
@@ -416,4 +416,4 @@ Now, create a release build of your native app from within Android Studio as usu
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.72/_integration-with-existing-apps-objc.md
+++ b/website/versioned_docs/version-0.72/_integration-with-existing-apps-objc.md
@@ -400,4 +400,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.72/_integration-with-existing-apps-swift.md
+++ b/website/versioned_docs/version-0.72/_integration-with-existing-apps-swift.md
@@ -378,4 +378,4 @@ Here is the _React Native_ high score screen:
 
 At this point you can continue developing your app as usual. Refer to our [debugging](debugging) and [deployment](running-on-device) docs to learn more about working with React Native.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/

--- a/website/versioned_docs/version-0.72/hermes.md
+++ b/website/versioned_docs/version-0.72/hermes.md
@@ -98,7 +98,7 @@ Hermes supports the Chrome debugger by implementing the Chrome inspector protoco
 Note that this is very different with the "Remote JS Debugging" from the In-App Dev Menu documented in the [Debugging](debugging#debugging-using-a-custom-javascript-debugger) section, which actually runs the JS code on Chrome's V8 on your development machine (laptop or desktop).
 :::
 
-Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://facebook.github.io/metro/docs/configuration). When running `yarn start` the address is written to stdout on startup.
+Chrome connects to Hermes running on device via Metro, so you'll need to know where Metro is listening. Typically this will be on `localhost:8081`, but this is [configurable](https://metrobundler.dev/docs/configuration). When running `yarn start` the address is written to stdout on startup.
 
 Once you know where the Metro server is listening, you can connect with Chrome using the following steps:
 

--- a/website/versioned_docs/version-0.72/images.md
+++ b/website/versioned_docs/version-0.72/images.md
@@ -69,7 +69,7 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [bundler defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/configuration#resolver-options) in your [Metro configuration](https://facebook.github.io/metro/docs/configuration).
+You can add support for other types by adding an [`assetExts` resolver option](https://metrobundler.dev/docs/configuration#resolver-options) in your [Metro configuration](https://metrobundler.dev/docs/configuration).
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/website/versioned_docs/version-0.72/metro.md
+++ b/website/versioned_docs/version-0.72/metro.md
@@ -3,7 +3,7 @@ id: metro
 title: Metro
 ---
 
-React Native uses [Metro](https://facebook.github.io/metro/) to build your JavaScript code and assets.
+React Native uses [Metro](https://metrobundler.dev/) to build your JavaScript code and assets.
 
 ## Configuring Metro
 
@@ -13,7 +13,7 @@ Configuration options for Metro can be customized in your project's `metro.confi
 - [**A function**](#advanced-using-a-config-function) that will be called with Metro's internal config defaults and should return a final config object.
 
 :::tip
-Please see [**Configuring Metro**](https://facebook.github.io/metro/docs/configuration) on the Metro website for documentation on all available config options.
+Please see [**Configuring Metro**](https://metrobundler.dev/docs/configuration) on the Metro website for documentation on all available config options.
 :::
 
 In React Native, your Metro config should extend either [`@react-native/metro-config`](https://www.npmjs.com/package/@react-native/metro-config) or [`@expo/metro-config`](https://www.npmjs.com/package/@expo/metro-config). These packages contain essential defaults necessary to build and run React Native apps.
@@ -26,7 +26,7 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
 /**
  * Metro configuration
- * https://facebook.github.io/metro/docs/configuration
+ * https://metrobundler.dev/docs/configuration
  *
  * @type {import('metro-config').MetroConfig}
  */
@@ -100,5 +100,5 @@ const config = {
 
 ## Learn more about Metro
 
-- [Metro website](https://facebook.github.io/metro/)
+- [Metro website](https://metrobundler.dev/)
 - [Video: "Metro & React Native DevX" talk at App.js 2023](https://www.youtube.com/watch?v=c9D4pg0y9cI)

--- a/website/versioned_docs/version-0.72/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.72/out-of-tree-platforms.md
@@ -22,7 +22,7 @@ Right now the process of creating a React Native platform from scratch is not ve
 
 ### Bundling
 
-As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://facebook.github.io/metro/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
+As of React Native 0.57 you can now register your React Native platform with React Native's JavaScript bundler, [Metro](https://metrobundler.dev/). This means you can pass `--platform example` to `npx react-native bundle`, and it will look for JavaScript files with the `.example.js` suffix.
 
 To register your platform with RNPM, your module's name must match one of these patterns:
 

--- a/website/versioned_docs/version-0.72/troubleshooting.md
+++ b/website/versioned_docs/version-0.72/troubleshooting.md
@@ -149,4 +149,4 @@ echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo s
 
 If you run into issue where executing `npm run android` or `yarn android` on macOS throws the above error, try to run `sudo chmod +x android/gradlew` command to make `gradlew` files into executable.
 
-[metro]: https://facebook.github.io/metro/
+[metro]: https://metrobundler.dev/


### PR DESCRIPTION
We updated the domain for Metro 😄. Updating references here to save a redirect hop when navigating between sites.