### PR TITLE
Update accessibilityIgnoresInvertColors in TouchableWithoutFeedback

### DIFF
--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -81,7 +81,11 @@ export default TouchableWithoutFeedbackExample;
 
 ## Props
 
-### `accessibilityIgnoresInvertColors`
+### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+
+A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
+
+See the [Accessibility guide](accessibility.md#accessibilityignoresinvertcolors) for more information.
 
 | Type    |
 | ------- |


### PR DESCRIPTION
Hey, I noticed that the `accessibilityIgnoresInvertColors` in `TouchableWithoutFeedback` documentation is missing information about iOS platform support. This could be confusing, since this property is only supported for iOS.

<img width="973" alt="Screenshot 2024-04-03 at 12 32 41" src="https://github.com/facebook/react-native-website/assets/41058200/821ae638-da59-4dea-85d4-799526065f5d">
