### PR TITLE
Update textinput.md - autoFocus

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -214,7 +214,7 @@ If `false`, disables auto-correct. The default value is `true`.
 
 ### `autoFocus`
 
-If `true`, focuses the input on `componentDidMount` or `useEffect`. The default value is `false`.
+If `true`, focuses the input. The default value is `false`.
 
 | Type |
 | ---- |


### PR DESCRIPTION
- remove the mention of `useEffect` and `componentDidMount` from doc about `autoFocus`.
- the underlying Implementation was changed from JS to Native
  -  [iOS PR](https://github.com/facebook/react-native/pull/27803), [Android PR](https://github.com/facebook/react-native/pull/27924),  [JS Removal PR](https://github.com/facebook/react-native/pull/27923)