### PR TITLE
docs: add resizeMultiplier to Image props

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -314,6 +314,16 @@ When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/pro
 
 ---
 
+### `referrerPolicy`
+
+A string indicating which referrer to use when fetching the resource. Sets the value for `Referrer-Policy` header in the image request. Works similar to `referrerpolicy` attribute in HTML.
+
+| Type                                                                                                                                                                                     | Default                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| enum(`'no-referrer'`, `'no-referrer-when-downgrade'`, `'origin'`, `'origin-when-cross-origin'`, `'same-origin'`, `'strict-origin'`, `'strict-origin-when-cross-origin'`, `'unsafe-url'`) | `'strict-origin-when-cross-origin'` |
+
+---
+
 ### `resizeMethod` <div class="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
@@ -329,16 +339,6 @@ More details about `resize` and `scale` can be found at https://frescolib.org/do
 | Type                                  | Default  |
 | ------------------------------------- | -------- |
 | enum(`'auto'`, `'resize'`, `'scale'`) | `'auto'` |
-
----
-
-### `referrerPolicy`
-
-A string indicating which referrer to use when fetching the resource. Sets the value for `Referrer-Policy` header in the image request. Works similar to `referrerpolicy` attribute in HTML.
-
-| Type                                                                                                                                                                                     | Default                             |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| enum(`'no-referrer'`, `'no-referrer-when-downgrade'`, `'origin'`, `'origin-when-cross-origin'`, `'same-origin'`, `'strict-origin'`, `'strict-origin-when-cross-origin'`, `'unsafe-url'`) | `'strict-origin-when-cross-origin'` |
 
 ---
 
@@ -362,6 +362,18 @@ Determines how to resize the image when the frame doesn't match the raw image di
 | Type                                                              | Default   |
 | ----------------------------------------------------------------- | --------- |
 | enum(`'cover'`, `'contain'`, `'stretch'`, `'repeat'`, `'center'`) | `'cover'` |
+
+---
+
+### `resizeMultiplier` <div class="label android">Android</div>
+
+When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
+
+This prop is most useful in cases where the destination dimensions are quite small and the source image is significantly larger. The `resize` resize method performs downsampling and significant image quality is lost between the source and destination image sizes, often resulting in a blurry image. By using a multiplier, the decoded image is slightly larger than the target size but smaller than the source image (if the source image is large enough). This allows aliasing artifacts to produce faux quality through scaling operations on the multiplied image.
+
+| Type   | Default |
+| ------ | ------- |
+| number | `1.0`   |
 
 ---
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -371,6 +371,8 @@ When the `resizeMethod` is set to `resize`, the destination dimensions are multi
 
 This prop is most useful in cases where the destination dimensions are quite small and the source image is significantly larger. The `resize` resize method performs downsampling and significant image quality is lost between the source and destination image sizes, often resulting in a blurry image. By using a multiplier, the decoded image is slightly larger than the target size but smaller than the source image (if the source image is large enough). This allows aliasing artifacts to produce faux quality through scaling operations on the multiplied image.
 
+If you have a source image with dimensions 200x200 and destination dimensions of 24x24, a resizeMultiplier of `2.0` will tell Fresco to downsample the image to 48x48. Fresco picks the closest power of 2 (so, 50x50) and decodes the image into a bitmap of that size. Without the multiplier, the closest power of 2 would be 25x25. The resultant image is scaled down by the system.
+
 | Type   | Default |
 | ------ | ------- |
 | number | `1.0`   |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This prop was [added in 0.75.0](https://github.com/facebook/react-native/commit/b6c343353765d8b13344841613250214fe8783db), but no documentation outside of JSDoc exists. This PR fixes that. It also organizes `referrerPolicy` alphabetically
