### PR TITLE
Add padding to TextInput in handling-text-input code example

### DIFF
--- a/docs/handling-text-input.md
+++ b/docs/handling-text-input.md
@@ -16,7 +16,7 @@ const PizzaTranslator = () => {
   return (
     <View style={{padding: 10}}>
       <TextInput
-        style={{height: 40}}
+        style={{height: 40, padding: 5}}
         placeholder="Type here to translate!"
         onChangeText={newText => setText(newText)}
         defaultValue={text}


### PR DESCRIPTION
This PR is a small change to the [Handling Text Input](https://reactnative.dev/docs/handling-text-input) code example.

As of now it looks like this, the text cursor collides with the box:

![1](https://github.com/user-attachments/assets/27b6f064-804a-4050-85ac-55dd0ec5cc5b)

Adding a tiny bit of padding to the `TextInput` makes the cursor look better positioned:

![2](https://github.com/user-attachments/assets/c19350f9-d608-4917-bef1-71c87fc021bf)

Best regards and thank you for your awesome work!