### PR TITLE
expo-cli installation added

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,6 +23,8 @@ Run the following command to create a new React Native project called "AwesomePr
 <TabItem value="npm">
 
 ```shell
+npm install --global expo-cli
+
 npx create-expo-app AwesomeProject
 
 cd AwesomeProject


### PR DESCRIPTION
npx create-expo-app throws an error without installing expo-cli

```
npm ERR! code ENOENT
npm ERR! syscall lstat
npm ERR! path C:\Users\user\AppData\Roaming\npm
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, lstat 'C:\Users\user\AppData\Roaming\npm'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```

