### PR TITLE
Add Min OS Version columns to RN releases

### DIFF
--- a/website/minOSVersions.json
+++ b/website/minOSVersions.json
@@ -1,0 +1,67 @@
+{
+  "next": {
+    "ios": "13.4",
+    "android": "Android 6.0 (API 23)"
+  },
+  "0.74": {
+    "ios": "13.4",
+    "android": "Android 6.0 (API 23)"
+  },
+  "0.73": {
+    "ios": "13.4",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.72": {
+    "ios": "12.4",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.71": {
+    "ios": "12.4",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.70": {
+    "ios": "12.4",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.69": {
+    "ios": "11.0",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.68": {
+    "ios": "11.0",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.67": {
+    "ios": "11.0",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.66": {
+    "ios": "11.0",
+    "android": "Android 5.0 (API 21)"
+  },
+
+  "0.65": {
+    "ios": "11.0",
+    "android": "Android 5.0 (API 21)"
+  },
+  "0.64": {
+    "ios": "10.0",
+    "android": "Android 4.1 (API 16)"
+  },
+  "0.63": {
+    "ios": "10.0",
+    "android": "Android 4.1 (API 16)"
+  },
+  "0.62": {
+    "ios": "9.0",
+    "android": "Android 4.1 (API 16)"
+  },
+  "0.61": {
+    "ios": "9.0",
+    "android": "Android 4.1 (API 16)"
+  },
+  "0.60": {
+    "ios": "9.0",
+    "android": "Android 4.1 (API 16)"
+  }
+}

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+const minOSVersions = require('../../minOSVersions.json');
 const versions = require('../../versions.json');
 // The versionsArchived mapping is a custom feature, NOT a Docusaurus feature
 const versionsArchived = require('../../versionsArchived.json');
@@ -36,6 +37,14 @@ const VersionItem = ({version, archivedDocumentationUrl, currentVersion}) => {
     releaseNotesURL = `https://github.com/facebook/react-native/releases/tag/v${version}.0`;
   }
 
+  let minOSVersion = minOSVersions[version] ?? {
+    andriod: 'TBD',
+    ios: 'TBD',
+  };
+
+  let androidMinOSVersion = minOSVersion.android ?? 'TBD';
+  let iosMinOSVersion = minOSVersion.ios ?? 'TBD';
+
   const releaseNotesLink = <a href={releaseNotesURL}>{releaseNotesTitle}</a>;
 
   return (
@@ -43,6 +52,12 @@ const VersionItem = ({version, archivedDocumentationUrl, currentVersion}) => {
       <th>{versionName}</th>
       <td>{documentationLink}</td>
       <td>{releaseNotesLink}</td>
+      <td>
+        [Android] minimum API level: <code>{androidMinOSVersion}</code>
+      </td>
+      <td>
+        [iOS] minimum OS: <code>{iosMinOSVersion}</code>
+      </td>
     </tr>
   );
 };


### PR DESCRIPTION
Add Min OS Version columns for iOS and Android to RN versions pages

## Screenshots

<img width="1126" alt="Screenshot 2024-08-02 at 3 28 43 PM" src="https://github.com/user-attachments/assets/6533902a-c8ad-46bf-a5a3-e3bebfeaf9ce">
