### PR TITLE
remove community packages references from useWindowDimensions

### DIFF
--- a/docs/usewindowdimensions.md
+++ b/docs/usewindowdimensions.md
@@ -46,9 +46,6 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [`useDimensions`](https://github.com/react-native-community/hooks#usedimensions) hook from the community [React Native Hooks](https://github.com/react-native-community/hooks) library aims to make handling screen/window size changes easier to work with.
-- [React Native Responsive Dimensions](https://github.com/react-native-toolkit/react-native-responsive-dimensions) also comes with responsive hooks.
-
 ## Properties
 
 ### `fontScale`

--- a/website/versioned_docs/version-0.70/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.70/usewindowdimensions.md
@@ -48,9 +48,6 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [`useDimensions`](https://github.com/react-native-community/hooks#usedimensions) hook from the community [React Native Hooks](https://github.com/react-native-community/hooks) library aims to make handling screen/window size changes easier to work with.
-- [React Native Responsive Dimensions](https://github.com/react-native-toolkit/react-native-responsive-dimensions) also comes with responsive hooks.
-
 ## Properties
 
 ### `fontScale`

--- a/website/versioned_docs/version-0.71/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.71/usewindowdimensions.md
@@ -46,9 +46,6 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [`useDimensions`](https://github.com/react-native-community/hooks#usedimensions) hook from the community [React Native Hooks](https://github.com/react-native-community/hooks) library aims to make handling screen/window size changes easier to work with.
-- [React Native Responsive Dimensions](https://github.com/react-native-toolkit/react-native-responsive-dimensions) also comes with responsive hooks.
-
 ## Properties
 
 ### `fontScale`

--- a/website/versioned_docs/version-0.72/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.72/usewindowdimensions.md
@@ -46,9 +46,6 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [`useDimensions`](https://github.com/react-native-community/hooks#usedimensions) hook from the community [React Native Hooks](https://github.com/react-native-community/hooks) library aims to make handling screen/window size changes easier to work with.
-- [React Native Responsive Dimensions](https://github.com/react-native-toolkit/react-native-responsive-dimensions) also comes with responsive hooks.
-
 ## Properties
 
 ### `fontScale`

--- a/website/versioned_docs/version-0.73/usewindowdimensions.md
+++ b/website/versioned_docs/version-0.73/usewindowdimensions.md
@@ -46,9 +46,6 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-- The [`useDimensions`](https://github.com/react-native-community/hooks#usedimensions) hook from the community [React Native Hooks](https://github.com/react-native-community/hooks) library aims to make handling screen/window size changes easier to work with.
-- [React Native Responsive Dimensions](https://github.com/react-native-toolkit/react-native-responsive-dimensions) also comes with responsive hooks.
-
 ## Properties
 
 ### `fontScale`


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Fixes: #3977
Removes community alternatives for the useWindowDimensions hook, as they have either been removed or are no longer maintained.
