### PR TITLE
Convert the CircleCI workflow to a GitHub Actions workflow

### DIFF
--- a/.github/actions/restore_cache_checkout/action.yml
+++ b/.github/actions/restore_cache_checkout/action.yml
@@ -1,0 +1,9 @@
+name: restore_cache_checkout
+runs:
+  using: composite
+  steps:
+  - name: restore_cache
+    uses: actions/cache@v3.3.2
+    with:
+      key: v1-repo-${{ github.sha }}
+      path: UPDATE_ME

--- a/.github/actions/run_yarn/action.yml
+++ b/.github/actions/run_yarn/action.yml
@@ -1,0 +1,17 @@
+name: run_yarn
+runs:
+  using: composite
+  steps:
+  - name: restore_cache
+    uses: actions/cache@v3.3.2
+    with:
+      key: v1-yarn-${{ github.base_ref }}
+      path: UPDATE_ME
+      restore-keys: v1-yarn-${{ github.base_ref }}
+  - name: save_cache
+    uses: actions/cache@v3.3.2
+    with:
+      path: |
+        node_modules
+        ~/.cache/yarn
+      key: v1-yarn-${{ github.base_ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,52 @@
+name: facebook/react-native-website/tests
+on:
+  push:
+    branches:
+    - main
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+    - name: save_cache
+      uses: actions/cache@v3.3.2
+      with:
+        path: "~/react-native-website"
+        key: v1-repo-${{ github.sha }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        cache: yarn
+    - uses: "./.github/actions/restore_cache_checkout"
+    - uses: "./.github/actions/run_yarn"
+    - uses: borales/actions-yarn@v4
+      with:
+        cmd: install
+    - uses: borales/actions-yarn@v4
+      with:
+        cmd: ci:lint
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--max_old_space_size=4096"
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        cache: yarn
+    - uses: "./.github/actions/restore_cache_checkout"
+    - uses: "./.github/actions/run_yarn"
+    - uses: borales/actions-yarn@v4
+      with:
+        cmd: install
+    - uses: borales/actions-yarn@v4
+      with:
+        cmd: build


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.

**Issues**

1. _facebook/react-native-website/tests -> lint_

```
error Command "ci:lint" not found.
```
2. _facebook/react-native-website/tests -> build_

```
error Command "build" not found.
```

## How did you test this change?

I tested these changes in a [forked repo](https://github.com/robandpdx-org/react-native-website/actions/runs/9118638811).

https://fburl.com/workplace/f6mz6tmw