### PR TITLE
chore: changed href to the new react.dev site

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -379,7 +379,7 @@ module.exports = {
             items: [
               {
                 label: 'ReactJS',
-                href: 'https://reactjs.org/',
+                href: 'https://react.dev/',
               },
               {
                 label: 'Privacy Policy',


### PR DESCRIPTION
I changed the href link to point to https://react.dev/ instead of https://reactjs.org/. I know reactjs.org redirects to react.dev, but I feel like it could be updated on the site as well