### PR TITLE
update getting-started-macos-android

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -26,10 +26,10 @@ We recommend installing the OpenJDK distribution called Azul **Zulu** using [Hom
 
 ```shell
 brew tap homebrew/cask-versions
-brew install --cask zulu17
+brew install --cask zulu@17
 
 # Get path to where cask was installed to double-click installer
-brew info --cask zulu17
+brew info --cask zulu@17
 ```
 
 After you install the JDK, update your `JAVA_HOME` environment variable. If you used above steps, JDK will likely be at `/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home`


### PR DESCRIPTION
Updating getting-started-macos-android in order of the new zulu version name.

<img width="495" alt="Captura de Tela 2024-04-29 às 10 34 48" src="https://github.com/facebook/react-native-website/assets/81118928/80ebbc02-cb92-437d-ae65-c1632a98ab16">
