### PR TITLE
Fix `interpolate()` link on Animated docs

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -168,7 +168,7 @@ You can combine two animated values via addition, subtraction, multiplication, d
 
 The `interpolate()` function allows input ranges to map to different output ranges. By default, it will extrapolate the curve beyond the ranges given, but you can also have it clamp the output value. It uses linear interpolation by default but also supports easing functions.
 
-- [`interpolate()`](animated#interpolate)
+- [`interpolate()`](animatedvalue#interpolate)
 
 Read more about interpolation in the [Animation](animations#interpolation) guide.
 


### PR DESCRIPTION
I noticed this link was broken, so I am fixing it.