### PR TITLE
fix table header appearance in dark mode

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -225,7 +225,6 @@ hr {
     }
 
     tr th {
-      background-color: var(--divider) !important;
       text-transform: uppercase;
       padding: 6px 10px;
       font-size: 0.7rem;
@@ -370,10 +369,6 @@ html[data-theme="dark"] {
       a code {
         background-color: transparent;
       }
-    }
-
-    table thead tr {
-      background-color: var(--ifm-menu-color-background-active);
     }
 
     .prism-code {


### PR DESCRIPTION
# Why

Looks like we have introduce a small visual regression with one of the Docusaurus upgrade, so let's fix it!

![Screenshot 2023-12-30 at 09 59 01](https://github.com/facebook/react-native-website/assets/719641/2e9d491e-cc79-4f18-a1e8-52f9fb3cd65f)

# How

Remove custom CSS overwrites, stick to the default values which seems to look fine now.

# Preview

![Screenshot 2023-12-30 at 09 58 40](https://github.com/facebook/react-native-website/assets/719641/2949b487-04e0-46a5-a97b-6fd90f161085)

