### PR TITLE
[NA] Move Codegen Docs back

### DIFF
--- a/docs/the-new-architecture/codegen-cli.md
+++ b/docs/the-new-architecture/codegen-cli.md
@@ -1,4 +1,4 @@
-# The **Codegen** CLI
+# The Codegen CLI
 
 Calling gradle or manually calling a script might be hard to remember and it requeires a lot of cerimonies.
 

--- a/docs/the-new-architecture/codegen-cli.md
+++ b/docs/the-new-architecture/codegen-cli.md
@@ -1,6 +1,6 @@
 # The Codegen CLI
 
-Calling gradle or manually calling a script might be hard to remember and it requeires a lot of cerimonies.
+Calling Gradle or manually calling a script might be hard to remember and it requires a lot of cerimony.
 
 To simplify it, we created a CLI tool that can help you running those tasks: the **Codegen** cli.
 
@@ -8,11 +8,11 @@ To simplify it, we created a CLI tool that can help you running those tasks: the
 npx react-native codegen [--path path] [--platform string] [--outputPath path]
 ```
 
-This command runs `react-native-codegen` for your project. The following options are available:
+This command runs [react-native-codegen](https://www.npmjs.com/package/react-native-codegen) for your project. The following options are available:
 
 - `--path` - Path to `package.json`. The default path is the current working directory.
-- `--platform` - Target platform. Supported values: `android`, `ios`, `all`. The default value is all.
-- `--outputPath` - Output path. The default value is the value defined in `codegenCofig.outputDir`.
+- `--platform` - Target platform. Supported values: `android`, `ios`, `all`. The default value is `all`.
+- `--outputPath` - Output path. The default value is the value defined in `codegenConfig.outputDir`.
 
 ## Examples
 
@@ -55,5 +55,5 @@ To enable this setup:
 - Run **Codegen** locally with the codegen CLI.
 - Update your `package.json` to include the generated code.
 - Update your `podspec` to include the generated code.
-- Update your `build.gradle` file to include the generated code.
-- Update `cmakeListsPath` in `react-native.config.js` (example) so that Gradle doesn't look for CMakeLists file in the build directory but instead in your outputDir.
+- Update your `build.Gradle` file to include the generated code.
+- Update `cmakeListsPath` in `react-native.config.js` so that Gradle doesn't look for CMakeLists file in the build directory but instead in your outputDir.

--- a/docs/the-new-architecture/codegen-cli.md
+++ b/docs/the-new-architecture/codegen-cli.md
@@ -1,0 +1,59 @@
+# The **Codegen** CLI
+
+Calling gradle or manually calling a script might be hard to remember and it requeires a lot of cerimonies.
+
+To simplify it, we created a CLI tool that can help you running those tasks: the **Codegen** cli.
+
+```shell
+npx react-native codegen [--path path] [--platform string] [--outputPath path]
+```
+
+This command runs `react-native-codegen` for your project. The following options are available:
+
+- `--path` - Path to `package.json`. The default path is the current working directory.
+- `--platform` - Target platform. Supported values: `android`, `ios`, `all`. The default value is all.
+- `--outputPath` - Output path. The default value is the value defined in `codegenCofig.outputDir`.
+
+## Examples
+
+- Read `package.json` from the current working directory, generate code based on its codegenConfig.
+
+```shell
+npx react-native codegen
+```
+
+- Read `package.json` from the current working directory, generate iOS code in the location defined in the codegenConfig.
+
+```shell
+npx react-native codegen --platform ios
+```
+
+- Read `package.json` from `third-party/some-library`, generate Android code in `third-party/some-library/android/generated`.
+
+```shell
+npx react-native codegen \
+    --path third-party/some-library \
+    --platform android \
+    --outputPath third-party/some-library/android/generated
+```
+
+## Including Generated Code into Libraries
+
+The **Codegen** CLI is a great tool for library developers. It can be used to peek at the generated code to see which interfaces you need to implement. Or you can generate the code if you want to ship it in your library.
+
+This setup has several benefits:
+
+- No need to rely on the app to run **Codegen** for you, the generated code is always there.
+- The implementation files are always consistent with the generated interfaces.
+- No need to include two sets of files to support both architectures on Android. You can only keep the New Architecture one, and it is guaranteed to be backwards compatible.
+- No need to worry about **Codegen** version mismatch between what is used by the app, and what was used during library development.
+- Since all native code is there, it is possible to ship the native part of the library as a prebuild.
+
+To enable this setup:
+
+- Add the `includesGeneratedCode` property into your library's `codegenConfig` field in the `package.json` file. Set its value to `true`.
+- Run **Codegen** locally with the codegen CLI.
+- Update your `package.json` to include the generated code.
+- Update your `podspec` to include the generated code.
+- Update your `build.gradle` file to include the generated code.
+- Update `cmakeListsPath` in `react-native.config.js` (example) so that Gradle doesn't look for CMakeLists file in the build directory but instead in your outputDir.

--- a/docs/the-new-architecture/using-codegen.md
+++ b/docs/the-new-architecture/using-codegen.md
@@ -1,0 +1,199 @@
+# Using Codegen
+
+This guide teaches how to configure **Codegen**, and how to invoke it manually for each platform, and describes the generated code.
+
+## Prerequisites
+
+You always need a React Native app to generate the code properly, even when invoking the **Codegen** manually.
+
+The **Codegen** process is tightly coupled with the build of the app, and the scripts are located in the `react-native` NPM package.
+
+For the sake of this guide, create a project using the React Native CLI as follows:
+
+```bash
+npx @react-native-community/cli@latest init SampleApp --version 0.76.0
+```
+
+**Codegen** is used to generate the glue-code for your custom modules or components. See the guides for Turbo Native Modules and Fabric Native Components for more details on how to create them.
+
+<!-- TODO: add links -->
+
+## Configuring **Codegen**
+
+**Codegen** can be configured in your app by modifying the `package.json` file. **Codegen** is controlled by a custom field called `codegenConfig`.
+
+```json title="package.json"
+  "codegenConfig": {
+    "name": "<SpecName>",
+    "type": "<types>",
+    "jsSrcsDir": "<source_dir>",
+    "android": {
+      "javaPackageName": "<java.package.name>"
+    }
+  },
+```
+
+You can add this snippet to your app and customise the various fields:
+
+- `name:` This is the name that will be used to create files containig your specs. The convention is that it should have the suffix `Spec`, but this is not mandatory.
+- `type`: the type of code we need to generate. Allowed values are `modules`, `components`, `all`.
+  - `modules:` use this value if you only need to generate code for Turbo Native Modules.
+  - `components:` use this value if you only need to generate code for Native Fabric Components.
+  - `all`: use this value if you have a mixture of components and modules.
+- `jsSrcsDir`: this is the root folder where all your specs live.
+- `android.javaPackageName`: this is an android specific setting to let **Codegen** generate the files in a custom package.
+
+When **Codegen** runs, it searches among all the dependencies of the app, looking for JS files that respects some specific conventions, and it generates the required code:
+
+- Turbo Native Modules requires that the spec files are prefixed with `Native`. For example, `NativeLocalStorage.ts` is a valid name for a spec file.
+- Native Fabric Components requires that the spec files are suffixed with `NativeComponent`. For example, `WebViewNativeComponent.tx` is a valid name for a spec file.
+
+## Running **Codegen**
+
+The rest of this guide assumes that you have a Native Turbo Module and/or a Native Fabric Component already set up in your project. We also assume that you have valid specification files in the `jsSrcsDir` specified in the `package.json`.
+
+### Android
+
+**Codegen** for Android is integrated with the React Native Gradle Plugin (RNGP). The RNGP contains a task that can be invoked that reads the configurations defined in the `package.json` file and execute **Codegen**. To run the gradle task, first navigate inside the `android `folder of your project. Then run:
+
+```bash
+./gradlew generateCodegenArtifactsFromSchema
+```
+
+This task invokes the `generateCodegenArtifactsFromSchema` command on all the the imported projects of the app (the app and all the node modules which are linked to it). It generates the code in the corresponding `node_modules/<dependency>` folder. So, for example, if you have a Fabric Native Component whose node module is called `my-fabric-component`, the generated code is located in the `SampleApp/node_modules/my-fabric-component/android/build/generated/source/codegen` path. For the app, the code is generated in the `android/app/build/generated/source/codegen` folder.
+
+#### The Generated Code
+
+After running the gradle command above, you should find the codegen code in the `SampleApp/android/app/build` folder. The structure should look like this:
+
+```
+build
+└── generated
+    └── source
+        └── codegen
+            ├── java
+            │   └── com
+            │       ├── facebook
+            │       │   └── react
+            │       │       └── viewmanagers
+            │       │           ├── <nativeComponent>ManagerDelegate.java
+            │       │           └── <nativeComponent>ManagerInterface.java
+            │       └── sampleapp
+            │           └── NativeLocalStorageSpec.java
+            ├── jni
+            │   ├── <codegenConfig.name>-generated.cpp
+            │   ├── <codegenConfig.name>.h
+            │   ├── CMakeLists.txt
+            │   └── react
+            │       └── renderer
+            │           └── components
+            │               └── <codegenConfig.name>
+            │                   ├── <codegenConfig.name>JSI-generated.cpp
+            │                   ├── <codegenConfig.name>.h
+            │                   ├── ComponentDescriptors.cpp
+            │                   ├── ComponentDescriptors.h
+            │                   ├── EventEmitters.cpp
+            │                   ├── EventEmitters.h
+            │                   ├── Props.cpp
+            │                   ├── Props.h
+            │                   ├── ShadowNodes.cpp
+            │                   ├── ShadowNodes.h
+            │                   ├── States.cpp
+            │                   └── States.h
+            └── schema.json
+```
+
+The generated code is split in two folders:
+
+- `java` which contains the platform specific code
+- `jni` which contains the C++ code required to let JS and Java interac correctly.
+
+In the `java` folder, you can find the Fabric Native component generated code in the `com/facebook/viewmanagers` subfolder.
+
+- the `<nativeComponent>ManagerDelegate.java` contains the methods that the `ViewManager` can call on the custom Native Component
+- the `<nativeComponent>ManagerInterface.java` contains the interface of the `ViewManager`.
+
+In the folder whose name was setup in the `codegenConfig.android.javaPackageName`, instead, you can find the abstract class that a Turbo Native Module has to implement to carry out its tasks.
+
+In the `jni` folder, finally, there is all the boilerplate code to connect JS to Android.
+
+- `<codegenConfig.name>.h` this contains the interface of your custom C++ Turbo Native Modules.
+- `<codegenConfig.name>-generated.cpp` this contains the glue code of your custom custom C++ Turbo Native Modules.
+- `react/renderer/components/<codegenConfig.name>`: this folder contains all the glue-code required by your custom component.
+
+This structure has been generated by using the value `all` for the `codegenConfig.type` field. If you use the value `modules`, expect to see no `react/renderer/components/` folder. If you use the value `components`, expect not to see any of the other files.
+
+### iOS
+
+**Codegen** for iOS relies on some Node scripts that are invoked during the build process. The scripts are located in the `SampleApp/node_modules/react-native/scripts/` folder.
+
+The main script is the `generate-Codegen-artifacts.js` script. To invoke the script, you can run this command from the root folder of your app:
+
+```bash
+node node_modules/react-native/scripts/generate-Codegen-artifacts.js \
+    --path <path/to/your/app> \
+    --outputPath <an/output/path> \
+    --targetPlatform <android | ios>
+```
+
+where:
+
+- `--path` is the path to the root folder of your app.
+- `--outputPath` is the destination where **Codegen** should write the generated files.
+- `--targetPlatform` is the platform you'd like to generate the code for.
+
+#### The Generated Code
+
+Assuming that you ran the script with the command:
+
+```shell
+node node_modules/react-native/scripts/generate-Codegen-artifacts.js \
+    --path . \
+    --outputPath ios/ \
+    --targetPlatform ios
+```
+
+You should now find a new `build` folder in your `ios` app. The foulder should look something like this:
+
+```
+build
+└── generated
+    └── ios
+        ├── <codegenConfig.name>
+        │   ├── <codegenConfig.name>-generated.mm
+        │   └── <codegenConfig.name>.h
+        ├── <codegenConfig.name>JSI-generated.cpp
+        ├── <codegenConfig.name>JSI.h
+        ├── FBReactNativeSpec
+        │   ├── FBReactNativeSpec-generated.mm
+        │   └── FBReactNativeSpec.h
+        ├── FBReactNativeSpecJSI-generated.cpp
+        ├── FBReactNativeSpecJSI.h
+        ├── RCTModulesConformingToProtocolsProvider.h
+        ├── RCTModulesConformingToProtocolsProvider.mm
+        └── react
+            └── renderer
+                └── components
+                    └── <codegenConfig.name>
+                        ├── ComponentDescriptors.cpp
+                        ├── ComponentDescriptors.h
+                        ├── EventEmitters.cpp
+                        ├── EventEmitters.h
+                        ├── Props.cpp
+                        ├── Props.h
+                        ├── RCTComponentViewHelpers.h
+                        ├── ShadowNodes.cpp
+                        ├── ShadowNodes.h
+                        ├── States.cpp
+                        └── States.h
+```
+
+Part of these generated files are used by React Native in the Core. Then there are a set of files which contains the same name you specified in the package.json `codegenConfig.name` field.
+
+- `<codegenConfig.name>/<codegenConfig.name>.h`: this contains the interface of your custom iOS Turbo Native Modules.
+- `<codegenConfig.name>/<codegenConfig.name>-generated.mm`: this contains the glue code of your custom iOS Turbo Native Modules.
+- `<codegenConfig.name>JSI.h`: this contains the interface of your custom C++ Turbo Native Modules.
+- `<codegenConfig.name>JSI-generated.h`: this contains the glue code of your custom custom C++ Turbo Native Modules.
+- `react/renderer/components/<codegenConfig.name>`: this folder contains all the glue-code required by your custom component.
+
+This structure has been generated by using the value `all` for the `codegenConfig.type` field. If you use the value `modules`, expect to see no `react/renderer/components/` folder. If you use the value `components`, expect not to see any of the other files.

--- a/docs/the-new-architecture/using-codegen.md
+++ b/docs/the-new-architecture/using-codegen.md
@@ -1,6 +1,11 @@
 # Using Codegen
 
-This guide teaches how to configure **Codegen**, and how to invoke it manually for each platform, and describes the generated code.
+This guide teaches how to:
+
+- Configure **Codegen**.
+- Invoke it manually for each platform.
+
+It also describes the generated code.
 
 ## Prerequisites
 
@@ -35,7 +40,7 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 You can add this snippet to your app and customise the various fields:
 
-- `name:` This is the name that will be used to create files containig your specs. The convention is that it should have the suffix `Spec`, but this is not mandatory.
+- `name:` This is the name that will be used to create files containig your specs. As a convention, It should have the suffix `Spec`, but this is not mandatory.
 - `type`: the type of code we need to generate. Allowed values are `modules`, `components`, `all`.
   - `modules:` use this value if you only need to generate code for Turbo Native Modules.
   - `components:` use this value if you only need to generate code for Native Fabric Components.
@@ -50,7 +55,7 @@ When **Codegen** runs, it searches among all the dependencies of the app, lookin
 
 ## Running **Codegen**
 
-The rest of this guide assumes that you have a Native Turbo Module and/or a Native Fabric Component already set up in your project. We also assume that you have valid specification files in the `jsSrcsDir` specified in the `package.json`.
+The rest of this guide assumes that you have a Native Turbo Module, a Native Fabric Component or both already set up in your project. We also assume that you have valid specification files in the `jsSrcsDir` specified in the `package.json`.
 
 ### Android
 
@@ -60,11 +65,11 @@ The rest of this guide assumes that you have a Native Turbo Module and/or a Nati
 ./gradlew generateCodegenArtifactsFromSchema
 ```
 
-This task invokes the `generateCodegenArtifactsFromSchema` command on all the the imported projects of the app (the app and all the node modules which are linked to it). It generates the code in the corresponding `node_modules/<dependency>` folder. So, for example, if you have a Fabric Native Component whose node module is called `my-fabric-component`, the generated code is located in the `SampleApp/node_modules/my-fabric-component/android/build/generated/source/codegen` path. For the app, the code is generated in the `android/app/build/generated/source/codegen` folder.
+This task invokes the `generateCodegenArtifactsFromSchema` command on all the the imported projects of the app (the app and all the node modules which are linked to it). It generates the code in the corresponding `node_modules/<dependency>` folder. For example, if you have a Fabric Native Component whose Node module is called `my-fabric-component`, the generated code is located in the `SampleApp/node_modules/my-fabric-component/android/build/generated/source/codegen` path. For the app, the code is generated in the `android/app/build/generated/source/codegen` folder.
 
 #### The Generated Code
 
-After running the gradle command above, you should find the codegen code in the `SampleApp/android/app/build` folder. The structure should look like this:
+After running the gradle command above, you will find the codegen code in the `SampleApp/android/app/build` folder. The structure will look like this:
 
 ```
 build
@@ -139,12 +144,12 @@ node node_modules/react-native/scripts/generate-Codegen-artifacts.js \
 where:
 
 - `--path` is the path to the root folder of your app.
-- `--outputPath` is the destination where **Codegen** should write the generated files.
+- `--outputPath` is the destination where **Codegen** will write the generated files.
 - `--targetPlatform` is the platform you'd like to generate the code for.
 
 #### The Generated Code
 
-Assuming that you ran the script with the command:
+Running the script with these arguments:
 
 ```shell
 node node_modules/react-native/scripts/generate-Codegen-artifacts.js \
@@ -153,7 +158,7 @@ node node_modules/react-native/scripts/generate-Codegen-artifacts.js \
     --targetPlatform ios
 ```
 
-You should now find a new `build` folder in your `ios` app. The foulder should look something like this:
+Will generate these files in the `ios/build` folder:
 
 ```
 build

--- a/docs/the-new-architecture/what-is-codegen.md
+++ b/docs/the-new-architecture/what-is-codegen.md
@@ -10,6 +10,6 @@ React Native invokes **Codegen** automatically every time an iOS or Android app 
 
 **Codegen** is a process that is tightly coupled with a React Native app. The **Codegen** scripts live inside the `react-native` NPM package and the apps calls those scripts at build time.
 
-**Codegen** crawls the folders in your project, starting form a directory you specify in your `package.json`, looking for some specific JS files that contains the specificiation (or specs) for your custom modules and components. Spec files are JS files written in a typed dialect: React native currently supports Flow and TypeScript.
+**Codegen** crawls the folders in your project, starting form a directory you specify in your `package.json`, looking for some specific JS files that contains the specificiation (or specs) for your custom modules and components. Spec files are JS files written in a typed dialect: React Native currently supports Flow and TypeScript.
 
 Every time **Codegen** finds a spec files, it generates the boilerplate code associated to it. **Codegen** generates some C++ glue-code and then it generates platform-specific code, using Java for Android and Objective-C++ for iOS.

--- a/docs/the-new-architecture/what-is-codegen.md
+++ b/docs/the-new-architecture/what-is-codegen.md
@@ -1,0 +1,15 @@
+# What is Codegen?
+
+**Codegen** is a tool to avoid writing a lot of repetitive code. Using Codegen **is not mandatory**: you can write all the generated manually. However, **Codegen** generates scaffolding code that could save you a lot of time.
+
+React Native invokes **Codegen** automatically every time an iOS or Android app is built. Occasionally, you would like to manually run the **Codegen** scripts to know which types and files are actually generated: this is a common scenario when developing Turbo Native Modules and Fabric Native Components.
+
+<!-- TODO: Add links to TM and FC -->
+
+## How does Codegen works
+
+**Codegen** is a process that is tightly coupled with a React Native app. The **Codegen** scripts live inside the `react-native` NPM package and the apps calls those scripts at build time.
+
+**Codegen** crawls the folders in your project, starting form a directory you specify in your `package.json`, looking for some specific JS files that contains the specificiation (or specs) for your custom modules and components. Spec files are JS files written in a typed dialect: React native currently supports Flow and TypeScript.
+
+Every time **Codegen** finds a spec files, it generates the boilerplate code associated to it. **Codegen** generates some C++ glue-code and then it generates platform-specific code, using Java for Android and Objective-C++ for iOS.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -77,6 +77,11 @@
       "profile-hermes"
     ],
     "JavaScript Runtime": ["javascript-environment", "timers", "hermes"],
+    "Codegen": [
+      "the-new-architecture/what-is-codegen",
+      "the-new-architecture/using-codegen",
+      "the-new-architecture/codegen-cli"
+    ],
     "Android and iOS guides": [
       {
         "type": "category",


### PR DESCRIPTION
This PR moves the Codegen docs back into the website, in preparation of the New Architecture by default in 0.76.
