### PR TITLE
[docs] Remove references to Chrome profiler from Profiling guide

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -3,13 +3,11 @@ id: profiling
 title: Profiling
 ---
 
-Use the built-in profiler to get detailed information about work done in the JavaScript thread and main thread side-by-side. Access it by selecting Perf Monitor from the Debug menu.
+Profiling is the process of analyzing an app's performance, resource usage, and behavior to identify potential bottlenecks or inefficiencies. It's worth making use of profiling tools to ensure your app works smoothly across different devices and conditions.
 
 For iOS, Instruments is an invaluable tool, and on Android you should learn to use [`systrace`](profiling.md#profiling-android-ui-performance-with-systrace).
 
 But first, [**make sure that Development Mode is OFF!**](performance.md#running-in-development-mode-devtrue) You should see `__DEV__ === false, development-level warning are OFF, performance optimizations are ON` in your application logs.
-
-Another way to profile JavaScript is to use the Chrome profiler while debugging. This won't give you accurate results as the code is running in Chrome but will give you a general idea of where bottlenecks might be. Run the profiler under Chrome's `Performance` tab. A flame graph will appear under `User Timing`. To view more details in tabular format, click at the `Bottom Up` tab below and then select `DedicatedWorker Thread` at the top left menu.
 
 ## Profiling Android UI Performance with `systrace`
 


### PR DESCRIPTION
No longer applies / connecting to JS DevTools isn't supported in a prod build. We also no longer recommend the in-app Perf Monitor.

Profiling features in React Native DevTools (at development time) will be separately documented. And in future, we'll likely review this entire guide when we productionise profiling builds with RNDT.

Resolves https://github.com/facebook/react-native-website/issues/4221.