### PR TITLE
Mention React Native visionOS in OOT platforms page

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -9,6 +9,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 - [React Native macOS](https://github.com/microsoft/react-native-macos) - React Native for macOS and Cocoa.
 - [React Native Windows](https://github.com/microsoft/react-native-windows) - React Native for Microsoft's Universal Windows Platform (UWP).
+- [React Native visionOS](https://github.com/callstack/react-native-visionos) - React Native for Apple's visionOS.
 
 **From Community**
 


### PR DESCRIPTION
In this Pull Request I added React Native visionOS to `out-of-tree-platforms.md` page  that we created and maintain at @callstack.