### PR TITLE
Clarify DT ts deprecation about patches

### DIFF
--- a/website/blog/2023-12-06-0.73-debugging-improvements-stable-symlinks.md
+++ b/website/blog/2023-12-06-0.73-debugging-improvements-stable-symlinks.md
@@ -193,7 +193,9 @@ For library authors:
 
 ### Deprecated `@types/react-native`
 
-As mentioned in [First-class Support for TypeScript](/blog/2023/01/03/typescript-first#declarations-shipped-with-react-native), we have shipped TypeScript types with `react-native` since 0.71. We will not ship `@types/react-native` for 0.73 and onward. Patches for existing versions may still ship. See instructions on [how to migrate](/blog/2023/01/03/typescript-first#how-to-migrate).
+As mentioned in [First-class Support for TypeScript](/blog/2023/01/03/typescript-first#declarations-shipped-with-react-native), we have shipped TypeScript types with `react-native` since 0.71 and we are now deprecating `@types/react-native` for 0.73.
+
+We will not ship any future patches for existing versions. The guidance is to migrate away from `@types/react-native`. See instructions on [how to migrate](/blog/2023/01/03/typescript-first#how-to-migrate).
 
 ## Acknowledgements
 


### PR DESCRIPTION
Want to call out that we will not be shipping patches on pre-existing versions due to DT deprecation process
