### PR TITLE
[DOC] use --variant instead of --mode

### DIFF
--- a/docs/running-on-device.md
+++ b/docs/running-on-device.md
@@ -72,7 +72,7 @@ yarn android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
-> Hint: You can also use the `React Native CLI` to generate and run a `release` build (e.g. from the root of your project: `yarn android --mode release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `release` build (e.g. from the root of your project: `yarn android --variant release`).
 
 <h2>Connecting to the development server</h2>
 
@@ -163,7 +163,7 @@ yarn android
 </TabItem>
 </Tabs>
 
-> Hint: You can also use the `React Native CLI` to generate and run a `release` build (e.g. from the root of your project: `yarn android --mode release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `release` build (e.g. from the root of your project: `yarn android --variant release`).
 
 <h2>Connecting to the development server</h2>
 
@@ -301,7 +301,7 @@ yarn android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](running-on-device.md#method-1-using-adb-reverse-recommended).
 
-> Hint: You can also use the `React Native CLI` to generate and run a `release` build (e.g. from the root of your project: `yarn android --mode release`).
+> Hint: You can also use the `React Native CLI` to generate and run a `release` build (e.g. from the root of your project: `yarn android --variant release`).
 
 <h2>Connecting to the development server</h2>
 


### PR DESCRIPTION
new expo cli command use --variant instead of --mode to specify the android debug/release mode

https://docs.expo.dev/more/expo-cli/#compiling-android