### PR TITLE
Update ToastAndroid with changes in Android 11

### DIFF
--- a/docs/toastandroid.md
+++ b/docs/toastandroid.md
@@ -12,6 +12,8 @@ You can alternatively use `showWithGravity(message, duration, gravity)` to speci
 
 The 'showWithGravityAndOffset(message, duration, gravity, xOffset, yOffset)' method adds the ability to specify an offset with in pixels.
 
+> Starting with Android 11 (API level 30), setting the gravity has no effect on text toasts. Read about the changes [here](https://developer.android.com/about/versions/11/behavior-changes-11#text-toast-api-changes).
+
 ```SnackPlayer name=Toast%20Android%20API%20Example&supportedPlatforms=android
 import React from 'react';
 import {View, StyleSheet, ToastAndroid, Button, StatusBar} from 'react-native';
@@ -83,6 +85,8 @@ static show(message: string, duration: number);
 
 ### `showWithGravity()`
 
+This property will only work on Android API 29 and below. For similar functionality on higher Android APIs, consider using snackbar or notification.
+
 ```tsx
 static showWithGravity(message: string, duration: number, gravity: number);
 ```
@@ -90,6 +94,8 @@ static showWithGravity(message: string, duration: number, gravity: number);
 ---
 
 ### `showWithGravityAndOffset()`
+
+This property will only work on Android API 29 and below. For similar functionality on higher Android APIs, consider using snackbar or notification.
 
 ```tsx
 static showWithGravityAndOffset(


### PR DESCRIPTION
`showWithGravity` and `showWithGravityAndOffset` from ToastAndroid does not work for text toasts as of Android 11. [ToastModule](https://github.com/facebook/react-native/blob/8dabed60f456e76a9e53273b601446f34de41fb5/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt#L48) uses `setGravity` which is no-op. More information can be found here:
- [setGravity docs](https://developer.android.com/reference/android/widget/Toast#setGravity(int,%20int,%20int))
- [Updates to toasts in Android 11 ](https://developer.android.com/about/versions/11/behavior-changes-11)

An alternative implementation could use `setView`, but:
1. It is [depracated](https://developer.android.com/reference/android/widget/Toast#setView(android.view.View))
2. [Custom toasts from the background are blocked](https://developer.android.com/about/versions/11/behavior-changes-11#custom-toasts-bg-blocked)

Android documentation specifies snackbar and notifications as alternatives to toasts. [link](https://developer.android.com/guide/topics/ui/notifiers/toasts)