### PR TITLE
[blog] Adjust Flipper wording + links in 0.74 post

### DIFF
--- a/website/blog/2024-04-22-release-0.74.md
+++ b/website/blog/2024-04-22-release-0.74.md
@@ -352,12 +352,12 @@ Delete any usages of <code>[application:didRegisterUserNotificationSettings:](ht
 
 ### Removal of Flipper React Native Plugin
 
-Use of [Flipper](https://fbflipper.com/) for inspecting React Native layouts, network requests, and [other React Native plugin features](https://www.internalfb.com/intern/staticdocs/flipper/docs/features/react-native/), is now unsupported. In 0.74, we have removed the native Flipper libraries and setup code from new React Native projects. This means fewer dependencies and quicker local setup (see [original RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0641-decoupling-flipper-from-react-native-core.md)).
+Use of [Flipper](https://fbflipper.com/) for inspecting React Native layouts, network requests, and [other React Native plugin features](https://fbflipper.com/docs/features/react-native/), is now unsupported. In 0.74, we have removed the native Flipper libraries and setup code from new React Native projects. This means fewer dependencies and quicker local setup (see [original RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0641-decoupling-flipper-from-react-native-core.md)).
 
 The diff for removing Flipper in your app can be seen in the [Upgrade Helper](https://react-native-community.github.io/upgrade-helper/). If you want to preserve Flipper in an existing app, ignore the relevant diff lines.
 
 <details>
-<summary>**💡 To re-integrate Flipper (unsupported)**</summary>
+<summary>**💡 To re-integrate Flipper**</summary>
 
 Flipper can still be used as a standalone tool for debugging an Android or iOS app, and can be manually integrated by following the Flipper docs ([Android guide](https://fbflipper.com/docs/getting-started/android-native/), [iOS guide](https://fbflipper.com/docs/getting-started/ios-native/)).
 
@@ -375,7 +375,7 @@ There are a number of dedicated debugging tools which replace Flipper features. 
 
 #### JavaScript debugging
 
-Using the **[Hermes Debugger](https://reactnative.dev/docs/debugging?js-debugger=hermes#opening-the-debugger)** remains our recommended debugging option for 0.74. You can also try the **[Experimental New Debugger](https://reactnative.dev/docs/debugging?js-debugger=new-debugger#opening-the-debugger)**, which is also the default in Expo. This continues to be an early preview — known issues and updates can be followed [here](https://github.com/react-native-community/discussions-and-proposals/discussions/733).
+Using the [Hermes Debugger](https://reactnative.dev/docs/debugging?js-debugger=hermes#opening-the-debugger) remains our recommended debugging option for 0.74. You can also try the [Experimental New Debugger](https://reactnative.dev/docs/debugging?js-debugger=new-debugger#opening-the-debugger), which is also the default in Expo. This continues to be an early preview — known issues and updates can be followed [here](https://github.com/react-native-community/discussions-and-proposals/discussions/733).
 
 ### Other Breaking Changes
 


### PR DESCRIPTION
Minor changes:

- Fix Flipper docs link.
- Remove "(unsupported)" from details heading (soften language — could be misconstrued to Flipper as a whole).
- Un-bold JS debugging links.