### PR TITLE
Promote to use a Promise api instead of callbacks

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -464,11 +464,7 @@ Abort prefetch request.
 ### `getSize()`
 
 ```tsx
-static getSize(
-  uri: string,
-  success: (width: number, height: number) => void,
-  failure?: (error: any) => void,
-): any;
+static getSize(uri: string): Promise<{width: number, height: number}>;
 ```
 
 Retrieve the width and height (in pixels) of an image prior to displaying it. This method can fail if the image cannot be found, or fails to download.
@@ -477,11 +473,9 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>               | Type   | Description                |
+| ---------------------------------------------------- | ------ | -------------------------- |
+| uri <div class="label basic required">Required</div> | string | The location of the image. |
 
 ---
 
@@ -490,10 +484,8 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 ```tsx
 static getSizeWithHeaders(
   uri: string,
-  headers: {[index: string]: string},
-  success: (width: number, height: number) => void,
-  failure?: (error: any) => void,
-): any;
+  headers: {[index: string]: string}
+): Promise<{width: number, height: number}>;
 ```
 
 Retrieve the width and height (in pixels) of an image prior to displaying it with the ability to provide the headers for the request. This method can fail if the image cannot be found, or fails to download. It also does not work for static image resources.
@@ -502,12 +494,10 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| headers <div class="label basic required">Required</div> | object   | The headers for the request.                                                                         |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                   | Type   | Description                  |
+| -------------------------------------------------------- | ------ | ---------------------------- |
+| uri <div class="label basic required">Required</div>     | string | The location of the image.   |
+| headers <div class="label basic required">Required</div> | object | The headers for the request. |
 
 ---
 


### PR DESCRIPTION
`getSize` now can return promises

- ![image](https://github.com/facebook/react-native-website/assets/4661784/e53d738b-c806-4338-98bd-39c94490db6b)

- react-native PR: https://github.com/facebook/react-native/pull/42895


