### PR TITLE
[docs] Add tip fragment suggesting alternative tooling re: Flipper

### DIFF
--- a/docs/debugging-native-code.md
+++ b/docs/debugging-native-code.md
@@ -1,6 +1,6 @@
 ---
-id: native-debugging
-title: Native Debugging
+id: debugging-native-code
+title: Debugging Native Code
 ---
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -12,9 +12,9 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
   </p>
 </div>
 
-## Accessing native logs
+## Accessing Logs
 
-You can display the console logs for an iOS or Android app by using the following commands in a terminal while the app is running:
+You can display the native logs for an iOS or Android app by using the following commands in a terminal while the app is running:
 
 ```shell
 # For Android:
@@ -25,11 +25,7 @@ npx react-native log-ios
 
 You may also access these through Debug > Open System Log… in the iOS Simulator or by running `adb logcat "*:S" ReactNative:V ReactNativeJS:V` in a terminal while an Android app is running on a device or emulator.
 
-:::info
-If you're using Expo CLI, console logs already appear in the same terminal output as the bundler.
-:::
-
-## Debugging native code
+## Debugging in a Native IDE
 
 When working with native code, such as when writing native modules, you can launch the app from Android Studio or Xcode and take advantage of the native debugging features (setting up breakpoints, etc.) as you would in case of building a standard native app.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -56,6 +56,17 @@ To debug using Flipper, the Flipper app must be [installed on your system](https
 Debugging React Native apps with Flipper is [deprecated in React Native 0.73](https://github.com/react-native-community/discussions-and-proposals/pull/641). We will eventually remove out-of-the box support for JS debugging via Flipper.
 :::
 
+:::tip
+
+#### Alternative debugging tools
+
+As React Native transitions away from Flipper, we recommend other existing methods, including first party IDEs, to inspect your application's native code and behaviour.
+
+- [Debugging Native Code](./debugging-native-code)
+- <a href="https://shift.infinite.red/why-you-dont-need-flipper-in-your-react-native-app-and-how-to-get-by-without-it-3af461955109" target="_blank">Why you don’t need Flipper in your React Native app … and how to get by without it ↗</a>
+
+:::
+
 </TabItem>
 <TabItem value="new-debugger">
 
@@ -90,9 +101,9 @@ npx react-devtools
 
 :::tip
 
-**Learn how to use React DevTools!**
+#### Learn how to use React DevTools!
 
-- [React DevTools guide](/docs/next/react-devtools)
+- [React DevTools guide](./react-devtools)
 - [React Developer Tools on react.dev](https://react.dev/learn/react-developer-tools)
 
 :::

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -63,7 +63,7 @@
     "Debugging": [
       "debugging",
       "react-devtools",
-      "native-debugging",
+      "debugging-native-code",
       "debugging-release-builds",
       "other-debugging-methods"
     ],

--- a/website/versioned_docs/version-0.74/debugging.md
+++ b/website/versioned_docs/version-0.74/debugging.md
@@ -56,6 +56,17 @@ To debug using Flipper, the Flipper app must be [installed on your system](https
 Debugging React Native apps with Flipper is [deprecated in React Native 0.73](https://github.com/react-native-community/discussions-and-proposals/pull/641). We will eventually remove out-of-the box support for JS debugging via Flipper.
 :::
 
+:::tip
+
+#### Alternative debugging tools
+
+As React Native transitions away from Flipper, we recommend other existing methods, including first party IDEs, to inspect your application's native code and behaviour.
+
+- [Debugging Native Code](./native-debugging)
+- <a href="https://shift.infinite.red/why-you-dont-need-flipper-in-your-react-native-app-and-how-to-get-by-without-it-3af461955109" target="_blank">Why you don’t need Flipper in your React Native app … and how to get by without it ↗</a>
+
+:::
+
 </TabItem>
 <TabItem value="new-debugger">
 


### PR DESCRIPTION
> [!Note]
> Stacked on https://github.com/facebook/react-native-website/pull/4139.

Adds a new admonition beneath the current guidance on Flipper. We want to gently nudge users to explore alternative tooling for inspecting their app's native logic. Linking to @jamonholmgren's [excellent post](https://shift.infinite.red/why-you-dont-need-flipper-in-your-react-native-app-and-how-to-get-by-without-it-3af461955109) is a good stand-in for a future detailed guide we want to include on this.

> [!Note]
> Nudging users towards first party native IDEs is a **long-term intent**. Even after we ship the new debugger, and build further capabilities into it which replace Flipper features, the upper bound for its functionality will be to model and inspect browser-like concepts. Phrased another way, native debugging tools will always be relevant for deeply inspecting native apps.

<img width="863" alt="image" src="https://github.com/facebook/react-native-website/assets/2547783/42b792ac-e19d-4779-971c-d2ef62fc808a">
