### PR TITLE
fix: RN CLI packaga name

### DIFF
--- a/docs/get-started-without-a-framework.md
+++ b/docs/get-started-without-a-framework.md
@@ -24,7 +24,7 @@ To do so, you'll first need to [set up your environment](set-up-your-environment
 You can use [React Native Community CLI](https://github.com/react-native-community/cli) to generate a new project. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native-community@latest init AwesomeProject
+npx @react-native-community/cli@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, or if you've installed [Expo](https://docs.expo.dev/bare/installing-expo-modules/) in your project, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to set up your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).

--- a/docs/get-started-without-a-framework.md
+++ b/docs/get-started-without-a-framework.md
@@ -44,7 +44,7 @@ If you are having trouble with iOS, try to reinstall the dependencies by running
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native-community@X.XX.X init AwesomeProject --version X.XX.X
+npx @react-native-community/cli@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument, read more [here](https://github.com/react-native-community/cli/blob/main/docs/init.md#initializing-project-with-custom-template).

--- a/website/versioned_docs/version-0.74/get-started-without-a-framework.md
+++ b/website/versioned_docs/version-0.74/get-started-without-a-framework.md
@@ -24,7 +24,7 @@ To do so, you'll first need to [set up your environment](set-up-your-environment
 You can use [React Native Community CLI](https://github.com/react-native-community/cli) to generate a new project. Let's create a new React Native project called "AwesomeProject":
 
 ```shell
-npx react-native-community@latest init AwesomeProject
+npx @react-native-community/cli@latest init AwesomeProject
 ```
 
 This is not necessary if you are integrating React Native into an existing application, or if you've installed [Expo](https://docs.expo.dev/bare/installing-expo-modules/) in your project, or if you're adding Android support to an existing React Native project (see [Integration with Existing Apps](integration-with-existing-apps.md)). You can also use a third-party CLI to set up your React Native app, such as [Ignite CLI](https://github.com/infinitered/ignite).
@@ -44,7 +44,7 @@ If you are having trouble with iOS, try to reinstall the dependencies by running
 If you want to start a new project with a specific React Native version, you can use the `--version` argument:
 
 ```shell
-npx react-native-community@X.XX.X init AwesomeProject --version X.XX.X
+npx @react-native-community/cli@X.XX.X init AwesomeProject --version X.XX.X
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument, read more [here](https://github.com/react-native-community/cli/blob/main/docs/init.md#initializing-project-with-custom-template).


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Fix RN CLI package name in "Getting started without a framework" docs.
