### PR TITLE
Add types/react-native deprecation notice to 73 blog post

### DIFF
--- a/website/blog/2023-12-06-0.73-debugging-improvements-stable-symlinks.md
+++ b/website/blog/2023-12-06-0.73-debugging-improvements-stable-symlinks.md
@@ -21,7 +21,7 @@ Today we're releasing React Native 0.73! This release adds improvements to debug
 - [Babel Package Renames](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#babel-package-renames)
 - [Other Breaking Changes](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#other-breaking-changes)
 - [React Native CLI Changes](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#react-native-cli-changes)
-- [Deprecated @types/react-native](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#react-native-cli-changes)
+- [Deprecated @types/react-native](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#deprecated-typesreact-native)
 
 <!--truncate-->
 

--- a/website/blog/2023-12-06-0.73-debugging-improvements-stable-symlinks.md
+++ b/website/blog/2023-12-06-0.73-debugging-improvements-stable-symlinks.md
@@ -21,6 +21,7 @@ Today we're releasing React Native 0.73! This release adds improvements to debug
 - [Babel Package Renames](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#babel-package-renames)
 - [Other Breaking Changes](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#other-breaking-changes)
 - [React Native CLI Changes](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#react-native-cli-changes)
+- [Deprecated @types/react-native](/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#react-native-cli-changes)
 
 <!--truncate-->
 
@@ -189,6 +190,10 @@ For library authors:
 - Remove `--variant` option from `build-android` command (replaced with `--mode`) ([#2026](https://github.com/react-native-community/cli/pull/2026)).
 
 [See full changelog for v12.0.0](https://github.com/react-native-community/cli/releases/tag/v12.0.0).
+
+### Deprecated `@types/react-native`
+
+As mentioned in [First-class Support for TypeScript](/blog/2023/01/03/typescript-first#declarations-shipped-with-react-native), we have shipped TypeScript types with `react-native` since 0.71. We will not ship `@types/react-native` for 0.73 and onward. Patches for existing versions may still ship. See instructions on [how to migrate](/blog/2023/01/03/typescript-first#how-to-migrate).
 
 ## Acknowledgements
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,7 +307,7 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-member-expression-to-functions@^7.22.15", "@babel/helper-member-expression-to-functions@^7.22.5", "@babel/helper-member-expression-to-functions@^7.23.0":
+"@babel/helper-member-expression-to-functions@^7.22.15", "@babel/helper-member-expression-to-functions@^7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz#9263e88cc5e41d39ec18c9a3e0eced59a3e7d366"
   integrity sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==
@@ -358,7 +358,7 @@
     "@babel/helper-environment-visitor" "^7.22.5"
     "@babel/helper-wrap-function" "^7.22.9"
 
-"@babel/helper-replace-supers@^7.22.20", "@babel/helper-replace-supers@^7.22.5", "@babel/helper-replace-supers@^7.22.9":
+"@babel/helper-replace-supers@^7.22.20", "@babel/helper-replace-supers@^7.22.5":
   version "7.22.20"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz#e37d367123ca98fe455a9887734ed2e16eb7a793"
   integrity sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==
@@ -2179,7 +2179,7 @@
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
 
-"@jest/schemas@^29.6.0", "@jest/schemas@^29.6.3":
+"@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
   integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==


### PR DESCRIPTION
Add deprecation notice about types/react-native for 0.73

Note: We need this PR to land: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67459 but the deprecation notice still stands