### PR TITLE
Correct `src` prop typing in native-components-android.md

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -188,7 +188,7 @@ import {requireNativeComponent} from 'react-native';
 /**
  * Composes `View`.
  *
- * - src: string
+ * - src: Array<{url: string}>
  * - borderRadius: number
  * - resizeMode: 'cover' | 'contain' | 'stretch'
  */


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
