### PR TITLE
docs: Update running-on-device.md for iOS to include mention about USB-C cables

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -362,7 +362,7 @@ You have built a great app using React Native, and you are now itching to releas
 
 ### 1. Plug in your device via USB
 
-Connect your iOS device to your Mac using a USB to Lightning cable. Navigate to the `ios` folder in your project, then open the `.xcodeproj` file, or if you are using CocoaPods open `.xcworkspace`, within it using Xcode.
+Connect your iOS device to your Mac using a USB to Lightning or USB-C cable. Navigate to the `ios` folder in your project, then open the `.xcodeproj` file, or if you are using CocoaPods open `.xcworkspace`, within it using Xcode.
 
 If this is your first time running an app on your iOS device, you may need to register your device for development. Open the **Product** menu from Xcode's menubar, then go to **Destination**. Look for and select your device from the list. Xcode will then register your device for development.
 


### PR DESCRIPTION
Times change and Lightning cables are no longer needed for connecting your iOS device! This PR adds a mention about USB-C cables, hooray!