### PR TITLE
Add a note about color scheme flickering on iOS between light and dark modes

### DIFF
--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -29,6 +29,8 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 > The color scheme preference will map to the user's Light or [Dark Mode](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode/) preference on iOS 13 devices and higher.
 
+> Note: When taking a screenshot, by default, the color scheme may flicker between light and dark mode. It happens because the iOS takes snapshots on both color schemes and updating the user interface with color scheme is asynchronous.
+
 </TabItem>
 </Tabs>
 

--- a/website/versioned_docs/version-0.70/appearance.md
+++ b/website/versioned_docs/version-0.70/appearance.md
@@ -29,6 +29,8 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 > The color scheme preference will map to the user's Light or [Dark Mode](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode/) preference on iOS 13 devices and higher.
 
+> Note: When taking a screenshot, by default, the color scheme may flicker between light and dark mode. It happens because the iOS takes snapshots on both color schemes and updating the user interface with color scheme is asynchronous.
+
 </TabItem>
 </Tabs>
 

--- a/website/versioned_docs/version-0.71/appearance.md
+++ b/website/versioned_docs/version-0.71/appearance.md
@@ -29,6 +29,8 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 > The color scheme preference will map to the user's Light or [Dark Mode](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode/) preference on iOS 13 devices and higher.
 
+> Note: When taking a screenshot, by default, the color scheme may flicker between light and dark mode. It happens because the iOS takes snapshots on both color schemes and updating the user interface with color scheme is asynchronous.
+
 </TabItem>
 </Tabs>
 

--- a/website/versioned_docs/version-0.72/appearance.md
+++ b/website/versioned_docs/version-0.72/appearance.md
@@ -29,6 +29,8 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 > The color scheme preference will map to the user's Light or [Dark Mode](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode/) preference on iOS 13 devices and higher.
 
+> Note: When taking a screenshot, by default, the color scheme may flicker between light and dark mode. It happens because the iOS takes snapshots on both color schemes and updating the user interface with color scheme is asynchronous.
+
 </TabItem>
 </Tabs>
 

--- a/website/versioned_docs/version-0.73/appearance.md
+++ b/website/versioned_docs/version-0.73/appearance.md
@@ -29,6 +29,8 @@ The `Appearance` module exposes information about the user's appearance preferen
 
 > The color scheme preference will map to the user's Light or [Dark Mode](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode/) preference on iOS 13 devices and higher.
 
+> Note: When taking a screenshot, by default, the color scheme may flicker between light and dark mode. It happens because the iOS takes snapshots on both color schemes and updating the user interface with color scheme is asynchronous.
+
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This PR adds a note about color scheme flickering on iOS between light and dark modes when taking a screenshot when using Appearance API.
