### PR TITLE
Remove unmaintained Keystore libraries

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -62,10 +62,7 @@ The [Android Keystore](https://developer.android.com/training/articles/keystore)
 In order to use iOS Keychain services or Android Secure Shared Preferences, you can either write a bridge yourself or use a library which wraps them for you and provides a unified API at your own risk. Some libraries to consider:
 
 - [expo-secure-store](https://docs.expo.dev/versions/latest/sdk/securestore/)
-- [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage) - uses Keychain on iOS and EncryptedSharedPreferences on Android.
 - [react-native-keychain](https://github.com/oblador/react-native-keychain)
-- [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info) - secure for iOS, but uses Android Shared Preferences for Android (which is not secure by default). There is however a [branch](https://github.com/mCodex/react-native-sensitive-info/tree/keystore) that uses Android Keystore.
-  - [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage) - wraps react-native-sensitive-info for Redux.
 
 > **Be mindful of unintentionally storing or exposing sensitive info.** This could happen accidentally, for example saving sensitive form data in redux state and persisting the whole state tree in Async Storage. Or sending user tokens and personal info to an application monitoring service such as Sentry or Crashlytics.
 


### PR DESCRIPTION
2 of the 4 Keystore libraries recommended in the docs are no longer maintained, and I think it is best to not list those as they might most likely not be compatible with the new arch, and have multiple bugs reported that will probably never get fixed:
- `react-native-encrypted-storage` has not been maintained for 2 years, and the repository has been archived in november 2023
- `react-native-sensitive-info` has not seen activity for 3 years

I have not found any new maintained libraries for this, which is a shame as `react-native-keychain` is not handling every use-case (it is opinionated about what your secrets are), and `expo-secure-store` requires to either use Expo or at least depend on the `expo` package, which has its drawbacks (version upgrades for example).