### PR TITLE
fix: use new doc link from react.dev for ts

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -221,7 +221,7 @@ yarn add --dev babel-plugin-module-resolver
 }
 ```
 
-[react-ts]: https://reactjs.org/docs/static-type-checking.html#typescript
+[react-ts]: https://react.dev/learn/typescript
 [ts]: https://www.typescriptlang.org/
 [flow]: https://flow.org
 [ts-template]: https://github.com/react-native-community/react-native-template-typescript

--- a/website/versioned_docs/version-0.74/typescript.md
+++ b/website/versioned_docs/version-0.74/typescript.md
@@ -221,7 +221,7 @@ yarn add --dev babel-plugin-module-resolver
 }
 ```
 
-[react-ts]: https://reactjs.org/docs/static-type-checking.html#typescript
+[react-ts]: https://react.dev/learn/typescript
 [ts]: https://www.typescriptlang.org/
 [flow]: https://flow.org
 [ts-template]: https://github.com/react-native-community/react-native-template-typescript


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Use the new links [https://react.dev/learn/typescript](https://react.dev/learn/typescript) from [https://react.dev/](https://react.dev/) for version next and 0.74.

Older versions are skipped as they are not being maintained.

closes #4058 
