### PR TITLE
[android][native-components-android.md] fix render android Fragment with flexbox

### DIFF
--- a/website/versioned_docs/version-0.70/native-components-android.md
+++ b/website/versioned_docs/version-0.70/native-components-android.md
@@ -511,8 +511,8 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup
 class MyViewManager(
     private val reactContext: ReactApplicationContext
 ) : ViewGroupManager<FrameLayout>() {
-  private var propWidth: Int? = null
-  private var propHeight: Int? = null
+  private var propWidth: Int = 0
+  private var propHeight: Int = 0
 
   override fun getName() = REACT_CLASS
 
@@ -544,9 +544,9 @@ class MyViewManager(
   }
 
   @ReactPropGroup(names = ["width", "height"], customType = "Style")
-  fun setStyle(view: FrameLayout, index: Int, value: Int) {
-    if (index == 0) propWidth = value
-    if (index == 1) propHeight = value
+  fun setStyle(view: FrameLayout, index: Int, value: Int?) {
+    if (index == 0) propWidth = value ?: 0
+    if (index == 1) propHeight = value ?: 0
   }
 
   /**
@@ -579,14 +579,29 @@ class MyViewManager(
    */
   private fun manuallyLayoutChildren(view: View) {
     // propWidth and propHeight coming from react-native props
-    val width = requireNotNull(propWidth)
-    val height = requireNotNull(propHeight)
+    val width = propWidth
+    val height = propHeight
 
-    view.measure(
-        View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY))
+    if (width > 0 && height > 0) {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        )
 
-    view.layout(0, 0, width, height)
+        view.layout(0, 0, width, height)
+    } else {
+        val parentView: ViewGroup = view.parent as ViewGroup
+
+        for (i in 0 until parentView.childCount) {
+            val child = parentView.getChildAt(i)
+            child.measure(
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredWidth, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredHeight, View.MeasureSpec.EXACTLY)
+            )
+
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+        }
+    }
   }
 
   companion object {
@@ -679,13 +694,13 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
   }
 
   @ReactPropGroup(names = {"width", "height"}, customType = "Style")
-  public void setStyle(FrameLayout view, int index, Integer value) {
+  public void setStyle(FrameLayout view, int index, @Nullable Integer value) {
     if (index == 0) {
-      propWidth = value;
+      propWidth = value != null ? value : 0;
     }
 
     if (index == 1) {
-      propHeight = value;
+      propHeight = value != null ? value : 0;
     }
   }
 
@@ -719,15 +734,28 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
    * Layout all children properly
    */
   public void manuallyLayoutChildren(View view) {
-      // propWidth and propHeight coming from react-native props
-      int width = propWidth;
-      int height = propHeight;
+    // propWidth and propHeight coming from react-native props
+    int width = propWidth;
+    int height = propHeight;
 
+    if (width > 0 && height > 0) {
       view.measure(
-              View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-              View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+          View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+          View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
 
       view.layout(0, 0, width, height);
+    } else {
+      ViewGroup parentView = (ViewGroup) view.getParent();
+
+      for (int i = 0; i < parentView.getChildCount(); i++) {
+        View child = parentView.getChildAt(i);
+        child.measure(
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
+
+        child.layout(0, 0, child.getMeasuredWidth(), child.getMeasuredHeight());
+      }
+    }
   }
 }
 ```

--- a/website/versioned_docs/version-0.71/native-components-android.md
+++ b/website/versioned_docs/version-0.71/native-components-android.md
@@ -511,8 +511,8 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup
 class MyViewManager(
     private val reactContext: ReactApplicationContext
 ) : ViewGroupManager<FrameLayout>() {
-  private var propWidth: Int? = null
-  private var propHeight: Int? = null
+  private var propWidth: Int = 0
+  private var propHeight: Int = 0
 
   override fun getName() = REACT_CLASS
 
@@ -544,9 +544,9 @@ class MyViewManager(
   }
 
   @ReactPropGroup(names = ["width", "height"], customType = "Style")
-  fun setStyle(view: FrameLayout, index: Int, value: Int) {
-    if (index == 0) propWidth = value
-    if (index == 1) propHeight = value
+  fun setStyle(view: FrameLayout, index: Int, value: Int?) {
+    if (index == 0) propWidth = value ?: 0
+    if (index == 1) propHeight = value ?: 0
   }
 
   /**
@@ -579,14 +579,29 @@ class MyViewManager(
    */
   private fun manuallyLayoutChildren(view: View) {
     // propWidth and propHeight coming from react-native props
-    val width = requireNotNull(propWidth)
-    val height = requireNotNull(propHeight)
+    val width = propWidth
+    val height = propHeight
 
-    view.measure(
-        View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY))
+    if (width > 0 && height > 0) {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        )
 
-    view.layout(0, 0, width, height)
+        view.layout(0, 0, width, height)
+    } else {
+        val parentView: ViewGroup = view.parent as ViewGroup
+
+        for (i in 0 until parentView.childCount) {
+            val child = parentView.getChildAt(i)
+            child.measure(
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredWidth, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredHeight, View.MeasureSpec.EXACTLY)
+            )
+
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+        }
+    }
   }
 
   companion object {
@@ -679,13 +694,13 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
   }
 
   @ReactPropGroup(names = {"width", "height"}, customType = "Style")
-  public void setStyle(FrameLayout view, int index, Integer value) {
+  public void setStyle(FrameLayout view, int index, @Nullable Integer value) {
     if (index == 0) {
-      propWidth = value;
+      propWidth = value != null ? value : 0;
     }
 
     if (index == 1) {
-      propHeight = value;
+      propHeight = value != null ? value : 0;
     }
   }
 
@@ -719,15 +734,28 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
    * Layout all children properly
    */
   public void manuallyLayoutChildren(View view) {
-      // propWidth and propHeight coming from react-native props
-      int width = propWidth;
-      int height = propHeight;
+    // propWidth and propHeight coming from react-native props
+    int width = propWidth;
+    int height = propHeight;
 
+    if (width > 0 && height > 0) {
       view.measure(
-              View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-              View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+          View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+          View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
 
       view.layout(0, 0, width, height);
+    } else {
+      ViewGroup parentView = (ViewGroup) view.getParent();
+
+      for (int i = 0; i < parentView.getChildCount(); i++) {
+        View child = parentView.getChildAt(i);
+        child.measure(
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
+
+        child.layout(0, 0, child.getMeasuredWidth(), child.getMeasuredHeight());
+      }
+    }
   }
 }
 ```

--- a/website/versioned_docs/version-0.72/native-components-android.md
+++ b/website/versioned_docs/version-0.72/native-components-android.md
@@ -511,8 +511,8 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup
 class MyViewManager(
     private val reactContext: ReactApplicationContext
 ) : ViewGroupManager<FrameLayout>() {
-  private var propWidth: Int? = null
-  private var propHeight: Int? = null
+  private var propWidth: Int = 0
+  private var propHeight: Int = 0
 
   override fun getName() = REACT_CLASS
 
@@ -544,9 +544,9 @@ class MyViewManager(
   }
 
   @ReactPropGroup(names = ["width", "height"], customType = "Style")
-  fun setStyle(view: FrameLayout, index: Int, value: Int) {
-    if (index == 0) propWidth = value
-    if (index == 1) propHeight = value
+  fun setStyle(view: FrameLayout, index: Int, value: Int?) {
+    if (index == 0) propWidth = value ?: 0
+    if (index == 1) propHeight = value ?: 0
   }
 
   /**
@@ -579,14 +579,29 @@ class MyViewManager(
    */
   private fun manuallyLayoutChildren(view: View) {
     // propWidth and propHeight coming from react-native props
-    val width = requireNotNull(propWidth)
-    val height = requireNotNull(propHeight)
+    val width = propWidth
+    val height = propHeight
 
-    view.measure(
-        View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY))
+    if (width > 0 && height > 0) {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        )
 
-    view.layout(0, 0, width, height)
+        view.layout(0, 0, width, height)
+    } else {
+        val parentView: ViewGroup = view.parent as ViewGroup
+
+        for (i in 0 until parentView.childCount) {
+            val child = parentView.getChildAt(i)
+            child.measure(
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredWidth, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredHeight, View.MeasureSpec.EXACTLY)
+            )
+
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+        }
+    }
   }
 
   companion object {
@@ -679,13 +694,13 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
   }
 
   @ReactPropGroup(names = {"width", "height"}, customType = "Style")
-  public void setStyle(FrameLayout view, int index, Integer value) {
+  public void setStyle(FrameLayout view, int index, @Nullable Integer value) {
     if (index == 0) {
-      propWidth = value;
+      propWidth = value != null ? value : 0;
     }
 
     if (index == 1) {
-      propHeight = value;
+      propHeight = value != null ? value : 0;
     }
   }
 
@@ -719,15 +734,28 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
    * Layout all children properly
    */
   public void manuallyLayoutChildren(View view) {
-      // propWidth and propHeight coming from react-native props
-      int width = propWidth;
-      int height = propHeight;
+    // propWidth and propHeight coming from react-native props
+    int width = propWidth;
+    int height = propHeight;
 
+    if (width > 0 && height > 0) {
       view.measure(
-              View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-              View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+          View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+          View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
 
       view.layout(0, 0, width, height);
+    } else {
+      ViewGroup parentView = (ViewGroup) view.getParent();
+
+      for (int i = 0; i < parentView.getChildCount(); i++) {
+        View child = parentView.getChildAt(i);
+        child.measure(
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
+
+        child.layout(0, 0, child.getMeasuredWidth(), child.getMeasuredHeight());
+      }
+    }
   }
 }
 ```

--- a/website/versioned_docs/version-0.73/native-components-android.md
+++ b/website/versioned_docs/version-0.73/native-components-android.md
@@ -511,8 +511,8 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup
 class MyViewManager(
     private val reactContext: ReactApplicationContext
 ) : ViewGroupManager<FrameLayout>() {
-  private var propWidth: Int? = null
-  private var propHeight: Int? = null
+  private var propWidth: Int = 0
+  private var propHeight: Int = 0
 
   override fun getName() = REACT_CLASS
 
@@ -544,9 +544,9 @@ class MyViewManager(
   }
 
   @ReactPropGroup(names = ["width", "height"], customType = "Style")
-  fun setStyle(view: FrameLayout, index: Int, value: Int) {
-    if (index == 0) propWidth = value
-    if (index == 1) propHeight = value
+  fun setStyle(view: FrameLayout, index: Int, value: Int?) {
+    if (index == 0) propWidth = value ?: 0
+    if (index == 1) propHeight = value ?: 0
   }
 
   /**
@@ -579,14 +579,29 @@ class MyViewManager(
    */
   private fun manuallyLayoutChildren(view: View) {
     // propWidth and propHeight coming from react-native props
-    val width = requireNotNull(propWidth)
-    val height = requireNotNull(propHeight)
+    val width = propWidth
+    val height = propHeight
 
-    view.measure(
-        View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY))
+    if (width > 0 && height > 0) {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        )
 
-    view.layout(0, 0, width, height)
+        view.layout(0, 0, width, height)
+    } else {
+        val parentView: ViewGroup = view.parent as ViewGroup
+
+        for (i in 0 until parentView.childCount) {
+            val child = parentView.getChildAt(i)
+            child.measure(
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredWidth, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(parentView.measuredHeight, View.MeasureSpec.EXACTLY)
+            )
+
+            child.layout(0, 0, child.measuredWidth, child.measuredHeight)
+        }
+    }
   }
 
   companion object {
@@ -679,13 +694,13 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
   }
 
   @ReactPropGroup(names = {"width", "height"}, customType = "Style")
-  public void setStyle(FrameLayout view, int index, Integer value) {
+  public void setStyle(FrameLayout view, int index, @Nullable Integer value) {
     if (index == 0) {
-      propWidth = value;
+      propWidth = value != null ? value : 0;
     }
 
     if (index == 1) {
-      propHeight = value;
+      propHeight = value != null ? value : 0;
     }
   }
 
@@ -719,15 +734,28 @@ public class MyViewManager extends ViewGroupManager<FrameLayout> {
    * Layout all children properly
    */
   public void manuallyLayoutChildren(View view) {
-      // propWidth and propHeight coming from react-native props
-      int width = propWidth;
-      int height = propHeight;
+    // propWidth and propHeight coming from react-native props
+    int width = propWidth;
+    int height = propHeight;
 
+    if (width > 0 && height > 0) {
       view.measure(
-              View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-              View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+          View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+          View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
 
       view.layout(0, 0, width, height);
+    } else {
+      ViewGroup parentView = (ViewGroup) view.getParent();
+
+      for (int i = 0; i < parentView.getChildCount(); i++) {
+        View child = parentView.getChildAt(i);
+        child.measure(
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredWidth(), View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(parentView.getMeasuredHeight(), View.MeasureSpec.EXACTLY));
+
+        child.layout(0, 0, child.getMeasuredWidth(), child.getMeasuredHeight());
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
Hi

I was creating a library that using Android Fragment and read RN docs about it https://reactnative.dev/docs/native-components-android?android-language=java#integration-with-an-android-fragment-example

But when I opened app I faced issue that flexbox wasn't working and I could set only fixed width & height. And moreover, when I removed width/height with FastRefresh app crashed

Library here: https://github.com/kesha-antonov/react-native-trueconf-sdk

Before changes (based only on RN docs):

https://github.com/facebook/react-native-website/assets/11584712/a8106f9d-1af1-4ec9-8808-68dc7145fb4c

After changes (flexbox works & adding/removing width/height doesn't crash the app):

https://github.com/facebook/react-native-website/assets/11584712/95c8066e-87a8-45d1-b08f-ece183db1f44

There's also example app: https://github.com/kesha-antonov/react-native-trueconf-sdk/tree/master/example

But you need to comment out these lines to boot it: https://github.com/kesha-antonov/react-native-trueconf-sdk/blob/master/android/build.gradle#L25-L27

And also comment out imports related to `com.trueconf` since access to those deps available only with credentials