### PR TITLE
Fixed a mistake in the code example in CalculatorPackage.kt in Turbo Native Modules guide.

### DIFF
--- a/docs/the-new-architecture/pillars-turbomodule.md
+++ b/docs/the-new-architecture/pillars-turbomodule.md
@@ -707,7 +707,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider
 
 class CalculatorPackage : TurboReactPackage() {
 - override fun getModule(name: String?, reactContext: ReactApplicationContext): NativeModule? = null
-+ override fun getModule(name: String?, reactContext: ReactApplicationContext): NativeModule? =
++ override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? =
 +   if (name == CalculatorModule.NAME) {
 +     CalculatorModule(reactContext)
 +   } else {

--- a/website/versioned_docs/version-0.73/the-new-architecture/pillars-turbomodule.md
+++ b/website/versioned_docs/version-0.73/the-new-architecture/pillars-turbomodule.md
@@ -707,7 +707,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider
 
 class CalculatorPackage : TurboReactPackage() {
 - override fun getModule(name: String?, reactContext: ReactApplicationContext): NativeModule? = null
-+ override fun getModule(name: String?, reactContext: ReactApplicationContext): NativeModule? =
++ override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? =
 +   if (name == CalculatorModule.NAME) {
 +     CalculatorModule(reactContext)
 +   } else {


### PR DESCRIPTION
Description: 
In the CalculatorPackage.kt file, there is a mistake in the code example. The getModule method of the CalculatorPackage class has an argument named "name" that is nullable. However, this argument in the extended class BaseReactPackage is non-null. This inconsistency causes an error in the Gradle build process.

extended class:
https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BaseReactPackage.java

Fixes #3963

![photo_2023-12-24 17 20 02](https://github.com/facebook/react-native-website/assets/53838054/a9fab312-3b1b-4efe-9809-d1f2cba5b3c1)
<img width="1496" alt="Screenshot 2023-12-24 at 17 54 59" src="https://github.com/facebook/react-native-website/assets/53838054/927ea45e-1302-42da-b572-28620d2e26ea">
-
