### PR TITLE
Update handling-text-input.md

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -14,7 +14,7 @@ import {Text, TextInput, View} from 'react-native';
 const PizzaTranslator = () => {
   const [text, setText] = useState('');
   return (
-    <View style={{padding: 10}}>
+    <View style={{padding: 100}}>
       <TextInput
         style={{height: 40}}
         placeholder="Type here to translate!"


### PR DESCRIPTION
I have set the text input padding as 100. Because the text input box will show in the center of device instead of top of the device. So, it will be more convenient to user to test the input box .

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
