### PR TITLE
remove "New" tag from pages existing for a while

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1547,9 +1547,7 @@ td .label {
   - to restrict badge only to the next version use "next/PAGEID"
 */
 
-.menu__link[href*="dynamiccolorios"]:after,
-.menu__link[href*="platformcolor"]:after,
-.menu__link[href*="pressable"]:after {
+.menu__link[href*="NO_NEW_PAGES_CURRENTLY"]:after {
   content: "new";
   display: inline-block;
   position: relative;


### PR DESCRIPTION
# Why

It has been pointed out that we still show "New" tag for page introduced few versions ago.

# How

Remove "New" tag decoration from `Pressable`, `DynamicColorIOS` and `PlatformColor` reference pages.

Retained the code with a placeholder, since it might be useful in the future.

# Preview

<img src="https://github.com/facebook/react-native-website/assets/719641/fc9ca4e3-16ef-4395-83aa-8d923ee3effb" width="280" />


