### PR TITLE
Update X follow button and footer link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,6 +45,7 @@ module.exports = {
       defer: true,
     },
     {src: 'https://snack.expo.dev/embed.js', defer: true},
+    {src: 'https://platform.twitter.com/widgets.js', async: true},
   ],
   favicon: 'img/favicon.ico',
   titleDelimiter: '·',
@@ -368,8 +369,8 @@ module.exports = {
                 to: 'blog',
               },
               {
-                label: 'Twitter',
-                href: 'https://twitter.com/reactnative',
+                label: 'X',
+                href: 'https://x.com/reactnative',
               },
               {
                 label: 'GitHub',

--- a/website/src/css/index.scss
+++ b/website/src/css/index.scss
@@ -308,9 +308,9 @@
   max-width: 1200px;
   margin: -10px auto 0;
 
-  .twitter-follow-button,
   .github-button {
     margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
@@ -784,38 +784,5 @@ html[data-theme="dark"] .Section p a {
   .TwoColumns.TwoFigures {
     grid-template-columns: 1fr;
     grid-template-areas: "first" "last";
-  }
-}
-
-/* Twitter Follow Button */
-
-.twitter-follow-button {
-  display: inline-block;
-  position: relative;
-  height: 28px;
-  box-sizing: border-box;
-  padding: 1px 10px 1px 9px;
-  background-color: #1b95e0;
-  color: #fff;
-  border-radius: 4px;
-  font-weight: 400;
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 26px;
-
-  &:hover {
-    color: #fff;
-    background-color: #0c7abf;
-  }
-
-  .icon {
-    position: relative;
-    display: inline-block;
-    top: 4px;
-    height: 18px;
-    width: 18px;
-    margin-right: 4px;
-    background: transparent 0 0 no-repeat;
-    background-image: url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%3Cpath%20fill%3D%22none%22%20d%3D%22M0%200h72v72H0z%22%2F%3E%3Cpath%20class%3D%22icon%22%20fill%3D%22%23fff%22%20d%3D%22M68.812%2015.14c-2.348%201.04-4.87%201.744-7.52%202.06%202.704-1.62%204.78-4.186%205.757-7.243-2.53%201.5-5.33%202.592-8.314%203.176C56.35%2010.59%2052.948%209%2049.182%209c-7.23%200-13.092%205.86-13.092%2013.093%200%201.026.118%202.02.338%202.98C25.543%2024.527%2015.9%2019.318%209.44%2011.396c-1.125%201.936-1.77%204.184-1.77%206.58%200%204.543%202.312%208.552%205.824%2010.9-2.146-.07-4.165-.658-5.93-1.64-.002.056-.002.11-.002.163%200%206.345%204.513%2011.638%2010.504%2012.84-1.1.298-2.256.457-3.45.457-.845%200-1.666-.078-2.464-.23%201.667%205.2%206.5%208.985%2012.23%209.09-4.482%203.51-10.13%205.605-16.26%205.605-1.055%200-2.096-.06-3.122-.184%205.794%203.717%2012.676%205.882%2020.067%205.882%2024.083%200%2037.25-19.95%2037.25-37.25%200-.565-.013-1.133-.038-1.693%202.558-1.847%204.778-4.15%206.532-6.774z%22%2F%3E%3C%2Fsvg%3E);
   }
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -132,10 +132,10 @@ function HomeCallToAction() {
 function TwitterButton({accountName}) {
   return (
     <a
-      href={`https://twitter.com/intent/follow?screen_name=${accountName}&region=follow_link`}
-      target="_blank"
-      className="twitter-follow-button">
-      <div className="icon" />
+      className="twitter-follow-button"
+      href={`https://twitter.com/${accountName}?ref_src=twsrc%5Etfw`}
+      data-show-count="false"
+      data-size="large">
       Follow @{accountName}
     </a>
   );


### PR DESCRIPTION
## Summary

Update Twitter → X naming and branding on site homepage and in footer. Also switches (back) from custom follow button to official button widget from [publish.twitter.com](https://publish.twitter.com).

<details>
<summary><strong>Restores previous setup!</strong></summary>

This was motivated by seeing an updated follow button on the [archive.reactnative.dev](https://archive.reactnative.dev) site today! See 
https://github.com/facebook/react-native-website/commit/2161ea0297fdb72ff50bd9300056d4391ffa41ca for the historic source code.

<img width="1262" alt="image" src="https://github.com/facebook/react-native-website/assets/2547783/de2dd3ec-bb38-449c-94ab-3fbae36e4d4d">

</details>

## Test plan

**Header**

| Desktop | Mobile |
|--------|--------|
| <img width="1498" alt="image" src="https://github.com/facebook/react-native-website/assets/2547783/8a95f81a-1199-4ab1-988e-49709ee22314"> | <img width="495" alt="image" src="https://github.com/facebook/react-native-website/assets/2547783/043eeb36-583b-42b2-bbae-658f98f4f61c"> |

**Inline follow button**

<img width="1234" alt="image" src="https://github.com/facebook/react-native-website/assets/2547783/e744ea3b-bce9-4bc7-b7dd-2e2ca9e3dec5">

**Footer**

<img width="246" alt="image" src="https://github.com/facebook/react-native-website/assets/2547783/387658b3-c4e3-4225-a0f3-94ea58a6b236">

