### PR TITLE
[android] 'native-modules-android' & 'native-components-android' docs consistency

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -795,8 +795,11 @@ public class MyPackage implements ReactPackage {
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"
-    override fun getPackages() = PackageList(this).packages.apply {
-      add(MyPackage())
+override fun getPackages(): List<ReactPackage> =
+    PackageList(this).packages.apply {
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // add(MyReactNativePackage())
+        add(MyAppPackage())
     }
 ```
 
@@ -804,13 +807,14 @@ public class MyPackage implements ReactPackage {
 <TabItem value="java">
 
 ```java title="MainApplication.java"
-    @Override
-    protected List<ReactPackage> getPackages() {
-      List<ReactPackage> packages = new PackageList(this).getPackages();
-      ...
-      packages.add(new MyPackage());
-      return packages;
-    }
+@Override
+protected List<ReactPackage> getPackages() {
+    List<ReactPackage> packages = new PackageList(this).getPackages();
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyReactNativePackage());
+    packages.add(new MyAppPackage());
+    return packages;
+}
 ```
 
 </TabItem>

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -294,7 +294,6 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 override fun getPackages(): List<ReactPackage> =
     PackageList(this).packages.apply {
         // Packages that cannot be autolinked yet can be added manually here, for example:
-        // packages.add(new MyReactNativePackage());
         add(MyAppPackage())
     }
 ```

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -278,13 +278,13 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 
 ```java
 @Override
-  protected List<ReactPackage> getPackages() {
-    @SuppressWarnings("UnnecessaryLocalVariable")
+protected List<ReactPackage> getPackages() {
     List<ReactPackage> packages = new PackageList(this).getPackages();
     // Packages that cannot be autolinked yet can be added manually here, for example:
-    // packages.add(new MyAppPackage());
+    // packages.add(new MyReactNativePackage());
+    packages.add(new MyAppPackage());
     return packages;
-  }
+}
 ```
 
 </TabItem>
@@ -294,7 +294,8 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 override fun getPackages(): List<ReactPackage> =
     PackageList(this).packages.apply {
         // Packages that cannot be autolinked yet can be added manually here, for example:
-        // add(MyAppPackage())
+        // add(MyReactNativePackage())
+        add(MyAppPackage())
     }
 ```
 

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -281,8 +281,8 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
   protected List<ReactPackage> getPackages() {
     @SuppressWarnings("UnnecessaryLocalVariable")
     List<ReactPackage> packages = new PackageList(this).getPackages();
-    // below MyAppPackage is added to the list of packages returned
-    packages.add(new MyAppPackage());
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyAppPackage());
     return packages;
   }
 ```
@@ -294,7 +294,7 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 override fun getPackages(): List<ReactPackage> =
     PackageList(this).packages.apply {
         // Packages that cannot be autolinked yet can be added manually here, for example:
-        add(MyAppPackage())
+        // add(MyAppPackage())
     }
 ```
 

--- a/website/versioned_docs/version-0.73/native-components-android.md
+++ b/website/versioned_docs/version-0.73/native-components-android.md
@@ -791,8 +791,11 @@ public class MyPackage implements ReactPackage {
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"
-    override fun getPackages() = PackageList(this).packages.apply {
-      add(MyPackage())
+override fun getPackages(): List<ReactPackage> =
+    PackageList(this).packages.apply {
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // add(MyReactNativePackage())
+        add(MyAppPackage())
     }
 ```
 
@@ -800,13 +803,14 @@ public class MyPackage implements ReactPackage {
 <TabItem value="java">
 
 ```java title="MainApplication.java"
-    @Override
-    protected List<ReactPackage> getPackages() {
-      List<ReactPackage> packages = new PackageList(this).getPackages();
-      ...
-      packages.add(new MyPackage());
-      return packages;
-    }
+@Override
+protected List<ReactPackage> getPackages() {
+    List<ReactPackage> packages = new PackageList(this).getPackages();
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyReactNativePackage());
+    packages.add(new MyAppPackage());
+    return packages;
+}
 ```
 
 </TabItem>

--- a/website/versioned_docs/version-0.73/native-modules-android.md
+++ b/website/versioned_docs/version-0.73/native-modules-android.md
@@ -278,13 +278,13 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 
 ```java
 @Override
-  protected List<ReactPackage> getPackages() {
-    @SuppressWarnings("UnnecessaryLocalVariable")
+protected List<ReactPackage> getPackages() {
     List<ReactPackage> packages = new PackageList(this).getPackages();
-    // below MyAppPackage is added to the list of packages returned
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyReactNativePackage());
     packages.add(new MyAppPackage());
     return packages;
-  }
+}
 ```
 
 </TabItem>
@@ -294,7 +294,7 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 override fun getPackages(): List<ReactPackage> =
     PackageList(this).packages.apply {
         // Packages that cannot be autolinked yet can be added manually here, for example:
-        // packages.add(new MyReactNativePackage());
+        // add(MyReactNativePackage())
         add(MyAppPackage())
     }
 ```


### PR DESCRIPTION
Hi, just a minor fix.
There is a Java comment example in the Kotlin section. Maybe a copy/paste errata?