### PR TITLE
Update image.md

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -94,9 +94,6 @@ You will need to add some optional modules in `android/app/build.gradle`, depend
 
 ```groovy
 dependencies {
-  // If your app supports Android versions before Ice Cream Sandwich (API level 14)
-  implementation 'com.facebook.fresco:animated-base-support:1.3.0'
-
   // For animated GIF support
   implementation 'com.facebook.fresco:animated-gif:3.1.3'
 


### PR DESCRIPTION
Consider removing the `fresco:animated-base-support` dependency since React Native no longer supports Android versions before API level 14? This line was breaking my release builds while upgrading to React Native 0.73 and the bump to Fresco 3.1.3.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
