### PR TITLE
[For Netlify Redirect Test] Add a fake redirect

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,5 +1,8 @@
 # Redirects from what the browser requests to what we serve
 
+# Adding this for testing
+/docs/:version/sourcemaps       https://github.com/reactwg/react-native-new-architecture#guides
+
 # Renamed pages
 /docs/android-setup             /docs/getting-started
 /docs/building-for-apple-tv     /docs/building-for-tv
@@ -11,8 +14,6 @@
 /docs/testing                   /contributing/how-to-run-and-write-tests
 /docs/understanding-cli         https://github.com/react-native-community/cli#react-native-cli
 
-# Adding this for testing
-/docs/:version/sourcemaps       https://github.com/reactwg/react-native-new-architecture#guides
 
 /contributing/how-to-contribute         /contributing/overview
 /releases/release-candidate-minor         /releases/release-branch-cut-and-rc0
@@ -55,4 +56,5 @@
 /help         /community/overview
 
 # Latest version might be linked to directly and should redirect
-/docs/$LATEST_VERSION$/*  /docs/:splat
+# Try removing this 
+# /docs/$LATEST_VERSION$/*  /docs/:splat

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -11,6 +11,9 @@
 /docs/testing                   /contributing/how-to-run-and-write-tests
 /docs/understanding-cli         https://github.com/react-native-community/cli#react-native-cli
 
+# Adding this for testing
+/docs/:version/sourcemaps       https://github.com/reactwg/react-native-new-architecture#guides
+
 /contributing/how-to-contribute         /contributing/overview
 /releases/release-candidate-minor         /releases/release-branch-cut-and-rc0
 


### PR DESCRIPTION
See https://answers.netlify.com/t/placeholder-redirects-dont-support-periods/113543/2


Head's up I couldn't reply to that thread anymore because Netlify reported my account as spam
If you try `https://deploy-preview-4029--react-native.netlify.app/docs/0.72/sourcemaps` this link -- the redirect fails

If anyone else can message on that thread with this PR, that will be helpful, thanks!

Edit: Actually what's even stranger is that it does work.. but just not for 0.72? 
Do we hardcode something for 0.72? I'm very confused
