### PR TITLE
Open twitter url in new tab

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -133,6 +133,7 @@ function TwitterButton({accountName}) {
   return (
     <a
       href={`https://twitter.com/intent/follow?screen_name=${accountName}&region=follow_link`}
+      target="_blank"
       className="twitter-follow-button">
       <div className="icon" />
       Follow @{accountName}


### PR DESCRIPTION
The twitter url in hero section of home page is an external url, so clicking on it spoils the SPA router and opens the page in the same tab. This is going to give better user experience if this url opens in a new tab, and that's what I have done in this commit.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
