### PR TITLE
Replace RCTEventEmitter with RCTModernEventEmitter in Android Native UI Components guide

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -217,7 +217,7 @@ class MyCustomView(context: Context) : View(context) {
     }
     val reactContext = context as ReactContext
     reactContext
-        .getJSModule(RCTEventEmitter::class.java)
+        .getJSModule(RCTModernEventEmitter::class.java)
         .receiveEvent(id, "topChange", event)
   }
 }
@@ -234,7 +234,7 @@ class MyCustomView extends View {
       event.putString("message", "MyMessage");
       ReactContext reactContext = (ReactContext)getContext();
       reactContext
-          .getJSModule(RCTEventEmitter.class)
+          .getJSModule(RCTModernEventEmitter.class)
           .receiveEvent(getId(), "topChange", event);
     }
 }


### PR DESCRIPTION
I was following this guide and noticed that `RCTEventEmitter` is marked as deprecated in the latest (0.74) ReactNative release. Looks like there is a `RCTModernEventEmitter` that should be used instead.

> This [RCTModernEventEmitter] is a transitional replacement for RCTEventEmitter that works with Fabric and non-Fabric renderers. RCTEventEmitter works with Fabric as well, but there are negative perf implications and it should be avoided.