### PR TITLE
update examples to use cross-platform SafeAreaView

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -9,7 +9,8 @@ Sometimes it's useful to know whether or not the device has a screen reader that
 
 ```SnackPlayer name=AccessibilityInfo%20Example&supportedPlatforms=android,ios
 import React, {useState, useEffect} from 'react';
-import {AccessibilityInfo, View, Text, StyleSheet} from 'react-native';
+import {AccessibilityInfo, Text, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
@@ -43,14 +44,16 @@ const App = () => {
   }, []);
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.status}>
-        The reduce motion is {reduceMotionEnabled ? 'enabled' : 'disabled'}.
-      </Text>
-      <Text style={styles.status}>
-        The screen reader is {screenReaderEnabled ? 'enabled' : 'disabled'}.
-      </Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.status}>
+          The reduce motion is {reduceMotionEnabled ? 'enabled' : 'disabled'}.
+        </Text>
+        <Text style={styles.status}>
+          The screen reader is {screenReaderEnabled ? 'enabled' : 'disabled'}.
+        </Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/actionsheetios.md
+++ b/docs/actionsheetios.md
@@ -7,9 +7,10 @@ Displays native to iOS [Action Sheet](https://developer.apple.com/design/human-i
 
 ## Example
 
-```SnackPlayer name=ActionSheetIOS&supportedPlatforms=ios
+```SnackPlayer name=ActionSheetIOS%20Example&supportedPlatforms=ios
 import React, {useState} from 'react';
-import {ActionSheetIOS, Button, StyleSheet, Text, View} from 'react-native';
+import {ActionSheetIOS, Button, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [result, setResult] = useState('🔮');
@@ -34,10 +35,12 @@ const App = () => {
     );
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.result}>{result}</Text>
-      <Button onPress={onPress} title="Show Action Sheet" />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.result}>{result}</Text>
+        <Button onPress={onPress} title="Show Action Sheet" />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -9,15 +9,18 @@ Displays a circular loading indicator.
 
 ```SnackPlayer name=ActivityIndicator%20Example
 import React from 'react';
-import {ActivityIndicator, StyleSheet, View} from 'react-native';
+import {ActivityIndicator, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={[styles.container, styles.horizontal]}>
-    <ActivityIndicator />
-    <ActivityIndicator size="large" />
-    <ActivityIndicator size="small" color="#0000ff" />
-    <ActivityIndicator size="large" color="#00ff00" />
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={[styles.container, styles.horizontal]}>
+      <ActivityIndicator />
+      <ActivityIndicator size="large" />
+      <ActivityIndicator size="small" color="#0000ff" />
+      <ActivityIndicator size="large" color="#00ff00" />
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -13,7 +13,8 @@ This is an API that works both on Android and iOS and can show static alerts. Al
 
 ```SnackPlayer name=Alert%20Example&supportedPlatforms=ios,android
 import React from 'react';
-import {View, StyleSheet, Button, Alert} from 'react-native';
+import {StyleSheet, Button, Alert} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const createTwoButtonAlert = () =>
@@ -41,10 +42,12 @@ const App = () => {
     ]);
 
   return (
-    <View style={styles.container}>
-      <Button title={'2-Button Alert'} onPress={createTwoButtonAlert} />
-      <Button title={'3-Button Alert'} onPress={createThreeButtonAlert} />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Button title={'2-Button Alert'} onPress={createTwoButtonAlert} />
+        <Button title={'3-Button Alert'} onPress={createThreeButtonAlert} />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -79,7 +82,8 @@ The cancel event can be handled by providing an `onDismiss` callback property in
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
-import {View, StyleSheet, Button, Alert} from 'react-native';
+import {StyleSheet, Button, Alert} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const showAlert = () =>
   Alert.alert(
@@ -102,9 +106,11 @@ const showAlert = () =>
   );
 
 const App = () => (
-  <View style={styles.container}>
-    <Button title="Show alert" onPress={showAlert} />
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <Button title="Show alert" onPress={showAlert} />
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -13,16 +13,10 @@ The core workflow for creating an animation is to create an `Animated.Value`, ho
 
 The following example contains a `View` which will fade in and fade out based on the animated value `fadeAnim`
 
-```SnackPlayer name=Animated
+```SnackPlayer name=Animated%20Example
 import React, {useRef} from 'react';
-import {
-  Animated,
-  Text,
-  View,
-  StyleSheet,
-  Button,
-  SafeAreaView,
-} from 'react-native';
+import {Animated, Text, View, StyleSheet, Button} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   // fadeAnim will be used as the value for opacity. Initial Value: 0
@@ -47,22 +41,24 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Animated.View
-        style={[
-          styles.fadingContainer,
-          {
-            // Bind opacity to animated value
-            opacity: fadeAnim,
-          },
-        ]}>
-        <Text style={styles.fadingText}>Fading View!</Text>
-      </Animated.View>
-      <View style={styles.buttonRow}>
-        <Button title="Fade In View" onPress={fadeIn} />
-        <Button title="Fade Out View" onPress={fadeOut} />
-      </View>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Animated.View
+          style={[
+            styles.fadingContainer,
+            {
+              // Bind opacity to animated value
+              opacity: fadeAnim,
+            },
+          ]}>
+          <Text style={styles.fadingText}>Fading View!</Text>
+        </Animated.View>
+        <View style={styles.buttonRow}>
+          <Button title="Fade In View" onPress={fadeIn} />
+          <Button title="Fade Out View" onPress={fadeOut} />
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/animatedvaluexy.md
+++ b/docs/animatedvaluexy.md
@@ -7,9 +7,10 @@ title: Animated.ValueXY
 
 ## Example
 
-```SnackPlayer name=Animated.ValueXY
+```SnackPlayer name=Animated.ValueXY%20Example
 import React, {useRef} from 'react';
-import {Animated, PanResponder, StyleSheet, View} from 'react-native';
+import {Animated, PanResponder, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const DraggableView = () => {
   const pan = useRef(new Animated.ValueXY()).current;
@@ -32,12 +33,14 @@ const DraggableView = () => {
   });
 
   return (
-    <View style={styles.container}>
-      <Animated.View
-        {...panResponder.panHandlers}
-        style={[pan.getLayout(), styles.box]}
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Animated.View
+          {...panResponder.panHandlers}
+          style={[pan.getLayout(), styles.box]}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -313,7 +313,6 @@ The following example implements a horizontal scrolling carousel where the scrol
 ```SnackPlayer name=Animated&supportedPlatforms=ios,android
 import React, {useRef} from 'react';
 import {
-  SafeAreaView,
   ScrollView,
   Text,
   StyleSheet,
@@ -322,6 +321,7 @@ import {
   Animated,
   useWindowDimensions,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const images = new Array(6).fill(
   'https://images.unsplash.com/photo-1556740749-887f6717d7e4',
@@ -333,57 +333,61 @@ const App = () => {
   const {width: windowWidth} = useWindowDimensions();
 
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.scrollContainer}>
-        <ScrollView
-          horizontal={true}
-          pagingEnabled
-          showsHorizontalScrollIndicator={false}
-          onScroll={Animated.event([
-            {
-              nativeEvent: {
-                contentOffset: {
-                  x: scrollX,
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.scrollContainer}>
+          <ScrollView
+            horizontal={true}
+            pagingEnabled
+            showsHorizontalScrollIndicator={false}
+            onScroll={Animated.event([
+              {
+                nativeEvent: {
+                  contentOffset: {
+                    x: scrollX,
+                  },
                 },
               },
-            },
-          ])}
-          scrollEventThrottle={1}>
-          {images.map((image, imageIndex) => {
-            return (
-              <View style={{width: windowWidth, height: 250}} key={imageIndex}>
-                <ImageBackground source={{uri: image}} style={styles.card}>
-                  <View style={styles.textContainer}>
-                    <Text style={styles.infoText}>
-                      {'Image - ' + imageIndex}
-                    </Text>
-                  </View>
-                </ImageBackground>
-              </View>
-            );
-          })}
-        </ScrollView>
-        <View style={styles.indicatorContainer}>
-          {images.map((image, imageIndex) => {
-            const width = scrollX.interpolate({
-              inputRange: [
-                windowWidth * (imageIndex - 1),
-                windowWidth * imageIndex,
-                windowWidth * (imageIndex + 1),
-              ],
-              outputRange: [8, 16, 8],
-              extrapolate: 'clamp',
-            });
-            return (
-              <Animated.View
-                key={imageIndex}
-                style={[styles.normalDot, {width}]}
-              />
-            );
-          })}
+            ])}
+            scrollEventThrottle={1}>
+            {images.map((image, imageIndex) => {
+              return (
+                <View
+                  style={{width: windowWidth, height: 250}}
+                  key={imageIndex}>
+                  <ImageBackground source={{uri: image}} style={styles.card}>
+                    <View style={styles.textContainer}>
+                      <Text style={styles.infoText}>
+                        {'Image - ' + imageIndex}
+                      </Text>
+                    </View>
+                  </ImageBackground>
+                </View>
+              );
+            })}
+          </ScrollView>
+          <View style={styles.indicatorContainer}>
+            {images.map((image, imageIndex) => {
+              const width = scrollX.interpolate({
+                inputRange: [
+                  windowWidth * (imageIndex - 1),
+                  windowWidth * imageIndex,
+                  windowWidth * (imageIndex + 1),
+                ],
+                outputRange: [8, 16, 8],
+                extrapolate: 'clamp',
+              });
+              return (
+                <Animated.View
+                  key={imageIndex}
+                  style={[styles.normalDot, {width}]}
+                />
+              );
+            })}
+          </View>
         </View>
-      </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -24,7 +24,8 @@ To see the current state, you can check `AppState.currentState`, which will be k
 
 ```SnackPlayer name=AppState%20Example
 import React, {useRef, useState, useEffect} from 'react';
-import {AppState, StyleSheet, Text, View} from 'react-native';
+import {AppState, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const AppStateExample = () => {
   const appState = useRef(AppState.currentState);
@@ -50,9 +51,11 @@ const AppStateExample = () => {
   }, []);
 
   return (
-    <View style={styles.container}>
-      <Text>Current state is: {appStateVisible}</Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>Current state is: {appStateVisible}</Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/backhandler.md
+++ b/docs/backhandler.md
@@ -45,7 +45,8 @@ The following example implements a scenario where you confirm if the user wants 
 
 ```SnackPlayer name=BackHandler&supportedPlatforms=android
 import React, {useEffect} from 'react';
-import {Text, View, StyleSheet, BackHandler, Alert} from 'react-native';
+import {Text, StyleSheet, BackHandler, Alert} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   useEffect(() => {
@@ -70,9 +71,11 @@ const App = () => {
   }, []);
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Click Back button!</Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.text}>Click Back button!</Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/button.md
+++ b/docs/button.md
@@ -20,70 +20,66 @@ If this button doesn't look right for your app, you can build your own button us
 
 ```SnackPlayer name=Button%20Example
 import React from 'react';
-import {
-  StyleSheet,
-  Button,
-  View,
-  SafeAreaView,
-  Text,
-  Alert,
-} from 'react-native';
+import {StyleSheet, Button, View, Text, Alert} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const Separator = () => <View style={styles.separator} />;
 
 const App = () => (
-  <SafeAreaView style={styles.container}>
-    <View>
-      <Text style={styles.title}>
-        The title and onPress handler are required. It is recommended to set
-        accessibilityLabel to help make your app usable by everyone.
-      </Text>
-      <Button
-        title="Press me"
-        onPress={() => Alert.alert('Simple Button pressed')}
-      />
-    </View>
-    <Separator />
-    <View>
-      <Text style={styles.title}>
-        Adjust the color in a way that looks standard on each platform. On iOS,
-        the color prop controls the color of the text. On Android, the color
-        adjusts the background color of the button.
-      </Text>
-      <Button
-        title="Press me"
-        color="#f194ff"
-        onPress={() => Alert.alert('Button with adjusted color pressed')}
-      />
-    </View>
-    <Separator />
-    <View>
-      <Text style={styles.title}>
-        All interaction for the component are disabled.
-      </Text>
-      <Button
-        title="Press me"
-        disabled
-        onPress={() => Alert.alert('Cannot press this one')}
-      />
-    </View>
-    <Separator />
-    <View>
-      <Text style={styles.title}>
-        This layout strategy lets the title define the width of the button.
-      </Text>
-      <View style={styles.fixToText}>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <View>
+        <Text style={styles.title}>
+          The title and onPress handler are required. It is recommended to set
+          accessibilityLabel to help make your app usable by everyone.
+        </Text>
         <Button
-          title="Left button"
-          onPress={() => Alert.alert('Left button pressed')}
-        />
-        <Button
-          title="Right button"
-          onPress={() => Alert.alert('Right button pressed')}
+          title="Press me"
+          onPress={() => Alert.alert('Simple Button pressed')}
         />
       </View>
-    </View>
-  </SafeAreaView>
+      <Separator />
+      <View>
+        <Text style={styles.title}>
+          Adjust the color in a way that looks standard on each platform. On
+          iOS, the color prop controls the color of the text. On Android, the
+          color adjusts the background color of the button.
+        </Text>
+        <Button
+          title="Press me"
+          color="#f194ff"
+          onPress={() => Alert.alert('Button with adjusted color pressed')}
+        />
+      </View>
+      <Separator />
+      <View>
+        <Text style={styles.title}>
+          All interaction for the component are disabled.
+        </Text>
+        <Button
+          title="Press me"
+          disabled
+          onPress={() => Alert.alert('Cannot press this one')}
+        />
+      </View>
+      <Separator />
+      <View>
+        <Text style={styles.title}>
+          This layout strategy lets the title define the width of the button.
+        </Text>
+        <View style={styles.fixToText}>
+          <Button
+            title="Left button"
+            onPress={() => Alert.alert('Left button pressed')}
+          />
+          <Button
+            title="Right button"
+            onPress={() => Alert.alert('Right button pressed')}
+          />
+        </View>
+      </View>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -14,7 +14,6 @@ title: '🚧 Clipboard'
 ```SnackPlayer name=Clipboard%20API%20Example&supportedPlatforms=ios,android
 import React, {useState} from 'react';
 import {
-  SafeAreaView,
   View,
   Text,
   TouchableOpacity,
@@ -35,7 +34,7 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={{flex: 1}}>
+    <View style={{flex: 1}}>
       <View style={styles.container}>
         <TouchableOpacity onPress={() => copyToClipboard()}>
           <Text>Click here to copy to Clipboard</Text>
@@ -46,7 +45,7 @@ const App = () => {
 
         <Text style={styles.copiedText}>{copiedText}</Text>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -22,9 +22,10 @@ If you are targeting foldable devices or devices which can change the screen siz
 
 ## Example
 
-```SnackPlayer name=Dimensions
+```SnackPlayer name=Dimensions%20Example
 import React, {useState, useEffect} from 'react';
-import {View, StyleSheet, Text, Dimensions} from 'react-native';
+import {StyleSheet, Text, Dimensions} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const windowDimensions = Dimensions.get('window');
 const screenDimensions = Dimensions.get('screen');
@@ -46,20 +47,22 @@ const App = () => {
   });
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.header}>Window Dimensions</Text>
-      {Object.entries(dimensions.window).map(([key, value]) => (
-        <Text>
-          {key} - {value}
-        </Text>
-      ))}
-      <Text style={styles.header}>Screen Dimensions</Text>
-      {Object.entries(dimensions.screen).map(([key, value]) => (
-        <Text>
-          {key} - {value}
-        </Text>
-      ))}
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.header}>Window Dimensions</Text>
+        {Object.entries(dimensions.window).map(([key, value]) => (
+          <Text>
+            {key} - {value}
+          </Text>
+        ))}
+        <Text style={styles.header}>Screen Dimensions</Text>
+        {Object.entries(dimensions.screen).map(([key, value]) => (
+          <Text>
+            {key} - {value}
+          </Text>
+        ))}
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/drawerlayoutandroid.md
+++ b/docs/drawerlayoutandroid.md
@@ -14,13 +14,8 @@ React component that wraps the platform `DrawerLayout` (Android only). The Drawe
 
 ```SnackPlayer name=DrawerLayoutAndroid%20Component%20Example&supportedPlatforms=android&ext=js
 import React, {useRef, useState} from 'react';
-import {
-  Button,
-  DrawerLayoutAndroid,
-  Text,
-  StyleSheet,
-  View,
-} from 'react-native';
+import {Button, DrawerLayoutAndroid, Text, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const drawer = useRef(null);
@@ -34,45 +29,45 @@ const App = () => {
   };
 
   const navigationView = () => (
-    <View style={[styles.container, styles.navigationContainer]}>
+    <SafeAreaView style={[styles.container, styles.navigationContainer]}>
       <Text style={styles.paragraph}>I'm in the Drawer!</Text>
       <Button
         title="Close drawer"
         onPress={() => drawer.current.closeDrawer()}
       />
-    </View>
+    </SafeAreaView>
   );
 
   return (
-    <DrawerLayoutAndroid
-      ref={drawer}
-      drawerWidth={300}
-      drawerPosition={drawerPosition}
-      renderNavigationView={navigationView}>
-      <View style={styles.container}>
-        <Text style={styles.paragraph}>Drawer on the {drawerPosition}!</Text>
-        <Button
-          title="Change Drawer Position"
-          onPress={() => changeDrawerPosition()}
-        />
-        <Text style={styles.paragraph}>
-          Swipe from the side or press button below to see it!
-        </Text>
-        <Button
-          title="Open drawer"
-          onPress={() => drawer.current.openDrawer()}
-        />
-      </View>
-    </DrawerLayoutAndroid>
+    <SafeAreaProvider>
+      <DrawerLayoutAndroid
+        ref={drawer}
+        drawerWidth={300}
+        drawerPosition={drawerPosition}
+        renderNavigationView={navigationView}>
+        <SafeAreaView style={styles.container}>
+          <Text style={styles.paragraph}>Drawer on the {drawerPosition}!</Text>
+          <Button
+            title="Change Drawer Position"
+            onPress={() => changeDrawerPosition()}
+          />
+          <Text style={styles.paragraph}>
+            Swipe from the side or press button below to see it!
+          </Text>
+          <Button
+            title="Open drawer"
+            onPress={() => drawer.current.openDrawer()}
+          />
+        </SafeAreaView>
+      </DrawerLayoutAndroid>
+    </SafeAreaProvider>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 16,
+    paddingHorizontal: 16,
   },
   navigationContainer: {
     backgroundColor: '#ecf0f1',

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -71,6 +71,7 @@ const App = () => {
       toValue: 1,
       duration: 1200,
       easing,
+      useNativeDriver: false,
     }).start();
   };
 
@@ -231,6 +232,7 @@ const App = () => {
       toValue: 1,
       duration: 1200,
       easing,
+      useNativeDriver: false,
     }).start();
   };
 

--- a/docs/easing.md
+++ b/docs/easing.md
@@ -60,6 +60,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   let opacity = new Animated.Value(0);
@@ -70,7 +71,6 @@ const App = () => {
       toValue: 1,
       duration: 1200,
       easing,
-      useNativeDriver: true,
     }).start();
   };
 
@@ -89,28 +89,32 @@ const App = () => {
   ];
 
   return (
-    <View style={styles.container}>
-      <StatusBar hidden={true} />
-      <Text style={styles.title}>Press rows below to preview the Easing!</Text>
-      <View style={styles.boxContainer}>
-        <Animated.View style={animatedStyles} />
-      </View>
-      <SectionList
-        style={styles.list}
-        sections={SECTIONS}
-        keyExtractor={item => item.title}
-        renderItem={({item}) => (
-          <TouchableOpacity
-            onPress={() => animate(item.easing)}
-            style={styles.listRow}>
-            <Text>{item.title}</Text>
-          </TouchableOpacity>
-        )}
-        renderSectionHeader={({section: {title}}) => (
-          <Text style={styles.listHeader}>{title}</Text>
-        )}
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container} edges={['right', 'top', 'left']}>
+        <StatusBar hidden={true} />
+        <Text style={styles.title}>
+          Press rows below to preview the Easing!
+        </Text>
+        <View style={styles.boxContainer}>
+          <Animated.View style={animatedStyles} />
+        </View>
+        <SectionList
+          style={styles.list}
+          sections={SECTIONS}
+          keyExtractor={item => item.title}
+          renderItem={({item}) => (
+            <TouchableOpacity
+              onPress={() => animate(item.easing)}
+              style={styles.listRow}>
+              <Text>{item.title}</Text>
+            </TouchableOpacity>
+          )}
+          renderSectionHeader={({section: {title}}) => (
+            <Text style={styles.listHeader}>{title}</Text>
+          )}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -214,8 +218,9 @@ import {
   Text,
   TouchableOpacity,
   View,
+  type EasingFunction,
 } from 'react-native';
-import type {EasingFunction} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   let opacity = new Animated.Value(0);
@@ -226,7 +231,6 @@ const App = () => {
       toValue: 1,
       duration: 1200,
       easing,
-      useNativeDriver: true,
     }).start();
   };
 
@@ -245,28 +249,32 @@ const App = () => {
   ];
 
   return (
-    <View style={styles.container}>
-      <StatusBar hidden={true} />
-      <Text style={styles.title}>Press rows below to preview the Easing!</Text>
-      <View style={styles.boxContainer}>
-        <Animated.View style={animatedStyles} />
-      </View>
-      <SectionList
-        style={styles.list}
-        sections={SECTIONS}
-        keyExtractor={item => item.title}
-        renderItem={({item}) => (
-          <TouchableOpacity
-            onPress={() => animate(item.easing)}
-            style={styles.listRow}>
-            <Text>{item.title}</Text>
-          </TouchableOpacity>
-        )}
-        renderSectionHeader={({section: {title}}) => (
-          <Text style={styles.listHeader}>{title}</Text>
-        )}
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container} edges={['right', 'top', 'left']}>
+        <StatusBar hidden={true} />
+        <Text style={styles.title}>
+          Press rows below to preview the Easing!
+        </Text>
+        <View style={styles.boxContainer}>
+          <Animated.View style={animatedStyles} />
+        </View>
+        <SectionList
+          style={styles.list}
+          sections={SECTIONS}
+          keyExtractor={item => item.title}
+          renderItem={({item}) => (
+            <TouchableOpacity
+              onPress={() => animate(item.easing)}
+              style={styles.listRow}>
+              <Text>{item.title}</Text>
+            </TouchableOpacity>
+          )}
+          renderSectionHeader={({section: {title}}) => (
+            <Text style={styles.listHeader}>{title}</Text>
+          )}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -25,16 +25,10 @@ If you need section support, use [`<SectionList>`](sectionlist.md).
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer name=flatlist-simple&ext=js
+```SnackPlayer name=Simple%20FlatList%20Example&ext=js
 import React from 'react';
-import {
-  SafeAreaView,
-  View,
-  FlatList,
-  StyleSheet,
-  Text,
-  StatusBar,
-} from 'react-native';
+import {View, FlatList, StyleSheet, Text, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const DATA = [
   {
@@ -57,8 +51,8 @@ const Item = ({title}) => (
   </View>
 );
 
-const App = () => {
-  return (
+const App = () => (
+  <SafeAreaProvider>
     <SafeAreaView style={styles.container}>
       <FlatList
         data={DATA}
@@ -66,8 +60,8 @@ const App = () => {
         keyExtractor={item => item.id}
       />
     </SafeAreaView>
-  );
-};
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -91,16 +85,10 @@ export default App;
 </TabItem>
 <TabItem value="typescript">
 
-```SnackPlayer name=flatlist-simple&ext=tsx
+```SnackPlayer name=Simple%20FlatList%20Example&ext=tsx
 import React from 'react';
-import {
-  SafeAreaView,
-  View,
-  FlatList,
-  StyleSheet,
-  Text,
-  StatusBar,
-} from 'react-native';
+import {View, FlatList, StyleSheet, Text, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const DATA = [
   {
@@ -125,8 +113,8 @@ const Item = ({title}: ItemProps) => (
   </View>
 );
 
-const App = () => {
-  return (
+const App = () => (
+  <SafeAreaProvider>
     <SafeAreaView style={styles.container}>
       <FlatList
         data={DATA}
@@ -134,8 +122,8 @@ const App = () => {
         keyExtractor={item => item.id}
       />
     </SafeAreaView>
-  );
-};
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -173,12 +161,12 @@ More complex, selectable example below.
 import React, {useState} from 'react';
 import {
   FlatList,
-  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,
   TouchableOpacity,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const DATA = [
   {
@@ -219,14 +207,16 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <FlatList
-        data={DATA}
-        renderItem={renderItem}
-        keyExtractor={item => item.id}
-        extraData={selectedId}
-      />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <FlatList
+          data={DATA}
+          renderItem={renderItem}
+          keyExtractor={item => item.id}
+          extraData={selectedId}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -255,12 +245,12 @@ export default App;
 import React, {useState} from 'react';
 import {
   FlatList,
-  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,
   TouchableOpacity,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 type ItemData = {
   id: string;
@@ -313,14 +303,16 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <FlatList
-        data={DATA}
-        renderItem={renderItem}
-        keyExtractor={item => item.id}
-        extraData={selectedId}
-      />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <FlatList
+          data={DATA}
+          renderItem={renderItem}
+          keyExtractor={item => item.id}
+          extraData={selectedId}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -2314,13 +2314,8 @@ Both `width` and `height` can take the following values:
 
 ```SnackPlayer name=Width%20and%20Height&ext=js
 import React, {useState} from 'react';
-import {
-  View,
-  SafeAreaView,
-  TouchableOpacity,
-  Text,
-  StyleSheet,
-} from 'react-native';
+import {View, TouchableOpacity, Text, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const WidthHeightBasics = () => {
   const [widthType, setWidthType] = useState('auto');
@@ -2359,43 +2354,45 @@ const PreviewLayout = ({
   setWidthType,
   setHeightType,
 }) => (
-  <SafeAreaView style={{flex: 1, padding: 10}}>
-    <View style={styles.row}>
-      <Text style={styles.label}>width </Text>
-      {widthValues.map(value => (
-        <TouchableOpacity
-          key={value}
-          onPress={() => setWidthType(value)}
-          style={[styles.button, widthType === value && styles.selected]}>
-          <Text
-            style={[
-              styles.buttonLabel,
-              widthType === value && styles.selectedLabel,
-            ]}>
-            {value}
-          </Text>
-        </TouchableOpacity>
-      ))}
-    </View>
-    <View style={styles.row}>
-      <Text style={styles.label}>height </Text>
-      {heightValues.map(value => (
-        <TouchableOpacity
-          key={value}
-          onPress={() => setHeightType(value)}
-          style={[styles.button, heightType === value && styles.selected]}>
-          <Text
-            style={[
-              styles.buttonLabel,
-              heightType === value && styles.selectedLabel,
-            ]}>
-            {value}
-          </Text>
-        </TouchableOpacity>
-      ))}
-    </View>
-    {children}
-  </SafeAreaView>
+  <SafeAreaProvider>
+    <SafeAreaView style={{flex: 1, padding: 10}}>
+      <View style={styles.row}>
+        <Text style={styles.label}>width </Text>
+        {widthValues.map(value => (
+          <TouchableOpacity
+            key={value}
+            onPress={() => setWidthType(value)}
+            style={[styles.button, widthType === value && styles.selected]}>
+            <Text
+              style={[
+                styles.buttonLabel,
+                widthType === value && styles.selectedLabel,
+              ]}>
+              {value}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>height </Text>
+        {heightValues.map(value => (
+          <TouchableOpacity
+            key={value}
+            onPress={() => setHeightType(value)}
+            style={[styles.button, heightType === value && styles.selected]}>
+            <Text
+              style={[
+                styles.buttonLabel,
+                heightType === value && styles.selectedLabel,
+              ]}>
+              {value}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {children}
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({
@@ -2442,15 +2439,9 @@ export default WidthHeightBasics;
 <TabItem value="typescript">
 
 ```SnackPlayer name=Width%20and%20Height&ext=tsx
-import React, {useState} from 'react';
-import {
-  View,
-  SafeAreaView,
-  TouchableOpacity,
-  Text,
-  StyleSheet,
-} from 'react-native';
-import type {PropsWithChildren} from 'react';
+import React, {useState, PropsWithChildren} from 'react';
+import {View, TouchableOpacity, Text, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 type Dimension = 'auto' | `${number}%` | number;
 
@@ -2500,43 +2491,45 @@ const PreviewLayout = ({
   setWidthType,
   setHeightType,
 }: PreviewLayoutProps) => (
-  <SafeAreaView style={{flex: 1, padding: 10}}>
-    <View style={styles.row}>
-      <Text style={styles.label}>width </Text>
-      {widthValues.map(value => (
-        <TouchableOpacity
-          key={value}
-          onPress={() => setWidthType(value)}
-          style={[styles.button, widthType === value && styles.selected]}>
-          <Text
-            style={[
-              styles.buttonLabel,
-              widthType === value && styles.selectedLabel,
-            ]}>
-            {value}
-          </Text>
-        </TouchableOpacity>
-      ))}
-    </View>
-    <View style={styles.row}>
-      <Text style={styles.label}>height </Text>
-      {heightValues.map(value => (
-        <TouchableOpacity
-          key={value}
-          onPress={() => setHeightType(value)}
-          style={[styles.button, heightType === value && styles.selected]}>
-          <Text
-            style={[
-              styles.buttonLabel,
-              heightType === value && styles.selectedLabel,
-            ]}>
-            {value}
-          </Text>
-        </TouchableOpacity>
-      ))}
-    </View>
-    {children}
-  </SafeAreaView>
+  <SafeAreaProvider>
+    <SafeAreaView style={{flex: 1, padding: 10}}>
+      <View style={styles.row}>
+        <Text style={styles.label}>width </Text>
+        {widthValues.map(value => (
+          <TouchableOpacity
+            key={value}
+            onPress={() => setWidthType(value)}
+            style={[styles.button, widthType === value && styles.selected]}>
+            <Text
+              style={[
+                styles.buttonLabel,
+                widthType === value && styles.selectedLabel,
+              ]}>
+              {value}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>height </Text>
+        {heightValues.map(value => (
+          <TouchableOpacity
+            key={value}
+            onPress={() => setHeightType(value)}
+            style={[styles.button, heightType === value && styles.selected]}>
+            <Text
+              style={[
+                styles.buttonLabel,
+                heightType === value && styles.selectedLabel,
+              ]}>
+              {value}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      {children}
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/image-style-props.md
+++ b/docs/image-style-props.md
@@ -9,78 +9,70 @@ title: Image Style Props
 
 ```SnackPlayer name=Image%20Resize%20Modes%20Example
 import React from 'react';
-import {View, Image, Text, StyleSheet} from 'react-native';
+import {View, Image, Text, StyleSheet, ScrollView} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const DisplayAnImageWithStyle = () => {
-  return (
-    <View style={styles.container}>
-      <View>
-        <Image
-          style={{
-            resizeMode: 'cover',
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>resizeMode : cover</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            resizeMode: 'contain',
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>resizeMode : contain</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            resizeMode: 'stretch',
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>resizeMode : stretch</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            resizeMode: 'repeat',
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>resizeMode : repeat</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            resizeMode: 'center',
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>resizeMode : center</Text>
-      </View>
-    </View>
-  );
-};
+const asset = require('@expo/snack-static/react-native-logo.png');
+
+const DisplayAnImageWithStyle = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ScrollView style={styles.scrollView}>
+        <View>
+          <Image style={[styles.image, {resizeMode: 'cover'}]} source={asset} />
+          <Text style={styles.text}>resizeMode : cover</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {resizeMode: 'contain'}]}
+            source={asset}
+          />
+          <Text style={styles.text}>resizeMode : contain</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {resizeMode: 'stretch'}]}
+            source={asset}
+          />
+          <Text style={styles.text}>resizeMode : stretch</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {resizeMode: 'repeat'}]}
+            source={asset}
+          />
+          <Text style={styles.text}>resizeMode : repeat</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {resizeMode: 'center'}]}
+            source={asset}
+          />
+          <Text style={styles.text}>resizeMode : center</Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-around',
+    flex: 1,
+  },
+  scrollView: {
+    padding: 12,
     alignItems: 'center',
-    height: '100%',
+    gap: 16,
+  },
+  image: {
+    borderWidth: 1,
+    borderColor: 'red',
+    height: 100,
+    width: 200,
+  },
+  text: {
     textAlign: 'center',
+    marginBottom: 12,
   },
 });
 
@@ -91,11 +83,12 @@ export default DisplayAnImageWithStyle;
 
 ```SnackPlayer name=Style%20BorderWidth%20and%20BorderColor%20Example
 import React from 'react';
-import {View, Image, StyleSheet, Text} from 'react-native';
+import {Image, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const DisplayAnImageWithStyle = () => {
-  return (
-    <View style={styles.container}>
+const DisplayAnImageWithStyle = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
       <Image
         style={{
           borderColor: 'red',
@@ -106,18 +99,16 @@ const DisplayAnImageWithStyle = () => {
         source={require('@expo/snack-static/react-native-logo.png')}
       />
       <Text>borderColor & borderWidth</Text>
-    </View>
-  );
-};
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
-    display: 'flex',
+    flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    height: '100%',
-    textAlign: 'center',
   },
 });
 
@@ -128,67 +119,62 @@ export default DisplayAnImageWithStyle;
 
 ```SnackPlayer name=Style%20Border%20Radius%20Example
 import React from 'react';
-import {View, Image, StyleSheet, Text} from 'react-native';
+import {View, Image, StyleSheet, Text, ScrollView} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const DisplayAnImageWithStyle = () => {
-  return (
-    <View style={styles.container}>
-      <View>
-        <Image
-          style={{
-            borderTopRightRadius: 20,
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>borderTopRightRadius</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            borderBottomRightRadius: 20,
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>borderBottomRightRadius</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            borderBottomLeftRadius: 20,
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>borderBottomLeftRadius</Text>
-      </View>
-      <View>
-        <Image
-          style={{
-            borderTopLeftRadius: 20,
-            height: 100,
-            width: 200,
-          }}
-          source={require('@expo/snack-static/react-native-logo.png')}
-        />
-        <Text>borderTopLeftRadius</Text>
-      </View>
-    </View>
-  );
-};
+const asset = require('@expo/snack-static/react-native-logo.png');
+
+const DisplayAnImageWithStyle = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollView}>
+        <View>
+          <Image
+            style={[styles.image, {borderTopRightRadius: 20}]}
+            source={asset}
+          />
+          <Text>borderTopRightRadius</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {borderBottomRightRadius: 20}]}
+            source={asset}
+          />
+          <Text>borderBottomRightRadius</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {borderBottomLeftRadius: 20}]}
+            source={asset}
+          />
+          <Text>borderBottomLeftRadius</Text>
+        </View>
+        <View>
+          <Image
+            style={[styles.image, {borderTopLeftRadius: 20}]}
+            source={asset}
+          />
+          <Text>borderTopLeftRadius</Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-around',
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+    justifyContent: 'center',
     alignItems: 'center',
-    height: '100%',
-    textAlign: 'center',
+  },
+  image: {
+    borderWidth: 1,
+    borderColor: 'red',
+    height: 100,
+    width: 200,
   },
 });
 
@@ -199,11 +185,12 @@ export default DisplayAnImageWithStyle;
 
 ```SnackPlayer name=Style%20tintColor%20Function%20Component
 import React from 'react';
-import {View, Image, StyleSheet, Text} from 'react-native';
+import {Image, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const DisplayAnImageWithStyle = () => {
-  return (
-    <View style={styles.container}>
+const DisplayAnImageWithStyle = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
       <Image
         style={{
           tintColor: '#000000',
@@ -214,18 +201,15 @@ const DisplayAnImageWithStyle = () => {
         source={require('@expo/snack-static/react-native-logo.png')}
       />
       <Text>tintColor</Text>
-    </View>
-  );
-};
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
-    display: 'flex',
-    flexDirection: 'column',
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    height: '100%',
-    textAlign: 'center',
   },
 });
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -11,13 +11,14 @@ This example shows fetching and displaying an image from local storage as well a
 
 ## Examples
 
-```SnackPlayer name=Example
+```SnackPlayer name=Image%20Example
 import React from 'react';
-import {View, Image, StyleSheet} from 'react-native';
+import {Image, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: 50,
+    flex: 1,
   },
   tinyLogo: {
     width: 50,
@@ -29,9 +30,9 @@ const styles = StyleSheet.create({
   },
 });
 
-const DisplayAnImage = () => {
-  return (
-    <View style={styles.container}>
+const DisplayAnImage = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
       <Image
         style={styles.tinyLogo}
         source={require('@expo/snack-static/react-native-logo.png')}
@@ -48,22 +49,23 @@ const DisplayAnImage = () => {
           uri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg==',
         }}
       />
-    </View>
-  );
-};
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 export default DisplayAnImage;
 ```
 
 You can also add `style` to an image:
 
-```SnackPlayer name=Example
+```SnackPlayer name=Styled%20Image%20Example
 import React from 'react';
-import {View, Image, StyleSheet} from 'react-native';
+import {Image, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: 50,
+    flex: 1,
   },
   stretch: {
     width: 50,
@@ -72,16 +74,16 @@ const styles = StyleSheet.create({
   },
 });
 
-const DisplayAnImageWithStyle = () => {
-  return (
-    <View style={styles.container}>
+const DisplayAnImageWithStyle = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
       <Image
         style={styles.stretch}
         source={require('@expo/snack-static/react-native-logo.png')}
       />
-    </View>
-  );
-};
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 export default DisplayAnImageWithStyle;
 ```

--- a/docs/imagebackground.md
+++ b/docs/imagebackground.md
@@ -13,16 +13,19 @@ Note that you must specify some width and height style attributes.
 
 ```SnackPlayer name=ImageBackground
 import React from 'react';
-import {ImageBackground, StyleSheet, Text, View} from 'react-native';
+import {ImageBackground, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const image = {uri: 'https://legacy.reactjs.org/logo-og.png'};
 
 const App = () => (
-  <View style={styles.container}>
-    <ImageBackground source={image} resizeMode="cover" style={styles.image}>
-      <Text style={styles.text}>Inside</Text>
-    </ImageBackground>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container} edges={['left', 'right']}>
+      <ImageBackground source={image} resizeMode="cover" style={styles.image}>
+        <Text style={styles.text}>Inside</Text>
+      </ImageBackground>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/inputaccessoryview.md
+++ b/docs/inputaccessoryview.md
@@ -9,33 +9,53 @@ To use this component wrap your custom toolbar with the InputAccessoryView compo
 
 ```SnackPlayer name=InputAccessoryView&supportedPlatforms=ios
 import React, {useState} from 'react';
-import {Button, InputAccessoryView, ScrollView, TextInput} from 'react-native';
+import {
+  Button,
+  InputAccessoryView,
+  ScrollView,
+  TextInput,
+  StyleSheet,
+} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
+
+const inputAccessoryViewID = 'uniqueID';
+const initialText = '';
 
 const App = () => {
-  const inputAccessoryViewID = 'uniqueID';
-  const initialText = '';
   const [text, setText] = useState(initialText);
 
   return (
-    <>
-      <ScrollView keyboardDismissMode="interactive">
-        <TextInput
-          style={{
-            padding: 16,
-            marginTop: 50,
-          }}
-          inputAccessoryViewID={inputAccessoryViewID}
-          onChangeText={setText}
-          value={text}
-          placeholder={'Please type here…'}
-        />
-      </ScrollView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <ScrollView keyboardDismissMode="interactive">
+          <TextInput
+            style={styles.textInput}
+            inputAccessoryViewID={inputAccessoryViewID}
+            onChangeText={setText}
+            value={text}
+            placeholder={'Please type here…'}
+          />
+        </ScrollView>
+      </SafeAreaView>
       <InputAccessoryView nativeID={inputAccessoryViewID}>
         <Button onPress={() => setText(initialText)} title="Clear text" />
       </InputAccessoryView>
-    </>
+    </SafeAreaProvider>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  textInput: {
+    padding: 16,
+    borderColor: 'black',
+    borderWidth: 1,
+  },
+});
 
 export default App;
 ```

--- a/docs/interactionmanager.md
+++ b/docs/interactionmanager.md
@@ -55,8 +55,8 @@ import {
   Platform,
   StyleSheet,
   Text,
-  View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const instructions = Platform.select({
   ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
@@ -98,10 +98,12 @@ const Ball = ({onShown}) => {
 
 const App = () => {
   return (
-    <View style={styles.container}>
-      <Text>{instructions}</Text>
-      <Ball onShown={() => Alert.alert('Animation is done')} />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>{instructions}</Text>
+        <Ball onShown={() => Alert.alert('Animation is done')} />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -134,8 +136,8 @@ import {
   Platform,
   StyleSheet,
   Text,
-  View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const instructions = Platform.select({
   ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
@@ -181,10 +183,12 @@ const Ball = ({onShown}: BallProps) => {
 
 const App = () => {
   return (
-    <View style={styles.container}>
-      <Text>{instructions}</Text>
-      <Ball onShown={() => Alert.alert('Animation is done')} />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>{instructions}</Text>
+        <Ball onShown={() => Alert.alert('Animation is done')} />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -222,8 +226,8 @@ import {
   Platform,
   StyleSheet,
   Text,
-  View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const instructions = Platform.select({
   ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
@@ -260,10 +264,12 @@ const Ball = ({onInteractionIsDone}) => {
 
 const App = () => {
   return (
-    <View style={styles.container}>
-      <Text>{instructions}</Text>
-      <Ball onInteractionIsDone={() => Alert.alert('Interaction is done')} />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>{instructions}</Text>
+        <Ball onInteractionIsDone={() => Alert.alert('Interaction is done')} />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -296,8 +302,8 @@ import {
   Platform,
   StyleSheet,
   Text,
-  View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const instructions = Platform.select({
   ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
@@ -338,10 +344,12 @@ const Ball = ({onInteractionIsDone}: BallProps) => {
 
 const App = () => {
   return (
-    <View style={styles.container}>
-      <Text>{instructions}</Text>
-      <Ball onInteractionIsDone={() => Alert.alert('Interaction is done')} />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>{instructions}</Text>
+        <Ball onInteractionIsDone={() => Alert.alert('Interaction is done')} />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -11,10 +11,11 @@ The Keyboard module allows you to listen for native events and react to them, as
 
 ```SnackPlayer name=Keyboard%20Example&supportedPlatforms=ios,android
 import React, {useState, useEffect} from 'react';
-import {Keyboard, Text, TextInput, StyleSheet, View} from 'react-native';
+import {Keyboard, Text, TextInput, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const Example = () => {
-  const [keyboardStatus, setKeyboardStatus] = useState('');
+  const [keyboardStatus, setKeyboardStatus] = useState('Keyboard Hidden');
 
   useEffect(() => {
     const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
@@ -31,14 +32,16 @@ const Example = () => {
   }, []);
 
   return (
-    <View style={style.container}>
-      <TextInput
-        style={style.input}
-        placeholder="Click here…"
-        onSubmitEditing={Keyboard.dismiss}
-      />
-      <Text style={style.status}>{keyboardStatus}</Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={style.container}>
+        <TextInput
+          style={style.input}
+          placeholder="Click here…"
+          onSubmitEditing={Keyboard.dismiss}
+        />
+        <Text style={style.status}>{keyboardStatus}</Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -53,7 +56,7 @@ const style = StyleSheet.create({
     borderRadius: 4,
   },
   status: {
-    padding: 10,
+    padding: 16,
     textAlign: 'center',
   },
 });

--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -16,39 +16,17 @@ The following example shows how different properties can affect or shape a React
 
 ```SnackPlayer name=LayoutProps%20Example&ext=js
 import React, {useState} from 'react';
-import {
-  Button,
-  ScrollView,
-  StatusBar,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
-  const flexDirections = ['row', 'row-reverse', 'column', 'column-reverse'];
-  const justifyContents = [
-    'flex-start',
-    'flex-end',
-    'center',
-    'space-between',
-    'space-around',
-    'space-evenly',
-  ];
-  const alignItemsArr = [
-    'flex-start',
-    'flex-end',
-    'center',
-    'stretch',
-    'baseline',
-  ];
-  const wraps = ['nowrap', 'wrap', 'wrap-reverse'];
-  const directions = ['inherit', 'ltr', 'rtl'];
   const [flexDirection, setFlexDirection] = useState(0);
   const [justifyContent, setJustifyContent] = useState(0);
   const [alignItems, setAlignItems] = useState(0);
   const [direction, setDirection] = useState(0);
   const [wrap, setWrap] = useState(0);
+
+  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
 
   const hookedStyles = {
     flexDirection: flexDirections[flexDirection],
@@ -65,99 +43,126 @@ const App = () => {
     }
     setterFunction(value + 1);
   };
-  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
+
   return (
-    <>
-      <View style={{paddingTop: StatusBar.currentHeight}} />
-      <View style={[styles.container, styles.playingSpace, hookedStyles]}>
-        {squares.map(elem => elem)}
-      </View>
-      <ScrollView style={styles.container}>
-        <View style={styles.controlSpace}>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Flex Direction"
-              onPress={() =>
-                changeSetting(flexDirection, flexDirections, setFlexDirection)
-              }
-            />
-            <Text style={styles.text}>{flexDirections[flexDirection]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Justify Content"
-              onPress={() =>
-                changeSetting(
-                  justifyContent,
-                  justifyContents,
-                  setJustifyContent,
-                )
-              }
-            />
-            <Text style={styles.text}>{justifyContents[justifyContent]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Align Items"
-              onPress={() =>
-                changeSetting(alignItems, alignItemsArr, setAlignItems)
-              }
-            />
-            <Text style={styles.text}>{alignItemsArr[alignItems]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Direction"
-              onPress={() => changeSetting(direction, directions, setDirection)}
-            />
-            <Text style={styles.text}>{directions[direction]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Flex Wrap"
-              onPress={() => changeSetting(wrap, wraps, setWrap)}
-            />
-            <Text style={styles.text}>{wraps[wrap]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Add Square"
-              onPress={() => setSquares([...squares, <Square />])}
-            />
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Delete Square"
-              onPress={() =>
-                setSquares(squares.filter((v, i) => i !== squares.length - 1))
-              }
-            />
-          </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={[styles.container, styles.playingSpace, hookedStyles]}>
+          {squares.map(elem => elem)}
         </View>
-      </ScrollView>
-    </>
+        <ScrollView style={styles.layoutContainer}>
+          <View style={styles.controlSpace}>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Flex Direction"
+                onPress={() =>
+                  changeSetting(flexDirection, flexDirections, setFlexDirection)
+                }
+              />
+              <Text style={styles.text}>{flexDirections[flexDirection]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Justify Content"
+                onPress={() =>
+                  changeSetting(
+                    justifyContent,
+                    justifyContents,
+                    setJustifyContent,
+                  )
+                }
+              />
+              <Text style={styles.text}>{justifyContents[justifyContent]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Align Items"
+                onPress={() =>
+                  changeSetting(alignItems, alignItemsArr, setAlignItems)
+                }
+              />
+              <Text style={styles.text}>{alignItemsArr[alignItems]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Direction"
+                onPress={() =>
+                  changeSetting(direction, directions, setDirection)
+                }
+              />
+              <Text style={styles.text}>{directions[direction]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Flex Wrap"
+                onPress={() => changeSetting(wrap, wraps, setWrap)}
+              />
+              <Text style={styles.text}>{wraps[wrap]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Add Square"
+                onPress={() => setSquares([...squares, <Square />])}
+              />
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Delete Square"
+                onPress={() =>
+                  setSquares(squares.filter((v, i) => i !== squares.length - 1))
+                }
+              />
+            </View>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
+const flexDirections = ['row', 'row-reverse', 'column', 'column-reverse'];
+const justifyContents = [
+  'flex-start',
+  'flex-end',
+  'center',
+  'space-between',
+  'space-around',
+  'space-evenly',
+];
+const alignItemsArr = [
+  'flex-start',
+  'flex-end',
+  'center',
+  'stretch',
+  'baseline',
+];
+const wraps = ['nowrap', 'wrap', 'wrap-reverse'];
+const directions = ['inherit', 'ltr', 'rtl'];
+
 const styles = StyleSheet.create({
   container: {
-    height: '50%',
+    flex: 1,
+  },
+  layoutContainer: {
+    flex: 0.5,
   },
   playingSpace: {
     backgroundColor: 'white',
     borderColor: 'blue',
     borderWidth: 3,
+    overflow: 'hidden',
   },
   controlSpace: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    backgroundColor: '#F5F5F5',
   },
   buttonView: {
     width: '50%',
     padding: 10,
   },
-  text: {textAlign: 'center'},
+  text: {
+    textAlign: 'center',
+  },
 });
 
 const Square = () => (
@@ -172,7 +177,7 @@ const Square = () => (
 
 const randomHexColor = () => {
   return '#000000'.replace(/0/g, () => {
-    return Math.round(Math.random() * 16).toString(16);
+    return Math.round(Math.random() * 14).toString(16);
   });
 };
 
@@ -187,41 +192,22 @@ import React, {useState} from 'react';
 import {
   Button,
   ScrollView,
-  StatusBar,
   StyleSheet,
   Text,
   View,
+  FlexAlignType,
+  FlexStyle,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
-  const flexDirections = [
-    'row',
-    'row-reverse',
-    'column',
-    'column-reverse',
-  ] as const;
-  const justifyContents = [
-    'flex-start',
-    'flex-end',
-    'center',
-    'space-between',
-    'space-around',
-    'space-evenly',
-  ] as const;
-  const alignItemsArr = [
-    'flex-start',
-    'flex-end',
-    'center',
-    'stretch',
-    'baseline',
-  ] as const;
-  const wraps = ['nowrap', 'wrap', 'wrap-reverse'] as const;
-  const directions = ['inherit', 'ltr', 'rtl'] as const;
   const [flexDirection, setFlexDirection] = useState(0);
   const [justifyContent, setJustifyContent] = useState(0);
   const [alignItems, setAlignItems] = useState(0);
   const [direction, setDirection] = useState(0);
   const [wrap, setWrap] = useState(0);
+
+  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
 
   const hookedStyles = {
     flexDirection: flexDirections[flexDirection],
@@ -229,11 +215,11 @@ const App = () => {
     alignItems: alignItemsArr[alignItems],
     direction: directions[direction],
     flexWrap: wraps[wrap],
-  };
+  } as FlexStyle;
 
   const changeSetting = (
     value: number,
-    options: readonly unknown[],
+    options: any[],
     setterFunction: (index: number) => void,
   ) => {
     if (value === options.length - 1) {
@@ -242,99 +228,131 @@ const App = () => {
     }
     setterFunction(value + 1);
   };
-  const [squares, setSquares] = useState([<Square />, <Square />, <Square />]);
+
   return (
-    <>
-      <View style={{paddingTop: StatusBar.currentHeight}} />
-      <View style={[styles.container, styles.playingSpace, hookedStyles]}>
-        {squares.map(elem => elem)}
-      </View>
-      <ScrollView style={styles.container}>
-        <View style={styles.controlSpace}>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Flex Direction"
-              onPress={() =>
-                changeSetting(flexDirection, flexDirections, setFlexDirection)
-              }
-            />
-            <Text style={styles.text}>{flexDirections[flexDirection]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Justify Content"
-              onPress={() =>
-                changeSetting(
-                  justifyContent,
-                  justifyContents,
-                  setJustifyContent,
-                )
-              }
-            />
-            <Text style={styles.text}>{justifyContents[justifyContent]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Align Items"
-              onPress={() =>
-                changeSetting(alignItems, alignItemsArr, setAlignItems)
-              }
-            />
-            <Text style={styles.text}>{alignItemsArr[alignItems]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Direction"
-              onPress={() => changeSetting(direction, directions, setDirection)}
-            />
-            <Text style={styles.text}>{directions[direction]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Change Flex Wrap"
-              onPress={() => changeSetting(wrap, wraps, setWrap)}
-            />
-            <Text style={styles.text}>{wraps[wrap]}</Text>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Add Square"
-              onPress={() => setSquares([...squares, <Square />])}
-            />
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              title="Delete Square"
-              onPress={() =>
-                setSquares(squares.filter((v, i) => i !== squares.length - 1))
-              }
-            />
-          </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={[styles.container, styles.playingSpace, hookedStyles]}>
+          {squares.map(elem => elem)}
         </View>
-      </ScrollView>
-    </>
+        <ScrollView style={styles.layoutContainer}>
+          <View style={styles.controlSpace}>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Flex Direction"
+                onPress={() =>
+                  changeSetting(flexDirection, flexDirections, setFlexDirection)
+                }
+              />
+              <Text style={styles.text}>{flexDirections[flexDirection]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Justify Content"
+                onPress={() =>
+                  changeSetting(
+                    justifyContent,
+                    justifyContents,
+                    setJustifyContent,
+                  )
+                }
+              />
+              <Text style={styles.text}>{justifyContents[justifyContent]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Align Items"
+                onPress={() =>
+                  changeSetting(alignItems, alignItemsArr, setAlignItems)
+                }
+              />
+              <Text style={styles.text}>{alignItemsArr[alignItems]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Direction"
+                onPress={() =>
+                  changeSetting(direction, directions, setDirection)
+                }
+              />
+              <Text style={styles.text}>{directions[direction]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Change Flex Wrap"
+                onPress={() => changeSetting(wrap, wraps, setWrap)}
+              />
+              <Text style={styles.text}>{wraps[wrap]}</Text>
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Add Square"
+                onPress={() => setSquares([...squares, <Square />])}
+              />
+            </View>
+            <View style={styles.buttonView}>
+              <Button
+                title="Delete Square"
+                onPress={() =>
+                  setSquares(squares.filter((v, i) => i !== squares.length - 1))
+                }
+              />
+            </View>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
+const flexDirections = [
+  'row',
+  'row-reverse',
+  'column',
+  'column-reverse',
+] as FlexStyle['flexDirection'][];
+const justifyContents = [
+  'flex-start',
+  'flex-end',
+  'center',
+  'space-between',
+  'space-around',
+  'space-evenly',
+] as FlexStyle['justifyContent'][];
+const alignItemsArr = [
+  'flex-start',
+  'flex-end',
+  'center',
+  'stretch',
+  'baseline',
+] as FlexAlignType[];
+const wraps = ['nowrap', 'wrap', 'wrap-reverse'];
+const directions = ['inherit', 'ltr', 'rtl'];
+
 const styles = StyleSheet.create({
   container: {
-    height: '50%',
+    flex: 1,
+  },
+  layoutContainer: {
+    flex: 0.5,
   },
   playingSpace: {
     backgroundColor: 'white',
     borderColor: 'blue',
     borderWidth: 3,
+    overflow: 'hidden',
   },
   controlSpace: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    backgroundColor: '#F5F5F5',
   },
   buttonView: {
     width: '50%',
     padding: 10,
   },
-  text: {textAlign: 'center'},
+  text: {
+    textAlign: 'center',
+  },
 });
 
 const Square = () => (
@@ -349,7 +367,7 @@ const Square = () => (
 
 const randomHexColor = () => {
   return '#000000'.replace(/0/g, () => {
-    return Math.round(Math.random() * 16).toString(16);
+    return Math.round(Math.random() * 14).toString(16);
   });
 };
 

--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -19,7 +19,7 @@ if (Platform.OS === 'android') {
 
 ## Example
 
-```SnackPlayer name=LayoutAnimation&supportedPlatforms=android,ios
+```SnackPlayer name=LayoutAnimation%20Example&supportedPlatforms=android,ios
 import React, {useState} from 'react';
 import {
   LayoutAnimation,
@@ -30,6 +30,7 @@ import {
   UIManager,
   View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 if (
   Platform.OS === 'android' &&
@@ -41,34 +42,37 @@ const App = () => {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <View style={style.container}>
-      <TouchableOpacity
-        onPress={() => {
-          LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
-          setExpanded(!expanded);
-        }}>
-        <Text>Press me to {expanded ? 'collapse' : 'expand'}!</Text>
-      </TouchableOpacity>
-      {expanded && (
-        <View style={style.tile}>
-          <Text>I disappear sometimes!</Text>
-        </View>
-      )}
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={style.container}>
+        <TouchableOpacity
+          onPress={() => {
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
+            setExpanded(!expanded);
+          }}>
+          <Text>Press me to {expanded ? 'collapse' : 'expand'}!</Text>
+        </TouchableOpacity>
+        {expanded && (
+          <View style={style.tile}>
+            <Text>I disappear sometimes!</Text>
+          </View>
+        )}
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
 const style = StyleSheet.create({
-  tile: {
-    backgroundColor: 'lightgrey',
-    borderWidth: 0.5,
-    borderColor: '#d6d7da',
-  },
   container: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    overflow: 'hidden',
+    gap: 16,
+  },
+  tile: {
+    backgroundColor: 'lightgrey',
+    borderWidth: 0.5,
+    borderColor: '#d6d7da',
+    padding: 4,
   },
 });
 

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -10,36 +10,39 @@ The Modal component is a basic way to present content above an enclosing view.
 ```SnackPlayer name=Modal&supportedPlatforms=android,ios
 import React, {useState} from 'react';
 import {Alert, Modal, StyleSheet, Text, Pressable, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [modalVisible, setModalVisible] = useState(false);
   return (
-    <View style={styles.centeredView}>
-      <Modal
-        animationType="slide"
-        transparent={true}
-        visible={modalVisible}
-        onRequestClose={() => {
-          Alert.alert('Modal has been closed.');
-          setModalVisible(!modalVisible);
-        }}>
-        <View style={styles.centeredView}>
-          <View style={styles.modalView}>
-            <Text style={styles.modalText}>Hello World!</Text>
-            <Pressable
-              style={[styles.button, styles.buttonClose]}
-              onPress={() => setModalVisible(!modalVisible)}>
-              <Text style={styles.textStyle}>Hide Modal</Text>
-            </Pressable>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.centeredView}>
+        <Modal
+          animationType="slide"
+          transparent={true}
+          visible={modalVisible}
+          onRequestClose={() => {
+            Alert.alert('Modal has been closed.');
+            setModalVisible(!modalVisible);
+          }}>
+          <View style={styles.centeredView}>
+            <View style={styles.modalView}>
+              <Text style={styles.modalText}>Hello World!</Text>
+              <Pressable
+                style={[styles.button, styles.buttonClose]}
+                onPress={() => setModalVisible(!modalVisible)}>
+                <Text style={styles.textStyle}>Hide Modal</Text>
+              </Pressable>
+            </View>
           </View>
-        </View>
-      </Modal>
-      <Pressable
-        style={[styles.button, styles.buttonOpen]}
-        onPress={() => setModalVisible(true)}>
-        <Text style={styles.textStyle}>Show Modal</Text>
-      </Pressable>
-    </View>
+        </Modal>
+        <Pressable
+          style={[styles.button, styles.buttonOpen]}
+          onPress={() => setModalVisible(true)}>
+          <Text style={styles.textStyle}>Show Modal</Text>
+        </Pressable>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -48,7 +51,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    marginTop: 22,
   },
   modalView: {
     margin: 20,

--- a/docs/panresponder.md
+++ b/docs/panresponder.md
@@ -83,6 +83,7 @@ const ExampleComponent = () => {
 ```SnackPlayer name=PanResponder
 import React, {useRef} from 'react';
 import {Animated, View, StyleSheet, PanResponder, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const pan = useRef(new Animated.ValueXY()).current;
@@ -98,16 +99,18 @@ const App = () => {
   ).current;
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.titleText}>Drag this box!</Text>
-      <Animated.View
-        style={{
-          transform: [{translateX: pan.x}, {translateY: pan.y}],
-        }}
-        {...panResponder.panHandlers}>
-        <View style={styles.box} />
-      </Animated.View>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.titleText}>Drag this box!</Text>
+        <Animated.View
+          style={{
+            transform: [{translateX: pan.x}, {translateY: pan.y}],
+          }}
+          {...panResponder.panHandlers}>
+          <View style={styles.box} />
+        </Animated.View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -26,8 +26,8 @@ import {
   StatusBar,
   StyleSheet,
   Text,
-  View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const requestCameraPermission = async () => {
   try {
@@ -54,10 +54,12 @@ const requestCameraPermission = async () => {
 };
 
 const App = () => (
-  <View style={styles.container}>
-    <Text style={styles.item}>Try permissions</Text>
-    <Button title="request permissions" onPress={requestCameraPermission} />
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.item}>Try permissions</Text>
+      <Button title="request permissions" onPress={requestCameraPermission} />
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/pixelratio.md
+++ b/docs/pixelratio.md
@@ -39,6 +39,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const size = 50;
 const cat = {
@@ -48,34 +49,38 @@ const cat = {
 };
 
 const App = () => (
-  <ScrollView style={styles.scrollContainer}>
-    <View style={styles.container}>
-      <Text>Current Pixel Ratio is:</Text>
-      <Text style={styles.value}>{PixelRatio.get()}</Text>
-    </View>
-    <View style={styles.container}>
-      <Text>Current Font Scale is:</Text>
-      <Text style={styles.value}>{PixelRatio.getFontScale()}</Text>
-    </View>
-    <View style={styles.container}>
-      <Text>On this device images with a layout width of</Text>
-      <Text style={styles.value}>{size} px</Text>
-      <Image source={cat} />
-    </View>
-    <View style={styles.container}>
-      <Text>require images with a pixel width of</Text>
-      <Text style={styles.value}>
-        {PixelRatio.getPixelSizeForLayoutSize(size)} px
-      </Text>
-      <Image
-        source={cat}
-        style={{
-          width: PixelRatio.getPixelSizeForLayoutSize(size),
-          height: PixelRatio.getPixelSizeForLayoutSize(size),
-        }}
-      />
-    </View>
-  </ScrollView>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollContainer}>
+        <View style={styles.container}>
+          <Text>Current Pixel Ratio is:</Text>
+          <Text style={styles.value}>{PixelRatio.get()}</Text>
+        </View>
+        <View style={styles.container}>
+          <Text>Current Font Scale is:</Text>
+          <Text style={styles.value}>{PixelRatio.getFontScale()}</Text>
+        </View>
+        <View style={styles.container}>
+          <Text>On this device images with a layout width of</Text>
+          <Text style={styles.value}>{size} px</Text>
+          <Image source={cat} />
+        </View>
+        <View style={styles.container}>
+          <Text>require images with a pixel width of</Text>
+          <Text style={styles.value}>
+            {PixelRatio.getPixelSizeForLayoutSize(size)} px
+          </Text>
+          <Image
+            source={cat}
+            style={{
+              width: PixelRatio.getPixelSizeForLayoutSize(size),
+              height: PixelRatio.getPixelSizeForLayoutSize(size),
+            }}
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -8,27 +8,32 @@ title: Platform
 ```SnackPlayer name=Platform%20API%20Example&supportedPlatforms=ios,android
 import React from 'react';
 import {Platform, StyleSheet, Text, ScrollView} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text>OS</Text>
-      <Text style={styles.value}>{Platform.OS}</Text>
-      <Text>OS Version</Text>
-      <Text style={styles.value}>{Platform.Version}</Text>
-      <Text>isTV</Text>
-      <Text style={styles.value}>{Platform.isTV.toString()}</Text>
-      {Platform.OS === 'ios' && (
-        <>
-          <Text>isPad</Text>
-          <Text style={styles.value}>{Platform.isPad.toString()}</Text>
-        </>
-      )}
-      <Text>Constants</Text>
-      <Text style={styles.value}>
-        {JSON.stringify(Platform.constants, null, 2)}
-      </Text>
-    </ScrollView>
+    <SafeAreaProvider>
+      <SafeAreaView>
+        <ScrollView contentContainerStyle={styles.container}>
+          <Text>OS</Text>
+          <Text style={styles.value}>{Platform.OS}</Text>
+          <Text>OS Version</Text>
+          <Text style={styles.value}>{Platform.Version}</Text>
+          <Text>isTV</Text>
+          <Text style={styles.value}>{Platform.isTV.toString()}</Text>
+          {Platform.OS === 'ios' && (
+            <>
+              <Text>isPad</Text>
+              <Text style={styles.value}>{Platform.isPad.toString()}</Text>
+            </>
+          )}
+          <Text>Constants</Text>
+          <Text style={styles.value}>
+            {JSON.stringify(Platform.constants, null, 2)}
+          </Text>
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/platformcolor.md
+++ b/docs/platformcolor.md
@@ -45,17 +45,21 @@ For a full list of the types of system colors supported, see:
 
 ```SnackPlayer name=PlatformColor%20Example&supportedPlatforms=android,ios
 import React from 'react';
-import {Platform, PlatformColor, StyleSheet, Text, View} from 'react-native';
+import {Platform, PlatformColor, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={styles.container}>
-    <Text style={styles.label}>I am a special label color!</Text>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.label}>I am a special label color!</Text>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({
   label: {
     padding: 16,
+    fontWeight: '800',
     ...Platform.select({
       ios: {
         color: PlatformColor('label'),

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -45,6 +45,7 @@ Fingers are not the most precise instruments, and it is common for users to acci
 ```SnackPlayer name=Pressable
 import React, {useState} from 'react';
 import {Pressable, StyleSheet, Text, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [timesPressed, setTimesPressed] = useState(0);
@@ -57,25 +58,27 @@ const App = () => {
   }
 
   return (
-    <View style={styles.container}>
-      <Pressable
-        onPress={() => {
-          setTimesPressed(current => current + 1);
-        }}
-        style={({pressed}) => [
-          {
-            backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
-          },
-          styles.wrapperCustom,
-        ]}>
-        {({pressed}) => (
-          <Text style={styles.text}>{pressed ? 'Pressed!' : 'Press Me'}</Text>
-        )}
-      </Pressable>
-      <View style={styles.logBox}>
-        <Text testID="pressable_press_console">{textLog}</Text>
-      </View>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Pressable
+          onPress={() => {
+            setTimesPressed(current => current + 1);
+          }}
+          style={({pressed}) => [
+            {
+              backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
+            },
+            styles.wrapperCustom,
+          ]}>
+          {({pressed}) => (
+            <Text style={styles.text}>{pressed ? 'Pressed!' : 'Press Me'}</Text>
+          )}
+        </Pressable>
+        <View style={styles.logBox}>
+          <Text testID="pressable_press_console">{textLog}</Text>
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -9,13 +9,8 @@ This component is used inside a ScrollView or ListView to add pull to refresh fu
 
 ```SnackPlayer name=RefreshControl&supportedPlatforms=ios,android
 import React from 'react';
-import {
-  RefreshControl,
-  SafeAreaView,
-  ScrollView,
-  StyleSheet,
-  Text,
-} from 'react-native';
+import {RefreshControl, ScrollView, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [refreshing, setRefreshing] = React.useState(false);
@@ -28,15 +23,17 @@ const App = () => {
   }, []);
 
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView
-        contentContainerStyle={styles.scrollView}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-        }>
-        <Text>Pull down to see RefreshControl indicator</Text>
-      </ScrollView>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <ScrollView
+          contentContainerStyle={styles.scrollView}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }>
+          <Text>Pull down to see RefreshControl indicator</Text>
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -21,19 +21,14 @@ This is where `FlatList` comes into play. `FlatList` renders items lazily, when 
 
 ## Example
 
-```SnackPlayer name=ScrollView
+```SnackPlayer name=ScrollView%20Example
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  SafeAreaView,
-  ScrollView,
-  StatusBar,
-} from 'react-native';
+import {StyleSheet, Text, ScrollView, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const App = () => {
-  return (
-    <SafeAreaView style={styles.container}>
+const App = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView style={styles.scrollView}>
         <Text style={styles.text}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -46,8 +41,8 @@ const App = () => {
         </Text>
       </ScrollView>
     </SafeAreaView>
-  );
-};
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -56,10 +51,10 @@ const styles = StyleSheet.create({
   },
   scrollView: {
     backgroundColor: 'pink',
-    marginHorizontal: 20,
   },
   text: {
     fontSize: 42,
+    padding: 12,
   },
 });
 

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -22,14 +22,8 @@ If you don't need section support and want a simpler interface, use [`<FlatList>
 
 ```SnackPlayer name=SectionList%20Example
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  SectionList,
-  StatusBar,
-} from 'react-native';
+import {StyleSheet, Text, View, SectionList, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const DATA = [
   {
@@ -51,20 +45,22 @@ const DATA = [
 ];
 
 const App = () => (
-  <SafeAreaView style={styles.container}>
-    <SectionList
-      sections={DATA}
-      keyExtractor={(item, index) => item + index}
-      renderItem={({item}) => (
-        <View style={styles.item}>
-          <Text style={styles.title}>{item}</Text>
-        </View>
-      )}
-      renderSectionHeader={({section: {title}}) => (
-        <Text style={styles.header}>{title}</Text>
-      )}
-    />
-  </SafeAreaView>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <SectionList
+        sections={DATA}
+        keyExtractor={(item, index) => item + index}
+        renderItem={({item}) => (
+          <View style={styles.item}>
+            <Text style={styles.title}>{item}</Text>
+          </View>
+        )}
+        renderSectionHeader={({section: {title}}) => (
+          <Text style={styles.header}>{title}</Text>
+        )}
+      />
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -9,30 +9,33 @@ title: Settings
 
 ```SnackPlayer name=Settings%20Example&supportedPlatforms=ios
 import React, {useState} from 'react';
-import {Button, Settings, StyleSheet, Text, View} from 'react-native';
+import {Button, Settings, StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [data, setData] = useState(() => Settings.get('data'));
 
   return (
-    <View style={styles.container}>
-      <Text>Stored value:</Text>
-      <Text style={styles.value}>{data}</Text>
-      <Button
-        onPress={() => {
-          Settings.set({data: 'React'});
-          setData(Settings.get('data'));
-        }}
-        title="Store 'React'"
-      />
-      <Button
-        onPress={() => {
-          Settings.set({data: 'Native'});
-          setData(Settings.get('data'));
-        }}
-        title="Store 'Native'"
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>Stored value:</Text>
+        <Text style={styles.value}>{data}</Text>
+        <Button
+          onPress={() => {
+            Settings.set({data: 'React'});
+            setData(Settings.get('data'));
+          }}
+          title="Store 'React'"
+        />
+        <Button
+          onPress={() => {
+            Settings.set({data: 'Native'});
+            setData(Settings.get('data'));
+          }}
+          title="Store 'Native'"
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -11,7 +11,9 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 ```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios&ext=js&dependencies=@react-native-community/slider
 import React, {useState} from 'react';
 import {Text, View, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 import Slider from '@react-native-community/slider';
+
 const ShadowPropSlider = ({label, value, ...props}) => {
   return (
     <>
@@ -30,52 +32,54 @@ const App = () => {
   const [shadowOpacity, setShadowOpacity] = useState(0.1);
 
   return (
-    <View style={styles.container}>
-      <View
-        style={[
-          styles.square,
-          {
-            shadowOffset: {
-              width: shadowOffsetWidth,
-              height: -shadowOffsetHeight,
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View
+          style={[
+            styles.square,
+            {
+              shadowOffset: {
+                width: shadowOffsetWidth,
+                height: -shadowOffsetHeight,
+              },
+              shadowOpacity,
+              shadowRadius,
             },
-            shadowOpacity,
-            shadowRadius,
-          },
-        ]}
-      />
-      <View style={styles.controls}>
-        <ShadowPropSlider
-          label="shadowOffset - X"
-          minimumValue={-50}
-          maximumValue={50}
-          value={shadowOffsetWidth}
-          onValueChange={setShadowOffsetWidth}
+          ]}
         />
-        <ShadowPropSlider
-          label="shadowOffset - Y"
-          minimumValue={-50}
-          maximumValue={50}
-          value={shadowOffsetHeight}
-          onValueChange={setShadowOffsetHeight}
-        />
-        <ShadowPropSlider
-          label="shadowRadius"
-          minimumValue={0}
-          maximumValue={100}
-          value={shadowRadius}
-          onValueChange={setShadowRadius}
-        />
-        <ShadowPropSlider
-          label="shadowOpacity"
-          minimumValue={0}
-          maximumValue={1}
-          step={0.05}
-          value={shadowOpacity}
-          onValueChange={val => setShadowOpacity(val)}
-        />
-      </View>
-    </View>
+        <View style={styles.controls}>
+          <ShadowPropSlider
+            label="shadowOffset - X"
+            minimumValue={-50}
+            maximumValue={50}
+            value={shadowOffsetWidth}
+            onValueChange={setShadowOffsetWidth}
+          />
+          <ShadowPropSlider
+            label="shadowOffset - Y"
+            minimumValue={-50}
+            maximumValue={50}
+            value={shadowOffsetHeight}
+            onValueChange={setShadowOffsetHeight}
+          />
+          <ShadowPropSlider
+            label="shadowRadius"
+            minimumValue={0}
+            maximumValue={100}
+            value={shadowRadius}
+            onValueChange={setShadowRadius}
+          />
+          <ShadowPropSlider
+            label="shadowOpacity"
+            minimumValue={0}
+            maximumValue={1}
+            step={0.05}
+            value={shadowOpacity}
+            onValueChange={val => setShadowOpacity(val)}
+          />
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -108,8 +112,8 @@ export default App;
 ```SnackPlayer name=Shadow%20Props&supportedPlatforms=ios&ext=tsx&dependencies=@react-native-community/slider
 import React, {useState} from 'react';
 import {Text, View, StyleSheet} from 'react-native';
-import Slider from '@react-native-community/slider';
-import type {SliderProps} from '@react-native-community/slider';
+import Slider, {SliderProps} from '@react-native-community/slider';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 type ShadowPropSliderProps = SliderProps & {
   label: string;
@@ -133,52 +137,54 @@ const App = () => {
   const [shadowOpacity, setShadowOpacity] = useState(0.1);
 
   return (
-    <View style={styles.container}>
-      <View
-        style={[
-          styles.square,
-          {
-            shadowOffset: {
-              width: shadowOffsetWidth,
-              height: -shadowOffsetHeight,
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View
+          style={[
+            styles.square,
+            {
+              shadowOffset: {
+                width: shadowOffsetWidth,
+                height: -shadowOffsetHeight,
+              },
+              shadowOpacity,
+              shadowRadius,
             },
-            shadowOpacity,
-            shadowRadius,
-          },
-        ]}
-      />
-      <View style={styles.controls}>
-        <ShadowPropSlider
-          label="shadowOffset - X"
-          minimumValue={-50}
-          maximumValue={50}
-          value={shadowOffsetWidth}
-          onValueChange={setShadowOffsetWidth}
+          ]}
         />
-        <ShadowPropSlider
-          label="shadowOffset - Y"
-          minimumValue={-50}
-          maximumValue={50}
-          value={shadowOffsetHeight}
-          onValueChange={setShadowOffsetHeight}
-        />
-        <ShadowPropSlider
-          label="shadowRadius"
-          minimumValue={0}
-          maximumValue={100}
-          value={shadowRadius}
-          onValueChange={setShadowRadius}
-        />
-        <ShadowPropSlider
-          label="shadowOpacity"
-          minimumValue={0}
-          maximumValue={1}
-          step={0.05}
-          value={shadowOpacity}
-          onValueChange={val => setShadowOpacity(val)}
-        />
-      </View>
-    </View>
+        <View style={styles.controls}>
+          <ShadowPropSlider
+            label="shadowOffset - X"
+            minimumValue={-50}
+            maximumValue={50}
+            value={shadowOffsetWidth}
+            onValueChange={setShadowOffsetWidth}
+          />
+          <ShadowPropSlider
+            label="shadowOffset - Y"
+            minimumValue={-50}
+            maximumValue={50}
+            value={shadowOffsetHeight}
+            onValueChange={setShadowOffsetHeight}
+          />
+          <ShadowPropSlider
+            label="shadowRadius"
+            minimumValue={0}
+            maximumValue={100}
+            value={shadowRadius}
+            onValueChange={setShadowRadius}
+          />
+          <ShadowPropSlider
+            label="shadowOpacity"
+            minimumValue={0}
+            maximumValue={1}
+            step={0.05}
+            value={shadowOpacity}
+            onValueChange={val => setShadowOpacity(val)}
+          />
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -12,7 +12,8 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 ```SnackPlayer name=Example&supportedPlatforms=ios,android&ext=js
 import React from 'react';
-import {Alert, Share, View, Button} from 'react-native';
+import {Alert, Share, Button} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const ShareExample = () => {
   const onShare = async () => {
@@ -35,9 +36,11 @@ const ShareExample = () => {
     }
   };
   return (
-    <View style={{marginTop: 50}}>
-      <Button onPress={onShare} title="Share" />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView>
+        <Button onPress={onShare} title="Share" />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -49,7 +52,8 @@ export default ShareExample;
 
 ```SnackPlayer name=Example&supportedPlatforms=ios,android&ext=tsx
 import React from 'react';
-import {Alert, Share, View, Button} from 'react-native';
+import {Alert, Share, Button} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const ShareExample = () => {
   const onShare = async () => {
@@ -72,9 +76,11 @@ const ShareExample = () => {
     }
   };
   return (
-    <View style={{marginTop: 50}}>
-      <Button onPress={onShare} title="Share" />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView>
+        <Button onPress={onShare} title="Share" />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -19,12 +19,12 @@ import React, {useState} from 'react';
 import {
   Button,
   Platform,
-  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const STYLES = ['default', 'dark-content', 'light-content'];
 const TRANSITIONS = ['fade', 'slide', 'none'];
@@ -57,39 +57,47 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar
-        animated={true}
-        backgroundColor="#61dafb"
-        barStyle={statusBarStyle}
-        showHideTransition={statusBarTransition}
-        hidden={hidden}
-      />
-      <Text style={styles.textStyle}>
-        StatusBar Visibility:{'\n'}
-        {hidden ? 'Hidden' : 'Visible'}
-      </Text>
-      <Text style={styles.textStyle}>
-        StatusBar Style:{'\n'}
-        {statusBarStyle}
-      </Text>
-      {Platform.OS === 'ios' ? (
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <StatusBar
+          animated={true}
+          backgroundColor="#61dafb"
+          barStyle={statusBarStyle}
+          showHideTransition={statusBarTransition}
+          hidden={hidden}
+        />
         <Text style={styles.textStyle}>
-          StatusBar Transition:{'\n'}
-          {statusBarTransition}
+          StatusBar Visibility:{'\n'}
+          {hidden ? 'Hidden' : 'Visible'}
         </Text>
-      ) : null}
-      <View style={styles.buttonsContainer}>
-        <Button title="Toggle StatusBar" onPress={changeStatusBarVisibility} />
-        <Button title="Change StatusBar Style" onPress={changeStatusBarStyle} />
+        <Text style={styles.textStyle}>
+          StatusBar Style:{'\n'}
+          {statusBarStyle}
+        </Text>
         {Platform.OS === 'ios' ? (
-          <Button
-            title="Change StatusBar Transition"
-            onPress={changeStatusBarTransition}
-          />
+          <Text style={styles.textStyle}>
+            StatusBar Transition:{'\n'}
+            {statusBarTransition}
+          </Text>
         ) : null}
-      </View>
-    </SafeAreaView>
+        <View style={styles.buttonsContainer}>
+          <Button
+            title="Toggle StatusBar"
+            onPress={changeStatusBarVisibility}
+          />
+          <Button
+            title="Change StatusBar Style"
+            onPress={changeStatusBarStyle}
+          />
+          {Platform.OS === 'ios' ? (
+            <Button
+              title="Change StatusBar Transition"
+              onPress={changeStatusBarTransition}
+            />
+          ) : null}
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -119,13 +127,13 @@ import React, {useState} from 'react';
 import {
   Button,
   Platform,
-  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,
   View,
+  StatusBarStyle,
 } from 'react-native';
-import type {StatusBarStyle} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const STYLES = ['default', 'dark-content', 'light-content'] as const;
 const TRANSITIONS = ['fade', 'slide', 'none'] as const;
@@ -160,39 +168,47 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar
-        animated={true}
-        backgroundColor="#61dafb"
-        barStyle={statusBarStyle}
-        showHideTransition={statusBarTransition}
-        hidden={hidden}
-      />
-      <Text style={styles.textStyle}>
-        StatusBar Visibility:{'\n'}
-        {hidden ? 'Hidden' : 'Visible'}
-      </Text>
-      <Text style={styles.textStyle}>
-        StatusBar Style:{'\n'}
-        {statusBarStyle}
-      </Text>
-      {Platform.OS === 'ios' ? (
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <StatusBar
+          animated={true}
+          backgroundColor="#61dafb"
+          barStyle={statusBarStyle}
+          showHideTransition={statusBarTransition}
+          hidden={hidden}
+        />
         <Text style={styles.textStyle}>
-          StatusBar Transition:{'\n'}
-          {statusBarTransition}
+          StatusBar Visibility:{'\n'}
+          {hidden ? 'Hidden' : 'Visible'}
         </Text>
-      ) : null}
-      <View style={styles.buttonsContainer}>
-        <Button title="Toggle StatusBar" onPress={changeStatusBarVisibility} />
-        <Button title="Change StatusBar Style" onPress={changeStatusBarStyle} />
+        <Text style={styles.textStyle}>
+          StatusBar Style:{'\n'}
+          {statusBarStyle}
+        </Text>
         {Platform.OS === 'ios' ? (
-          <Button
-            title="Change StatusBar Transition"
-            onPress={changeStatusBarTransition}
-          />
+          <Text style={styles.textStyle}>
+            StatusBar Transition:{'\n'}
+            {statusBarTransition}
+          </Text>
         ) : null}
-      </View>
-    </SafeAreaView>
+        <View style={styles.buttonsContainer}>
+          <Button
+            title="Toggle StatusBar"
+            onPress={changeStatusBarVisibility}
+          />
+          <Button
+            title="Change StatusBar Style"
+            onPress={changeStatusBarStyle}
+          />
+          {Platform.OS === 'ios' ? (
+            <Button
+              title="Change StatusBar Transition"
+              onPress={changeStatusBarTransition}
+            />
+          ) : null}
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -7,12 +7,15 @@ A StyleSheet is an abstraction similar to CSS StyleSheets.
 
 ```SnackPlayer name=StyleSheet
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={styles.container}>
-    <Text style={styles.title}>React Native</Text>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>React Native</Text>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({
@@ -60,12 +63,15 @@ Combines two styles such that `style2` will override any styles in `style1`. If 
 
 ```SnackPlayer name=Compose
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={container}>
-    <Text style={text}>React Native</Text>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={container}>
+      <Text style={text}>React Native</Text>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const page = StyleSheet.create({
@@ -86,7 +92,6 @@ const lists = StyleSheet.create({
     backgroundColor: '#61dafb',
   },
   listItem: {
-    fontStyle: 'italic',
     fontWeight: 'bold',
   },
 });
@@ -119,14 +124,17 @@ Flattens an array of style objects, into one aggregated style object.
 
 ```SnackPlayer name=Flatten
 import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={page.container}>
-    <Text style={flattenStyle}>React Native</Text>
-    <Text>Flatten Style</Text>
-    <Text style={page.code}>{JSON.stringify(flattenStyle, null, 2)}</Text>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={page.container}>
+      <Text style={flattenStyle}>React Native</Text>
+      <Text>Flatten Style</Text>
+      <Text style={page.code}>{JSON.stringify(flattenStyle, null, 2)}</Text>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const page = StyleSheet.create({
@@ -188,19 +196,22 @@ A very common pattern is to create overlays with position absolute and zero posi
 ```SnackPlayer name=absoluteFill
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={styles.container}>
-    <View style={styles.box1}>
-      <Text style={styles.text}>1</Text>
-    </View>
-    <View style={[styles.box2, StyleSheet.absoluteFill]}>
-      <Text style={styles.text}>2</Text>
-    </View>
-    <View style={styles.box3}>
-      <Text style={styles.text}>3</Text>
-    </View>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.box1}>
+        <Text style={styles.text}>1</Text>
+      </View>
+      <View style={[styles.box2, StyleSheet.absoluteFill]}>
+        <Text style={styles.text}>2</Text>
+      </View>
+      <View style={styles.box3}>
+        <Text style={styles.text}>3</Text>
+      </View>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({
@@ -246,19 +257,22 @@ Sometimes you may want `absoluteFill` but with a couple tweaks - `absoluteFillOb
 ```SnackPlayer name=absoluteFillObject
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <View style={styles.container}>
-    <View style={styles.box1}>
-      <Text style={styles.text}>1</Text>
-    </View>
-    <View style={styles.box2}>
-      <Text style={styles.text}>2</Text>
-    </View>
-    <View style={styles.box3}>
-      <Text style={styles.text}>3</Text>
-    </View>
-  </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.box1}>
+        <Text style={styles.text}>1</Text>
+      </View>
+      <View style={styles.box2}>
+        <Text style={styles.text}>2</Text>
+      </View>
+      <View style={styles.box3}>
+        <Text style={styles.text}>3</Text>
+      </View>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -11,22 +11,25 @@ This is a controlled component that requires an `onValueChange` callback that up
 
 ```SnackPlayer name=Switch&supportedPlatforms=android,ios
 import React, {useState} from 'react';
-import {View, Switch, StyleSheet} from 'react-native';
+import {Switch, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [isEnabled, setIsEnabled] = useState(false);
   const toggleSwitch = () => setIsEnabled(previousState => !previousState);
 
   return (
-    <View style={styles.container}>
-      <Switch
-        trackColor={{false: '#767577', true: '#81b0ff'}}
-        thumbColor={isEnabled ? '#f5dd4b' : '#f4f3f4'}
-        ios_backgroundColor="#3e3e3e"
-        onValueChange={toggleSwitch}
-        value={isEnabled}
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Switch
+          trackColor={{false: '#767577', true: '#81b0ff'}}
+          thumbColor={isEnabled ? '#f5dd4b' : '#f4f3f4'}
+          ios_backgroundColor="#3e3e3e"
+          onValueChange={toggleSwitch}
+          value={isEnabled}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/systrace.md
+++ b/docs/systrace.md
@@ -11,14 +11,8 @@ title: Systrace
 
 ```SnackPlayer name=Systrace%20Example
 import React from 'react';
-import {
-  Button,
-  Text,
-  View,
-  SafeAreaView,
-  StyleSheet,
-  Systrace,
-} from 'react-native';
+import {Button, Text, View, StyleSheet, Systrace} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const enableProfiling = () => {
@@ -32,22 +26,24 @@ const App = () => {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={[styles.header, styles.paragraph]}>
-        React Native Systrace API
-      </Text>
-      <View style={styles.buttonRow}>
-        <Button
-          title="Capture the non-Timed JS events in EasyProfiler"
-          onPress={() => enableProfiling()}
-        />
-        <Button
-          title="Stop capturing"
-          onPress={() => stopProfiling()}
-          color="#FF0000"
-        />
-      </View>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={[styles.header, styles.paragraph]}>
+          React Native Systrace API
+        </Text>
+        <View style={styles.buttonsColumn}>
+          <Button
+            title="Capture the non-Timed JS events in EasyProfiler"
+            onPress={() => enableProfiling()}
+          />
+          <Button
+            title="Stop capturing"
+            onPress={() => stopProfiling()}
+            color="#FF0000"
+          />
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -57,8 +53,8 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingTop: 44,
     padding: 8,
+    gap: 16,
   },
   header: {
     fontSize: 18,
@@ -66,14 +62,11 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   paragraph: {
-    margin: 24,
     fontSize: 25,
     textAlign: 'center',
   },
-  buttonRow: {
-    flexBasis: 150,
-    marginVertical: 16,
-    justifyContent: 'space-evenly',
+  buttonsColumn: {
+    gap: 16,
   },
 });
 

--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -628,7 +628,7 @@ const CustomSlider = ({
 
 type CustomPickerProps = {
   label: string;
-  data: ReadonlyArray<string | undefined>;
+  data?: ArrayLike<any> | null;
   currentIndex: number;
   onSelected: (index: number) => void;
 };

--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -16,7 +16,6 @@ import {
   FlatList,
   Platform,
   ScrollView,
-  StatusBar,
   StyleSheet,
   Switch,
   Text,
@@ -24,6 +23,7 @@ import {
   View,
 } from 'react-native';
 import Slider from '@react-native-community/slider';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const fontStyles = ['normal', 'italic'];
 const fontVariants = [
@@ -60,10 +60,10 @@ const textAlignmentsVertical = ['auto', 'top', 'bottom', 'center'];
 const writingDirections = ['auto', 'ltr', 'rtl'];
 
 const App = () => {
-  const [fontSize, setFontSize] = useState(10);
+  const [fontSize, setFontSize] = useState(20);
   const [fontStyleIdx, setFontStyleIdx] = useState(0);
   const [fontWeightIdx, setFontWeightIdx] = useState(0);
-  const [lineHeight, setLineHeight] = useState(10);
+  const [lineHeight, setLineHeight] = useState(24);
   const [textAlignIdx, setTextAlignIdx] = useState(0);
   const [textDecorationLineIdx, setTextDecorationLineIdx] = useState(0);
   const [includeFontPadding, setIncludeFontPadding] = useState(false);
@@ -82,155 +82,160 @@ const App = () => {
   const [, ...validFontVariants] = fontVariants;
 
   return (
-    <View style={styles.container}>
-      <Text
-        style={[
-          styles.paragraph,
-          {
-            fontSize,
-            fontStyle: fontStyles[fontStyleIdx],
-            fontWeight: fontWeights[fontWeightIdx],
-            lineHeight,
-            textAlign: textAlignments[textAlignIdx],
-            textDecorationLine: textDecorationLines[textDecorationLineIdx],
-            textTransform: textTransformations[textTransformIdx],
-            textAlignVertical: textAlignmentsVertical[textVerticalAlignIdx],
-            fontVariant:
-              fontVariantIdx === 0
-                ? undefined
-                : [validFontVariants[fontVariantIdx - 1]],
-            letterSpacing,
-            includeFontPadding,
-            textDecorationStyle: textDecorationStyles[textDecorationStyleIdx],
-            writingDirection: writingDirections[writingDirectionIdx],
-            textShadowOffset,
-            textShadowRadius,
-          },
-        ]}>
-        Lorem Ipsum is simply dummy text of the printing and typesetting
-        industry. 112 Likes
-      </Text>
-      <ScrollView>
-        <View>
-          <Text>Common platform properties</Text>
-          <CustomSlider
-            label="Text Shadow Offset - Height"
-            value={textShadowOffset.height}
-            minimumValue={-40}
-            maximumValue={40}
-            handleValueChange={val =>
-              setTextShadowOffset(prev => ({...prev, height: val}))
-            }
-          />
-          <CustomSlider
-            label="Text Shadow Offset - Width"
-            value={textShadowOffset.width}
-            minimumValue={-40}
-            maximumValue={40}
-            handleValueChange={val =>
-              setTextShadowOffset(prev => ({...prev, width: val}))
-            }
-          />
-          <CustomSlider
-            label="Font Size"
-            value={fontSize}
-            maximumValue={40}
-            handleValueChange={setFontSize}
-          />
-          <CustomPicker
-            label="Font Style"
-            data={fontStyles}
-            currentIndex={fontStyleIdx}
-            onSelected={setFontStyleIdx}
-          />
-          <CustomPicker
-            label="Font Weight"
-            data={fontWeights}
-            currentIndex={fontWeightIdx}
-            onSelected={setFontWeightIdx}
-          />
-          <CustomSlider
-            label="Line Height"
-            value={lineHeight}
-            minimumValue={10}
-            maximumValue={50}
-            handleValueChange={setLineHeight}
-          />
-          <CustomPicker
-            label="Text Align"
-            data={textAlignments}
-            currentIndex={textAlignIdx}
-            onSelected={setTextAlignIdx}
-          />
-          <CustomPicker
-            label="Text Decoration Line"
-            data={textDecorationLines}
-            currentIndex={textDecorationLineIdx}
-            onSelected={setTextDecorationLineIdx}
-          />
-          <CustomSlider
-            label="Text Shadow Radius"
-            value={textShadowRadius}
-            handleValueChange={setTextShadowRadius}
-          />
-          <CustomPicker
-            label="Font Variant"
-            data={fontVariants}
-            currentIndex={fontVariantIdx}
-            onSelected={setFontVariantIdx}
-          />
-          <CustomSlider
-            label="Letter Spacing"
-            step={0.1}
-            value={letterSpacing}
-            handleValueChange={setLetterSpacing}
-          />
-          <CustomPicker
-            label="Text Transform"
-            data={textTransformations}
-            currentIndex={textTransformIdx}
-            onSelected={setTextTransformIdx}
-          />
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.pargraphWrapper}>
+          <Text
+            style={[
+              styles.paragraph,
+              {
+                fontSize,
+                fontStyle: fontStyles[fontStyleIdx],
+                fontWeight: fontWeights[fontWeightIdx],
+                lineHeight,
+                textAlign: textAlignments[textAlignIdx],
+                textDecorationLine: textDecorationLines[textDecorationLineIdx],
+                textTransform: textTransformations[textTransformIdx],
+                textAlignVertical: textAlignmentsVertical[textVerticalAlignIdx],
+                fontVariant:
+                  fontVariantIdx === 0
+                    ? undefined
+                    : [validFontVariants[fontVariantIdx - 1]],
+                letterSpacing,
+                includeFontPadding,
+                textDecorationStyle:
+                  textDecorationStyles[textDecorationStyleIdx],
+                writingDirection: writingDirections[writingDirectionIdx],
+                textShadowOffset,
+                textShadowRadius,
+              },
+            ]}>
+            Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. 112 Likes
+          </Text>
         </View>
-        {Platform.OS === 'android' && (
-          <View style={styles.platformContainer}>
-            <Text style={styles.platformContainerTitle}>
-              Android only properties
-            </Text>
-            <CustomPicker
-              label="Text Vertical Align"
-              data={textAlignmentsVertical}
-              currentIndex={textVerticalAlignIdx}
-              onSelected={setTextVerticalAlignIdx}
+        <ScrollView style={{padding: 12}}>
+          <View>
+            <Text>Common platform properties</Text>
+            <CustomSlider
+              label="Text Shadow Offset - Height"
+              value={textShadowOffset.height}
+              minimumValue={-40}
+              maximumValue={40}
+              handleValueChange={val =>
+                setTextShadowOffset(prev => ({...prev, height: val}))
+              }
             />
-            <CustomSwitch
-              label="Include Font Padding"
-              handleValueChange={setIncludeFontPadding}
-              value={includeFontPadding}
+            <CustomSlider
+              label="Text Shadow Offset - Width"
+              value={textShadowOffset.width}
+              minimumValue={-40}
+              maximumValue={40}
+              handleValueChange={val =>
+                setTextShadowOffset(prev => ({...prev, width: val}))
+              }
+            />
+            <CustomSlider
+              label="Font Size"
+              value={fontSize}
+              maximumValue={40}
+              handleValueChange={setFontSize}
+            />
+            <CustomPicker
+              label="Font Style"
+              data={fontStyles}
+              currentIndex={fontStyleIdx}
+              onSelected={setFontStyleIdx}
+            />
+            <CustomPicker
+              label="Font Weight"
+              data={fontWeights}
+              currentIndex={fontWeightIdx}
+              onSelected={setFontWeightIdx}
+            />
+            <CustomSlider
+              label="Line Height"
+              value={lineHeight}
+              minimumValue={10}
+              maximumValue={50}
+              handleValueChange={setLineHeight}
+            />
+            <CustomPicker
+              label="Text Align"
+              data={textAlignments}
+              currentIndex={textAlignIdx}
+              onSelected={setTextAlignIdx}
+            />
+            <CustomPicker
+              label="Text Decoration Line"
+              data={textDecorationLines}
+              currentIndex={textDecorationLineIdx}
+              onSelected={setTextDecorationLineIdx}
+            />
+            <CustomSlider
+              label="Text Shadow Radius"
+              value={textShadowRadius}
+              handleValueChange={setTextShadowRadius}
+            />
+            <CustomPicker
+              label="Font Variant"
+              data={fontVariants}
+              currentIndex={fontVariantIdx}
+              onSelected={setFontVariantIdx}
+            />
+            <CustomSlider
+              label="Letter Spacing"
+              step={0.1}
+              value={letterSpacing}
+              handleValueChange={setLetterSpacing}
+            />
+            <CustomPicker
+              label="Text Transform"
+              data={textTransformations}
+              currentIndex={textTransformIdx}
+              onSelected={setTextTransformIdx}
             />
           </View>
-        )}
-        {Platform.OS === 'ios' && (
-          <View style={styles.platformContainer}>
-            <Text style={styles.platformContainerTitle}>
-              iOS only properties
-            </Text>
-            <CustomPicker
-              label="Text Decoration Style"
-              data={textDecorationStyles}
-              currentIndex={textDecorationStyleIdx}
-              onSelected={setTextDecorationStyleIdx}
-            />
-            <CustomPicker
-              label="Writing Direction"
-              data={writingDirections}
-              currentIndex={writingDirectionIdx}
-              onSelected={setWritingDirectionIdx}
-            />
-          </View>
-        )}
-      </ScrollView>
-    </View>
+          {Platform.OS === 'android' && (
+            <View style={styles.platformContainer}>
+              <Text style={styles.platformContainerTitle}>
+                Android only properties
+              </Text>
+              <CustomPicker
+                label="Text Vertical Align"
+                data={textAlignmentsVertical}
+                currentIndex={textVerticalAlignIdx}
+                onSelected={setTextVerticalAlignIdx}
+              />
+              <CustomSwitch
+                label="Include Font Padding"
+                handleValueChange={setIncludeFontPadding}
+                value={includeFontPadding}
+              />
+            </View>
+          )}
+          {Platform.OS === 'ios' && (
+            <View style={styles.platformContainer}>
+              <Text style={styles.platformContainerTitle}>
+                iOS only properties
+              </Text>
+              <CustomPicker
+                label="Text Decoration Style"
+                data={textDecorationStyles}
+                currentIndex={textDecorationStyleIdx}
+                onSelected={setTextDecorationStyleIdx}
+              />
+              <CustomPicker
+                label="Writing Direction"
+                data={writingDirections}
+                currentIndex={writingDirectionIdx}
+                onSelected={setWritingDirectionIdx}
+              />
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -265,8 +270,8 @@ const CustomSlider = ({
       )}
       <View style={styles.wrapperHorizontal}>
         <Slider
-          thumbTintColor="#DAA520"
-          minimumTrackTintColor="#DAA520"
+          thumbTintColor="#06bcee"
+          minimumTrackTintColor="#64d7ffbb"
           minimumValue={minimumValue}
           maximumValue={maximumValue}
           step={step}
@@ -318,22 +323,20 @@ const CustomPicker = ({label, data, currentIndex, onSelected}) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: StatusBar.currentHeight,
-    backgroundColor: '#ecf0f1',
-    padding: 8,
+  },
+  pargraphWrapper: {
+    backgroundColor: 'black',
   },
   paragraph: {
-    color: 'black',
+    color: '#fff',
     textDecorationColor: 'yellow',
     textShadowColor: 'red',
     textShadowRadius: 1,
-    margin: 24,
+    padding: 24,
   },
   wrapperHorizontal: {
-    height: 54,
     justifyContent: 'center',
     color: 'black',
-    marginBottom: 12,
   },
   itemStyleHorizontal: {
     marginRight: 10,
@@ -341,13 +344,13 @@ const styles = StyleSheet.create({
     padding: 8,
     borderWidth: 1,
     borderColor: 'grey',
-    borderRadius: 25,
+    borderRadius: 8,
     textAlign: 'center',
     justifyContent: 'center',
   },
   itemSelectedStyleHorizontal: {
     borderWidth: 2,
-    borderColor: '#DAA520',
+    borderColor: '#06bcee',
   },
   platformContainer: {
     marginTop: 8,
@@ -358,7 +361,7 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: 'bold',
-    marginVertical: 4,
+    marginVertical: 8,
   },
 });
 
@@ -374,59 +377,21 @@ import {
   FlatList,
   Platform,
   ScrollView,
-  StatusBar,
   StyleSheet,
   Switch,
   Text,
   TouchableWithoutFeedback,
   View,
+  TextStyle,
 } from 'react-native';
 import Slider from '@react-native-community/slider';
-
-const fontStyles = ['normal', 'italic'] as const;
-const fontVariants = [
-  undefined,
-  'small-caps',
-  'oldstyle-nums',
-  'lining-nums',
-  'tabular-nums',
-  'proportional-nums',
-] as const;
-const fontWeights = [
-  'normal',
-  'bold',
-  '100',
-  '200',
-  '300',
-  '400',
-  '500',
-  '600',
-  '700',
-  '800',
-  '900',
-] as const;
-const textAlignments = ['auto', 'left', 'right', 'center', 'justify'] as const;
-const textDecorationLines = [
-  'none',
-  'underline',
-  'line-through',
-  'underline line-through',
-] as const;
-const textDecorationStyles = ['solid', 'double', 'dotted', 'dashed'] as const;
-const textTransformations = [
-  'none',
-  'uppercase',
-  'lowercase',
-  'capitalize',
-] as const;
-const textAlignmentsVertical = ['auto', 'top', 'bottom', 'center'] as const;
-const writingDirections = ['auto', 'ltr', 'rtl'] as const;
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
-  const [fontSize, setFontSize] = useState(10);
+  const [fontSize, setFontSize] = useState(20);
   const [fontStyleIdx, setFontStyleIdx] = useState(0);
   const [fontWeightIdx, setFontWeightIdx] = useState(0);
-  const [lineHeight, setLineHeight] = useState(10);
+  const [lineHeight, setLineHeight] = useState(24);
   const [textAlignIdx, setTextAlignIdx] = useState(0);
   const [textDecorationLineIdx, setTextDecorationLineIdx] = useState(0);
   const [includeFontPadding, setIncludeFontPadding] = useState(false);
@@ -445,162 +410,167 @@ const App = () => {
   const [, ...validFontVariants] = fontVariants;
 
   return (
-    <View style={styles.container}>
-      <Text
-        style={[
-          styles.paragraph,
-          {
-            fontSize,
-            fontStyle: fontStyles[fontStyleIdx],
-            fontWeight: fontWeights[fontWeightIdx],
-            lineHeight,
-            textAlign: textAlignments[textAlignIdx],
-            textDecorationLine: textDecorationLines[textDecorationLineIdx],
-            textTransform: textTransformations[textTransformIdx],
-            textAlignVertical: textAlignmentsVertical[textVerticalAlignIdx],
-            fontVariant:
-              fontVariantIdx === 0
-                ? undefined
-                : [validFontVariants[fontVariantIdx - 1]],
-            letterSpacing,
-            includeFontPadding,
-            textDecorationStyle: textDecorationStyles[textDecorationStyleIdx],
-            writingDirection: writingDirections[writingDirectionIdx],
-            textShadowOffset,
-            textShadowRadius,
-          },
-        ]}>
-        Lorem Ipsum is simply dummy text of the printing and typesetting
-        industry. 112 Likes
-      </Text>
-      <ScrollView>
-        <View>
-          <Text>Common platform properties</Text>
-          <CustomSlider
-            label="Text Shadow Offset - Height"
-            value={textShadowOffset.height}
-            minimumValue={-40}
-            maximumValue={40}
-            handleValueChange={(val: number) =>
-              setTextShadowOffset(prev => ({...prev, height: val}))
-            }
-          />
-          <CustomSlider
-            label="Text Shadow Offset - Width"
-            value={textShadowOffset.width}
-            minimumValue={-40}
-            maximumValue={40}
-            handleValueChange={(val: number) =>
-              setTextShadowOffset(prev => ({...prev, width: val}))
-            }
-          />
-          <CustomSlider
-            label="Font Size"
-            value={fontSize}
-            maximumValue={40}
-            handleValueChange={setFontSize}
-          />
-          <CustomPicker
-            label="Font Style"
-            data={fontStyles}
-            currentIndex={fontStyleIdx}
-            onSelected={setFontStyleIdx}
-          />
-          <CustomPicker
-            label="Font Weight"
-            data={fontWeights}
-            currentIndex={fontWeightIdx}
-            onSelected={setFontWeightIdx}
-          />
-          <CustomSlider
-            label="Line Height"
-            value={lineHeight}
-            minimumValue={10}
-            maximumValue={50}
-            handleValueChange={setLineHeight}
-          />
-          <CustomPicker
-            label="Text Align"
-            data={textAlignments}
-            currentIndex={textAlignIdx}
-            onSelected={setTextAlignIdx}
-          />
-          <CustomPicker
-            label="Text Decoration Line"
-            data={textDecorationLines}
-            currentIndex={textDecorationLineIdx}
-            onSelected={setTextDecorationLineIdx}
-          />
-          <CustomSlider
-            label="Text Shadow Radius"
-            value={textShadowRadius}
-            handleValueChange={setTextShadowRadius}
-          />
-          <CustomPicker
-            label="Font Variant"
-            data={fontVariants}
-            currentIndex={fontVariantIdx}
-            onSelected={setFontVariantIdx}
-          />
-          <CustomSlider
-            label="Letter Spacing"
-            step={0.1}
-            value={letterSpacing}
-            handleValueChange={setLetterSpacing}
-          />
-          <CustomPicker
-            label="Text Transform"
-            data={textTransformations}
-            currentIndex={textTransformIdx}
-            onSelected={setTextTransformIdx}
-          />
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.pargraphWrapper}>
+          <Text
+            style={[
+              styles.paragraph,
+              {
+                fontSize,
+                fontStyle: fontStyles[fontStyleIdx],
+                fontWeight: fontWeights[fontWeightIdx],
+                lineHeight,
+                textAlign: textAlignments[textAlignIdx],
+                textDecorationLine: textDecorationLines[textDecorationLineIdx],
+                textTransform: textTransformations[textTransformIdx],
+                textAlignVertical: textAlignmentsVertical[textVerticalAlignIdx],
+                fontVariant:
+                  fontVariantIdx === 0
+                    ? undefined
+                    : [validFontVariants[fontVariantIdx - 1]],
+                letterSpacing,
+                includeFontPadding,
+                textDecorationStyle:
+                  textDecorationStyles[textDecorationStyleIdx],
+                writingDirection: writingDirections[writingDirectionIdx],
+                textShadowOffset,
+                textShadowRadius,
+              } as TextStyle,
+            ]}>
+            Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. 112 Likes
+          </Text>
         </View>
-        {Platform.OS === 'android' && (
-          <View style={styles.platformContainer}>
-            <Text style={styles.platformContainerTitle}>
-              Android only properties
-            </Text>
-            <CustomPicker
-              label="Text Vertical Align"
-              data={textAlignmentsVertical}
-              currentIndex={textVerticalAlignIdx}
-              onSelected={setTextVerticalAlignIdx}
+        <ScrollView style={{padding: 12}}>
+          <View>
+            <Text>Common platform properties</Text>
+            <CustomSlider
+              label="Text Shadow Offset - Height"
+              value={textShadowOffset.height}
+              minimumValue={-40}
+              maximumValue={40}
+              handleValueChange={(val: number) =>
+                setTextShadowOffset(prev => ({...prev, height: val}))
+              }
             />
-            <CustomSwitch
-              label="Include Font Padding"
-              handleValueChange={setIncludeFontPadding}
-              value={includeFontPadding}
+            <CustomSlider
+              label="Text Shadow Offset - Width"
+              value={textShadowOffset.width}
+              minimumValue={-40}
+              maximumValue={40}
+              handleValueChange={(val: number) =>
+                setTextShadowOffset(prev => ({...prev, width: val}))
+              }
+            />
+            <CustomSlider
+              label="Font Size"
+              value={fontSize}
+              maximumValue={40}
+              handleValueChange={setFontSize}
+            />
+            <CustomPicker
+              label="Font Style"
+              data={fontStyles}
+              currentIndex={fontStyleIdx}
+              onSelected={setFontStyleIdx}
+            />
+            <CustomPicker
+              label="Font Weight"
+              data={fontWeights}
+              currentIndex={fontWeightIdx}
+              onSelected={setFontWeightIdx}
+            />
+            <CustomSlider
+              label="Line Height"
+              value={lineHeight}
+              minimumValue={10}
+              maximumValue={50}
+              handleValueChange={setLineHeight}
+            />
+            <CustomPicker
+              label="Text Align"
+              data={textAlignments}
+              currentIndex={textAlignIdx}
+              onSelected={setTextAlignIdx}
+            />
+            <CustomPicker
+              label="Text Decoration Line"
+              data={textDecorationLines}
+              currentIndex={textDecorationLineIdx}
+              onSelected={setTextDecorationLineIdx}
+            />
+            <CustomSlider
+              label="Text Shadow Radius"
+              value={textShadowRadius}
+              handleValueChange={setTextShadowRadius}
+            />
+            <CustomPicker
+              label="Font Variant"
+              data={fontVariants}
+              currentIndex={fontVariantIdx}
+              onSelected={setFontVariantIdx}
+            />
+            <CustomSlider
+              label="Letter Spacing"
+              step={0.1}
+              value={letterSpacing}
+              handleValueChange={setLetterSpacing}
+            />
+            <CustomPicker
+              label="Text Transform"
+              data={textTransformations}
+              currentIndex={textTransformIdx}
+              onSelected={setTextTransformIdx}
             />
           </View>
-        )}
-        {Platform.OS === 'ios' && (
-          <View style={styles.platformContainer}>
-            <Text style={styles.platformContainerTitle}>
-              iOS only properties
-            </Text>
-            <CustomPicker
-              label="Text Decoration Style"
-              data={textDecorationStyles}
-              currentIndex={textDecorationStyleIdx}
-              onSelected={setTextDecorationStyleIdx}
-            />
-            <CustomPicker
-              label="Writing Direction"
-              data={writingDirections}
-              currentIndex={writingDirectionIdx}
-              onSelected={setWritingDirectionIdx}
-            />
-          </View>
-        )}
-      </ScrollView>
-    </View>
+          {Platform.OS === 'android' && (
+            <View style={styles.platformContainer}>
+              <Text style={styles.platformContainerTitle}>
+                Android only properties
+              </Text>
+              <CustomPicker
+                label="Text Vertical Align"
+                data={textAlignmentsVertical}
+                currentIndex={textVerticalAlignIdx}
+                onSelected={setTextVerticalAlignIdx}
+              />
+              <CustomSwitch
+                label="Include Font Padding"
+                handleValueChange={setIncludeFontPadding}
+                value={includeFontPadding}
+              />
+            </View>
+          )}
+          {Platform.OS === 'ios' && (
+            <View style={styles.platformContainer}>
+              <Text style={styles.platformContainerTitle}>
+                iOS only properties
+              </Text>
+              <CustomPicker
+                label="Text Decoration Style"
+                data={textDecorationStyles}
+                currentIndex={textDecorationStyleIdx}
+                onSelected={setTextDecorationStyleIdx}
+              />
+              <CustomPicker
+                label="Writing Direction"
+                data={writingDirections}
+                currentIndex={writingDirectionIdx}
+                onSelected={setWritingDirectionIdx}
+              />
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
 type CustomSwitchProps = {
   label: string;
-  handleValueChange: (value: boolean) => void;
   value: boolean;
+  handleValueChange: (value: boolean) => void;
 };
 
 const CustomSwitch = ({label, handleValueChange, value}: CustomSwitchProps) => {
@@ -621,11 +591,11 @@ const CustomSwitch = ({label, handleValueChange, value}: CustomSwitchProps) => {
 
 type CustomSliderProps = {
   label: string;
+  value: number;
   handleValueChange: (value: number) => void;
   step?: number;
   minimumValue?: number;
   maximumValue?: number;
-  value: number;
 };
 
 const CustomSlider = ({
@@ -643,8 +613,8 @@ const CustomSlider = ({
       )}
       <View style={styles.wrapperHorizontal}>
         <Slider
-          thumbTintColor="#DAA520"
-          minimumTrackTintColor="#DAA520"
+          thumbTintColor="#06bcee"
+          minimumTrackTintColor="#64d7ffbb"
           minimumValue={minimumValue}
           maximumValue={maximumValue}
           step={step}
@@ -674,11 +644,10 @@ const CustomPicker = ({
       <Text style={styles.title}>{label}</Text>
       <View style={styles.wrapperHorizontal}>
         <FlatList
-          bounces
           horizontal
           data={data}
           keyExtractor={item => String(item)}
-          renderItem={({item, index}) => {
+          renderItem={({item, index}: {item: string; index: number}) => {
             const selected = index === currentIndex;
             return (
               <TouchableWithoutFeedback onPress={() => onSelected(index)}>
@@ -705,25 +674,57 @@ const CustomPicker = ({
   );
 };
 
+const fontStyles = ['normal', 'italic'];
+const fontVariants = [
+  undefined,
+  'small-caps',
+  'oldstyle-nums',
+  'lining-nums',
+  'tabular-nums',
+  'proportional-nums',
+];
+const fontWeights = [
+  'normal',
+  'bold',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+];
+const textAlignments = ['auto', 'left', 'right', 'center', 'justify'];
+const textDecorationLines = [
+  'none',
+  'underline',
+  'line-through',
+  'underline line-through',
+];
+const textDecorationStyles = ['solid', 'double', 'dotted', 'dashed'];
+const textTransformations = ['none', 'uppercase', 'lowercase', 'capitalize'];
+const textAlignmentsVertical = ['auto', 'top', 'bottom', 'center'];
+const writingDirections = ['auto', 'ltr', 'rtl'];
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingTop: StatusBar.currentHeight,
-    backgroundColor: '#ecf0f1',
-    padding: 8,
+  },
+  pargraphWrapper: {
+    backgroundColor: 'black',
   },
   paragraph: {
-    color: 'black',
+    color: '#fff',
     textDecorationColor: 'yellow',
     textShadowColor: 'red',
     textShadowRadius: 1,
-    margin: 24,
+    padding: 24,
   },
   wrapperHorizontal: {
-    height: 54,
     justifyContent: 'center',
     color: 'black',
-    marginBottom: 12,
   },
   itemStyleHorizontal: {
     marginRight: 10,
@@ -731,13 +732,13 @@ const styles = StyleSheet.create({
     padding: 8,
     borderWidth: 1,
     borderColor: 'grey',
-    borderRadius: 25,
+    borderRadius: 8,
     textAlign: 'center',
     justifyContent: 'center',
   },
   itemSelectedStyleHorizontal: {
     borderWidth: 2,
-    borderColor: '#DAA520',
+    borderColor: '#06bcee',
   },
   platformContainer: {
     marginTop: 8,
@@ -748,7 +749,7 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: 'bold',
-    marginVertical: 4,
+    marginVertical: 8,
   },
 });
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -9,9 +9,10 @@ A React component for displaying text.
 
 In the following example, the nested title and body text will inherit the `fontFamily` from `styles.baseText`, but the title provides its own additional styles. The title and body will stack on top of each other on account of the literal newlines:
 
-```SnackPlayer name=Text%20Functional%20Component%20Example
+```SnackPlayer name=Text%20Function%20Component%20Example
 import React, {useState} from 'react';
 import {Text, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const TextInANest = () => {
   const [titleText, setTitleText] = useState("Bird's Nest");
@@ -22,18 +23,25 @@ const TextInANest = () => {
   };
 
   return (
-    <Text style={styles.baseText}>
-      <Text style={styles.titleText} onPress={onPressTitle}>
-        {titleText}
-        {'\n'}
-        {'\n'}
-      </Text>
-      <Text numberOfLines={5}>{bodyText}</Text>
-    </Text>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.baseText}>
+          <Text style={styles.titleText} onPress={onPressTitle}>
+            {titleText}
+            {'\n'}
+            {'\n'}
+          </Text>
+          <Text numberOfLines={5}>{bodyText}</Text>
+        </Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   baseText: {
     fontFamily: 'Cochin',
   },
@@ -53,15 +61,18 @@ Both Android and iOS allow you to display formatted text by annotating ranges of
 ```SnackPlayer name=Nested%20Text%20Example
 import React from 'react';
 import {Text, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const BoldAndBeautiful = () => {
-  return (
-    <Text style={styles.baseText}>
-      I am bold
-      <Text style={styles.innerText}> and red</Text>
-    </Text>
-  );
-};
+const BoldAndBeautiful = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.baseText}>
+        I am bold
+        <Text style={styles.innerText}> and red</Text>
+      </Text>
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   baseText: {

--- a/docs/text.md
+++ b/docs/text.md
@@ -75,6 +75,9 @@ const BoldAndBeautiful = () => (
 );
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   baseText: {
     fontWeight: 'bold',
   },

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -7,29 +7,32 @@ A foundational component for inputting text into the app via a keyboard. Props p
 
 The most basic use case is to plop down a `TextInput` and subscribe to the `onChangeText` events to read the user input. There are also other events, such as `onSubmitEditing` and `onFocus` that can be subscribed to. A minimal example:
 
-```SnackPlayer name=TextInput
+```SnackPlayer name=TextInput%20Example
 import React from 'react';
-import {SafeAreaView, StyleSheet, TextInput} from 'react-native';
+import {StyleSheet, TextInput} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const TextInputExample = () => {
   const [text, onChangeText] = React.useState('Useless Text');
   const [number, onChangeNumber] = React.useState('');
 
   return (
-    <SafeAreaView>
-      <TextInput
-        style={styles.input}
-        onChangeText={onChangeText}
-        value={text}
-      />
-      <TextInput
-        style={styles.input}
-        onChangeText={onChangeNumber}
-        value={number}
-        placeholder="useless placeholder"
-        keyboardType="numeric"
-      />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView>
+        <TextInput
+          style={styles.input}
+          onChangeText={onChangeText}
+          value={text}
+        />
+        <TextInput
+          style={styles.input}
+          onChangeText={onChangeNumber}
+          value={number}
+          placeholder="useless placeholder"
+          keyboardType="numeric"
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -45,38 +48,52 @@ const styles = StyleSheet.create({
 export default TextInputExample;
 ```
 
-Two methods exposed via the native element are .focus() and .blur() that will focus or blur the TextInput programmatically.
+Two methods exposed via the native element are `.focus()` and `.blur()` that will focus or blur the TextInput programmatically.
 
 Note that some props are only available with `multiline={true/false}`. Additionally, border styles that apply to only one side of the element (e.g., `borderBottomColor`, `borderLeftWidth`, etc.) will not be applied if `multiline=true`. To achieve the same effect, you can wrap your `TextInput` in a `View`:
 
-```SnackPlayer name=TextInput
+```SnackPlayer name=Multiline%20TextInput%20Example
 import React from 'react';
-import {View, TextInput} from 'react-native';
+import {TextInput, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const MultilineTextInputExample = () => {
   const [value, onChangeText] = React.useState('Useless Multiline Placeholder');
 
-  // If you type something in the text box that is a color, the background will change to that
-  // color.
+  // If you type something in the text box that is a color,
+  // the background will change to that color.
   return (
-    <View
-      style={{
-        backgroundColor: value,
-        borderBottomColor: '#000000',
-        borderBottomWidth: 1,
-      }}>
-      <TextInput
-        editable
-        multiline
-        numberOfLines={4}
-        maxLength={40}
-        onChangeText={text => onChangeText(text)}
-        value={value}
-        style={{padding: 10}}
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView
+        style={[
+          styles.container,
+          {
+            backgroundColor: value,
+          },
+        ]}>
+        <TextInput
+          editable
+          multiline
+          numberOfLines={4}
+          maxLength={40}
+          onChangeText={text => onChangeText(text)}
+          value={value}
+          style={styles.textInput}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    borderBottomColor: '#000',
+    borderBottomWidth: 1,
+  },
+  textInput: {
+    padding: 10,
+  },
+});
 
 export default MultilineTextInputExample;
 ```

--- a/docs/toastandroid.md
+++ b/docs/toastandroid.md
@@ -10,11 +10,12 @@ React Native's ToastAndroid API exposes the Android platform's ToastAndroid modu
 
 You can alternatively use `showWithGravity(message, duration, gravity)` to specify where the toast appears in the screen's layout. May be `ToastAndroid.TOP`, `ToastAndroid.BOTTOM` or `ToastAndroid.CENTER`.
 
-The 'showWithGravityAndOffset(message, duration, gravity, xOffset, yOffset)' method adds the ability to specify an offset with in pixels.
+The `showWithGravityAndOffset(message, duration, gravity, xOffset, yOffset)` method adds the ability to specify an offset with in pixels.
 
 ```SnackPlayer name=Toast%20Android%20API%20Example&supportedPlatforms=android
 import React from 'react';
-import {View, StyleSheet, ToastAndroid, Button, StatusBar} from 'react-native';
+import {StyleSheet, ToastAndroid, Button, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const showToast = () => {
@@ -40,17 +41,19 @@ const App = () => {
   };
 
   return (
-    <View style={styles.container}>
-      <Button title="Toggle Toast" onPress={() => showToast()} />
-      <Button
-        title="Toggle Toast With Gravity"
-        onPress={() => showToastWithGravity()}
-      />
-      <Button
-        title="Toggle Toast With Gravity & Offset"
-        onPress={() => showToastWithGravityAndOffset()}
-      />
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Button title="Toggle Toast" onPress={() => showToast()} />
+        <Button
+          title="Toggle Toast With Gravity"
+          onPress={() => showToastWithGravity()}
+        />
+        <Button
+          title="Toggle Toast With Gravity & Offset"
+          onPress={() => showToastWithGravityAndOffset()}
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -33,22 +33,25 @@ function MyComponent(props: MyComponentProps) {
 ```SnackPlayer name=TouchableHighlight%20Example
 import React, {useState} from 'react';
 import {StyleSheet, Text, TouchableHighlight, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const TouchableHighlightExample = () => {
   const [count, setCount] = useState(0);
   const onPress = () => setCount(count + 1);
 
   return (
-    <View style={styles.container}>
-      <TouchableHighlight onPress={onPress}>
-        <View style={styles.button}>
-          <Text>Touch Here</Text>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <TouchableHighlight onPress={onPress}>
+          <View style={styles.button}>
+            <Text>Touch Here</Text>
+          </View>
+        </TouchableHighlight>
+        <View style={styles.countContainer}>
+          <Text style={styles.countText}>{count || null}</Text>
         </View>
-      </TouchableHighlight>
-      <View style={styles.countContainer}>
-        <Text style={styles.countText}>{count || null}</Text>
-      </View>
-    </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -15,33 +15,30 @@ Background drawable of native feedback touchable can be customized with `backgro
 
 ```SnackPlayer name=TouchableNativeFeedback%20Android%20Component%20Example&supportedPlatforms=android
 import React, {useState} from 'react';
-import {
-  Text,
-  View,
-  StyleSheet,
-  TouchableNativeFeedback,
-  StatusBar,
-} from 'react-native';
+import {Text, View, StyleSheet, TouchableNativeFeedback} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [rippleColor, setRippleColor] = useState(randomHexColor());
   const [rippleOverflow, setRippleOverflow] = useState(false);
   return (
-    <View style={styles.container}>
-      <TouchableNativeFeedback
-        onPress={() => {
-          setRippleColor(randomHexColor());
-          setRippleOverflow(!rippleOverflow);
-        }}
-        background={TouchableNativeFeedback.Ripple(
-          rippleColor,
-          rippleOverflow,
-        )}>
-        <View style={styles.touchable}>
-          <Text style={styles.text}>TouchableNativeFeedback</Text>
-        </View>
-      </TouchableNativeFeedback>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <TouchableNativeFeedback
+          onPress={() => {
+            setRippleColor(randomHexColor());
+            setRippleOverflow(!rippleOverflow);
+          }}
+          background={TouchableNativeFeedback.Ripple(
+            rippleColor,
+            rippleOverflow,
+          )}>
+          <View style={styles.touchable}>
+            <Text style={styles.text}>TouchableNativeFeedback</Text>
+          </View>
+        </TouchableNativeFeedback>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 
@@ -55,12 +52,19 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    paddingTop: StatusBar.currentHeight,
-    backgroundColor: '#ecf0f1',
-    padding: 8,
+    backgroundColor: 'black',
+    paddingHorizontal: 20,
   },
-  touchable: {flex: 0.5, borderColor: 'black', borderWidth: 1},
-  text: {alignSelf: 'center'},
+  touchable: {
+    flex: 0.33,
+    justifyContent: 'center',
+    backgroundColor: '#eeeeee',
+    borderColor: 'black',
+    borderWidth: 1,
+  },
+  text: {
+    alignSelf: 'center',
+  },
 });
 
 export default App;

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -14,20 +14,23 @@ Opacity is controlled by wrapping the children in an `Animated.View`, which is a
 ```SnackPlayer name=TouchableOpacity%20Example
 import React, {useState} from 'react';
 import {StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const [count, setCount] = useState(0);
   const onPress = () => setCount(prevCount => prevCount + 1);
 
   return (
-    <View style={styles.container}>
-      <View style={styles.countContainer}>
-        <Text>Count: {count}</Text>
-      </View>
-      <TouchableOpacity style={styles.button} onPress={onPress}>
-        <Text>Press Here</Text>
-      </TouchableOpacity>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.countContainer}>
+          <Text>Count: {count}</Text>
+        </View>
+        <TouchableOpacity style={styles.button} onPress={onPress}>
+          <Text>Press Here</Text>
+        </TouchableOpacity>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -30,6 +30,7 @@ function MyComponent(props: MyComponentProps) {
 ```SnackPlayer name=TouchableWithoutFeedback
 import React, {useState} from 'react';
 import {StyleSheet, TouchableWithoutFeedback, Text, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const TouchableWithoutFeedbackExample = () => {
   const [count, setCount] = useState(0);
@@ -39,16 +40,18 @@ const TouchableWithoutFeedbackExample = () => {
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.countContainer}>
-        <Text style={styles.countText}>Count: {count}</Text>
-      </View>
-      <TouchableWithoutFeedback onPress={onPress}>
-        <View style={styles.button}>
-          <Text>Touch Here</Text>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.countContainer}>
+          <Text style={styles.countText}>Count: {count}</Text>
         </View>
-      </TouchableWithoutFeedback>
-    </View>
+        <TouchableWithoutFeedback onPress={onPress}>
+          <View style={styles.button}>
+            <Text>Touch Here</Text>
+          </View>
+        </TouchableWithoutFeedback>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -7,128 +7,131 @@ Transforms are style properties that will help you modify the appearance and pos
 
 ## Example
 
-```SnackPlayer name=Transforms
+```SnackPlayer name=Transforms%20Example
 import React from 'react';
-import {SafeAreaView, ScrollView, StyleSheet, Text, View} from 'react-native';
+import {ScrollView, StyleSheet, Text, View} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => (
-  <SafeAreaView style={styles.container}>
-    <ScrollView contentContainerStyle={styles.scrollContentContainer}>
-      <View style={styles.box}>
-        <Text style={styles.text}>Original Object</Text>
-      </View>
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContentContainer}>
+        <View style={styles.box}>
+          <Text style={styles.text}>Original Object</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{scale: 2}],
-          },
-        ]}>
-        <Text style={styles.text}>Scale by 2</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{scale: 2}],
+            },
+          ]}>
+          <Text style={styles.text}>Scale by 2</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{scaleX: 2}],
-          },
-        ]}>
-        <Text style={styles.text}>ScaleX by 2</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{scaleX: 2}],
+            },
+          ]}>
+          <Text style={styles.text}>ScaleX by 2</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{scaleY: 2}],
-          },
-        ]}>
-        <Text style={styles.text}>ScaleY by 2</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{scaleY: 2}],
+            },
+          ]}>
+          <Text style={styles.text}>ScaleY by 2</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{rotate: '45deg'}],
-          },
-        ]}>
-        <Text style={styles.text}>Rotate by 45 deg</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{rotate: '45deg'}],
+            },
+          ]}>
+          <Text style={styles.text}>Rotate by 45 deg</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{rotateX: '45deg'}, {rotateZ: '45deg'}],
-          },
-        ]}>
-        <Text style={styles.text}>Rotate X&Z by 45 deg</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{rotateX: '45deg'}, {rotateZ: '45deg'}],
+            },
+          ]}>
+          <Text style={styles.text}>Rotate X&Z by 45 deg</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{rotateY: '45deg'}, {rotateZ: '45deg'}],
-          },
-        ]}>
-        <Text style={styles.text}>Rotate Y&Z by 45 deg</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{rotateY: '45deg'}, {rotateZ: '45deg'}],
+            },
+          ]}>
+          <Text style={styles.text}>Rotate Y&Z by 45 deg</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{skewX: '45deg'}],
-          },
-        ]}>
-        <Text style={styles.text}>SkewX by 45 deg</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{skewX: '45deg'}],
+            },
+          ]}>
+          <Text style={styles.text}>SkewX by 45 deg</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{skewY: '45deg'}],
-          },
-        ]}>
-        <Text style={styles.text}>SkewY by 45 deg</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{skewY: '45deg'}],
+            },
+          ]}>
+          <Text style={styles.text}>SkewY by 45 deg</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{skewX: '30deg'}, {skewY: '30deg'}],
-          },
-        ]}>
-        <Text style={styles.text}>Skew X&Y by 30 deg</Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{skewX: '30deg'}, {skewY: '30deg'}],
+            },
+          ]}>
+          <Text style={styles.text}>Skew X&Y by 30 deg</Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{translateX: -50}],
-          },
-        ]}>
-        <Text style={styles.text}>TranslateX by -50 </Text>
-      </View>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{translateX: -50}],
+            },
+          ]}>
+          <Text style={styles.text}>TranslateX by -50 </Text>
+        </View>
 
-      <View
-        style={[
-          styles.box,
-          {
-            transform: [{translateY: 50}],
-          },
-        ]}>
-        <Text style={styles.text}>TranslateY by 50 </Text>
-      </View>
-    </ScrollView>
-  </SafeAreaView>
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [{translateY: 50}],
+            },
+          ]}>
+          <Text style={styles.text}>TranslateY by 50 </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  </SafeAreaProvider>
 );
 
 const styles = StyleSheet.create({
@@ -208,9 +211,10 @@ The `transformOrigin` property sets the origin for a view's transformations. The
 
 # Example
 
-```SnackPlayer name=TransformOrigin
+```SnackPlayer name=TransformOrigin%20Example
 import React, {useRef, useEffect} from 'react';
-import {Animated, View, StyleSheet, SafeAreaView, Easing} from 'react-native';
+import {Animated, View, StyleSheet, Easing} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const rotateAnim = useRef(new Animated.Value(0)).current;
@@ -232,18 +236,20 @@ const App = () => {
   });
 
   return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.transformOriginWrapper}>
-        <Animated.View
-          style={[
-            styles.transformOriginView,
-            {
-              transform: [{rotate: spin}],
-            },
-          ]}
-        />
-      </View>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <View style={styles.transformOriginWrapper}>
+          <Animated.View
+            style={[
+              styles.transformOriginView,
+              {
+                transform: [{rotate: spin}],
+              },
+            ]}
+          />
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/usecolorscheme.md
+++ b/docs/usecolorscheme.md
@@ -23,14 +23,17 @@ The `useColorScheme` React hook provides and subscribes to color scheme updates 
 
 ```SnackPlayer
 import React from 'react';
-import {Text, StyleSheet, useColorScheme, View} from 'react-native';
+import {Text, StyleSheet, useColorScheme} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const colorScheme = useColorScheme();
   return (
-    <View style={styles.container}>
-      <Text>useColorScheme(): {colorScheme}</Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text>useColorScheme(): {colorScheme}</Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/usewindowdimensions.md
+++ b/docs/usewindowdimensions.md
@@ -17,18 +17,21 @@ const {height, width} = useWindowDimensions();
 
 ```SnackPlayer name=useWindowDimensions&supportedPlatforms=ios,android
 import React from 'react';
-import {View, StyleSheet, Text, useWindowDimensions} from 'react-native';
+import {StyleSheet, Text, useWindowDimensions} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   const {height, width, scale, fontScale} = useWindowDimensions();
   return (
-    <View style={styles.container}>
-      <Text style={styles.header}>Window Dimension Data</Text>
-      <Text>Height: {height}</Text>
-      <Text>Width: {width}</Text>
-      <Text>Font scale: {fontScale}</Text>
-      <Text>Pixel ratio: {scale}</Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.header}>Window Dimension Data</Text>
+        <Text>Height: {height}</Text>
+        <Text>Width: {width}</Text>
+        <Text>Font scale: {fontScale}</Text>
+        <Text>Pixel ratio: {scale}</Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 const styles = StyleSheet.create({

--- a/docs/vibration.md
+++ b/docs/vibration.md
@@ -7,7 +7,7 @@ Vibrates the device.
 
 ## Example
 
-```SnackPlayer name=Vibration&supportedPlatforms=ios,android
+```SnackPlayer name=Vibration%20Example&supportedPlatforms=ios,android
 import React from 'react';
 import {
   Button,
@@ -15,9 +15,9 @@ import {
   Text,
   Vibration,
   View,
-  SafeAreaView,
   StyleSheet,
 } from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const Separator = () => {
   return <View style={Platform.OS === 'android' ? styles.separator : null} />;
@@ -38,40 +38,42 @@ const App = () => {
       : 'wait 1s, vibrate, wait 2s, vibrate, wait 3s';
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={[styles.header, styles.paragraph]}>Vibration API</Text>
-      <View>
-        <Button title="Vibrate once" onPress={() => Vibration.vibrate()} />
-      </View>
-      <Separator />
-      {Platform.OS === 'android'
-        ? [
-            <View>
-              <Button
-                title="Vibrate for 10 seconds"
-                onPress={() => Vibration.vibrate(10 * ONE_SECOND_IN_MS)}
-              />
-            </View>,
-            <Separator />,
-          ]
-        : null}
-      <Text style={styles.paragraph}>Pattern: {PATTERN_DESC}</Text>
-      <Button
-        title="Vibrate with pattern"
-        onPress={() => Vibration.vibrate(PATTERN)}
-      />
-      <Separator />
-      <Button
-        title="Vibrate with pattern until cancelled"
-        onPress={() => Vibration.vibrate(PATTERN, true)}
-      />
-      <Separator />
-      <Button
-        title="Stop vibration pattern"
-        onPress={() => Vibration.cancel()}
-        color="#FF0000"
-      />
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container}>
+        <Text style={[styles.header, styles.paragraph]}>Vibration API</Text>
+        <View>
+          <Button title="Vibrate once" onPress={() => Vibration.vibrate()} />
+        </View>
+        <Separator />
+        {Platform.OS === 'android'
+          ? [
+              <View>
+                <Button
+                  title="Vibrate for 10 seconds"
+                  onPress={() => Vibration.vibrate(10 * ONE_SECOND_IN_MS)}
+                />
+              </View>,
+              <Separator />,
+            ]
+          : null}
+        <Text style={styles.paragraph}>Pattern: {PATTERN_DESC}</Text>
+        <Button
+          title="Vibrate with pattern"
+          onPress={() => Vibration.vibrate(PATTERN)}
+        />
+        <Separator />
+        <Button
+          title="Vibrate with pattern until cancelled"
+          onPress={() => Vibration.vibrate(PATTERN, true)}
+        />
+        <Separator />
+        <Button
+          title="Stop vibration pattern"
+          onPress={() => Vibration.cancel()}
+          color="#FF0000"
+        />
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -8,22 +8,22 @@ title: View Style Props
 ```SnackPlayer name=ViewStyleProps
 import React from 'react';
 import {View, StyleSheet} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const ViewStyleProps = () => {
-  return (
-    <View style={styles.container}>
+const App = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container}>
       <View style={styles.top} />
       <View style={styles.middle} />
       <View style={styles.bottom} />
-    </View>
-  );
-};
+    </SafeAreaView>
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'space-between',
-    backgroundColor: '#fff',
     padding: 20,
     margin: 10,
   },
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ViewStyleProps;
+export default App;
 ```
 
 # Reference

--- a/docs/view.md
+++ b/docs/view.md
@@ -12,19 +12,17 @@ This example creates a `View` that wraps two boxes with color and a text compone
 ```SnackPlayer name=View%20Example
 import React from 'react';
 import {View, Text} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const ViewBoxesWithColorAndText = () => {
   return (
-    <View
-      style={{
-        flexDirection: 'row',
-        height: 100,
-        padding: 20,
-      }}>
-      <View style={{backgroundColor: 'blue', flex: 0.3}} />
-      <View style={{backgroundColor: 'red', flex: 0.5}} />
-      <Text>Hello World!</Text>
-    </View>
+    <SafeAreaProvider>
+      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
+        <View style={{backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{backgroundColor: 'red', flex: 0.4}} />
+        <Text>Hello World!</Text>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 };
 

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -16,14 +16,8 @@ Virtualization massively improves memory consumption and performance of large li
 
 ```SnackPlayer name=VirtualizedListExample&ext=js
 import React from 'react';
-import {
-  SafeAreaView,
-  View,
-  VirtualizedList,
-  StyleSheet,
-  Text,
-  StatusBar,
-} from 'react-native';
+import {View, VirtualizedList, StyleSheet, Text, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const getItem = (_data, index) => ({
   id: Math.random().toString(12).substring(0),
@@ -38,9 +32,9 @@ const Item = ({title}) => (
   </View>
 );
 
-const App = () => {
-  return (
-    <SafeAreaView style={styles.container}>
+const App = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container} edges={['top']}>
       <VirtualizedList
         initialNumToRender={4}
         renderItem={({item}) => <Item title={item.title} />}
@@ -49,8 +43,8 @@ const App = () => {
         getItem={getItem}
       />
     </SafeAreaView>
-  );
-};
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -78,14 +72,8 @@ export default App;
 
 ```SnackPlayer name=VirtualizedListExample&ext=tsx
 import React from 'react';
-import {
-  SafeAreaView,
-  View,
-  VirtualizedList,
-  StyleSheet,
-  Text,
-  StatusBar,
-} from 'react-native';
+import {View, VirtualizedList, StyleSheet, Text, StatusBar} from 'react-native';
+import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 type ItemData = {
   id: string;
@@ -109,9 +97,9 @@ const Item = ({title}: ItemProps) => (
   </View>
 );
 
-const App = () => {
-  return (
-    <SafeAreaView style={styles.container}>
+const App = () => (
+  <SafeAreaProvider>
+    <SafeAreaView style={styles.container} edges={['top']}>
       <VirtualizedList
         initialNumToRender={4}
         renderItem={({item}) => <Item title={item.title} />}
@@ -120,8 +108,8 @@ const App = () => {
         getItem={getItem}
       />
     </SafeAreaView>
-  );
-};
+  </SafeAreaProvider>
+);
 
 const styles = StyleSheet.create({
   container: {

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -46,12 +46,14 @@ async function toJsxNode(node) {
       },
     })
   );
-  const dependencies = params.dependencies || '';
-  const platform = params.platform || 'web';
-  const supportedPlatforms = params.supportedPlatforms || 'ios,android,web';
-  const theme = params.theme || 'light';
-  const preview = params.preview || 'true';
-  const loading = params.loading || 'lazy';
+  const dependencies =
+    'react-native-safe-area-context' +
+    (params.dependencies ? `,${params.dependencies}` : '');
+  const platform = params.platform ?? 'web';
+  const supportedPlatforms = params.supportedPlatforms ?? 'ios,android,web';
+  const theme = params.theme ?? 'light';
+  const preview = params.preview ?? 'true';
+  const loading = params.loading ?? 'lazy';
 
   // Need help constructing this AST node?
   // Use the MDX Playground and explore what your output mdast should look like

--- a/scripts/lint-examples/package.json
+++ b/scripts/lint-examples/package.json
@@ -8,19 +8,20 @@
     "tsc-examples": "./bin/tsc-examples.js"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.9",
-    "@babel/preset-env": "^7.14.0",
-    "@babel/runtime": "^7.12.5",
-    "@react-native/babel-preset": "^0.73.18",
-    "@react-native-community/slider": "^4.4.2",
-    "@react-native/eslint-config": "^0.73.1",
-    "@react-native/typescript-config": "^0.73.1",
-    "@types/react": "^18.2.6",
-    "eslint": "^8.19.0",
+    "@babel/core": "^7.25.2",
+    "@babel/preset-env": "^7.25.4",
+    "@babel/runtime": "^7.25.6",
+    "@react-native/babel-preset": "^0.75.3",
+    "@react-native-community/slider": "^4.5.3",
+    "@react-native/eslint-config": "^0.75.3",
+    "@react-native/typescript-config": "^0.75.3",
+    "@types/react": "^18.2.79",
+    "eslint": "^8.57.1",
     "glob-promise": "^4.2.2",
     "prettier": "2.8.8",
     "react": "18.2.0",
-    "react-native": "^0.73.0",
-    "typescript": "5.0.4"
+    "react-native": "^0.75.3",
+    "react-native-safe-area-context": "^4.11.0",
+    "typescript": "5.5.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,10 +185,10 @@
     "@babel/highlight" "^7.24.7"
     picocolors "^1.0.0"
 
-"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.2":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.2.tgz#e41928bd33475305c586f6acbbb7e3ade7a6f7f5"
-  integrity sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==
+"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.2", "@babel/compat-data@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.4.tgz#7d2a80ce229890edcf4cc259d4d696cb4dae2fcb"
+  integrity sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -212,7 +212,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.13.16", "@babel/core@^7.20.0", "@babel/core@^7.21.3", "@babel/core@^7.23.3", "@babel/core@^7.7.5":
+"@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.20.0", "@babel/core@^7.21.3", "@babel/core@^7.23.3", "@babel/core@^7.25.2", "@babel/core@^7.7.5":
   version "7.25.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.25.2.tgz#ed8eec275118d7613e77a352894cd12ded8eba77"
   integrity sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==
@@ -242,12 +242,12 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.1"
 
-"@babel/generator@^7.12.5", "@babel/generator@^7.20.0", "@babel/generator@^7.23.3", "@babel/generator@^7.25.0", "@babel/generator@^7.7.2":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.25.0.tgz#f858ddfa984350bc3d3b7f125073c9af6988f18e"
-  integrity sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==
+"@babel/generator@^7.12.5", "@babel/generator@^7.20.0", "@babel/generator@^7.23.3", "@babel/generator@^7.25.0", "@babel/generator@^7.25.6", "@babel/generator@^7.7.2":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.25.6.tgz#0df1ad8cb32fe4d2b01d8bf437f153d19342a87c"
+  integrity sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==
   dependencies:
-    "@babel/types" "^7.25.0"
+    "@babel/types" "^7.25.6"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^2.5.1"
@@ -267,7 +267,7 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
-"@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.24.7", "@babel/helper-compilation-targets@^7.24.8", "@babel/helper-compilation-targets@^7.25.2":
+"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.24.7", "@babel/helper-compilation-targets@^7.24.8", "@babel/helper-compilation-targets@^7.25.2":
   version "7.25.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz#e1d9410a90974a3a5a66e84ff55ef62e3c02d06c"
   integrity sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==
@@ -278,20 +278,20 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz#a109bf9c3d58dfed83aaf42e85633c89f43a6253"
-  integrity sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.0", "@babel/helper-create-class-features-plugin@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz#57eaf1af38be4224a9d9dd01ddde05b741f50e14"
+  integrity sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.24.7"
     "@babel/helper-member-expression-to-functions" "^7.24.8"
     "@babel/helper-optimise-call-expression" "^7.24.7"
     "@babel/helper-replace-supers" "^7.25.0"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.24.7"
-    "@babel/traverse" "^7.25.0"
+    "@babel/traverse" "^7.25.4"
     semver "^6.3.1"
 
-"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.24.7", "@babel/helper-create-regexp-features-plugin@^7.25.0":
+"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.24.7", "@babel/helper-create-regexp-features-plugin@^7.25.0", "@babel/helper-create-regexp-features-plugin@^7.25.2":
   version "7.25.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.2.tgz#24c75974ed74183797ffd5f134169316cd1808d9"
   integrity sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==
@@ -311,21 +311,16 @@
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
 
-"@babel/helper-define-polyfill-provider@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.1.tgz#fadc63f0c2ff3c8d02ed905dcea747c5b0fb74fd"
-  integrity sha512-o7SDgTJuvx5vLKD6SFvkydkSMBvahDKGiNJzG22IZYXhiqoe9efY7zocICBgzHV4IRg5wdgl2nEL/tulKIEIbA==
+"@babel/helper-define-polyfill-provider@^0.6.1", "@babel/helper-define-polyfill-provider@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz#18594f789c3594acb24cfdb4a7f7b7d2e8bd912d"
+  integrity sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==
   dependencies:
     "@babel/helper-compilation-targets" "^7.22.6"
     "@babel/helper-plugin-utils" "^7.22.5"
     debug "^4.1.1"
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
-
-"@babel/helper-environment-visitor@^7.18.9":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz#96159db61d34a29dba454c959f5ae4a649ba9167"
-  integrity sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==
 
 "@babel/helper-member-expression-to-functions@^7.24.8":
   version "7.24.8"
@@ -370,7 +365,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz#94ee67e8ec0e5d44ea7baeb51e571bd26af07878"
   integrity sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==
 
-"@babel/helper-remap-async-to-generator@^7.18.9", "@babel/helper-remap-async-to-generator@^7.24.7", "@babel/helper-remap-async-to-generator@^7.25.0":
+"@babel/helper-remap-async-to-generator@^7.24.7", "@babel/helper-remap-async-to-generator@^7.25.0":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz#d2f0fbba059a42d68e5e378feaf181ef6055365e"
   integrity sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==
@@ -446,12 +441,12 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.7", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.0", "@babel/parser@^7.20.7", "@babel/parser@^7.25.0", "@babel/parser@^7.25.3", "@babel/parser@^7.7.0":
-  version "7.25.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.3.tgz#91fb126768d944966263f0657ab222a642b82065"
-  integrity sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.7", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.0", "@babel/parser@^7.20.7", "@babel/parser@^7.25.0", "@babel/parser@^7.25.6", "@babel/parser@^7.7.0":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.6.tgz#85660c5ef388cbbf6e3d2a694ee97a38f18afe2f"
+  integrity sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==
   dependencies:
-    "@babel/types" "^7.25.2"
+    "@babel/types" "^7.25.6"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.3":
   version "7.25.3"
@@ -492,17 +487,7 @@
     "@babel/helper-plugin-utils" "^7.24.8"
     "@babel/traverse" "^7.25.0"
 
-"@babel/plugin-proposal-async-generator-functions@^7.0.0":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz#bfb7276d2d573cb67ba379984a2334e262ba5326"
-  integrity sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/helper-remap-async-to-generator" "^7.18.9"
-    "@babel/plugin-syntax-async-generators" "^7.8.4"
-
-"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.13.0", "@babel/plugin-proposal-class-properties@^7.18.0":
+"@babel/plugin-proposal-class-properties@^7.13.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
   integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==
@@ -518,21 +503,13 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-export-default-from" "^7.22.5"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.13.8", "@babel/plugin-proposal-nullish-coalescing-operator@^7.18.0":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.13.8":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz#fdd940a99a740e577d6c753ab6fbb43fdb9467e1"
   integrity sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-
-"@babel/plugin-proposal-numeric-separator@^7.0.0":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz#899b14fbafe87f053d2c5ff05b36029c62e13c75"
-  integrity sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
-    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
 "@babel/plugin-proposal-object-rest-spread@7.12.1":
   version "7.12.1"
@@ -543,26 +520,7 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
     "@babel/plugin-transform-parameters" "^7.12.1"
 
-"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.20.0":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz#aa662940ef425779c75534a5c41e9d936edc390a"
-  integrity sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==
-  dependencies:
-    "@babel/compat-data" "^7.20.5"
-    "@babel/helper-compilation-targets" "^7.20.7"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
-    "@babel/plugin-transform-parameters" "^7.20.7"
-
-"@babel/plugin-proposal-optional-catch-binding@^7.0.0":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz#f9400d0e6a3ea93ba9ef70b09e72dd6da638a2cb"
-  integrity sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
-
-"@babel/plugin-proposal-optional-chaining@^7.13.12", "@babel/plugin-proposal-optional-chaining@^7.20.0":
+"@babel/plugin-proposal-optional-chaining@^7.13.12":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz#886f5c8978deb7d30f678b2e24346b287234d3ea"
   integrity sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==
@@ -590,7 +548,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.0.0", "@babel/plugin-syntax-class-properties@^7.12.13", "@babel/plugin-syntax-class-properties@^7.8.3":
+"@babel/plugin-syntax-class-properties@^7.12.13", "@babel/plugin-syntax-class-properties@^7.8.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
   integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
@@ -625,7 +583,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.18.0", "@babel/plugin-syntax-flow@^7.22.5":
+"@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.18.0", "@babel/plugin-syntax-flow@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz#163b820b9e7696ce134df3ee716d9c0c98035859"
   integrity sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==
@@ -667,7 +625,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.24.7", "@babel/plugin-syntax-jsx@^7.7.2":
+"@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.24.7", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz#39a1fa4a7e3d3d7f34e2acc6be585b718d30e02d"
   integrity sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==
@@ -695,7 +653,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
+"@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
@@ -752,15 +710,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-async-generator-functions@^7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz#b785cf35d73437f6276b1e30439a57a50747bddf"
-  integrity sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==
+"@babel/plugin-transform-async-generator-functions@^7.24.3", "@babel/plugin-transform-async-generator-functions@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz#2afd4e639e2d055776c9f091b6c0c180ed8cf083"
+  integrity sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.8"
     "@babel/helper-remap-async-to-generator" "^7.25.0"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
-    "@babel/traverse" "^7.25.0"
+    "@babel/traverse" "^7.25.4"
 
 "@babel/plugin-transform-async-to-generator@^7.20.0", "@babel/plugin-transform-async-to-generator@^7.24.7":
   version "7.24.7"
@@ -771,7 +729,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/helper-remap-async-to-generator" "^7.24.7"
 
-"@babel/plugin-transform-block-scoped-functions@^7.0.0", "@babel/plugin-transform-block-scoped-functions@^7.24.7":
+"@babel/plugin-transform-block-scoped-functions@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz#a4251d98ea0c0f399dafe1a35801eaba455bbf1f"
   integrity sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==
@@ -785,13 +743,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.8"
 
-"@babel/plugin-transform-class-properties@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz#256879467b57b0b68c7ddfc5b76584f398cd6834"
-  integrity sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==
+"@babel/plugin-transform-class-properties@^7.24.1", "@babel/plugin-transform-class-properties@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz#bae7dbfcdcc2e8667355cd1fb5eda298f05189fd"
+  integrity sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.24.7"
-    "@babel/helper-plugin-utils" "^7.24.7"
+    "@babel/helper-create-class-features-plugin" "^7.25.4"
+    "@babel/helper-plugin-utils" "^7.24.8"
 
 "@babel/plugin-transform-class-static-block@^7.24.7":
   version "7.24.7"
@@ -802,16 +760,16 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
-"@babel/plugin-transform-classes@^7.0.0", "@babel/plugin-transform-classes@^7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz#63122366527d88e0ef61b612554fe3f8c793991e"
-  integrity sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==
+"@babel/plugin-transform-classes@^7.0.0", "@babel/plugin-transform-classes@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz#d29dbb6a72d79f359952ad0b66d88518d65ef89a"
+  integrity sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.24.7"
-    "@babel/helper-compilation-targets" "^7.24.8"
+    "@babel/helper-compilation-targets" "^7.25.2"
     "@babel/helper-plugin-utils" "^7.24.8"
     "@babel/helper-replace-supers" "^7.25.0"
-    "@babel/traverse" "^7.25.0"
+    "@babel/traverse" "^7.25.4"
     globals "^11.1.0"
 
 "@babel/plugin-transform-computed-properties@^7.0.0", "@babel/plugin-transform-computed-properties@^7.24.7":
@@ -822,7 +780,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/template" "^7.24.7"
 
-"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.20.0", "@babel/plugin-transform-destructuring@^7.24.8":
+"@babel/plugin-transform-destructuring@^7.20.0", "@babel/plugin-transform-destructuring@^7.24.8":
   version "7.24.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz#c828e814dbe42a2718a838c2a2e16a408e055550"
   integrity sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==
@@ -876,7 +834,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
-"@babel/plugin-transform-flow-strip-types@^7.0.0", "@babel/plugin-transform-flow-strip-types@^7.20.0", "@babel/plugin-transform-flow-strip-types@^7.22.5":
+"@babel/plugin-transform-flow-strip-types@^7.20.0", "@babel/plugin-transform-flow-strip-types@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.22.5.tgz#0bb17110c7bf5b35a60754b2f00c58302381dee2"
   integrity sha512-tujNbZdxdG0/54g/oua8ISToaXTFBf8EnSb5PgQSciIXWOWKX3S4+JR7ZE9ol8FZwf9kxitzkGQ+QWeov/mCiA==
@@ -916,7 +874,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.8"
 
-"@babel/plugin-transform-logical-assignment-operators@^7.24.7":
+"@babel/plugin-transform-logical-assignment-operators@^7.24.1", "@babel/plugin-transform-logical-assignment-operators@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.7.tgz#a58fb6eda16c9dc8f9ff1c7b1ba6deb7f4694cb0"
   integrity sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==
@@ -924,7 +882,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-transform-member-expression-literals@^7.0.0", "@babel/plugin-transform-member-expression-literals@^7.24.7":
+"@babel/plugin-transform-member-expression-literals@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz#3b4454fb0e302e18ba4945ba3246acb1248315df"
   integrity sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==
@@ -981,7 +939,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
+"@babel/plugin-transform-nullish-coalescing-operator@^7.24.1", "@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz#1de4534c590af9596f53d67f52a92f12db984120"
   integrity sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==
@@ -989,7 +947,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
 
-"@babel/plugin-transform-numeric-separator@^7.24.7":
+"@babel/plugin-transform-numeric-separator@^7.24.1", "@babel/plugin-transform-numeric-separator@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.7.tgz#bea62b538c80605d8a0fac9b40f48e97efa7de63"
   integrity sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==
@@ -997,7 +955,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-transform-object-rest-spread@^7.24.7":
+"@babel/plugin-transform-object-rest-spread@^7.24.5", "@babel/plugin-transform-object-rest-spread@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.7.tgz#d13a2b93435aeb8a197e115221cab266ba6e55d6"
   integrity sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==
@@ -1007,7 +965,7 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
     "@babel/plugin-transform-parameters" "^7.24.7"
 
-"@babel/plugin-transform-object-super@^7.0.0", "@babel/plugin-transform-object-super@^7.24.7":
+"@babel/plugin-transform-object-super@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz#66eeaff7830bba945dd8989b632a40c04ed625be"
   integrity sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==
@@ -1015,7 +973,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/helper-replace-supers" "^7.24.7"
 
-"@babel/plugin-transform-optional-catch-binding@^7.24.7":
+"@babel/plugin-transform-optional-catch-binding@^7.24.1", "@babel/plugin-transform-optional-catch-binding@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.7.tgz#00eabd883d0dd6a60c1c557548785919b6e717b4"
   integrity sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==
@@ -1023,7 +981,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
-"@babel/plugin-transform-optional-chaining@^7.24.7", "@babel/plugin-transform-optional-chaining@^7.24.8":
+"@babel/plugin-transform-optional-chaining@^7.24.5", "@babel/plugin-transform-optional-chaining@^7.24.7", "@babel/plugin-transform-optional-chaining@^7.24.8":
   version "7.24.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz#bb02a67b60ff0406085c13d104c99a835cdf365d"
   integrity sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==
@@ -1032,20 +990,20 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.24.7"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.12.1", "@babel/plugin-transform-parameters@^7.20.7", "@babel/plugin-transform-parameters@^7.24.7":
+"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.12.1", "@babel/plugin-transform-parameters@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz#5881f0ae21018400e320fc7eb817e529d1254b68"
   integrity sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-private-methods@^7.22.5", "@babel/plugin-transform-private-methods@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz#e6318746b2ae70a59d023d5cc1344a2ba7a75f5e"
-  integrity sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==
+"@babel/plugin-transform-private-methods@^7.22.5", "@babel/plugin-transform-private-methods@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz#9bbefbe3649f470d681997e0b64a4b254d877242"
+  integrity sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.24.7"
-    "@babel/helper-plugin-utils" "^7.24.7"
+    "@babel/helper-create-class-features-plugin" "^7.25.4"
+    "@babel/helper-plugin-utils" "^7.24.8"
 
 "@babel/plugin-transform-private-property-in-object@^7.22.11", "@babel/plugin-transform-private-property-in-object@^7.24.7":
   version "7.24.7"
@@ -1057,7 +1015,7 @@
     "@babel/helper-plugin-utils" "^7.24.7"
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
-"@babel/plugin-transform-property-literals@^7.0.0", "@babel/plugin-transform-property-literals@^7.24.7":
+"@babel/plugin-transform-property-literals@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz#f0d2ed8380dfbed949c42d4d790266525d63bbdc"
   integrity sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==
@@ -1118,7 +1076,7 @@
     "@babel/helper-annotate-as-pure" "^7.22.5"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-transform-regenerator@^7.24.7":
+"@babel/plugin-transform-regenerator@^7.20.0", "@babel/plugin-transform-regenerator@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.7.tgz#021562de4534d8b4b1851759fd7af4e05d2c47f8"
   integrity sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==
@@ -1167,7 +1125,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-template-literals@^7.0.0", "@babel/plugin-transform-template-literals@^7.24.7":
+"@babel/plugin-transform-template-literals@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz#a05debb4a9072ae8f985bcf77f3f215434c8f8c8"
   integrity sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==
@@ -1215,20 +1173,20 @@
     "@babel/helper-create-regexp-features-plugin" "^7.24.7"
     "@babel/helper-plugin-utils" "^7.24.7"
 
-"@babel/plugin-transform-unicode-sets-regex@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz#d40705d67523803a576e29c63cef6e516b858ed9"
-  integrity sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==
+"@babel/plugin-transform-unicode-sets-regex@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz#be664c2a0697ffacd3423595d5edef6049e8946c"
+  integrity sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.24.7"
-    "@babel/helper-plugin-utils" "^7.24.7"
+    "@babel/helper-create-regexp-features-plugin" "^7.25.2"
+    "@babel/helper-plugin-utils" "^7.24.8"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.14.0", "@babel/preset-env@^7.20.2", "@babel/preset-env@^7.22.9", "@babel/preset-env@^7.23.3":
-  version "7.25.3"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.25.3.tgz#0bf4769d84ac51d1073ab4a86f00f30a3a83c67c"
-  integrity sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.20.2", "@babel/preset-env@^7.22.9", "@babel/preset-env@^7.23.3", "@babel/preset-env@^7.25.4":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.25.4.tgz#be23043d43a34a2721cd0f676c7ba6f1481f6af6"
+  integrity sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==
   dependencies:
-    "@babel/compat-data" "^7.25.2"
+    "@babel/compat-data" "^7.25.4"
     "@babel/helper-compilation-targets" "^7.25.2"
     "@babel/helper-plugin-utils" "^7.24.8"
     "@babel/helper-validator-option" "^7.24.8"
@@ -1257,13 +1215,13 @@
     "@babel/plugin-syntax-top-level-await" "^7.14.5"
     "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
     "@babel/plugin-transform-arrow-functions" "^7.24.7"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.0"
+    "@babel/plugin-transform-async-generator-functions" "^7.25.4"
     "@babel/plugin-transform-async-to-generator" "^7.24.7"
     "@babel/plugin-transform-block-scoped-functions" "^7.24.7"
     "@babel/plugin-transform-block-scoping" "^7.25.0"
-    "@babel/plugin-transform-class-properties" "^7.24.7"
+    "@babel/plugin-transform-class-properties" "^7.25.4"
     "@babel/plugin-transform-class-static-block" "^7.24.7"
-    "@babel/plugin-transform-classes" "^7.25.0"
+    "@babel/plugin-transform-classes" "^7.25.4"
     "@babel/plugin-transform-computed-properties" "^7.24.7"
     "@babel/plugin-transform-destructuring" "^7.24.8"
     "@babel/plugin-transform-dotall-regex" "^7.24.7"
@@ -1291,7 +1249,7 @@
     "@babel/plugin-transform-optional-catch-binding" "^7.24.7"
     "@babel/plugin-transform-optional-chaining" "^7.24.8"
     "@babel/plugin-transform-parameters" "^7.24.7"
-    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.25.4"
     "@babel/plugin-transform-private-property-in-object" "^7.24.7"
     "@babel/plugin-transform-property-literals" "^7.24.7"
     "@babel/plugin-transform-regenerator" "^7.24.7"
@@ -1304,10 +1262,10 @@
     "@babel/plugin-transform-unicode-escapes" "^7.24.7"
     "@babel/plugin-transform-unicode-property-regex" "^7.24.7"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
-    "@babel/plugin-transform-unicode-sets-regex" "^7.24.7"
+    "@babel/plugin-transform-unicode-sets-regex" "^7.25.4"
     "@babel/preset-modules" "0.1.6-no-external-plugins"
     babel-plugin-polyfill-corejs2 "^0.4.10"
-    babel-plugin-polyfill-corejs3 "^0.10.4"
+    babel-plugin-polyfill-corejs3 "^0.10.6"
     babel-plugin-polyfill-regenerator "^0.6.1"
     core-js-compat "^3.37.1"
     semver "^6.3.1"
@@ -1377,10 +1335,10 @@
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.22.6", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
-  version "7.22.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
-  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.22.6", "@babel/runtime@^7.25.0", "@babel/runtime@^7.25.6", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
+  integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -1393,23 +1351,23 @@
     "@babel/parser" "^7.25.0"
     "@babel/types" "^7.25.0"
 
-"@babel/traverse@^7.12.9", "@babel/traverse@^7.20.0", "@babel/traverse@^7.22.8", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4":
-  version "7.25.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.3.tgz#f1b901951c83eda2f3e29450ce92743783373490"
-  integrity sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==
+"@babel/traverse@^7.12.9", "@babel/traverse@^7.20.0", "@babel/traverse@^7.22.8", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.6.tgz#04fad980e444f182ecf1520504941940a90fea41"
+  integrity sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==
   dependencies:
     "@babel/code-frame" "^7.24.7"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
+    "@babel/generator" "^7.25.6"
+    "@babel/parser" "^7.25.6"
     "@babel/template" "^7.25.0"
-    "@babel/types" "^7.25.2"
+    "@babel/types" "^7.25.6"
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.7", "@babel/types@^7.20.0", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.22.5", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.0", "@babel/types@^7.25.2", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
-  version "7.25.2"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.25.2.tgz#55fb231f7dc958cd69ea141a4c2997e819646125"
-  integrity sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==
+"@babel/types@^7.0.0", "@babel/types@^7.12.7", "@babel/types@^7.20.0", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.22.5", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.0", "@babel/types@^7.25.2", "@babel/types@^7.25.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.25.6.tgz#893942ddb858f32ae7a004ec9d3a76b3463ef8e6"
+  integrity sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==
   dependencies:
     "@babel/helper-string-parser" "^7.24.8"
     "@babel/helper-validator-identifier" "^7.24.7"
@@ -1995,22 +1953,22 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz#c5a1a4bfe1b57f0c3e61b29883525c6da3e5c091"
   integrity sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==
 
-"@eslint-community/eslint-utils@^4.2.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.4.0":
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.6.2.tgz#1816b5f6948029c5eaacb0703b850ee0cb37d8f8"
-  integrity sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==
+"@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.6.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.11.1.tgz#a547badfc719eb3e5f4b556325e542fbe9d7a18f"
+  integrity sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==
 
-"@eslint/eslintrc@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.0.tgz#82256f164cc9e0b59669efc19d57f8092706841d"
-  integrity sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==
+"@eslint/eslintrc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz#388a269f0f25c1b6adc317b5a2c55714894c70ad"
+  integrity sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -2022,10 +1980,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.44.0":
-  version "8.44.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.44.0.tgz#961a5903c74139390478bdc808bcde3fc45ab7af"
-  integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
+"@eslint/js@8.57.1":
+  version "8.57.1"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
+  integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
@@ -2039,13 +1997,13 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@humanwhocodes/config-array@^0.11.10":
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
-  integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
+"@humanwhocodes/config-array@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"
+  integrity sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==
   dependencies:
-    "@humanwhocodes/object-schema" "^1.2.1"
-    debug "^4.1.1"
+    "@humanwhocodes/object-schema" "^2.0.3"
+    debug "^4.3.1"
     minimatch "^3.0.5"
 
 "@humanwhocodes/module-importer@^1.0.1":
@@ -2053,10 +2011,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
-"@humanwhocodes/object-schema@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
-  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+"@humanwhocodes/object-schema@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
+  integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -2507,50 +2465,50 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
-"@react-native-community/cli-clean@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.1.1.tgz#4f92b3d5eaa301c9db3fef2cbbaf68b87652f6f1"
-  integrity sha512-lbEQJ9xO8DmNbES7nFcGIQC0Q15e9q1zwKfkN2ty2eM93ZTFqYzOwsddlNoRN9FO7diakMWoWgielhcfcIeIrQ==
+"@react-native-community/cli-clean@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-14.1.0.tgz#fee1a178fa58c84dfe18e23ee79fd3110d974971"
+  integrity sha512-/C4j1yntLo6faztNgZnsDtgpGqa6j0+GYrxOY8LqaKAN03OCnoeUUKO6w78dycbYSGglc1xjJg2RZI/M2oF2AA==
   dependencies:
-    "@react-native-community/cli-tools" "12.1.1"
+    "@react-native-community/cli-tools" "14.1.0"
     chalk "^4.1.2"
     execa "^5.0.0"
+    fast-glob "^3.3.2"
 
-"@react-native-community/cli-config@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-12.1.1.tgz#6fe932b6215f731b39eb54c800d1b068a2080666"
-  integrity sha512-og8/yH7ZNMBcRJOGaHcn9BLt1WJF3XvgBw8iYsByVSEN7yvzAbYZ+CvfN6EdObGOqendbnE4lN9CVyQYM9Ufsw==
+"@react-native-community/cli-config@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-14.1.0.tgz#8cdebb890eeb3c25d6c117ee56c952e96ea2afbf"
+  integrity sha512-P3FK2rPUJBD1fmQHLgTqpHxsc111pnMdEEFR7KeqprCNz+Qr2QpPxfNy0V7s15tGL5rAv+wpbOGcioIV50EbxA==
   dependencies:
-    "@react-native-community/cli-tools" "12.1.1"
+    "@react-native-community/cli-tools" "14.1.0"
     chalk "^4.1.2"
-    cosmiconfig "^5.1.0"
+    cosmiconfig "^9.0.0"
     deepmerge "^4.3.0"
-    glob "^7.1.3"
+    fast-glob "^3.3.2"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.1.1.tgz#b2e3854f8f77d2f60f845a0a9553123cedfa4669"
-  integrity sha512-q427jvbJ0WdDuS6HNdc3EbmUu/dX/+FWCcZI60xB7m1i/8p+LzmrsoR2yIJCricsAIV3hhiFOGfquZDgrbF27Q==
+"@react-native-community/cli-debugger-ui@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.1.0.tgz#0008039ad2c386730c415d9dfc6884d68fda2c93"
+  integrity sha512-+YbeCL0wLcBcqDwraJFGsqzcXu9S+bwTVrfImne/4mT6itfe3Oa93yrOVJgNbstrt5pJHuwpU76ZXfXoiuncsg==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-12.1.1.tgz#e651a63c537ad7c9b8d9baa69e63947f5384a6bd"
-  integrity sha512-IUZJ/KUCuz+IzL9GdHUlIf6zF93XadxCBDPseUYb0ucIS+rEb3RmYC+IukYhUWwN3y4F/yxipYy3ytKrQ33AxA==
+"@react-native-community/cli-doctor@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-14.1.0.tgz#129b25a7792f7bb0ed1218d17665ce74bb995d08"
+  integrity sha512-xIf0oQDRKt7lufUenRwcLYdINGc0x1FSXHaHjd7lQDGT5FJnCEYlIkYEDDgAl5tnVJSvM/IL2c6O+mffkNEPzQ==
   dependencies:
-    "@react-native-community/cli-config" "12.1.1"
-    "@react-native-community/cli-platform-android" "12.1.1"
-    "@react-native-community/cli-platform-ios" "12.1.1"
-    "@react-native-community/cli-tools" "12.1.1"
+    "@react-native-community/cli-config" "14.1.0"
+    "@react-native-community/cli-platform-android" "14.1.0"
+    "@react-native-community/cli-platform-apple" "14.1.0"
+    "@react-native-community/cli-platform-ios" "14.1.0"
+    "@react-native-community/cli-tools" "14.1.0"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     deepmerge "^4.3.0"
-    envinfo "^7.10.0"
+    envinfo "^7.13.0"
     execa "^5.0.0"
-    hermes-profile-transformer "^0.0.6"
-    ip "^1.1.5"
     node-stream-zip "^1.9.1"
     ora "^5.4.1"
     semver "^7.5.2"
@@ -2558,155 +2516,146 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-hermes@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-12.1.1.tgz#9b48c91acb4db88aab648e92d4d1fe19cd0a6191"
-  integrity sha512-J6yxQoZooFRT8+Dtz8Px/bwasQxnbxZZFAFQzOs3f6CAfXrcr/+JLVFZRWRv9XGfcuLdCHr22JUVPAnyEd48DA==
+"@react-native-community/cli-platform-android@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-14.1.0.tgz#3545347a810d209bba24941f62f802fdc09e252f"
+  integrity sha512-4JnXkAV+ca8XdUhZ7xjgDhXAMwTVjQs8JqiwP7FTYVrayShXy2cBXm/C3HNDoe+oQOF5tPT2SqsDAF2vYTnKiQ==
   dependencies:
-    "@react-native-community/cli-platform-android" "12.1.1"
-    "@react-native-community/cli-tools" "12.1.1"
-    chalk "^4.1.2"
-    hermes-profile-transformer "^0.0.6"
-    ip "^1.1.5"
-
-"@react-native-community/cli-platform-android@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-12.1.1.tgz#f6541ee07ee479ee0e1b082cbf4ff970737606e4"
-  integrity sha512-jnyc9y5cPltBo518pfVZ53dtKGDy02kkCkSIwv4ltaHYse7JyEFxFbzBn9lloWvbZ0iFHvEo1NN78YGPAlXSDw==
-  dependencies:
-    "@react-native-community/cli-tools" "12.1.1"
+    "@react-native-community/cli-tools" "14.1.0"
     chalk "^4.1.2"
     execa "^5.0.0"
-    fast-xml-parser "^4.2.4"
-    glob "^7.1.3"
+    fast-glob "^3.3.2"
+    fast-xml-parser "^4.4.1"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-ios@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.1.1.tgz#399fc39279b8bd95f372c0f69180696b6f9767e1"
-  integrity sha512-RA2lvFrswwQRIhCV3hoIYZmLe9TkRegpAWimdubtMxRHiv7Eh2dC0VWWR5VdWy3ltbJzeiEpxCoH/EcrMfp9tg==
+"@react-native-community/cli-platform-apple@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-14.1.0.tgz#d232cd0fc1ec0bccd165e40dd7d8a3c4bec5f571"
+  integrity sha512-DExd+pZ7hHxXt8I6BBmckeYUxxq7PQ+o4YSmGIeQx0xUpi+f82obBct2WNC3VWU72Jw6obwfoN6Fwe6F7Wxp5Q==
   dependencies:
-    "@react-native-community/cli-tools" "12.1.1"
+    "@react-native-community/cli-tools" "14.1.0"
     chalk "^4.1.2"
     execa "^5.0.0"
-    fast-xml-parser "^4.0.12"
-    glob "^7.1.3"
+    fast-glob "^3.3.2"
+    fast-xml-parser "^4.4.1"
     ora "^5.4.1"
 
-"@react-native-community/cli-plugin-metro@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.1.1.tgz#446f829aa37caee7440d863a42d0f600a4713d8b"
-  integrity sha512-HV+lW1mFSu6GL7du+0/tfq8/5jytKp+w3n4+MWzRkx5wXvUq3oJjzwe8y+ZvvCqkRPdsOiwFDgJrtPhvaZp+xA==
-
-"@react-native-community/cli-server-api@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-12.1.1.tgz#c00319cba3cdd1ba2cf82286cfa4aa3a6bc6a5b2"
-  integrity sha512-dUqqEmtEiCMyqFd6LF1UqH0WwXirK2tpU7YhyFsBbigBj3hPz2NmzghCe7DRIcC9iouU0guBxhgmiLtmUEPduQ==
+"@react-native-community/cli-platform-ios@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-14.1.0.tgz#e3b7ae8a97b69da4c7c89d9767ea58fb90c9c05f"
+  integrity sha512-ah/ZTiJXUdCVHujyRJ4OmCL5nTq8OWcURcE3UXa1z0sIIiA8io06n+v5n299T9rtPKMwRtVJlQjtO/nbODABPQ==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "12.1.1"
-    "@react-native-community/cli-tools" "12.1.1"
+    "@react-native-community/cli-platform-apple" "14.1.0"
+
+"@react-native-community/cli-server-api@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-14.1.0.tgz#b658f96014f6d725ddb50da69833eacdbb8263c8"
+  integrity sha512-1k2LBQaYsy9RDWFIfKVne3frOye73O33MV6eYMoRPff7wqxHCrsX1CYJQkmwpgVigZHxYwalHj+Axtu3gpomCA==
+  dependencies:
+    "@react-native-community/cli-debugger-ui" "14.1.0"
+    "@react-native-community/cli-tools" "14.1.0"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
     nocache "^3.0.1"
     pretty-format "^26.6.2"
     serve-static "^1.13.1"
-    ws "^7.5.1"
+    ws "^6.2.3"
 
-"@react-native-community/cli-tools@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-12.1.1.tgz#c70df5da2d3ad61e5e8ab70dd36d84a89c322b23"
-  integrity sha512-c9vjDVojZnivGsLoVoTZsJjHnwBEI785yV8mgyKTVFx1sciK8lCsIj1Lke7jNpz7UAE1jW94nI7de2B1aQ9rbA==
+"@react-native-community/cli-tools@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-14.1.0.tgz#fbbd40e9ccd93842992c8e45c10dfd8eeb56ff4a"
+  integrity sha512-r1KxSu2+OSuhWFoE//1UR7aSTXMLww/UYWQprEw4bSo/kvutGX//4r9ywgXSWp+39udpNN4jQpNTHuWhGZd/Bg==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
+    execa "^5.0.0"
     find-up "^5.0.0"
     mime "^2.4.1"
-    node-fetch "^2.6.0"
     open "^6.2.0"
     ora "^5.4.1"
     semver "^7.5.2"
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-types@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-12.1.1.tgz#5a5c0593f50dc394af5265364d0e919ba6134653"
-  integrity sha512-B9lFEIc1/H2GjiyRCk6ISJNn06h5j0cWuokNm3FmeyGOoGIfm4XYUbnM6IpGlIDdQpTtUzZfNq8CL4CIJZXF0g==
+"@react-native-community/cli-types@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-14.1.0.tgz#0ea5dad716f30cd49d2edd5d9fdea8e552cb44e8"
+  integrity sha512-aJwZI9mGRx3HdP8U4CGhqjt3S4r8GmeOqv4kRagC1UHDk4QNMC+bZ8JgPA4W7FrGiPey+lJQHMDPAXOo51SOUw==
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-12.1.1.tgz#55e413ee620bea1e6b58c92dad2e9f196d3a5af2"
-  integrity sha512-St/lyxQ//crrigfE2QCqmjDb0IH3S9nmolm0eqmCA1bB8WWUk5dpjTgQk6xxDxz+3YtMghDJkGZPK4AxDXT42g==
+"@react-native-community/cli@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-14.1.0.tgz#bbcc14e9b7ee54589e645c7cd42da0cc79307f41"
+  integrity sha512-k7aTdKNZIec7WMSqMJn9bDVLWPPOaYmshXcnjWy6t5ItsJnREju9p2azMTR5tXY5uIeynose3cxettbhk2Tbnw==
   dependencies:
-    "@react-native-community/cli-clean" "12.1.1"
-    "@react-native-community/cli-config" "12.1.1"
-    "@react-native-community/cli-debugger-ui" "12.1.1"
-    "@react-native-community/cli-doctor" "12.1.1"
-    "@react-native-community/cli-hermes" "12.1.1"
-    "@react-native-community/cli-plugin-metro" "12.1.1"
-    "@react-native-community/cli-server-api" "12.1.1"
-    "@react-native-community/cli-tools" "12.1.1"
-    "@react-native-community/cli-types" "12.1.1"
+    "@react-native-community/cli-clean" "14.1.0"
+    "@react-native-community/cli-config" "14.1.0"
+    "@react-native-community/cli-debugger-ui" "14.1.0"
+    "@react-native-community/cli-doctor" "14.1.0"
+    "@react-native-community/cli-server-api" "14.1.0"
+    "@react-native-community/cli-tools" "14.1.0"
+    "@react-native-community/cli-types" "14.1.0"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"
     execa "^5.0.0"
-    find-up "^4.1.0"
+    find-up "^5.0.0"
     fs-extra "^8.1.0"
     graceful-fs "^4.1.3"
     prompts "^2.4.2"
     semver "^7.5.2"
 
-"@react-native-community/slider@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.4.2.tgz#1fea0eb3ae31841fe87bd6c4fc67569066e9cf4b"
-  integrity sha512-D9bv+3Vd2gairAhnRPAghwccgEmoM7g562pm8i4qB3Esrms5mggF81G3UvCyc0w3jjtFHh8dpQkfEoKiP0NW/Q==
+"@react-native-community/slider@^4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.5.3.tgz#84821ae17e746d90f73553bb58386e9db4db124c"
+  integrity sha512-0mOdnIL3xPWYGkP7levDH3bBsjdMOiR5mQIzFrSkZznZdIfX9MvGnelNZxsWuibmkc3hczHybo7RRb6mE96H2g==
 
-"@react-native/assets-registry@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.73.1.tgz#e2a6b73b16c183a270f338dc69c36039b3946e85"
-  integrity sha512-2FgAbU7uKM5SbbW9QptPPZx8N9Ke2L7bsHb+EhAanZjFZunA9PaYtyjUQ1s7HD+zDVqOQIvjkpXSv7Kejd2tqg==
+"@react-native/assets-registry@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.75.3.tgz#a4371bfc6d553d47495de5c901d3c37003b67a25"
+  integrity sha512-i7MaRbYR06WdpJWv3a0PQ2ScFBUeevwcJ0tVopnFwTg0tBWp3NFEMDIcU8lyXVy9Y59WmrP1V2ROaRDaPiESgg==
 
-"@react-native/babel-plugin-codegen@*":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.0.tgz#01ba90840e23c6d1fbf739f75cce1d0f5be97bfa"
-  integrity sha512-xAM/eVSb5LBkKue3bDZgt76bdsGGzKeF/iEzUNbDTwRQrB3Q5GoceGNM/zVlF+z1xGAkr3jhL+ZyITZGSoIlgw==
+"@react-native/babel-plugin-codegen@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.75.3.tgz#8771593119200a4824eb16a5f9e492e1fa097f7a"
+  integrity sha512-8JmXEKq+Efb9AffsV48l8gmKe/ZQ2PbBygZjHdIf8DNZZhO/z5mt27J4B43MWNdp5Ww1l59T0mEaf8l/uywQUg==
   dependencies:
-    "@react-native/codegen" "*"
+    "@react-native/codegen" "0.75.3"
 
-"@react-native/babel-preset@*":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.74.0.tgz#1d933f7737549a6c54f8c808c3ccb452be5f7cbb"
-  integrity sha512-k+1aaYQeLn+GBmGA5Qs3NKI8uzhLvRRMML+pB/+43ZL6DvCklbuJ5KO5oqRRpF3KZ2t/VKUqqSichpXfFrXGjg==
+"@react-native/babel-preset@0.75.3", "@react-native/babel-preset@^0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.75.3.tgz#d52012e83ec1110901ff9a3b97a8e48be002214c"
+  integrity sha512-VZQkQEj36DKEGApXFYdVcFtqdglbnoVr7aOZpjffURSgPcIA9vWTm1b+OL4ayOaRZXTZKiDBNQCXvBX5E5AgQg==
   dependencies:
     "@babel/core" "^7.20.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.18.0"
     "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.18.0"
-    "@babel/plugin-proposal-numeric-separator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.20.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.20.0"
     "@babel/plugin-syntax-dynamic-import" "^7.8.0"
     "@babel/plugin-syntax-export-default-from" "^7.0.0"
     "@babel/plugin-syntax-flow" "^7.18.0"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
     "@babel/plugin-syntax-optional-chaining" "^7.0.0"
     "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-async-generator-functions" "^7.24.3"
     "@babel/plugin-transform-async-to-generator" "^7.20.0"
     "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-class-properties" "^7.24.1"
     "@babel/plugin-transform-classes" "^7.0.0"
     "@babel/plugin-transform-computed-properties" "^7.0.0"
     "@babel/plugin-transform-destructuring" "^7.20.0"
     "@babel/plugin-transform-flow-strip-types" "^7.20.0"
+    "@babel/plugin-transform-for-of" "^7.0.0"
     "@babel/plugin-transform-function-name" "^7.0.0"
     "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.24.1"
     "@babel/plugin-transform-modules-commonjs" "^7.0.0"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.0.0"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.1"
+    "@babel/plugin-transform-numeric-separator" "^7.24.1"
+    "@babel/plugin-transform-object-rest-spread" "^7.24.5"
+    "@babel/plugin-transform-optional-catch-binding" "^7.24.1"
+    "@babel/plugin-transform-optional-chaining" "^7.24.5"
     "@babel/plugin-transform-parameters" "^7.0.0"
     "@babel/plugin-transform-private-methods" "^7.22.5"
     "@babel/plugin-transform-private-property-in-object" "^7.22.11"
@@ -2714,6 +2663,7 @@
     "@babel/plugin-transform-react-jsx" "^7.0.0"
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+    "@babel/plugin-transform-regenerator" "^7.20.0"
     "@babel/plugin-transform-runtime" "^7.0.0"
     "@babel/plugin-transform-shorthand-properties" "^7.0.0"
     "@babel/plugin-transform-spread" "^7.0.0"
@@ -2721,168 +2671,121 @@
     "@babel/plugin-transform-typescript" "^7.5.0"
     "@babel/plugin-transform-unicode-regex" "^7.0.0"
     "@babel/template" "^7.0.0"
-    "@react-native/babel-plugin-codegen" "*"
+    "@react-native/babel-plugin-codegen" "0.75.3"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/babel-preset@^0.73.18":
-  version "0.73.18"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.73.18.tgz#0ff24ba35102d9ac071de8ab10706ccaee5e3e6f"
-  integrity sha512-FzPasmazoX9WZnmwotk6SK9ydiExdqS4Xt5VaukPoY9u8u3AUUODzqjTsWSOxjFD9eRF3Knyg5H8JMDe6pj5wQ==
-  dependencies:
-    "@babel/core" "^7.20.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.18.0"
-    "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.18.0"
-    "@babel/plugin-proposal-numeric-separator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.20.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.20.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.18.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-async-to-generator" "^7.20.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.20.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.20.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-private-methods" "^7.22.5"
-    "@babel/plugin-transform-private-property-in-object" "^7.22.11"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-sticky-regex" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.5.0"
-    "@babel/plugin-transform-unicode-regex" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    "@react-native/babel-plugin-codegen" "*"
-    babel-plugin-transform-flow-enums "^0.0.2"
-    react-refresh "^0.14.0"
-
-"@react-native/codegen@*", "@react-native/codegen@^0.73.2":
-  version "0.73.2"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.73.2.tgz#58af4e4c3098f0e6338e88ec64412c014dd51519"
-  integrity sha512-lfy8S7umhE3QLQG5ViC4wg5N1Z+E6RnaeIw8w1voroQsXXGPB72IBozh8dAHR3+ceTxIU0KX3A8OpJI8e1+HpQ==
+"@react-native/codegen@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.75.3.tgz#f4a9d2fcbca0e7d34dfc357a0831995f20a56fd4"
+  integrity sha512-I0bz5jwOkiR7vnhYLGoV22RGmesErUg03tjsCiQgmsMpbyCYumudEtLNN5+DplHGK56bu8KyzBqKkWXGSKSCZQ==
   dependencies:
     "@babel/parser" "^7.20.0"
-    flow-parser "^0.206.0"
     glob "^7.1.1"
+    hermes-parser "0.22.0"
     invariant "^2.2.4"
     jscodeshift "^0.14.0"
     mkdirp "^0.5.1"
     nullthrows "^1.1.1"
+    yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@^0.73.10":
-  version "0.73.10"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.73.10.tgz#f7dd76c3b7428384f21d9878b8e53f2fef452064"
-  integrity sha512-e9kWr1SpVsu0qoHzxtgJCKojvVwaNUfyXXGEFSvQue4zNhuzzoC3Bk9bsJgA1+W7ur4ajRbhz3lnBV8v6lmsbw==
+"@react-native/community-cli-plugin@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.75.3.tgz#b8982fa90398647c45eee441753ac014f57ae3cd"
+  integrity sha512-njsYm+jBWzfLcJcxavAY5QFzYTrmPtjbxq/64GSqwcQYzy9qAkI7LNTK/Wprq1I/4HOuHJO7Km+EddCXB+ByRQ==
   dependencies:
-    "@react-native-community/cli-server-api" "12.1.1"
-    "@react-native-community/cli-tools" "12.1.1"
-    "@react-native/dev-middleware" "^0.73.5"
-    "@react-native/metro-babel-transformer" "^0.73.12"
+    "@react-native-community/cli-server-api" "14.1.0"
+    "@react-native-community/cli-tools" "14.1.0"
+    "@react-native/dev-middleware" "0.75.3"
+    "@react-native/metro-babel-transformer" "0.75.3"
     chalk "^4.0.0"
     execa "^5.1.1"
-    metro "^0.80.0"
-    metro-config "^0.80.0"
-    metro-core "^0.80.0"
+    metro "^0.80.3"
+    metro-config "^0.80.3"
+    metro-core "^0.80.3"
     node-fetch "^2.2.0"
     readline "^1.3.0"
 
-"@react-native/debugger-frontend@^0.73.2":
-  version "0.73.2"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.73.2.tgz#4ad2748aa72e1aac640c0e916ff43c37f357f907"
-  integrity sha512-YDCerm7FwaWMsc4zVBWQ3jMuFoq+a3DGhS4LAynwsFqCyo8Gmir2ARvmOHQdqZZ2KrBWqaIyiHh1nJ/UrAJntw==
+"@react-native/debugger-frontend@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.75.3.tgz#095b196fafef5e84d2d3c5adbcbfc5f55aa1078f"
+  integrity sha512-99bLQsUwsxUMNR7Wa9eV2uyR38yfd6mOEqfN+JIm8/L9sKA926oh+CZkjDy1M8RmCB6spB5N9fVFVkrVdf2yFA==
 
-"@react-native/dev-middleware@^0.73.5":
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.73.5.tgz#b629c8d281889e4759dcdcf1b1785019cbdfdd75"
-  integrity sha512-Ca9RHPaQXQn9yZke4n8sG09u+RuWpQun4imKg3tuykwPH3UrTTSSxoP/I04xdxsAOxaCkCl/ZdgL6SiAmzxWiQ==
+"@react-native/dev-middleware@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.75.3.tgz#534587f86b922b27c5e87a7c6dfa869ce2e155b2"
+  integrity sha512-h2/6+UGmeMWjnT43axy27jNqoDRsE1C1qpjRC3sYpD4g0bI0jSTkY1kAgj8uqGGXLnHXiHOtjLDGdbAgZrsPaA==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "^0.73.2"
+    "@react-native/debugger-frontend" "0.75.3"
     chrome-launcher "^0.15.2"
-    chromium-edge-launcher "^1.0.0"
+    chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
     debug "^2.2.0"
     node-fetch "^2.2.0"
+    nullthrows "^1.1.1"
     open "^7.0.3"
+    selfsigned "^2.4.1"
     serve-static "^1.13.1"
-    temp-dir "^2.0.0"
+    ws "^6.2.2"
 
-"@react-native/eslint-config@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/eslint-config/-/eslint-config-0.73.1.tgz#2e75669260f324794a12e12e7064dd7fe613009b"
-  integrity sha512-Dgxk5JTfZqHvKL63iyMZanWqH/+P+GI3m7r7PtUEJgQbm+2XYbJnbAgJwebmDE7BzBFEcmxavjemHBkgs/eH3Q==
+"@react-native/eslint-config@^0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/eslint-config/-/eslint-config-0.75.3.tgz#dd1bf7872a705d30fb1a963d69fb2259165a505e"
+  integrity sha512-BUkgQ3+irVZFfikIX3JgQQut/LABcumMZD3lzWRpf1hpbsEsXmYLo3u9qpfyYsavnqVGtWg8bLZDDGG6lmQBhA==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/eslint-parser" "^7.20.0"
-    "@react-native/eslint-plugin" "^0.73.1"
-    "@typescript-eslint/eslint-plugin" "^5.57.1"
-    "@typescript-eslint/parser" "^5.57.1"
+    "@react-native/eslint-plugin" "0.75.3"
+    "@typescript-eslint/eslint-plugin" "^7.1.1"
+    "@typescript-eslint/parser" "^7.1.1"
     eslint-config-prettier "^8.5.0"
     eslint-plugin-eslint-comments "^3.2.0"
     eslint-plugin-ft-flow "^2.0.1"
-    eslint-plugin-jest "^26.5.3"
-    eslint-plugin-prettier "^4.2.1"
+    eslint-plugin-jest "^27.9.0"
     eslint-plugin-react "^7.30.1"
     eslint-plugin-react-hooks "^4.6.0"
     eslint-plugin-react-native "^4.0.0"
 
-"@react-native/eslint-plugin@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/eslint-plugin/-/eslint-plugin-0.73.1.tgz#79d2c4d90c80bfad8900db335bfbaf1ca599abdc"
-  integrity sha512-8BNMFE8CAI7JLWLOs3u33wcwcJ821LYs5g53Xyx9GhSg0h8AygTwDrwmYb/pp04FkCNCPjKPBoaYRthQZmxgwA==
+"@react-native/eslint-plugin@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/eslint-plugin/-/eslint-plugin-0.75.3.tgz#a599653915e353a0888ce521916271fab69274ce"
+  integrity sha512-p0BwuqflumZtUJ8VUt5YQPsYnxrwfHJZCTQ0N1X+4B8aoBNIKxtfzeIqJsSz/GvM86HGgGnd/nyxEo8IwkPo7Q==
 
-"@react-native/gradle-plugin@^0.73.4":
-  version "0.73.4"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.73.4.tgz#aa55784a8c2b471aa89934db38c090d331baf23b"
-  integrity sha512-PMDnbsZa+tD55Ug+W8CfqXiGoGneSSyrBZCMb5JfiB3AFST3Uj5e6lw8SgI/B6SKZF7lG0BhZ6YHZsRZ5MlXmg==
+"@react-native/gradle-plugin@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.75.3.tgz#ae51e47995bb5cd4782f47ccb56d6d8814d7d4a8"
+  integrity sha512-mSfa/Mq/AsALuG/kvXz5ECrc6HdY5waMHal2sSfa8KA0Gt3JqYQVXF9Pdwd4yR5ClPZDI2HRa1tdE8GVlhMvPA==
 
-"@react-native/js-polyfills@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.73.1.tgz#730b0a7aaab947ae6f8e5aa9d995e788977191ed"
-  integrity sha512-ewMwGcumrilnF87H4jjrnvGZEaPFCAC4ebraEK+CurDDmwST/bIicI4hrOAv+0Z0F7DEK4O4H7r8q9vH7IbN4g==
+"@react-native/js-polyfills@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.75.3.tgz#a49714021ddf99aeec214db33289c1ee336708e1"
+  integrity sha512-+JVFJ351GSJT3V7LuXscMqfnpR/UxzsAjbBjfAHBR3kqTbVqrAmBccqPCA3NLzgb/RY8khLJklwMUVlWrn8iFg==
 
-"@react-native/metro-babel-transformer@^0.73.12":
-  version "0.73.12"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.73.12.tgz#6b9c391285a4e376ea4c7bc42667bed015fdeb7c"
-  integrity sha512-VmxN5aaoOprzDzUR+8c3XYhG0FoMOO6n0ToylCW6EeZCuf5RTY7HWVOhacabGoB1mHrWzJ0wWEsqX+eD4iFxoA==
+"@react-native/metro-babel-transformer@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.75.3.tgz#7550e1cf68403a81f07c24c4b081c887b559ce1f"
+  integrity sha512-gDlEl6C2mwQPLxFOR+yla5MpJpDPNOFD6J5Hd9JM9+lOdUq6MNujh1Xn4ZMvglW7rfViq3nMjg4xPQeGUhDG+w==
   dependencies:
     "@babel/core" "^7.20.0"
-    "@react-native/babel-preset" "*"
-    babel-preset-fbjs "^3.4.0"
-    hermes-parser "0.15.0"
+    "@react-native/babel-preset" "0.75.3"
+    hermes-parser "0.22.0"
     nullthrows "^1.1.1"
 
-"@react-native/normalize-colors@^0.73.0", "@react-native/normalize-colors@^0.73.2":
-  version "0.73.2"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz#cc8e48fbae2bbfff53e12f209369e8d2e4cf34ec"
-  integrity sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==
+"@react-native/normalize-colors@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.75.3.tgz#3407ac591f17e5462e297784b04bc25e4d62e788"
+  integrity sha512-3mhF8AJFfIN0E5bEs/DQ4U2LzMJYm+FPSwY5bJ1DZhrxW1PFAh24bAPrSd8PwS0iarQ7biLdr1lWf/8LFv8pDA==
 
-"@react-native/typescript-config@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/typescript-config/-/typescript-config-0.73.1.tgz#c97a42f5cd264069bfe86b737c531ed2f042ae6d"
-  integrity sha512-7Wrmdp972ZO7xvDid+xRGtvX6xz47cpGj7Y7VKlUhSVFFqbOGfB5WCpY1vMr6R/fjl+Og2fRw+TETN2+JnJi0w==
+"@react-native/typescript-config@^0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/typescript-config/-/typescript-config-0.75.3.tgz#59d637530c826d76172b8668b9b3f028cc287d6d"
+  integrity sha512-yekwhjG9lDvib+3jYwagEXcyTJ4mEryDLCoQINWCwy+7GtMx2BrKweHc4Phcc1dqmK1U/XMzVUXF3X3hc+FVPA==
 
-"@react-native/virtualized-lists@^0.73.3":
-  version "0.73.3"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.73.3.tgz#6e74c1d6ac36b574472ecddd5be1645a9f6d9e68"
-  integrity sha512-3qPNlLk9T2+qZpqcB1lvuy5LjeQezNNG/oV1GMyTrXR8lf/gFgsz2+ZxlmpNt3S4/jBypQbHOpGi6K+DjrN96A==
+"@react-native/virtualized-lists@0.75.3":
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.75.3.tgz#c8fef0cba53648b769a17b106ef5df0477eb1147"
+  integrity sha512-cTLm7k7Y//SvV8UK8esrDHEw5OrwwSJ4Fqc3x52Imi6ROuhshfGIPFwhtn4pmAg9nWHzHwwqiJ+9hCSVnXXX+g==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -3398,6 +3301,13 @@
   dependencies:
     "@types/unist" "^2"
 
+"@types/node-forge@^1.3.0":
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.3.11.tgz#0972ea538ddb0f4d9c2fa0ec5db5724773a604da"
+  integrity sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "20.4.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.5.tgz#9dc0a5cb1ccce4f7a731660935ab70b9c00a5d69"
@@ -3469,13 +3379,12 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.6":
-  version "18.2.42"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.42.tgz#6f6b11a904f6d96dda3c2920328a97011a00aba7"
-  integrity sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==
+"@types/react@*", "@types/react@^18.2.79":
+  version "18.3.9"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.9.tgz#2cdf5f425ec8a133d67e9e3673909738b783db20"
+  integrity sha512-+BpAVyTpJkNWWSSnaLBk6ePpHLOGJKnEQNbINNovPWzvEUyAe3e+/d494QdEh71RekM/qV7lw6jzf1HGrJyAtQ==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/resolve@1.17.1":
@@ -3496,11 +3405,6 @@
   integrity sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==
   dependencies:
     "@types/node" "*"
-
-"@types/scheduler@*":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
-  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/semver@^7.3.12":
   version "7.5.0"
@@ -3594,30 +3498,30 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.57.1":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
-  integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
+"@typescript-eslint/eslint-plugin@^7.1.1":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz#b16d3cf3ee76bf572fdf511e79c248bdec619ea3"
+  integrity sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==
   dependencies:
-    "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.62.0"
-    "@typescript-eslint/type-utils" "5.62.0"
-    "@typescript-eslint/utils" "5.62.0"
-    debug "^4.3.4"
+    "@eslint-community/regexpp" "^4.10.0"
+    "@typescript-eslint/scope-manager" "7.18.0"
+    "@typescript-eslint/type-utils" "7.18.0"
+    "@typescript-eslint/utils" "7.18.0"
+    "@typescript-eslint/visitor-keys" "7.18.0"
     graphemer "^1.4.0"
-    ignore "^5.2.0"
-    natural-compare-lite "^1.4.0"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
+    ignore "^5.3.1"
+    natural-compare "^1.4.0"
+    ts-api-utils "^1.3.0"
 
-"@typescript-eslint/parser@^5.57.1":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
-  integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
+"@typescript-eslint/parser@^7.1.1":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.18.0.tgz#83928d0f1b7f4afa974098c64b5ce6f9051f96a0"
+  integrity sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.62.0"
-    "@typescript-eslint/types" "5.62.0"
-    "@typescript-eslint/typescript-estree" "5.62.0"
+    "@typescript-eslint/scope-manager" "7.18.0"
+    "@typescript-eslint/types" "7.18.0"
+    "@typescript-eslint/typescript-estree" "7.18.0"
+    "@typescript-eslint/visitor-keys" "7.18.0"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.62.0":
@@ -3628,20 +3532,33 @@
     "@typescript-eslint/types" "5.62.0"
     "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/type-utils@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz#286f0389c41681376cdad96b309cedd17d70346a"
-  integrity sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==
+"@typescript-eslint/scope-manager@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz#c928e7a9fc2c0b3ed92ab3112c614d6bd9951c83"
+  integrity sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.62.0"
-    "@typescript-eslint/utils" "5.62.0"
+    "@typescript-eslint/types" "7.18.0"
+    "@typescript-eslint/visitor-keys" "7.18.0"
+
+"@typescript-eslint/type-utils@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz#2165ffaee00b1fbbdd2d40aa85232dab6998f53b"
+  integrity sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "7.18.0"
+    "@typescript-eslint/utils" "7.18.0"
     debug "^4.3.4"
-    tsutils "^3.21.0"
+    ts-api-utils "^1.3.0"
 
 "@typescript-eslint/types@5.62.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
   integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
+
+"@typescript-eslint/types@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.18.0.tgz#b90a57ccdea71797ffffa0321e744f379ec838c9"
+  integrity sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==
 
 "@typescript-eslint/typescript-estree@5.62.0":
   version "5.62.0"
@@ -3656,7 +3573,31 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0":
+"@typescript-eslint/typescript-estree@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz#b5868d486c51ce8f312309ba79bdb9f331b37931"
+  integrity sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==
+  dependencies:
+    "@typescript-eslint/types" "7.18.0"
+    "@typescript-eslint/visitor-keys" "7.18.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^1.3.0"
+
+"@typescript-eslint/utils@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.18.0.tgz#bca01cde77f95fc6a8d5b0dbcbfb3d6ca4be451f"
+  integrity sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@typescript-eslint/scope-manager" "7.18.0"
+    "@typescript-eslint/types" "7.18.0"
+    "@typescript-eslint/typescript-estree" "7.18.0"
+
+"@typescript-eslint/utils@^5.10.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -3678,7 +3619,15 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@ungap/structured-clone@^1.0.0":
+"@typescript-eslint/visitor-keys@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz#0564629b6124d67607378d0f0332a0495b25e7d7"
+  integrity sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==
+  dependencies:
+    "@typescript-eslint/types" "7.18.0"
+    eslint-visitor-keys "^3.4.3"
+
+"@ungap/structured-clone@^1.0.0", "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
@@ -3891,7 +3840,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.10.0, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4310,13 +4259,13 @@ babel-plugin-polyfill-corejs2@^0.4.10, babel-plugin-polyfill-corejs2@^0.4.5:
     "@babel/helper-define-polyfill-provider" "^0.6.1"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz#789ac82405ad664c20476d0233b485281deb9c77"
-  integrity sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==
+babel-plugin-polyfill-corejs3@^0.10.6:
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz#2deda57caef50f59c525aeb4964d3b2f867710c7"
+  integrity sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.1"
-    core-js-compat "^3.36.1"
+    "@babel/helper-define-polyfill-provider" "^0.6.2"
+    core-js-compat "^3.38.0"
 
 babel-plugin-polyfill-corejs3@^0.8.3:
   version "0.8.3"
@@ -4339,11 +4288,6 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   integrity sha512-JfTApdE++cgcTWjsiCQlLyFBMbTUft9ja17saCc93lgV33h4tuCVj7tlvu//qpLwaG+3yEz7/KhahGrUMkVq9g==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.1"
-
-babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
-  version "7.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
-  integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
 babel-plugin-transform-flow-enums@^0.0.2:
   version "0.0.2"
@@ -4369,39 +4313,6 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
-
-babel-preset-fbjs@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz#38a14e5a7a3b285a3f3a86552d650dca5cf6111c"
-  integrity sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    "@babel/plugin-syntax-class-properties" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.0.0"
-    "@babel/plugin-syntax-jsx" "^7.0.0"
-    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-block-scoped-functions" "^7.0.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.0.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
-    "@babel/plugin-transform-for-of" "^7.0.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-member-expression-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-object-super" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-property-literals" "^7.0.0"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-template-literals" "^7.0.0"
-    babel-plugin-syntax-trailing-function-commas "^7.0.0-beta.0"
 
 babel-preset-jest@^29.5.0:
   version "29.5.0"
@@ -4872,10 +4783,10 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromium-edge-launcher@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz#0443083074715a13c669530b35df7bfea33b1509"
-  integrity sha512-pgtgjNKZ7i5U++1g1PWv75umkHvhVTDOQIZ+sjeUX9483S7Y6MUvO0lrd7ShGlQlFHMN4SwKTCq/X8hWrbv2KA==
+chromium-edge-launcher@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz#0c378f28c99aefc360705fa155de0113997f62fc"
+  integrity sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^4.0.0"
@@ -5238,10 +5149,10 @@ copy-webpack-plugin@^11.0.0:
     schema-utils "^4.0.0"
     serialize-javascript "^6.0.0"
 
-core-js-compat@^3.31.0, core-js-compat@^3.36.1, core-js-compat@^3.37.1:
-  version "3.38.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.38.0.tgz#d93393b1aa346b6ee683377b0c31172ccfe607aa"
-  integrity sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==
+core-js-compat@^3.31.0, core-js-compat@^3.37.1, core-js-compat@^3.38.0:
+  version "3.38.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.38.1.tgz#2bc7a298746ca5a7bcb9c164bcb120f2ebc09a09"
+  integrity sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==
   dependencies:
     browserslist "^4.23.3"
 
@@ -5260,7 +5171,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
+cosmiconfig@^5.0.5:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -5301,6 +5212,16 @@ cosmiconfig@^8.1.3, cosmiconfig@^8.2.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
     path-type "^4.0.0"
+
+cosmiconfig@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
+  integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
+  dependencies:
+    env-paths "^2.2.1"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -5668,15 +5589,6 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
-deprecated-react-native-prop-types@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-5.0.0.tgz#02a12f090da7bd9e8c3ac53c31cf786a1315d302"
-  integrity sha512-cIK8KYiiGVOFsKdPMmm1L3tA/Gl+JopXL6F5+C7x39MyPsQYnP57Im/D6bNUzcborD7fcMwiwZqcBdBXXZucYQ==
-  dependencies:
-    "@react-native/normalize-colors" "^0.73.0"
-    invariant "^2.2.4"
-    prop-types "^15.8.1"
-
 dequal@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
@@ -5958,10 +5870,15 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
-envinfo@^7.10.0:
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.0.tgz#c3793f44284a55ff8c82faf1ffd91bc6478ea01f"
-  integrity sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==
+env-paths@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+envinfo@^7.13.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.14.0.tgz#26dac5db54418f2a4c1159153a0b2ae980838aae"
+  integrity sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==
 
 error-ex@^1.3.1, error-ex@^1.3.2:
   version "1.3.2"
@@ -6195,10 +6112,10 @@ eslint-plugin-ft-flow@^2.0.1:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
-eslint-plugin-jest@^26.5.3:
-  version "26.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz#7931c31000b1c19e57dbfb71bbf71b817d1bf949"
-  integrity sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==
+eslint-plugin-jest@^27.9.0:
+  version "27.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz#7c98a33605e1d8b8442ace092b60e9919730000b"
+  integrity sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
@@ -6284,10 +6201,10 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.1.tgz#936821d3462675f25a18ac5fd88a67cc15b393bd"
-  integrity sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
@@ -6302,32 +6219,33 @@ eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
-  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.19.0, eslint@^8.20.0:
-  version "8.45.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.45.0.tgz#bab660f90d18e1364352c0a6b7c6db8edb458b78"
-  integrity sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==
+eslint@^8.20.0, eslint@^8.57.1:
+  version "8.57.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
+  integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.1.0"
-    "@eslint/js" "8.44.0"
-    "@humanwhocodes/config-array" "^0.11.10"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.4"
+    "@eslint/js" "8.57.1"
+    "@humanwhocodes/config-array" "^0.13.0"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
+    "@ungap/structured-clone" "^1.2.0"
+    ajv "^6.12.4"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.0"
-    eslint-visitor-keys "^3.4.1"
-    espree "^9.6.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
     esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -6350,7 +6268,7 @@ eslint@^8.19.0, eslint@^8.20.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-espree@^9.6.0:
+espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
   integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
@@ -6558,6 +6476,11 @@ expect@^29.6.2:
     jest-message-util "^29.6.2"
     jest-util "^29.6.2"
 
+exponential-backoff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
 express@^4.17.3:
   version "4.21.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
@@ -6617,10 +6540,10 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
-  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -6645,10 +6568,10 @@ fast-url-parser@1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@^4.0.12, fast-xml-parser@^4.2.4:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
-  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
+fast-xml-parser@^4.4.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz#2882b7d01a6825dfdf909638f2de0256351def37"
+  integrity sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==
   dependencies:
     strnum "^1.0.5"
 
@@ -6829,11 +6752,6 @@ flow-parser@0.*:
   version "0.213.1"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.213.1.tgz#c1916465050b165c9d8b931c02d78fe582e6c20c"
   integrity sha512-l+vyZO6hrWG60DredryA8mq62fK9vxL6/RR13HA/aVLBNh9No/wEJsKI+CJqPRkF4CIRUfcJQBeaMXSKcncxUQ==
-
-flow-parser@^0.206.0:
-  version "0.206.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.206.0.tgz#f4f794f8026535278393308e01ea72f31000bfef"
-  integrity sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==
 
 follow-redirects@^1.0.0:
   version "1.15.6"
@@ -7573,36 +7491,29 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hermes-estree@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.15.0.tgz#e32f6210ab18c7b705bdcb375f7700f2db15d6ba"
-  integrity sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ==
+hermes-estree@0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.22.0.tgz#38559502b119f728901d2cfe2ef422f277802a1d"
+  integrity sha512-FLBt5X9OfA8BERUdc6aZS36Xz3rRuB0Y/mfocSADWEJfomc1xfene33GdyAmtTkKTBXTN/EgAy+rjTKkkZJHlw==
 
-hermes-estree@0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.17.1.tgz#902806a900c185720424ffcf958027821d23c051"
-  integrity sha512-EdUJms+eRE40OQxysFlPr1mPpvUbbMi7uDAKlScBw8o3tQY22BZ5yx56OYyp1bVaBm+7Cjc3NQz24sJEFXkPxg==
+hermes-estree@0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.23.1.tgz#d0bac369a030188120ee7024926aabe5a9f84fdb"
+  integrity sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==
 
-hermes-parser@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.15.0.tgz#f611a297c2a2dbbfbce8af8543242254f604c382"
-  integrity sha512-Q1uks5rjZlE9RjMMjSUCkGrEIPI5pKJILeCtK1VmTj7U4pf3wVPoo+cxfu+s4cBAPy2JzikIIdCZgBoR6x7U1Q==
+hermes-parser@0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.22.0.tgz#fc8e0e6c7bfa8db85b04c9f9544a102c4fcb4040"
+  integrity sha512-gn5RfZiEXCsIWsFGsKiykekktUoh0PdFWYocXsUdZIyWSckT6UIyPcyyUIPSR3kpnELWeK3n3ztAse7Mat6PSA==
   dependencies:
-    hermes-estree "0.15.0"
+    hermes-estree "0.22.0"
 
-hermes-parser@0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.17.1.tgz#8b5cbaff235fed28487812ad718f9c7182d0db0f"
-  integrity sha512-yErtFLMEL6490fFJPurNn23OI2ciGAtaUfKUg9VPdcde9CmItCjOVQkJt1Xzawv5kuRzeIx0RE2E2Q9TbIgdzA==
+hermes-parser@0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.23.1.tgz#e5de648e664f3b3d84d01b48fc7ab164f4b68205"
+  integrity sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==
   dependencies:
-    hermes-estree "0.17.1"
-
-hermes-profile-transformer@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz#bd0f5ecceda80dd0ddaae443469ab26fb38fc27b"
-  integrity sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==
-  dependencies:
-    source-map "^0.7.3"
+    hermes-estree "0.23.1"
 
 history@^4.9.0:
   version "4.10.1"
@@ -7829,10 +7740,10 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.0.0, ignore@^5.0.5, ignore@^5.1.4, ignore@^5.2.0, ignore@^5.2.4:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
-  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+ignore@^5.0.0, ignore@^5.0.5, ignore@^5.1.4, ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.1:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 image-size@^1.0.2:
   version "1.0.2"
@@ -7980,11 +7891,6 @@ ip-regex@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
-
-ip@^1.1.5:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
-  integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -9894,57 +9800,64 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-metro-babel-transformer@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.80.1.tgz#4c0bf77c312313c88fa677aab33e20e93fb383db"
-  integrity sha512-8mFluLGyOKzhedSAFANCe1cyT2fBlt1+tl0dqlcJI6OCP/V0I22bNFlyogWzseOjVTd3c0iEAbRXioZOUGOMzQ==
+metro-babel-transformer@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.80.12.tgz#ad02ade921dd4ced27b26b18ff31eb60608e3f56"
+  integrity sha512-YZziRs0MgA3pzCkkvOoQRXjIoVjvrpi/yRlJnObyIvMP6lFdtyG4nUGIwGY9VXnBvxmXD6mPY2e+NSw6JAyiRg==
   dependencies:
     "@babel/core" "^7.20.0"
-    hermes-parser "0.17.1"
+    flow-enums-runtime "^0.0.6"
+    hermes-parser "0.23.1"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.80.1.tgz#66cf08fb5f19e26fdd7564635b12cdfb8df199b5"
-  integrity sha512-Hj2CWFVy11dEa7iNoy2fI14kD6DiFUD7houGTnFy9esCAm3y/hedciMXg4+1eihz+vtfhPWUIu+ZW/sXeIQkFQ==
-
-metro-cache@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.80.1.tgz#3edf8dcda2b4782dfaf82edd67c56d4e6bc36cbd"
-  integrity sha512-pAYrlPCnomv7EQi08YSeoeF7YL3/4S3JzNn+nVp8e7AIOekO6Hf9j/GPRKfIQwll+os5bE9qFa++NPPmD59IeQ==
+metro-cache-key@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.80.12.tgz#52f5de698b85866503ace45d0ad76f75aaec92a4"
+  integrity sha512-o4BspKnugg/pE45ei0LGHVuBJXwRgruW7oSFAeSZvBKA/sGr0UhOGY3uycOgWInnS3v5yTTfiBA9lHlNRhsvGA==
   dependencies:
-    metro-core "0.80.1"
-    rimraf "^3.0.2"
+    flow-enums-runtime "^0.0.6"
 
-metro-config@0.80.1, metro-config@^0.80.0:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.80.1.tgz#9a0e3359e77e93e781ca22e3be3667d6f00d5090"
-  integrity sha512-ADbPLfMAe68CJGwu6vM0cXImfME0bauLK8P98mQbiAP6xLYVehCdeXEWSe9plVWhzpPLNemSr1AlTvPTMdl3Bw==
+metro-cache@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.80.12.tgz#bd81af02c4f17b5aeab19bb030566b14147cee8b"
+  integrity sha512-p5kNHh2KJ0pbQI/H7ZBPCEwkyNcSz7OUkslzsiIWBMPQGFJ/xArMwkV7I+GJcWh+b4m6zbLxE5fk6fqbVK1xGA==
+  dependencies:
+    exponential-backoff "^3.1.1"
+    flow-enums-runtime "^0.0.6"
+    metro-core "0.80.12"
+
+metro-config@0.80.12, metro-config@^0.80.3:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.80.12.tgz#1543009f37f7ad26352ffc493fc6305d38bdf1c0"
+  integrity sha512-4rwOWwrhm62LjB12ytiuR5NgK1ZBNr24/He8mqCsC+HXZ+ATbrewLNztzbAZHtFsrxP4D4GLTGgh96pCpYLSAQ==
   dependencies:
     connect "^3.6.5"
     cosmiconfig "^5.0.5"
+    flow-enums-runtime "^0.0.6"
     jest-validate "^29.6.3"
-    metro "0.80.1"
-    metro-cache "0.80.1"
-    metro-core "0.80.1"
-    metro-runtime "0.80.1"
+    metro "0.80.12"
+    metro-cache "0.80.12"
+    metro-core "0.80.12"
+    metro-runtime "0.80.12"
 
-metro-core@0.80.1, metro-core@^0.80.0:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.80.1.tgz#3bed22dd2f18e9524c2a45405406873d4f6749c0"
-  integrity sha512-f2Kav0/467YBG0DGAEX6+EQoYcUK+8vXIrEHQSkxCPXTjFcyppXUt2O6SDHMlL/Z5CGpd4uK1c/byXEfImJJdA==
+metro-core@0.80.12, metro-core@^0.80.3:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.80.12.tgz#5ae337923ab19ff524077efa1aeacdf4480cfa28"
+  integrity sha512-QqdJ/yAK+IpPs2HU/h5v2pKEdANBagSsc6DRSjnwSyJsCoHlmyJKCaCJ7KhWGx+N4OHxh37hoA8fc2CuZbx0Fw==
   dependencies:
+    flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
-    metro-resolver "0.80.1"
+    metro-resolver "0.80.12"
 
-metro-file-map@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.80.1.tgz#67d187fc522cba7ce033564fac0c8f12c6fc866f"
-  integrity sha512-Z00OaxlVx1Ynr3r3bZwgI9RXaimh1evTgofuk5TeYC5LEKWcAVr7QU0cGbjfhXa/kzD8iFFYPbDBENOXc398XQ==
+metro-file-map@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.80.12.tgz#b03240166a68aa16c5a168c26e190d9da547eefb"
+  integrity sha512-sYdemWSlk66bWzW2wp79kcPMzwuG32x1ZF3otI0QZTmrnTaaTiGyhE66P1z6KR4n2Eu5QXiABa6EWbAQv0r8bw==
   dependencies:
     anymatch "^3.0.3"
     debug "^2.2.0"
     fb-watchman "^2.0.0"
+    flow-enums-runtime "^0.0.6"
     graceful-fs "^4.2.4"
     invariant "^2.2.4"
     jest-worker "^29.6.3"
@@ -9955,83 +9868,92 @@ metro-file-map@0.80.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-minify-terser@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.80.1.tgz#b7f156edf11ab29a0f09ab09f1703036e678fb44"
-  integrity sha512-LfX3n895J6MsyiQkLz2SYcKVmZA1ag0NfYDyQapdnOd/oZmkdSu5jUWt0IjiohRLqKSnvyDp00OdQDRfhD3S8g==
+metro-minify-terser@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.80.12.tgz#9951030e3bc52d7f3ac8664ce5862401c673e3c6"
+  integrity sha512-muWzUw3y5k+9083ZoX9VaJLWEV2Jcgi+Oan0Mmb/fBNMPqP9xVDuy4pOMn/HOiGndgfh/MK7s4bsjkyLJKMnXQ==
   dependencies:
+    flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-resolver@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.80.1.tgz#770da0d0b37354cd53b3ae73c14002f01c60d8e7"
-  integrity sha512-NuVTx+eplveM8mNybsCQ9BrATGw7lXhfEIvCa7gz6eMcKOQ6RBzwUXWMYKehw8KL4eIkNOHzdczAiGTRuhzrQg==
-
-metro-runtime@0.80.1, metro-runtime@^0.80.0:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.80.1.tgz#39835e38a0d283d5753af5b89aee1980dbe9d89c"
-  integrity sha512-RQ+crdwbC4oUYzWom8USCvJWEfFyIuQAeV0bVcNvbpaaz3Q4imXSINJkjDth37DHnxUlhNhEeAcRG6JQIO1QeA==
+metro-resolver@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.80.12.tgz#e3815914c21315b04db200032c3243a4cc22dfb6"
+  integrity sha512-PR24gYRZnYHM3xT9pg6BdbrGbM/Cu1TcyIFBVlAk7qDAuHkUNQ1nMzWumWs+kwSvtd9eZGzHoucGJpTUEeLZAw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    flow-enums-runtime "^0.0.6"
 
-metro-source-map@0.80.1, metro-source-map@^0.80.0:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.80.1.tgz#979ed445ea716a78ea9b183254d5a66b7e9d6949"
-  integrity sha512-RoVaBdS44H68WY3vaO+s9/wshypPy8gKgcbND+A4FRxVsKM3+PI2pRoaAk4lTshgbmmXUuBZADzXdCz4F2JmnQ==
+metro-runtime@0.80.12, metro-runtime@^0.80.3:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.80.12.tgz#a68af3a2a013f5372d3b8cee234fdd467455550b"
+  integrity sha512-LIx7+92p5rpI0i6iB4S4GBvvLxStNt6fF0oPMaUd1Weku7jZdfkCZzmrtDD9CSQ6EPb0T9NUZoyXIxlBa3wOCw==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    flow-enums-runtime "^0.0.6"
+
+metro-source-map@0.80.12, metro-source-map@^0.80.3:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.80.12.tgz#36a2768c880f8c459d6d758e2d0975e36479f49c"
+  integrity sha512-o+AXmE7hpvM8r8MKsx7TI21/eerYYy2DCDkWfoBkv+jNkl61khvDHlQn0cXZa6lrcNZiZkl9oHSMcwLLIrFmpw==
   dependencies:
     "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
+    flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-symbolicate "0.80.1"
+    metro-symbolicate "0.80.12"
     nullthrows "^1.1.1"
-    ob1 "0.80.1"
+    ob1 "0.80.12"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.80.1.tgz#028cdf32eecf9067ce6a6b9c133d1e911823b466"
-  integrity sha512-HxIHH/wLPyO9pZTmIfvCG/63n8UDTLjHzcWPMRUiLOc0cHa/NI2ewtik1VK2Lzm3swvU8EfD9XXJ//jEnIlhIg==
+metro-symbolicate@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.80.12.tgz#3a6aa783c6e494e2879342d88d5379fab69d1ed2"
+  integrity sha512-/dIpNdHksXkGHZXARZpL7doUzHqSNxgQ8+kQGxwpJuHnDhGkENxB5PS2QBaTDdEcmyTMjS53CN1rl9n1gR6fmw==
   dependencies:
+    flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-source-map "0.80.1"
+    metro-source-map "0.80.12"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.80.1.tgz#38729aab5d37e2d108aae1fab7e4bf94ef299a9b"
-  integrity sha512-sJkzY9WJ9p7t3TrvNuIxW/6z4nQZC1pN3nJl4eQmE2lmHBqEMeZr/83DyTnf9Up86abQAXHVZmG5JzXrq7Kb5g==
+metro-transform-plugins@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.80.12.tgz#4a3853630ad0f36cc2bffd53bae659ee171a389c"
+  integrity sha512-WQWp00AcZvXuQdbjQbx1LzFR31IInlkCDYJNRs6gtEtAyhwpMMlL2KcHmdY+wjDO9RPcliZ+Xl1riOuBecVlPA==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/template" "^7.0.0"
     "@babel/traverse" "^7.20.0"
+    flow-enums-runtime "^0.0.6"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.80.1.tgz#68b58e6a39cbfa8c8dde66acfe5f63c3f930f53d"
-  integrity sha512-SkX9JBQGbNkzJ2oF7sAi8Nbc0KRLj8Rus9Z4kPh++JCTNqEwsZV5z27ksr9I9EGbqL2/qfUrDZJo1OwozX6dhw==
+metro-transform-worker@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.80.12.tgz#80be8a185b7deb93402b682f58a1dd6724317ad1"
+  integrity sha512-KAPFN1y3eVqEbKLx1I8WOarHPqDMUa8WelWxaJCNKO/yHCP26zELeqTJvhsQup+8uwB6EYi/sp0b6TGoh6lOEA==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
-    metro "0.80.1"
-    metro-babel-transformer "0.80.1"
-    metro-cache "0.80.1"
-    metro-cache-key "0.80.1"
-    metro-source-map "0.80.1"
-    metro-transform-plugins "0.80.1"
+    flow-enums-runtime "^0.0.6"
+    metro "0.80.12"
+    metro-babel-transformer "0.80.12"
+    metro-cache "0.80.12"
+    metro-cache-key "0.80.12"
+    metro-minify-terser "0.80.12"
+    metro-source-map "0.80.12"
+    metro-transform-plugins "0.80.12"
     nullthrows "^1.1.1"
 
-metro@0.80.1, metro@^0.80.0:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.80.1.tgz#a4ac5975f5dcdde34a07d3a7d8ce9baca29ae319"
-  integrity sha512-yp0eLYFY+5seXr7KR1fe61eDL4Qf5dvLS6dl1eKn4DPKgROC9A4nTsulHdMy2ntXWgjnAZRJBDPHuh3tAi4/nQ==
+metro@0.80.12, metro@^0.80.3:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.80.12.tgz#29a61fb83581a71e50c4d8d5d8458270edfe34cc"
+  integrity sha512-1UsH5FzJd9quUsD1qY+zUG4JY3jo3YEMxbMYH9jT6NK3j4iORhlwTK8fYTfAUBhDKjgLfKjAh7aoazNE23oIRA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.20.0"
@@ -10047,35 +9969,33 @@ metro@0.80.1, metro@^0.80.0:
     debug "^2.2.0"
     denodeify "^1.2.1"
     error-stack-parser "^2.0.6"
+    flow-enums-runtime "^0.0.6"
     graceful-fs "^4.2.4"
-    hermes-parser "0.17.1"
+    hermes-parser "0.23.1"
     image-size "^1.0.2"
     invariant "^2.2.4"
     jest-worker "^29.6.3"
     jsc-safe-url "^0.2.2"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.80.1"
-    metro-cache "0.80.1"
-    metro-cache-key "0.80.1"
-    metro-config "0.80.1"
-    metro-core "0.80.1"
-    metro-file-map "0.80.1"
-    metro-minify-terser "0.80.1"
-    metro-resolver "0.80.1"
-    metro-runtime "0.80.1"
-    metro-source-map "0.80.1"
-    metro-symbolicate "0.80.1"
-    metro-transform-plugins "0.80.1"
-    metro-transform-worker "0.80.1"
+    metro-babel-transformer "0.80.12"
+    metro-cache "0.80.12"
+    metro-cache-key "0.80.12"
+    metro-config "0.80.12"
+    metro-core "0.80.12"
+    metro-file-map "0.80.12"
+    metro-resolver "0.80.12"
+    metro-runtime "0.80.12"
+    metro-source-map "0.80.12"
+    metro-symbolicate "0.80.12"
+    metro-transform-plugins "0.80.12"
+    metro-transform-worker "0.80.12"
     mime-types "^2.1.27"
-    node-fetch "^2.2.0"
     nullthrows "^1.1.1"
-    rimraf "^3.0.2"
     serialize-error "^2.1.0"
     source-map "^0.5.6"
     strip-ansi "^6.0.0"
     throat "^5.0.0"
-    ws "^7.5.1"
+    ws "^7.5.10"
     yargs "^17.6.2"
 
 micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
@@ -10951,10 +10871,10 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.0, minimatch@^9.0.1:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+minimatch@^9.0.0, minimatch@^9.0.1, minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -11047,11 +10967,6 @@ nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
-
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -11148,7 +11063,7 @@ node-emoji@^2.1.0:
     emojilib "^2.4.0"
     skin-tone "^2.0.0"
 
-node-fetch@^2.2.0, node-fetch@^2.6.0:
+node-fetch@^2.2.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
@@ -11241,10 +11156,12 @@ nullthrows@^1.1.1:
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
-ob1@0.80.1:
-  version "0.80.1"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.80.1.tgz#6507f8c95ff30a9ddb07f96fccbd8f3d4ccafc04"
-  integrity sha512-o9eYflOo+QnbC/k9GYQuAy90zOGQ/OBgrjlIeW6VrKhevSxth83JSdEvKuKaV7SMGJVQhSY3Zp8eGa3g0rLP0A==
+ob1@0.80.12:
+  version "0.80.12"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.80.12.tgz#0451944ba6e5be225cc9751d8cd0d7309d2d1537"
+  integrity sha512-VMArClVT6LkhUGpnuEoBuyjG9rzUyEzg4PDkav6wK1cLhOK02gPCYFxoiB4mqVnrMhDpIzJcrGNAMVi9P+hXrw==
+  dependencies:
+    flow-enums-runtime "^0.0.6"
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -12433,10 +12350,10 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-devtools-core@^4.27.7:
-  version "4.28.5"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.28.5.tgz#c8442b91f068cdf0c899c543907f7f27d79c2508"
-  integrity sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==
+react-devtools-core@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-5.3.1.tgz#d57f5b8f74f16e622bd6a7bc270161e4ba162666"
+  integrity sha512-7FSb9meX0btdBQLwdFOwt6bGqvRPabmVMMslv8fgoSPqXyuGpgQe36kx8gR86XPw7aV1yVouTp6fyZ0EH+NfUw==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"
@@ -12489,11 +12406,6 @@ react-helmet-async@*, react-helmet-async@^1.3.0:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -12503,6 +12415,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-json-view-lite@^1.2.0:
   version "1.3.0"
@@ -12523,44 +12440,51 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@types/react" "*"
 
-react-native@^0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.73.0.tgz#553bce5ed4bd3d9f71014127bd687133562c5049"
-  integrity sha512-ya7wu/L8BeATv2rtXZDToYyD9XuTTDCByi8LvJGr6GKSXcmokkCRMGAiTEZfPkq7+nhVmbasjtoAJDuMRYfudQ==
+react-native-safe-area-context@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.11.0.tgz#d45271363672dc1923ddb0ce5a6ad588e210c85d"
+  integrity sha512-Bg7bozxEB+ZS+H3tVYs5yY1cvxNXgR6nRQwpSMkYR9IN5CbxohLnSprrOPG/ostTCd4F6iCk0c51pExEhifSKQ==
+
+react-native@^0.75.3:
+  version "0.75.3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.75.3.tgz#31a6555a22228b75c06babe5b5edddb3ed1a457a"
+  integrity sha512-+Ne6u5H+tPo36sme19SCd1u2UID2uo0J/XzAJarxmrDj4Nsdi44eyUDKtQHmhgxjRGsuVJqAYrMK0abLSq8AHw==
   dependencies:
     "@jest/create-cache-key-function" "^29.6.3"
-    "@react-native-community/cli" "12.1.1"
-    "@react-native-community/cli-platform-android" "12.1.1"
-    "@react-native-community/cli-platform-ios" "12.1.1"
-    "@react-native/assets-registry" "^0.73.1"
-    "@react-native/codegen" "^0.73.2"
-    "@react-native/community-cli-plugin" "^0.73.10"
-    "@react-native/gradle-plugin" "^0.73.4"
-    "@react-native/js-polyfills" "^0.73.1"
-    "@react-native/normalize-colors" "^0.73.2"
-    "@react-native/virtualized-lists" "^0.73.3"
+    "@react-native-community/cli" "14.1.0"
+    "@react-native-community/cli-platform-android" "14.1.0"
+    "@react-native-community/cli-platform-ios" "14.1.0"
+    "@react-native/assets-registry" "0.75.3"
+    "@react-native/codegen" "0.75.3"
+    "@react-native/community-cli-plugin" "0.75.3"
+    "@react-native/gradle-plugin" "0.75.3"
+    "@react-native/js-polyfills" "0.75.3"
+    "@react-native/normalize-colors" "0.75.3"
+    "@react-native/virtualized-lists" "0.75.3"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"
     base64-js "^1.5.1"
-    deprecated-react-native-prop-types "^5.0.0"
+    chalk "^4.0.0"
+    commander "^9.4.1"
     event-target-shim "^5.0.1"
     flow-enums-runtime "^0.0.6"
+    glob "^7.1.1"
     invariant "^2.2.4"
     jest-environment-node "^29.6.3"
     jsc-android "^250231.0.0"
     memoize-one "^5.0.0"
-    metro-runtime "^0.80.0"
-    metro-source-map "^0.80.0"
+    metro-runtime "^0.80.3"
+    metro-source-map "^0.80.3"
     mkdirp "^0.5.1"
     nullthrows "^1.1.1"
     pretty-format "^26.5.2"
     promise "^8.3.0"
-    react-devtools-core "^4.27.7"
+    react-devtools-core "^5.3.1"
     react-refresh "^0.14.0"
-    react-shallow-renderer "^16.15.0"
     regenerator-runtime "^0.13.2"
     scheduler "0.24.0-canary-efb381bbf-20230505"
+    semver "^7.1.3"
     stacktrace-parser "^0.1.10"
     whatwg-fetch "^3.0.0"
     ws "^6.2.2"
@@ -12605,14 +12529,6 @@ react-router@5.3.4, react-router@^5.3.4:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
-
-react-shallow-renderer@^16.15.0:
-  version "16.15.0"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
-  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
-  dependencies:
-    object-assign "^4.1.1"
-    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
 react@18.2.0, react@^18.2.0:
   version "18.2.0"
@@ -13429,11 +13345,12 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
 
-selfsigned@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.1.1.tgz#18a7613d714c0cd3385c48af0075abf3f266af61"
-  integrity sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==
+selfsigned@^2.1.1, selfsigned@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.4.1.tgz#560d90565442a3ed35b674034cec4e95dceb4ae0"
+  integrity sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==
   dependencies:
+    "@types/node-forge" "^1.3.0"
     node-forge "^1"
 
 semver-compare@^1.0.0:
@@ -13463,12 +13380,10 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
+semver@^7.0.0, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.19.0:
   version "0.19.0"
@@ -13757,7 +13672,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.0, source-map@^0.7.3:
+source-map@^0.7.0:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
@@ -13928,7 +13843,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14032,7 +13956,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14045,6 +13969,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -14419,6 +14350,11 @@ trough@^2.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
   integrity sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==
 
+ts-api-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
+  integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -14542,10 +14478,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -15655,7 +15591,7 @@ workbox-window@7.0.0, workbox-window@^7.0.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15668,6 +15604,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -15722,14 +15667,14 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@^6.2.2:
+ws@^6.2.2, ws@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.3.tgz#ccc96e4add5fd6fedbc491903075c85c5a11d9ee"
   integrity sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7, ws@^7.3.1, ws@^7.5.1:
+ws@^7, ws@^7.3.1, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==


### PR DESCRIPTION
# Why & How

Update most of the `unversioned` examples to use cross-platform `SafeAreaView`, perform multiple tweaks and fixes to the existing code.

Not every evample really needed the safe area container, but  at the end for most of them, there is a value, so I have updated almost all examples to relay on `SafeAreaView`, unless there is concrete reason to not wrap the code.

# Preview

<img src="https://github.com/user-attachments/assets/5f58f43e-26a0-40b7-b8d3-977bc8988f9f" align="left" width="240" />
<img src="https://github.com/user-attachments/assets/c0de8bc3-5641-4f9b-b657-1de053f5e996" align="left" width="240" />
<img src="https://github.com/user-attachments/assets/bfd27716-d359-4ee4-8d24-e2cb74730341" align="left" width="240" />
