### PR TITLE
Simplify root npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ If you are looking for the source code of the [React Native Archive website](htt
 
 ### Running locally
 
-1.  `cd website` to go into the website portion of the project.
-1.  `yarn start` to start the development server _(powered by [Docusaurus](https://v2.docusaurus.io))_.
+1.  Run `yarn start` to start the development server _(powered by [Docusaurus](https://v2.docusaurus.io))_.
 1.  Open http://localhost:3000/ site in your favorite browser.
 
 ## 📖 Overview

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "scripts": {
     "postinstall": "yarn update-lock",
     "update-lock": "yarn-deduplicate",
-    "docusaurus": "yarn workspace react-native-website docusaurus",
-    "website:start": "yarn workspace react-native-website start",
-    "website:build": "yarn workspace react-native-website build",
-    "website:build:fast": "yarn workspace react-native-website build:fast",
-    "website:serve": "yarn workspace react-native-website serve"
+    "docusaurus": "yarn --cwd website docusaurus",
+    "start": "yarn --cwd website start",
+    "build": "yarn --cwd website build",
+    "build:fast": "yarn --cwd website build:fast",
+    "serve": "yarn --cwd website serve"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary

Remove "website:" prefixes from the root `start`, `build*`, `serve` npm scripts. This simplifies the steps needed to iterate in this project.

The `website/` dir is the only runnable target package in this monorepo — we can refactor later if this changes.

## Test plan

```sh
yarn start
```

<img width="638" alt="image" src="https://github.com/user-attachments/assets/4dcfd5a7-0a25-446a-984c-197c58a935e9">
