### PR TITLE
feat: respect users' preferred color schema

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -212,6 +212,11 @@ module.exports = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        defaultMode: 'light',
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       announcementBar: {
         id: 'reactconf2024-keynote',
         content:

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -73,7 +73,7 @@
       "build-speed",
       "optimizing-flatlist-configuration",
       "optimizing-javascript-loading",
-      "profiling",
+      "profiling"
     ],
     "JavaScript Runtime": ["javascript-environment", "timers", "hermes"],
     "Codegen": [


### PR DESCRIPTION
These are the changes to the [Docusaurus theme config](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode) so that it prefers the user's system color scheme over the default light one.

I left the light mode as the default one for cases when system preferences are unavailable to be consistent with the official [react.dev](https://react.dev/) documentation ([see this line of code](https://github.com/reactjs/ru.react.dev/blob/main/src/styles/index.css#L384)).