### PR TITLE
Remove PropTypes from `performance.md`

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -33,7 +33,7 @@ Similarly, you can happily scroll up and down through a `ScrollView` when the Ja
 
 ### Running in development mode (`dev=true`)
 
-JavaScript thread performance suffers greatly when running in dev mode. This is unavoidable: a lot more work needs to be done at runtime to provide you with good warnings and error messages, such as validating propTypes and various other assertions. Always make sure to test performance in [release builds](running-on-device.md#building-your-app-for-production).
+JavaScript thread performance suffers greatly when running in dev mode. This is unavoidable: a lot more work needs to be done at runtime to provide you with good warnings and error messages. Always make sure to test performance in [release builds](running-on-device.md#building-your-app-for-production).
 
 ### Using `console.log` statements
 

--- a/website/versioned_docs/version-0.75/performance.md
+++ b/website/versioned_docs/version-0.75/performance.md
@@ -33,7 +33,7 @@ Similarly, you can happily scroll up and down through a `ScrollView` when the Ja
 
 ### Running in development mode (`dev=true`)
 
-JavaScript thread performance suffers greatly when running in dev mode. This is unavoidable: a lot more work needs to be done at runtime to provide you with good warnings and error messages, such as validating propTypes and various other assertions. Always make sure to test performance in [release builds](running-on-device.md#building-your-app-for-production).
+JavaScript thread performance suffers greatly when running in dev mode. This is unavoidable: a lot more work needs to be done at runtime to provide you with good warnings and error messages. Always make sure to test performance in [release builds](running-on-device.md#building-your-app-for-production).
 
 ### Using `console.log` statements
 


### PR DESCRIPTION
Removes a minor reference to `propTypes` in `performance.md`. This PR updates it for 0.75 (currently live) and Next.