### PR TITLE
[docs] fix a missing word typo in the new architecture landing page

### DIFF
--- a/docs/the-new-architecture/landing-page.md
+++ b/docs/the-new-architecture/landing-page.md
@@ -217,7 +217,7 @@ The team plans to enable the New Architecture by default in an upcoming React Na
 
 Our guidance is as follows
 
-- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official will offer the best experience.
+- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official release will offer the best experience.
 - If you maintain a React Native library, we recommend enabling it and verifying your use cases are covered. You can find the [instructions here](https://github.com/reactwg/react-native-new-architecture#guides).
 
 ### Enable the New Architecture

--- a/website/versioned_docs/version-0.70/the-new-architecture/landing-page.md
+++ b/website/versioned_docs/version-0.70/the-new-architecture/landing-page.md
@@ -217,7 +217,7 @@ The team plans to enable the New Architecture by default in an upcoming React Na
 
 Our guidance is as follows
 
-- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official will offer the best experience.
+- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official release will offer the best experience.
 - If you maintain a React Native library, we recommend enabling it and verifying your use cases are covered. You can find the [instructions here](https://github.com/reactwg/react-native-new-architecture#guides).
 
 ### Enable the New Architecture

--- a/website/versioned_docs/version-0.71/the-new-architecture/landing-page.md
+++ b/website/versioned_docs/version-0.71/the-new-architecture/landing-page.md
@@ -217,7 +217,7 @@ The team plans to enable the New Architecture by default in an upcoming React Na
 
 Our guidance is as follows
 
-- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official will offer the best experience.
+- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official release will offer the best experience.
 - If you maintain a React Native library, we recommend enabling it and verifying your use cases are covered. You can find the [instructions here](https://github.com/reactwg/react-native-new-architecture#guides).
 
 ### Enable the New Architecture

--- a/website/versioned_docs/version-0.72/the-new-architecture/landing-page.md
+++ b/website/versioned_docs/version-0.72/the-new-architecture/landing-page.md
@@ -217,7 +217,7 @@ The team plans to enable the New Architecture by default in an upcoming React Na
 
 Our guidance is as follows
 
-- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official will offer the best experience.
+- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official release will offer the best experience.
 - If you maintain a React Native library, we recommend enabling it and verifying your use cases are covered. You can find the [instructions here](https://github.com/reactwg/react-native-new-architecture#guides).
 
 ### Enable the New Architecture

--- a/website/versioned_docs/version-0.73/the-new-architecture/landing-page.md
+++ b/website/versioned_docs/version-0.73/the-new-architecture/landing-page.md
@@ -217,7 +217,7 @@ The team plans to enable the New Architecture by default in an upcoming React Na
 
 Our guidance is as follows
 
-- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official will offer the best experience.
+- For most production apps, we do _not_ recommend enabling the New Architecture today. Waiting for the official release will offer the best experience.
 - If you maintain a React Native library, we recommend enabling it and verifying your use cases are covered. You can find the [instructions here](https://github.com/reactwg/react-native-new-architecture#guides).
 
 ### Enable the New Architecture


### PR DESCRIPTION
## Why

As I was reading the new architecture landing page, I noticed what seemed like a missing word in this sentence, "Waiting for the official will...":

<img width="1840" alt="Screenshot 2024-03-08 at 15 13 18" src="https://github.com/facebook/react-native-website/assets/12488826/ab9eb9ca-a682-4654-b161-c0c443676a0a">

## How

I added the word "release" after "official" -- assuming that was the intent of the sentence.

## Test Plan

I ran the website locally to verify these changes:

<img width="1840" alt="Screenshot 2024-03-08 at 15 13 25" src="https://github.com/facebook/react-native-website/assets/12488826/c7125e2e-6ceb-4675-abf2-03fb5276dae5">
