### PR TITLE
Add guidance on deps to the contributing guide

### DIFF
--- a/website/contributing/contributing-overview.md
+++ b/website/contributing/contributing-overview.md
@@ -98,25 +98,6 @@ We recommend referring to the `react-native-website` repository [Readme file](ht
 
 Code-level contributions to React Native generally come in the form of [pull requests](https://help.github.com/en/articles/about-pull-requests). These are done by forking the repo and making changes locally.
 
-Directly in the repo, there is the [`rn-tester` app](https://github.com/facebook/react-native/tree/main/packages/rn-tester) that you can install on your device (or simulators) and use to test the changes you're making to React Native sources.
-
-The process of proposing a change to React Native can be summarized as follows:
-
-1. Fork the React Native repository and create your branch from `main`.
-2. Make the desired changes to React Native sources (tip: [editor setup](./how-to-open-a-pull-request#1-make-changes-to-the-code)). Use the `packages/rn-tester` app to test them out.
-3. If you've added code that should be tested, add tests.
-4. If you've changed APIs, update the documentation, which lives in [separate repo](https://github.com/facebook/react-native-website/).
-5. Ensure the test suite passes, either locally or on CI once you opened a pull request.
-6. Make sure your code lints (for example via `yarn lint --fix`).
-7. Push the changes to your fork.
-8. Create a pull request to the React Native repository.
-9. Review and address comments on your pull request.
-10. A bot may comment with suggestions. Generally we ask you to resolve these first before a maintainer will review your code.
-11. If changes are requested and addressed, please [request review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to notify reviewers to take another look.
-12. If you haven't already, please complete the [Contributor License Agreement](/contributing/contribution-license-agreement) ("CLA"). **[Complete your CLA here.](https://code.facebook.com/cla)**
-
-If all goes well, your pull request will be merged. If it is not merged, maintainers will do their best to explain the reason why.
-
 ### Step-by-step Guide
 
 Whenever you are ready to contribute code, check out our [step-by-step guide to sending your first pull request](/contributing/how-to-open-a-pull-request), or read the [How to Contribute Code](/contributing/how-to-contribute-code) page for more details.

--- a/website/contributing/how-to-open-a-pull-request.md
+++ b/website/contributing/how-to-open-a-pull-request.md
@@ -50,7 +50,23 @@ git checkout --branch my_feature_branch --track origin/main
 
 ## Chapter II: Implementing your Changes
 
-### 1. Make changes to the code
+### 1. Install dependencies
+
+React Native is a JavaScript monorepo managed by [Yarn Workspaces (Yarn Classic)](https://classic.yarnpkg.com/lang/en/docs/workspaces/).
+
+Run a project-level install:
+
+```sh
+yarn
+```
+
+You will also need to build the `react-native-codegen` package once:
+
+```sh
+yarn --cwd packages/react-native-codegen build
+```
+
+### 2. Make changes to the code
 
 You can now open the project using your code editor of choice. [Visual Studio Code](https://code.visualstudio.com/) is popular with JavaScript developers, and recommended if you are making general changes to React Native.
 
@@ -60,11 +76,11 @@ IDE project configurations:
 - **Android Studio**: Open the repo root folder (containing the `.idea` config directory).
 - **Xcode**: Open `packages/rn-tester/RNTesterPods.xcworkspace`.
 
-### 2. Test your changes
+### 3. Test your changes
 
 Make sure your changes are correct and do not introduce any test failures. You can learn more in [Running and Writing Tests](/contributing/how-to-run-and-write-tests).
 
-### 3. Lint your code
+### 4. Lint your code
 
 We understand it can take a while to ramp up and get a sense of the style followed for each of the languages in use in the core React Native repository. Developers should not need to worry about minor nits, so whenever possible, we use tools that automate the process of rewriting your code to follow conventions.
 
@@ -74,7 +90,7 @@ We also use a linter to catch styling issues that may exist in your code. You ca
 
 To learn more about coding conventions, refer to the [Coding Style guide](/contributing/how-to-contribute-code#coding-style).
 
-### 4. View your changes
+### 5. View your changes
 
 Many popular editors integrate with source control in some way. You can also use `git status` and `git diff` on the command line to keep track of what has changed.
 


### PR DESCRIPTION
## Summary

Supports https://github.com/facebook/react-native/pull/46420 (see [discussion](https://github.com/reactwg/react-native-releases/issues/476#issuecomment-2349048001)).

- Add Yarn install instructions.
- Add instructions for building `react-native-codegen`.
- Remove duplicated set of steps from `contributing-overview.md` — these are a subset of the step-by-step guide and were drifting out of sync.

## Test plan

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/cf8f1171-acf2-429c-9ed1-43cc83ec1a49">
