### PR TITLE
Update signed-apk-android.md

### DIFF
--- a/website/versioned_docs/version-0.73/signed-apk-android.md
+++ b/website/versioned_docs/version-0.73/signed-apk-android.md
@@ -128,20 +128,20 @@ Before uploading the release build to the Play Store, make sure you test it thor
 <TabItem value="npm">
 
 ```shell
-npm run android -- --mode="release"
+npm run android -- --variant="release"
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```shell
-yarn android --mode release
+yarn android --variant release
 ```
 
 </TabItem>
 </Tabs>
 
-Note that `--mode release` is only available if you've set up signing as described above.
+Note that `--variant release` is only available if you've set up signing as described above.
 
 You can terminate any running bundler instances, since all your framework and JavaScript code is bundled in the APK's assets.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

The Android CLI command does not have --mode options. The correct one is --variant. See the example below obtained through the CLI help option:

``` 
yarn android -h
yarn run v1.22.19
$ expo run:android -h

  Description
    Run the native Android app locally

  Usage
    $ npx expo run:android <dir>

  Options
    --no-build-cache       Clear the native build cache
    --no-install           Skip installing dependencies
    --no-bundler           Skip starting the bundler
    --variant <name>       Build variant. Default: debug
    -d, --device [device]  Device name to run the app on
    -p, --port <port>      Port to start the dev server on. Default: 8081
    -h, --help             Output usage information

Done in 0.24s.
```` 
