### PR TITLE
Improve ccache instructions Fixes #4215

### DIFF
--- a/docs/build-speed.md
+++ b/docs/build-speed.md
@@ -72,47 +72,8 @@ We suggest to use [**ccache**](https://ccache.dev/) to cache the compilation of 
 Ccache works by wrapping the C++ compilers, storing the compilation results, and skipping the compilation
 if an intermediate compilation result was originally stored.
 
-To install it, you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md).
-
-On macOS, we can install ccache with `brew install ccache`.
-Once installed you can configure it as follows to cache NDK compile results:
-
-```
-ln -s $(which ccache) /usr/local/bin/gcc
-ln -s $(which ccache) /usr/local/bin/g++
-ln -s $(which ccache) /usr/local/bin/cc
-ln -s $(which ccache) /usr/local/bin/c++
-ln -s $(which ccache) /usr/local/bin/clang
-ln -s $(which ccache) /usr/local/bin/clang++
-```
-
-This will create symbolic links to `ccache` inside the `/usr/local/bin/` which are called `gcc`, `g++`, and so on.
-
-This works as long as `/usr/local/bin/` comes first than `/usr/bin/` inside your `$PATH` variable, which is the default.
-
-You can verify that it works using the `which` command:
-
-```
-$ which gcc
-/usr/local/bin/gcc
-```
-
-If the results is `/usr/local/bin/gcc`, then you're effectively calling `ccache` which will wrap the `gcc` calls.
-
-:::caution
-Please note that this setup of `ccache` will affect all the compilations that you're running on your machine, not only those related to React Native. Use it at your own risk. If you're failing to install/compile other software, this might be the reason. If that is the case, you can remove the symlink you created with:
-
-```
-unlink /usr/local/bin/gcc
-unlink /usr/local/bin/g++
-unlink /usr/local/bin/cc
-unlink /usr/local/bin/c++
-unlink /usr/local/bin/clang
-unlink /usr/local/bin/clang++
-```
-
-to revert your machine to the original status and use the default compilers.
-:::
+Ccache is available in the package manager for most operating systems. On macOS, we can install ccache with `brew install ccache`.
+Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md) to install from source.
 
 You can then do two clean builds (e.g. on Android you can first run `yarn react-native run-android`, delete the `android/app/build` folder and run the first command once more). You will notice that the second build was way faster than the first one (it should take seconds rather than minutes).
 While building, you can verify that `ccache` works correctly and check the cache hits/miss rate `ccache -s`
@@ -139,43 +100,22 @@ Should you need to wipe your cache, you can do so with `ccache --clear`
 
 #### XCode Specific Setup
 
-To make sure `ccache` works correctly with iOS and XCode, you need to follow a couple of extra steps:
+To make sure `ccache` works correctly with iOS and XCode, you need to enable React Native support for ccache in `ios/Podfile`.
 
-1. You must alter the way Xcode and `xcodebuild` call for the compiler command. By default they use _fully specified paths_ to the compiler binaries, so the symbolic links installed in `/usr/local/bin` will not be used. You may configure Xcode to use _relative_ names for the compilers using either of these two options:
-
-- environment variables prefixed on the command line if you use a direct command line: `CLANG=clang CLANGPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ xcodebuild <rest of xcodebuild command line>`
-- A `post_install` section in your `ios/Podfile` that alters the compiler in your Xcode workspace during the `pod install` step:
+Open `ios/Podfile` in your editor and uncomment the `ccache_enabled` line.
 
 ```ruby
   post_install do |installer|
-    react_native_post_install(installer)
-
-    # ...possibly other post_install items here
-
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        # Using the un-qualified names means you can swap in different implementations, for example ccache
-        config.build_settings["CC"] = "clang"
-        config.build_settings["LD"] = "clang"
-        config.build_settings["CXX"] = "clang++"
-        config.build_settings["LDPLUSPLUS"] = "clang++"
-      end
-    end
-
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      # TODO: Uncomment the line below
+      :ccache_enabled => true
+    )
   end
 ```
-
-2. You need a ccache configuration that allows for a certain level of sloppiness and cache behavior such that ccache registers cache hits during Xcode compiles. The ccache configuration variables that are different from standard are as follows if configured by environment variable:
-
-```bash
-export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
-export CCACHE_FILECLONE=true
-export CCACHE_DEPEND=true
-export CCACHE_INODECACHE=true
-```
-
-The same may be configured in a `ccache.conf` file or any other mechanism ccache provides. More on this can be found in the [official ccache manual](https://ccache.dev/manual/4.3.html).
 
 #### Using this approach on a CI
 

--- a/website/versioned_docs/version-0.74/build-speed.md
+++ b/website/versioned_docs/version-0.74/build-speed.md
@@ -72,47 +72,8 @@ We suggest to use [**ccache**](https://ccache.dev/) to cache the compilation of 
 Ccache works by wrapping the C++ compilers, storing the compilation results, and skipping the compilation
 if an intermediate compilation result was originally stored.
 
-To install it, you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md).
-
-On macOS, we can install ccache with `brew install ccache`.
-Once installed you can configure it as follows to cache NDK compile results:
-
-```
-ln -s $(which ccache) /usr/local/bin/gcc
-ln -s $(which ccache) /usr/local/bin/g++
-ln -s $(which ccache) /usr/local/bin/cc
-ln -s $(which ccache) /usr/local/bin/c++
-ln -s $(which ccache) /usr/local/bin/clang
-ln -s $(which ccache) /usr/local/bin/clang++
-```
-
-This will create symbolic links to `ccache` inside the `/usr/local/bin/` which are called `gcc`, `g++`, and so on.
-
-This works as long as `/usr/local/bin/` comes first than `/usr/bin/` inside your `$PATH` variable, which is the default.
-
-You can verify that it works using the `which` command:
-
-```
-$ which gcc
-/usr/local/bin/gcc
-```
-
-If the results is `/usr/local/bin/gcc`, then you're effectively calling `ccache` which will wrap the `gcc` calls.
-
-:::caution
-Please note that this setup of `ccache` will affect all the compilations that you're running on your machine, not only those related to React Native. Use it at your own risk. If you're failing to install/compile other software, this might be the reason. If that is the case, you can remove the symlink you created with:
-
-```
-unlink /usr/local/bin/gcc
-unlink /usr/local/bin/g++
-unlink /usr/local/bin/cc
-unlink /usr/local/bin/c++
-unlink /usr/local/bin/clang
-unlink /usr/local/bin/clang++
-```
-
-to revert your machine to the original status and use the default compilers.
-:::
+Ccache is available in the package manager for most operating systems. On macOS, we can install ccache with `brew install ccache`.
+Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md) to install from source.
 
 You can then do two clean builds (e.g. on Android you can first run `yarn react-native run-android`, delete the `android/app/build` folder and run the first command once more). You will notice that the second build was way faster than the first one (it should take seconds rather than minutes).
 While building, you can verify that `ccache` works correctly and check the cache hits/miss rate `ccache -s`
@@ -139,43 +100,22 @@ Should you need to wipe your cache, you can do so with `ccache --clear`
 
 #### XCode Specific Setup
 
-To make sure `ccache` works correctly with iOS and XCode, you need to follow a couple of extra steps:
+To make sure `ccache` works correctly with iOS and XCode, you need to enable React Native support for ccache in `ios/Podfile`.
 
-1. You must alter the way Xcode and `xcodebuild` call for the compiler command. By default they use _fully specified paths_ to the compiler binaries, so the symbolic links installed in `/usr/local/bin` will not be used. You may configure Xcode to use _relative_ names for the compilers using either of these two options:
-
-- environment variables prefixed on the command line if you use a direct command line: `CLANG=clang CLANGPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ xcodebuild <rest of xcodebuild command line>`
-- A `post_install` section in your `ios/Podfile` that alters the compiler in your Xcode workspace during the `pod install` step:
+Open `ios/Podfile` in your editor and uncomment the `ccache_enabled` line.
 
 ```ruby
   post_install do |installer|
-    react_native_post_install(installer)
-
-    # ...possibly other post_install items here
-
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        # Using the un-qualified names means you can swap in different implementations, for example ccache
-        config.build_settings["CC"] = "clang"
-        config.build_settings["LD"] = "clang"
-        config.build_settings["CXX"] = "clang++"
-        config.build_settings["LDPLUSPLUS"] = "clang++"
-      end
-    end
-
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      # TODO: Uncomment the line below
+      :ccache_enabled => true
+    )
   end
 ```
-
-2. You need a ccache configuration that allows for a certain level of sloppiness and cache behavior such that ccache registers cache hits during Xcode compiles. The ccache configuration variables that are different from standard are as follows if configured by environment variable:
-
-```bash
-export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
-export CCACHE_FILECLONE=true
-export CCACHE_DEPEND=true
-export CCACHE_INODECACHE=true
-```
-
-The same may be configured in a `ccache.conf` file or any other mechanism ccache provides. More on this can be found in the [official ccache manual](https://ccache.dev/manual/4.3.html).
 
 #### Using this approach on a CI
 

--- a/website/versioned_docs/version-0.75/build-speed.md
+++ b/website/versioned_docs/version-0.75/build-speed.md
@@ -72,47 +72,8 @@ We suggest to use [**ccache**](https://ccache.dev/) to cache the compilation of 
 Ccache works by wrapping the C++ compilers, storing the compilation results, and skipping the compilation
 if an intermediate compilation result was originally stored.
 
-To install it, you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md).
-
-On macOS, we can install ccache with `brew install ccache`.
-Once installed you can configure it as follows to cache NDK compile results:
-
-```
-ln -s $(which ccache) /usr/local/bin/gcc
-ln -s $(which ccache) /usr/local/bin/g++
-ln -s $(which ccache) /usr/local/bin/cc
-ln -s $(which ccache) /usr/local/bin/c++
-ln -s $(which ccache) /usr/local/bin/clang
-ln -s $(which ccache) /usr/local/bin/clang++
-```
-
-This will create symbolic links to `ccache` inside the `/usr/local/bin/` which are called `gcc`, `g++`, and so on.
-
-This works as long as `/usr/local/bin/` comes first than `/usr/bin/` inside your `$PATH` variable, which is the default.
-
-You can verify that it works using the `which` command:
-
-```
-$ which gcc
-/usr/local/bin/gcc
-```
-
-If the results is `/usr/local/bin/gcc`, then you're effectively calling `ccache` which will wrap the `gcc` calls.
-
-:::caution
-Please note that this setup of `ccache` will affect all the compilations that you're running on your machine, not only those related to React Native. Use it at your own risk. If you're failing to install/compile other software, this might be the reason. If that is the case, you can remove the symlink you created with:
-
-```
-unlink /usr/local/bin/gcc
-unlink /usr/local/bin/g++
-unlink /usr/local/bin/cc
-unlink /usr/local/bin/c++
-unlink /usr/local/bin/clang
-unlink /usr/local/bin/clang++
-```
-
-to revert your machine to the original status and use the default compilers.
-:::
+Ccache is available in the package manager for most operating systems. On macOS, we can install ccache with `brew install ccache`.
+Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md) to install from source.
 
 You can then do two clean builds (e.g. on Android you can first run `yarn react-native run-android`, delete the `android/app/build` folder and run the first command once more). You will notice that the second build was way faster than the first one (it should take seconds rather than minutes).
 While building, you can verify that `ccache` works correctly and check the cache hits/miss rate `ccache -s`
@@ -139,43 +100,22 @@ Should you need to wipe your cache, you can do so with `ccache --clear`
 
 #### XCode Specific Setup
 
-To make sure `ccache` works correctly with iOS and XCode, you need to follow a couple of extra steps:
+To make sure `ccache` works correctly with iOS and XCode, you need to enable React Native support for ccache in `ios/Podfile`.
 
-1. You must alter the way Xcode and `xcodebuild` call for the compiler command. By default they use _fully specified paths_ to the compiler binaries, so the symbolic links installed in `/usr/local/bin` will not be used. You may configure Xcode to use _relative_ names for the compilers using either of these two options:
-
-- environment variables prefixed on the command line if you use a direct command line: `CLANG=clang CLANGPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ xcodebuild <rest of xcodebuild command line>`
-- A `post_install` section in your `ios/Podfile` that alters the compiler in your Xcode workspace during the `pod install` step:
+Open `ios/Podfile` in your editor and uncomment the `ccache_enabled` line.
 
 ```ruby
   post_install do |installer|
-    react_native_post_install(installer)
-
-    # ...possibly other post_install items here
-
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        # Using the un-qualified names means you can swap in different implementations, for example ccache
-        config.build_settings["CC"] = "clang"
-        config.build_settings["LD"] = "clang"
-        config.build_settings["CXX"] = "clang++"
-        config.build_settings["LDPLUSPLUS"] = "clang++"
-      end
-    end
-
-    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      # TODO: Uncomment the line below
+      :ccache_enabled => true
+    )
   end
 ```
-
-2. You need a ccache configuration that allows for a certain level of sloppiness and cache behavior such that ccache registers cache hits during Xcode compiles. The ccache configuration variables that are different from standard are as follows if configured by environment variable:
-
-```bash
-export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
-export CCACHE_FILECLONE=true
-export CCACHE_DEPEND=true
-export CCACHE_INODECACHE=true
-```
-
-The same may be configured in a `ccache.conf` file or any other mechanism ccache provides. More on this can be found in the [official ccache manual](https://ccache.dev/manual/4.3.html).
 
 #### Using this approach on a CI
 


### PR DESCRIPTION
In RN 0.74 support was added to natively support ccachng on ios by setting `enable_ccache` in the Podfile.
This change updates the relevant docs to use the much simpler instructions
