### PR TITLE
feat: add `submitBehavior` and deprecate `blurOnSubmit` of TextInput component

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -224,6 +224,8 @@ If `true`, focuses the input on `componentDidMount` or `useEffect`. The default 
 
 ### `blurOnSubmit`
 
+> **Deprecated.** Note that `submitBehavior` now takes the place of `blurOnSubmit` and will override any behavior defined by `blurOnSubmit`. See [submitBehavior](textinput#submitbehavior)
+
 If `true`, the text field will blur when submitted. The default value is true for single-line fields and false for multiline fields. Note that for multiline fields, setting `blurOnSubmit` to `true` means that pressing return will blur the field and trigger the `onSubmitEditing` event instead of inserting a newline into the field.
 
 | Type |
@@ -835,6 +837,31 @@ If `false`, disables spell-check style (i.e. red underlines). The default value 
 | Type |
 | ---- |
 | bool |
+
+---
+
+### `submitBehavior`
+
+When the return key is pressed,
+
+For single line inputs:
+
+- `'newline'` defaults to `'blurAndSubmit'`
+- `undefined` defaults to `'blurAndSubmit'`
+
+For multiline inputs:
+
+- `'newline'` adds a newline
+- `undefined` defaults to `'newline'`
+
+For both single line and multiline inputs:
+
+- `'submit'` will only send a submit event and not blur the input
+- `'blurAndSubmit`' will both blur the input and send a submit event
+
+| Type                                       |
+| ------------------------------------------ |
+| enum('submit', 'blurAndSubmit', 'newline') |
 
 ---
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
A new prop `submitBehavior` is added to `TextInput` component and this deprecates `blurOnSubmit` prop.

This PR updates document to sync with the changes. Please refer to https://github.com/facebook/react-native/pull/45588 for more info.