### PR TITLE
fix: broken yogalayout link references

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -63,7 +63,7 @@ export default Flex;
 
 - `row-reverse` Align children from right to left. If wrapping is enabled, then the next line will start under the first item on the right of the container.
 
-You can learn more [here](https://yogalayout.com/docs/flex-direction).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-direction).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -507,7 +507,7 @@ export default DirectionLayout;
 
 - `space-evenly` Evenly distribute children within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
 
-You can learn more [here](https://yogalayout.com/docs/justify-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/justify-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -750,7 +750,7 @@ export default JustifyContentBasics;
 For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
 :::
 
-You can learn more [here](https://yogalayout.com/docs/align-items).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-items-self).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1235,7 +1235,7 @@ export default AlignSelfLayout;
 
 - `space-evenly` Evenly space wrapped lines across the container's cross axis, distributing the remaining space around the lines. Each space is the same size.
 
-You can learn more [here](https://yogalayout.com/docs/align-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1476,7 +1476,7 @@ export default AlignContentLayout;
 
 The [`flexWrap`](layout-props#flexwrap) property is set on containers and it controls what happens when children overflow the size of the container along the main axis. By default, children are forced into a single line (which can shrink elements). If wrapping is allowed, items are wrapped into multiple lines along the main axis if needed.
 
-When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
+When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://www.yogalayout.dev/docs/styling/flex-wrap).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1707,7 +1707,7 @@ export default FlexWrapLayout;
 
   `flexShrink` accepts any floating point value >= 0, with 0 being the default value (on the web, the default is 1). A container will shrink its children weighted by the children’s `flexShrink` values.
 
-You can learn more [here](https://yogalayout.com/docs/flex).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-basis-grow-shrink).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -2863,7 +2863,7 @@ export default PositionLayout;
 
 ## Going Deeper
 
-Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
+Check out the interactive [yoga playground](https://www.yogalayout.dev/playground) that you can use to get a better understanding of flexbox.
 
 We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](./layout-props.md).
 

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -507,7 +507,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://www.yogalayout.dev/docs/styling/layout-direction for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/architecture/architecture-glossary.md
+++ b/website/architecture/architecture-glossary.md
@@ -50,4 +50,4 @@ A _React Shadow Tree_ is created by the Fabric Renderer and consists of React Sh
 
 ## Yoga Tree (and Yoga Node)
 
-The _Yoga Tree_ is used by [Yoga](https://yogalayout.com/) to calculate layout information for a React Shadow Tree. Each React Shadow Node typically creates a _Yoga Node_ because React Native employs Yoga to calculate layout. However, this is not a hard requirement. Fabric can also create React Shadow Nodes that do not use Yoga; the implementation of each React Shadow Node determines how to calculate layout.
+The _Yoga Tree_ is used by [Yoga](https://www.yogalayout.dev/) to calculate layout information for a React Shadow Tree. Each React Shadow Node typically creates a _Yoga Node_ because React Native employs Yoga to calculate layout. However, this is not a hard requirement. Fabric can also create React Shadow Nodes that do not use Yoga; the implementation of each React Shadow Node determines how to calculate layout.

--- a/website/versioned_docs/version-0.70/flexbox.md
+++ b/website/versioned_docs/version-0.70/flexbox.md
@@ -57,7 +57,7 @@ export default Flex;
 
 - `row-reverse` Align children from right to left. If wrapping is enabled, then the next line will start under the first item on the right of the container.
 
-You can learn more [here](https://yogalayout.com/docs/flex-direction).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-direction).
 
 ```SnackPlayer name=Flex%20Direction
 import React, { useState } from "react";
@@ -302,7 +302,7 @@ export default DirectionLayout;
 
 - `space-evenly` Evenly distribute children within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
 
-You can learn more [here](https://yogalayout.com/docs/justify-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/justify-content).
 
 ```SnackPlayer name=Justify%20Content
 import React, { useState } from "react";
@@ -436,7 +436,7 @@ export default JustifyContentBasics;
 For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
 :::
 
-You can learn more [here](https://yogalayout.com/docs/align-items).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-items-self).
 
 ```SnackPlayer name=Align%20Items
 import React, { useState } from "react";
@@ -709,7 +709,7 @@ export default AlignSelfLayout;
 
 - `space-around` Evenly space wrapped lines across the container's cross axis, distributing the remaining space around the lines. Compared to `space-between`, using `space-around` will result in space being distributed to the beginning of the first line and the end of the last line.
 
-You can learn more [here](https://yogalayout.com/docs/align-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-content).
 
 ```SnackPlayer name=Align%20Content
 import React, { useState } from "react";
@@ -851,7 +851,7 @@ export default AlignContentLayout;
 
 The [`flexWrap`](layout-props#flexwrap) property is set on containers and it controls what happens when children overflow the size of the container along the main axis. By default, children are forced into a single line (which can shrink elements). If wrapping is allowed, items are wrapped into multiple lines along the main axis if needed.
 
-When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
+When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://www.yogalayout.dev/docs/styling/flex-wrap).
 
 ```SnackPlayer name=Flex%20Wrap
 import React, { useState } from "react";
@@ -992,7 +992,7 @@ export default FlexWrapLayout;
 
   `flexShrink` accepts any floating point value >= 0, with 0 being the default value (on the web, the default is 1). A container will shrink its children weighted by the children’s `flexShrink` values.
 
-You can learn more [here](https://yogalayout.com/docs/flex).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-basis-grow-shrink).
 
 ```SnackPlayer name=Flex%20Basis%2C%20Grow%2C%20and%20Shrink
 import React, { useState } from "react";
@@ -1512,7 +1512,7 @@ export default PositionLayout;
 
 ## Going Deeper
 
-Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
+Check out the interactive [yoga playground](https://www.yogalayout.dev/playground) that you can use to get a better understanding of flexbox.
 
 We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](./layout-props.md).
 

--- a/website/versioned_docs/version-0.70/layout-props.md
+++ b/website/versioned_docs/version-0.70/layout-props.md
@@ -303,7 +303,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://www.yogalayout.dev/docs/styling/layout-direction for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.71/flexbox.md
+++ b/website/versioned_docs/version-0.71/flexbox.md
@@ -63,7 +63,7 @@ export default Flex;
 
 - `row-reverse` Align children from right to left. If wrapping is enabled, then the next line will start under the first item on the right of the container.
 
-You can learn more [here](https://yogalayout.com/docs/flex-direction).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-direction).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -507,7 +507,7 @@ export default DirectionLayout;
 
 - `space-evenly` Evenly distribute children within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
 
-You can learn more [here](https://yogalayout.com/docs/justify-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/justify-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -750,7 +750,7 @@ export default JustifyContentBasics;
 For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
 :::
 
-You can learn more [here](https://yogalayout.com/docs/align-items).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-items-self).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1233,7 +1233,7 @@ export default AlignSelfLayout;
 
 - `space-around` Evenly space wrapped lines across the container's cross axis, distributing the remaining space around the lines. Compared to `space-between`, using `space-around` will result in space being distributed to the beginning of the first line and the end of the last line.
 
-You can learn more [here](https://yogalayout.com/docs/align-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1474,7 +1474,7 @@ export default AlignContentLayout;
 
 The [`flexWrap`](layout-props#flexwrap) property is set on containers and it controls what happens when children overflow the size of the container along the main axis. By default, children are forced into a single line (which can shrink elements). If wrapping is allowed, items are wrapped into multiple lines along the main axis if needed.
 
-When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
+When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://www.yogalayout.dev/docs/styling/flex-wrap).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1705,7 +1705,7 @@ export default FlexWrapLayout;
 
   `flexShrink` accepts any floating point value >= 0, with 0 being the default value (on the web, the default is 1). A container will shrink its children weighted by the children’s `flexShrink` values.
 
-You can learn more [here](https://yogalayout.com/docs/flex).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-basis-grow-shrink).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -2861,7 +2861,7 @@ export default PositionLayout;
 
 ## Going Deeper
 
-Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
+Check out the interactive [yoga playground](https://www.yogalayout.dev/playground) that you can use to get a better understanding of flexbox.
 
 We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](./layout-props.md).
 

--- a/website/versioned_docs/version-0.71/layout-props.md
+++ b/website/versioned_docs/version-0.71/layout-props.md
@@ -507,7 +507,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://www.yogalayout.dev/docs/styling/layout-direction for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.72/flexbox.md
+++ b/website/versioned_docs/version-0.72/flexbox.md
@@ -63,7 +63,7 @@ export default Flex;
 
 - `row-reverse` Align children from right to left. If wrapping is enabled, then the next line will start under the first item on the right of the container.
 
-You can learn more [here](https://yogalayout.com/docs/flex-direction).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-direction).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -507,7 +507,7 @@ export default DirectionLayout;
 
 - `space-evenly` Evenly distribute children within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
 
-You can learn more [here](https://yogalayout.com/docs/justify-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/justify-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -750,7 +750,7 @@ export default JustifyContentBasics;
 For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
 :::
 
-You can learn more [here](https://yogalayout.com/docs/align-items).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-items-self).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1233,7 +1233,7 @@ export default AlignSelfLayout;
 
 - `space-around` Evenly space wrapped lines across the container's cross axis, distributing the remaining space around the lines. Compared to `space-between`, using `space-around` will result in space being distributed to the beginning of the first line and the end of the last line.
 
-You can learn more [here](https://yogalayout.com/docs/align-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1474,7 +1474,7 @@ export default AlignContentLayout;
 
 The [`flexWrap`](layout-props#flexwrap) property is set on containers and it controls what happens when children overflow the size of the container along the main axis. By default, children are forced into a single line (which can shrink elements). If wrapping is allowed, items are wrapped into multiple lines along the main axis if needed.
 
-When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
+When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://www.yogalayout.dev/docs/styling/flex-wrap).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1705,7 +1705,7 @@ export default FlexWrapLayout;
 
   `flexShrink` accepts any floating point value >= 0, with 0 being the default value (on the web, the default is 1). A container will shrink its children weighted by the children’s `flexShrink` values.
 
-You can learn more [here](https://yogalayout.com/docs/flex).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-basis-grow-shrink).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -2861,7 +2861,7 @@ export default PositionLayout;
 
 ## Going Deeper
 
-Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
+Check out the interactive [yoga playground](https://www.yogalayout.dev/playground) that you can use to get a better understanding of flexbox.
 
 We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](./layout-props.md).
 

--- a/website/versioned_docs/version-0.72/layout-props.md
+++ b/website/versioned_docs/version-0.72/layout-props.md
@@ -507,7 +507,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://www.yogalayout.dev/docs/styling/layout-direction for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |

--- a/website/versioned_docs/version-0.73/flexbox.md
+++ b/website/versioned_docs/version-0.73/flexbox.md
@@ -63,7 +63,7 @@ export default Flex;
 
 - `row-reverse` Align children from right to left. If wrapping is enabled, then the next line will start under the first item on the right of the container.
 
-You can learn more [here](https://yogalayout.com/docs/flex-direction).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-direction).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -507,7 +507,7 @@ export default DirectionLayout;
 
 - `space-evenly` Evenly distribute children within the alignment container along the main axis. The spacing between each pair of adjacent items, the main-start edge and the first item, and the main-end edge and the last item, are all exactly the same.
 
-You can learn more [here](https://yogalayout.com/docs/justify-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/justify-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -750,7 +750,7 @@ export default JustifyContentBasics;
 For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
 :::
 
-You can learn more [here](https://yogalayout.com/docs/align-items).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-items-self).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1233,7 +1233,7 @@ export default AlignSelfLayout;
 
 - `space-around` Evenly space wrapped lines across the container's cross axis, distributing the remaining space around the lines. Compared to `space-between`, using `space-around` will result in space being distributed to the beginning of the first line and the end of the last line.
 
-You can learn more [here](https://yogalayout.com/docs/align-content).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/align-content).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1474,7 +1474,7 @@ export default AlignContentLayout;
 
 The [`flexWrap`](layout-props#flexwrap) property is set on containers and it controls what happens when children overflow the size of the container along the main axis. By default, children are forced into a single line (which can shrink elements). If wrapping is allowed, items are wrapped into multiple lines along the main axis if needed.
 
-When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://yogalayout.com/docs/flex-wrap).
+When wrapping lines, `alignContent` can be used to specify how the lines are placed in the container. Learn more [here](https://www.yogalayout.dev/docs/styling/flex-wrap).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -1705,7 +1705,7 @@ export default FlexWrapLayout;
 
   `flexShrink` accepts any floating point value >= 0, with 0 being the default value (on the web, the default is 1). A container will shrink its children weighted by the children’s `flexShrink` values.
 
-You can learn more [here](https://yogalayout.com/docs/flex).
+You can learn more [here](https://www.yogalayout.dev/docs/styling/flex-basis-grow-shrink).
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
@@ -2861,7 +2861,7 @@ export default PositionLayout;
 
 ## Going Deeper
 
-Check out the interactive [yoga playground](https://yogalayout.com/playground) that you can use to get a better understanding of flexbox.
+Check out the interactive [yoga playground](https://www.yogalayout.dev/playground) that you can use to get a better understanding of flexbox.
 
 We've covered the basics, but there are many other styles you may need for layouts. The full list of props that control layout is documented [here](./layout-props.md).
 

--- a/website/versioned_docs/version-0.73/layout-props.md
+++ b/website/versioned_docs/version-0.73/layout-props.md
@@ -507,7 +507,7 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 ### `direction`
 
-`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://yogalayout.com/docs/layout-direction for more details.
+`direction` specifies the directional flow of the user interface. The default is `inherit`, except for root node which will have value based on the current locale. See https://www.yogalayout.dev/docs/styling/layout-direction for more details.
 
 | Type                          | Required | Platform |
 | ----------------------------- | -------- | -------- |


### PR DESCRIPTION
While reading the docs I noticed these links are no longer working