### PR TITLE
Update iOS Simulator keyboard shortcut.

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 React Native provides an in-app developer menu which offers several debugging options. You can access the Dev Menu by shaking your device or via keyboard shortcuts:
 
-- iOS Simulator: <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> (or Device > Shake)
+- iOS Simulator: <kbd>Ctrl</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>Z</kbd> (or Device > Shake)
 - Android emulators: <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> (macOS) or <kbd>Ctrl</kbd> + <kbd>M</kbd> (Windows and Linux)
 
 Alternatively for Android devices and emulators, you can run `adb shell input keyevent 82` in your terminal.


### PR DESCRIPTION
The debugging docs page had an outdated keyboard shortcut to open the dev menu for an iOS Simulator.


<img width="307" alt="image" src="https://github.com/user-attachments/assets/23a064aa-79e7-4a3b-ad85-4f1393ff2ed1">
