### PR TITLE
Add a new `Platform.isVision` property (React Native 0.74.x)

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -112,6 +112,20 @@ Returns a boolean which defines if device is a TV.
 
 ---
 
+### `isVision`
+
+```tsx
+static isVision: boolean;
+```
+
+Returns a boolean which defines if device is an Apple Vision. _If you are using [Apple Vision Pro (Designed for iPad)](https://developer.apple.com/documentation/visionos/checking-whether-your-app-is-compatible-with-visionos) `isVision` will be `false` but `isPad` will be `true`_
+
+| Type    |
+| ------- |
+| boolean |
+
+---
+
 ### `isTesting`
 
 ```tsx


### PR DESCRIPTION
My college @okwasniewski recently introduce a new Platform prop `isVision` https://github.com/facebook/react-native/commit/258d8e51b451b221e557dad4647cbd210fe37392

