### PR TITLE
Change 'use' to 'lose' to signify that functions are still accessible

### DIFF
--- a/docs/new-architecture-library-android.md
+++ b/docs/new-architecture-library-android.md
@@ -115,4 +115,4 @@ class NativeAwesomeManager(reactContext: ReactApplicationContext) :
 </TabItem>
 </Tabs>
 
-Please note that the **generated abstract class** that you’re now extending (`MyAwesomeSpec` in this example) is itself extending `ReactContextBaseJavaModule`. Therefore you should not use access to any of the method/fields you were previously using (e.g., the `ReactApplicationContext` and so on). Moreover, the generated class will now also implement the `TurboModule` interface for you.
+Please note that the **generated abstract class** that you’re now extending (`MyAwesomeSpec` in this example) is itself extending `ReactContextBaseJavaModule`. Therefore you should not lose access to any of the method/fields you were previously using (e.g., the `ReactApplicationContext` and so on). Moreover, the generated class will now also implement the `TurboModule` interface for you.


### PR DESCRIPTION
The statement at the end says that since the generated abstract class itself extends ReactContextBaseJavaModule, all the functions are still accessible. But the sentence reads "should not use", which does not make sense, and "should not lose" should instead be used.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
