### PR TITLE
doc: update native deprecation to mention interop support

### DIFF
--- a/docs/the-new-architecture/_markdown_native_deprecation.mdx
+++ b/docs/the-new-architecture/_markdown_native_deprecation.mdx
@@ -1,4 +1,5 @@
 :::info
 Native Module and Native Components are our stable technologies used by the legacy architecture.
-They will be deprecated in the future when the New Architecture will be stable. The New Architecture uses [Turbo Native Module](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md) and [Fabric Native Components](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/fabric-native-components.md) to achieve similar results.
+
+We recommend using the New Architecture, which is enabled by default from [0.76](/blog/2024/10/23/release-0.75). You shuold write new modules and components as [Turbo Native Module](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md) and [Fabric Native Components](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/fabric-native-components.md). Existing Native Modules and Native Component will continue to run on the New Architecture using our interop layer.
 :::


### PR DESCRIPTION
The New Architecture supports running Native Modules and Native
Components using interop. Mention that we support running these on the
new architecture in most of our legacy docs.

Note I've also included a blank for our 0.76 release blog post so the target exists to link to.

## Change:
![CleanShot 2024-10-07 at 14 58 47@2x](https://github.com/user-attachments/assets/f0b7566a-c588-4963-8d58-7359559e6257)


