### PR TITLE
Give the CircleCI machines more memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ version: 2.1
 # -------------------------
 executors:
   node:
+    resource_class: large
     docker:
       - image: cimg/node:lts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 # -------------------------
 executors:
   node:
-    resource_class: large
+    resource_class: xlarge
     docker:
       - image: cimg/node:lts
 


### PR DESCRIPTION
Give it 8GB of memory since Docusaurus is liking to OOM during build, even when we restrict Node heap size.
