### PR TITLE
Update _getting-started-macos-android.md

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -33,7 +33,7 @@ After the JDK installation, add or update your `JAVA_HOME` environment variable 
 If you used above steps, JDK will likely be located at `/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home`:
 
 ```shell
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
 ```
 
 The Zulu OpenJDK distribution offers JDKs for **both Intel and M1 Macs**. This will make sure your builds are faster on M1 Macs compared to using an Intel-based JDK.


### PR DESCRIPTION

## Description

This pull request updates the instructions for setting up the JAVA_HOME environment variable in the _getting-started-macos-android.md file to reflect the use of Zulu JDK 17.

## Changes Made

	• Updated the JAVA_HOME path from Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home to /usr/libexec/java_home -v 17.
	• This change ensures compatibility with the latest Zulu JDK 17 installation paths.

## Additional Information

This update aims to simplify the setup process for developers and ensure consistency with the latest JDK distributions.