### PR TITLE
Add `--frozen-lockfile` to `yarn install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
             - v1-yarn-{{ .Branch }}
       - run:
           name: Yarn Install
-          command: yarn install --no-progress --non-interactive --cache-folder ~/.cache/yarn
+          command: yarn install --frozen-lockfile --no-progress --non-interactive --cache-folder ~/.cache/yarn
           working_directory: ~/react-native-website
       - save_cache:
           paths:


### PR DESCRIPTION
To catch cases where dependency changes require a lockfile change that wasn't committed alongside. (e.g. https://github.com/facebook/react-native-website/pull/3942)
