### PR TITLE
[0.75][main] Getting started: Bump documented Node.js minimum to 18.18

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node</h3>
 
-Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 18 or newer.
+Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 18.18 or newer.
 
 <h3>Java Development Kit</h3>
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18 or newer.
+If you have already installed Node on your system, make sure it is Node 18.18 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18 or newer.
+If you have already installed Node on your system, make sure it is Node 18.18 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/website/versioned_docs/version-0.75/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.75/_getting-started-linux-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node</h3>
 
-Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 18 or newer.
+Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 18.18 or newer.
 
 <h3>Java Development Kit</h3>
 

--- a/website/versioned_docs/version-0.75/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.75/_getting-started-macos-android.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18 or newer.
+If you have already installed Node on your system, make sure it is Node 18.18 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/website/versioned_docs/version-0.75/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.75/_getting-started-macos-ios.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18 or newer.
+If you have already installed Node on your system, make sure it is Node 18.18 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/website/versioned_docs/version-0.75/_getting-started-windows-android.md
+++ b/website/versioned_docs/version-0.75/_getting-started-windows-android.md
@@ -18,7 +18,7 @@ Open an Administrator Command Prompt (right click Command Prompt and select "Run
 choco install -y nodejs-lts microsoft-openjdk17
 ```
 
-If you have already installed Node on your system, make sure it is Node 18 or newer. If you already have a JDK on your system, we recommend JDK17. You may encounter problems using higher JDK versions.
+If you have already installed Node on your system, make sure it is Node 18.18 or newer. If you already have a JDK on your system, we recommend JDK17. You may encounter problems using higher JDK versions.
 
 > You can find additional installation options on [Node's Downloads page](https://nodejs.org/en/download/).
 


### PR DESCRIPTION
It's currently not possible to initialise a (community CLI) React Native >=0.75 project with Node 18.0, contrary to the docs, due to transitive dependency requirements. E.g:

Yarn 3.6.4 requires Node 18.12 and gives:
```
Usage Error: This tool requires a Node version compatible with >=18.12.0 (got 18.0.0). Upgrade Node, or set `YARN_IGNORE_NODE=1` in your environment.
```

The transitive dep `@typescript-eslint/parser` requires `^18.18.0` and causes the installation to fail.
```
[3/5] 🚚  Fetching packages...
error @typescript-eslint/parser@7.18.0: The engine "node" is incompatible with this module. Expected version "^18.18.0 || >=20.0.0". Got "18.0.0"
error Found incompatible module.
```

Repro with:
```
nvm i 18.0
nvm use 18.0
npx @react-native-community/cli@latest init --version 0.75.2
```

This updates our documented minimum to reflect that installation actually requires Node >=18.18.

(Documenting this officially frees us up to drop 18.0-18.17 support from our own tools, which is quite a bit of cruft that is serving no purpose given the above)