### PR TITLE
fix incorrect font after the latest Docusaurus update

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -91,6 +91,10 @@
   }
 }
 
+body {
+  font-family: var(--ifm-font-family-base);
+}
+
 html[data-theme="light"] {
   --ifm-code-background: rgba(0, 0, 0, 0.06);
   --docsearch-container-background: rgba(32, 35, 42, 0.6);


### PR DESCRIPTION
# Why & how

Spotted recently that custom "Optimistic Display" font is not used for all text components after the latest Docusaurus update.

This PR reuses defined for IFM theme base font value, and applies it to the document body, which correctly propoaget the wanted font family down the DOM tree.

# Preview

![Screenshot 2024-09-18 at 14 57 59](https://github.com/user-attachments/assets/c7e4d408-32e8-407d-9ba9-7d6b592d9f9a)

