### PR TITLE
Add CircleCI job running `yarn build`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,14 @@ jobs:
       - run_yarn
       - run: yarn ci:lint
 
+  build:
+    executor: node
+    working_directory: ~/react-native-website/website
+    steps:
+      - restore_cache_checkout
+      - run_yarn
+      - run: yarn build
+
 # -------------------------
 #        WORKFLOWS
 # -------------------------


### PR DESCRIPTION
We have a job for linting, but the only thing running the build is the netlify deploy, whose logs aren't public. Add CircleCI build check that is public.

