### PR TITLE
Adapt tsc command for yarn and npm

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -54,7 +54,24 @@ This command adds the latest version of every dependency. The versions may need 
 
 > You should leave the `./index.js` entrypoint file as it is otherwise you may run into an issue when it comes to bundling a production build.
 
-4. Run `yarn tsc` to type-check your new TypeScript files.
+4. Run `tsc` to type-check your new TypeScript files.
+
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultPackageManager} values={constants.packageManagers}>
+<TabItem value="npm">
+
+```shell
+npx tsc
+```
+
+</TabItem>
+<TabItem value="yarn">
+
+```shell
+yarn tsc
+```
+
+</TabItem>
+</Tabs>
 
 ## Using JavaScript Instead of TypeScript
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Command example was showing example for yarn only, i added a tab to show example for both (yarn + npx)
