### PR TITLE
Update _getting-started-windows-android.md

### DIFF
--- a/docs/_getting-started-windows-android.md
+++ b/docs/_getting-started-windows-android.md
@@ -90,7 +90,7 @@ Open a new Command Prompt window to ensure the new environment variable is loade
 2. Copy and paste **Get-ChildItem -Path Env:\\** into powershell
 3. Verify `ANDROID_HOME` has been added
 
-<h4>4. Add platform-tools to Path</h4>
+<h4>4. Add platform-tools and cmdline-tools to Path</h4>
 
 1. Open the **Windows Control Panel.**
 2. Click on **User Accounts,** then click **User Accounts** again
@@ -103,6 +103,9 @@ The default location for this folder is:
 
 ```powershell
 %LOCALAPPDATA%\Android\Sdk\platform-tools
+```
+```powershell
+%LOCALAPPDATA%\Android\Sdk\cmdline-tools
 ```
 
 <h3>React Native Command Line Interface</h3>


### PR DESCRIPTION
I added an instruction to also add command-line tools in the $PATH variable. If not so, react-native doctor will raise an error even if an SDK is already present in the system.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
