### PR TITLE
docs(ui-components): add Pressable component documentation

### DIFF
--- a/website/versioned_docs/version-0.70/components-and-apis.md
+++ b/website/versioned_docs/version-0.70/components-and-apis.md
@@ -68,6 +68,12 @@ These common user interface controls will render on any platform.
       <p>A basic button component for handling touches that should render nicely on any platform.</p>
     </a>
   </div>
+   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A Core Component wrapper that can detect various stages of press interactions on any of its defined children</p>
+    </a>
+  </div>
   <div className="component">
     <a href="./switch">
       <h3>Switch</h3>

--- a/website/versioned_docs/version-0.71/components-and-apis.md
+++ b/website/versioned_docs/version-0.71/components-and-apis.md
@@ -68,6 +68,12 @@ These common user interface controls will render on any platform.
       <p>A basic button component for handling touches that should render nicely on any platform.</p>
     </a>
   </div>
+   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A Core Component wrapper that can detect various stages of press interactions on any of its defined children</p>
+    </a>
+  </div>
   <div className="component">
     <a href="./switch">
       <h3>Switch</h3>

--- a/website/versioned_docs/version-0.72/components-and-apis.md
+++ b/website/versioned_docs/version-0.72/components-and-apis.md
@@ -68,6 +68,12 @@ These common user interface controls will render on any platform.
       <p>A basic button component for handling touches that should render nicely on any platform.</p>
     </a>
   </div>
+   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A Core Component wrapper that can detect various stages of press interactions on any of its defined children</p>
+    </a>
+  </div>
   <div className="component">
     <a href="./switch">
       <h3>Switch</h3>

--- a/website/versioned_docs/version-0.73/components-and-apis.md
+++ b/website/versioned_docs/version-0.73/components-and-apis.md
@@ -68,6 +68,12 @@ These common user interface controls will render on any platform.
       <p>A basic button component for handling touches that should render nicely on any platform.</p>
     </a>
   </div>
+   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A Core Component wrapper that can detect various stages of press interactions on any of its defined children</p>
+    </a>
+  </div>
   <div className="component">
     <a href="./switch">
       <h3>Switch</h3>


### PR DESCRIPTION
This PR introduces documentation for the `Pressable` component within the User Interface components section alongside `Button` and `Switch`.

#### Changes:
- Updated the `components-and-apis.md` file to include a section on the `Pressable` component.


Resolves: #4022 