### PR TITLE
Fix grammatical error in platform-specific-code.md

### DIFF
--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 
 `Platform.OS` will be `ios` when running on iOS and `android` when running on Android.
 
-There is also a `Platform.select` method available, that given an object where keys can be one of `'ios' | 'android' | 'native' | 'default'`, returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `ios` and `android` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
+There is also a `Platform.select` method available that, given an object where keys can be one of `'ios' | 'android' | 'native' | 'default'`, returns the most fitting value for the platform you are currently running on. That is, if you're running on a phone, `ios` and `android` keys will take preference. If those are not specified, `native` key will be used and then the `default` key.
 
 ```tsx
 import {Platform, StyleSheet} from 'react-native';


### PR DESCRIPTION
I made a minor correction to the `platform-specific-code.md` page regarding the placement of a comma in a sentence. The correction ensures that the parenthetical expression can be removed without changing the sentence's meaning. Specifically, I moved the comma after the word 'that' in the sentence starting with 'There is also a Platform.select method available...'.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
