### PR TITLE
add attribution for section contributors

### DIFF
--- a/website/blog/2024-04-22-release-0.74.md
+++ b/website/blog/2024-04-22-release-0.74.md
@@ -29,6 +29,8 @@ We are also removing deprecated APIs, with the removal of `PropTypes` and breaki
 
 ### Yoga 3.0
 
+_Authored by [Nick Gerleman](https://github.com/NickGerleman), [Joe Vilches](https://github.com/joevilches)_
+
 #### New Layout Behaviors
 
 React Native 0.74 includes [Yoga 3.0](https://yogalayout.dev/blog/announcing-yoga-3.0), the newest version of our layout engine. Yoga 3.0 improves layout by making styling more predictable, and supports rendering components written for the web.
@@ -157,6 +159,8 @@ React Native continues to default to `position: 'relative'` when no `position` i
 
 ### New Architecture: Bridgeless by Default
 
+_Authored by [Riccardo Cipolleschi](https://github.com/cipolleschi)_
+
 In this release, we are making Bridgeless Mode the default when the New Architecture is enabled. You can learn more about our switch to Bridgeless as the default in [this post](https://github.com/reactwg/react-native-new-architecture/discussions/174). To make the transition smoother we enhanced the interop layers to cover Bridgeless and worked with several libraries to make sure they will work in Bridgeless from day one.
 
 Bridgeless is not the only interop layer we worked on: we improved the New Renderer Interop layers too. The most exciting bit is that it is now enabled by default: you don't need to specify the components that have to go through it! You can read more about them [here](https://github.com/reactwg/react-native-new-architecture/discussions/175).
@@ -164,6 +168,8 @@ Bridgeless is not the only interop layer we worked on: we improved the New Rende
 Finally, if you want to learn more about the New Architecture, you can find documentation in the [react-native-new-architecture](https://github.com/reactwg/react-native-new-architecture/tree/main/docs) repo. When the New Architecture becomes the default, this information will be incorporated into [reactnative.dev](https://reactnative.dev).
 
 ### New Architecture: Batched `onLayout` updates
+
+_Authored by [Samuel Susla](https://github.com/sammy-SC)_
 
 State updates in `onLayout` callbacks are now batched. Previously, each state update in the `onLayout` event would result in a new render commit.
 
@@ -197,6 +203,8 @@ This change **may break code** that has relied on un-batched state updates. You'
 
 ### Yarn 3 for New Projects
 
+_Authored by [Alex Hunt](https://github.com/huntie)_
+
 [Yarn 3](https://yarnpkg.com/blog/release/3.0) is now the default JavaScript package manager for new projects initialized with React Native Community CLI.
 
 Yarn 3.x will be used with `nodeLinker: node-modules`, a mode providing compatibility with React Native libraries. This replaces Yarn Classic (1.x, deprecated) as the previous default. To upgrade Yarn version inside your existing app you can follow this [guide](https://yarnpkg.com/migration/guide).
@@ -214,6 +222,8 @@ The Community CLI also supports initializing projects with other package manager
 
 ### Android Minimum SDK Bump (Android 6.0)
 
+_Authored by [Nicola Corti](https://github.com/cortinico)_
+
 React Native 0.74 has a minimum Android SDK version requirement of 23 (Android 6.0). Previously, this was Android 5.0 (API 21). See our context for this change [here](https://github.com/react-native-community/discussions-and-proposals/discussions/740).
 
 #### Bonus: Android app size reduction
@@ -226,6 +236,8 @@ For example a newly created app with React Native 0.74 occupies ~13% less space 
 
 ### Removal of Deprecated `PropTypes`
 
+_Authored by [Tim Yung](https://github.com/yungsters)_
+
 Before 0.74, React Native continued to ship with `PropTypes`, an API that has been deprecated since React 15.5 in 2017! We are now removing all built-in `PropTypes` from React Native, reducing app size (26.4kB in a minified bundle) and memory overhead.
 
 The following `PropTypes` properties are removed: `Image.propTypes`, `Text.propTypes`, `TextInput.propTypes`, `ColorPropType`, `EdgeInsetsPropType`, `PointPropType`, `ViewPropTypes` (see [commit](https://github.com/facebook/react-native/commit/228cb80af9ded20107f3c7a30ffe00e24471bfeb)).
@@ -233,6 +245,8 @@ The following `PropTypes` properties are removed: `Image.propTypes`, `Text.propT
 If your app or library relies on `PropTypes`, we highly recommend migrating to a type system like TypeScript.
 
 ### API Changes to PushNotificationIOS (Deprecated)
+
+_Authored by [Ingrid Wang](https://github.com/ingridwang)_
 
 In React Native 0.74, we are making steps to remove the deprecated [PushNotificationIOS](https://reactnative.dev/docs/pushnotificationios) library. The changes in this release are focused on removing references to older iOS APIs. PushNotificationIOS has been migrated onto Apple’s [User Notifications](https://developer.apple.com/documentation/usernotifications?language=objc) framework and exposes new APIs for scheduling and handling notifications.
 


### PR DESCRIPTION
i'm adding attribution to the individual sections from their respective authors

<img width="364" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/220ad0f5-7fae-406f-bcdd-e12ca1054145">

<img width="524" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/127ee56d-0b8f-4537-9a1a-8a7b1e52eaae">

<img width="614" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/bb8ba5dd-5373-438d-8cd6-9bcd8ead81da">

<img width="355" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/8326ac38-1f7a-488b-bcfa-0e6f85aafbd2">

<img width="558" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/6618f96e-4d44-40d1-a663-e6aa5f309e40">

<img width="489" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/660ae777-4b13-4c30-81bc-f01dfaa57a1a">

<img width="651" alt="image" src="https://github.com/facebook/react-native-website/assets/5687023/7ac0cf58-f2a5-4646-9b40-fa8646f5b52d">
