### PR TITLE
docs(hermes) disable Hermes matches template changes

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -240,10 +240,13 @@ Edit your `ios/Podfile` file and make the change illustrated below:
 ```diff
    use_react_native!(
      :path => config[:reactNativePath],
-     # Hermes is now enabled by default. Disable by setting this flag to false.
-     # Upcoming versions of React Native may rely on get_default_flags(), but
-     # we make it explicit here to aid in the React Native upgrade process.
--    :hermes_enabled => flags[:hermes_enabled],
 +    :hermes_enabled => false,
+     # Enables Flipper.
+     #
+     # Note that if you have use_frameworks! enabled, Flipper will not work and
+     # you should disable the next line.
+     :flipper_configuration => flipper_config,
+     # An absolute path to your application root.
+     :app_path => "#{Pod::Config.instance.installation_root}/.."
    )
 ```

--- a/website/versioned_docs/version-0.73/hermes.md
+++ b/website/versioned_docs/version-0.73/hermes.md
@@ -240,10 +240,13 @@ Edit your `ios/Podfile` file and make the change illustrated below:
 ```diff
    use_react_native!(
      :path => config[:reactNativePath],
-     # Hermes is now enabled by default. Disable by setting this flag to false.
-     # Upcoming versions of React Native may rely on get_default_flags(), but
-     # we make it explicit here to aid in the React Native upgrade process.
--    :hermes_enabled => flags[:hermes_enabled],
 +    :hermes_enabled => false,
+     # Enables Flipper.
+     #
+     # Note that if you have use_frameworks! enabled, Flipper will not work and
+     # you should disable the next line.
+     :flipper_configuration => flipper_config,
+     # An absolute path to your application root.
+     :app_path => "#{Pod::Config.instance.installation_root}/.."
    )
 ```


### PR DESCRIPTION
The template has changed enough that the docs needed to be updated for the 0.73 release as well as next. This makes it clear how to disable Hermes.

Fixes #3950

# Fixed
![CleanShot 2023-12-12 at 10 38 59@2x](https://github.com/facebook/react-native-website/assets/49578/edf88a42-c2f5-40b5-8b86-3eb3fb37e8ff)


# 0.73 template:
![CleanShot 2023-12-12 at 10 43 04@2x](https://github.com/facebook/react-native-website/assets/49578/8ce5d19b-556a-449b-8bbb-d2e7580b873e)


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
