### PR TITLE
Remove `listKey` as it's no longer needed in RN 0.71+

### DIFF
--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -385,16 +385,6 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 
 ---
 
-### `listKey`
-
-A unique identifier for this list. If there are multiple VirtualizedLists at the same level of nesting within another VirtualizedList, this key is necessary for virtualization to work properly.
-
-| Type   | Required |
-| ------ | -------- |
-| string | True     |
-
----
-
 ### `keyExtractor`
 
 ```tsx

--- a/website/versioned_docs/version-0.71/virtualizedlist.md
+++ b/website/versioned_docs/version-0.71/virtualizedlist.md
@@ -385,16 +385,6 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 
 ---
 
-### `listKey`
-
-A unique identifier for this list. If there are multiple VirtualizedLists at the same level of nesting within another VirtualizedList, this key is necessary for virtualization to work properly.
-
-| Type   | Required |
-| ------ | -------- |
-| string | True     |
-
----
-
 ### `keyExtractor`
 
 ```tsx

--- a/website/versioned_docs/version-0.72/virtualizedlist.md
+++ b/website/versioned_docs/version-0.72/virtualizedlist.md
@@ -385,16 +385,6 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 
 ---
 
-### `listKey`
-
-A unique identifier for this list. If there are multiple VirtualizedLists at the same level of nesting within another VirtualizedList, this key is necessary for virtualization to work properly.
-
-| Type   | Required |
-| ------ | -------- |
-| string | True     |
-
----
-
 ### `keyExtractor`
 
 ```tsx

--- a/website/versioned_docs/version-0.73/virtualizedlist.md
+++ b/website/versioned_docs/version-0.73/virtualizedlist.md
@@ -385,16 +385,6 @@ Reverses the direction of scroll. Uses scale transforms of `-1`.
 
 ---
 
-### `listKey`
-
-A unique identifier for this list. If there are multiple VirtualizedLists at the same level of nesting within another VirtualizedList, this key is necessary for virtualization to work properly.
-
-| Type   | Required |
-| ------ | -------- |
-| string | True     |
-
----
-
 ### `keyExtractor`
 
 ```tsx


### PR DESCRIPTION
`listKey` was removed, see: https://github.com/facebook/react-native/issues/37212#issuecomment-1539259551
