### PR TITLE
Update image.md fresco GIF library version

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -98,7 +98,7 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.1.3'
+  implementation 'com.facebook.fresco:animated-gif:3.2.0'
 
   // For WebP support, including animated WebP
   implementation 'com.facebook.fresco:animated-webp:3.1.3'


### PR DESCRIPTION
with react-native 0.75, this library doesn't work:

```
  // For animated GIF support
  implementation 'com.facebook.fresco:animated-gif:3.1.3'
```

We need to switch to the latest library:
```
    // For animated GIF support
    implementation 'com.facebook.fresco:animated-gif:3.2.0'
```

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
