### PR TITLE
Fix MDX double `<p>` tags

### DIFF
--- a/docs/appregistry.md
+++ b/docs/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/docs/debugging-native-code.md
+++ b/docs/debugging-native-code.md
@@ -7,9 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing Logs

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/docs/permissionsandroid.md
+++ b/docs/permissionsandroid.md
@@ -5,9 +5,7 @@ title: PermissionsAndroid
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle notifications for your app, including scheduling and permissions.

--- a/website/blog/2020-07-06-version-0.63.md
+++ b/website/blog/2020-07-06-version-0.63.md
@@ -61,9 +61,7 @@ import {Pressable, Text} from 'react-native';
 </Pressable>;
 ```
 
-<p className="snippet-caption">
-  A simple example of a Pressable component in action
-</p>
+<p className="snippet-caption">A simple example of a Pressable component in action</p>
 
 You can learn more about it from [the documentation](https://reactnative.dev/docs/pressable).
 
@@ -85,10 +83,7 @@ import {Text, PlatformColor} from 'react-native';
 </Text>;
 ```
 
-<p className="snippet-caption">
-  Sets the color of the Text component to labelColor as defined by
-  iOS.
-</p>
+<p className="snippet-caption">Sets the color of the Text component to labelColor as defined by iOS.</p>
 
 Android, on the other hand, [provides colors like colorButtonNormal](https://developer.android.com/reference/android/R.attr#colorButtonNormal). You can use this color in React Native with:
 
@@ -103,10 +98,7 @@ import {View, Text, PlatformColor} from 'react-native';
 </View>;
 ```
 
-<p className="snippet-caption">
-  Sets the background color of the View component to
-  colorButtonNormal as defined by Android.
-</p>
+<p className="snippet-caption">Sets the background color of the View component to colorButtonNormal as defined by Android.</p>
 
 You can learn more about `PlatformColor` from [the documentation](https://reactnative.dev/docs/platformcolor). You can also check the actual [code examples present in the RNTester](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js).
 
@@ -125,9 +117,7 @@ const customDynamicTextColor = DynamicColorIOS({
 </Text>;
 ```
 
-<p className="snippet-caption">
-  Changes the text color based on the system theme
-</p>
+<p className="snippet-caption">Changes the text color based on the system theme</p>
 
 You can learn more about `DynamicColorIOS` from [the documentation](https://reactnative.dev/docs/dynamiccolorios).
 

--- a/website/versioned_docs/version-0.70/appregistry.md
+++ b/website/versioned_docs/version-0.70/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/website/versioned_docs/version-0.70/debugging.md
+++ b/website/versioned_docs/version-0.70/debugging.md
@@ -164,10 +164,8 @@ You can view installation instructions [in the README](https://github.com/infini
 # Native Debugging
 
 <div className="banner-native-code-required">
-  <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <h3>Projects with Native Code Only</h3><p>
+    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing console logs

--- a/website/versioned_docs/version-0.70/linking.md
+++ b/website/versioned_docs/version-0.70/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/website/versioned_docs/version-0.70/permissionsandroid.md
+++ b/website/versioned_docs/version-0.70/permissionsandroid.md
@@ -7,9 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/website/versioned_docs/version-0.70/pushnotificationios.md
+++ b/website/versioned_docs/version-0.70/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle push notifications for your app, including permission handling and icon badge number.

--- a/website/versioned_docs/version-0.71/appregistry.md
+++ b/website/versioned_docs/version-0.71/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/website/versioned_docs/version-0.71/debugging.md
+++ b/website/versioned_docs/version-0.71/debugging.md
@@ -164,10 +164,8 @@ You can view installation instructions [in the README](https://github.com/infini
 # Native Debugging
 
 <div className="banner-native-code-required">
-  <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <h3>Projects with Native Code Only</h3><p>
+    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing console logs

--- a/website/versioned_docs/version-0.71/linking.md
+++ b/website/versioned_docs/version-0.71/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/website/versioned_docs/version-0.71/permissionsandroid.md
+++ b/website/versioned_docs/version-0.71/permissionsandroid.md
@@ -7,9 +7,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import con
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/website/versioned_docs/version-0.71/pushnotificationios.md
+++ b/website/versioned_docs/version-0.71/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle push notifications for your app, including permission handling and icon badge number.

--- a/website/versioned_docs/version-0.72/appregistry.md
+++ b/website/versioned_docs/version-0.72/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/website/versioned_docs/version-0.72/linking.md
+++ b/website/versioned_docs/version-0.72/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/website/versioned_docs/version-0.72/native-debugging.md
+++ b/website/versioned_docs/version-0.72/native-debugging.md
@@ -6,10 +6,8 @@ title: Native Debugging
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 <div className="banner-native-code-required">
-  <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <h3>Projects with Native Code Only</h3><p>
+    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing native logs

--- a/website/versioned_docs/version-0.72/permissionsandroid.md
+++ b/website/versioned_docs/version-0.72/permissionsandroid.md
@@ -5,9 +5,7 @@ title: PermissionsAndroid
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/website/versioned_docs/version-0.72/pushnotificationios.md
+++ b/website/versioned_docs/version-0.72/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle push notifications for your app, including permission handling and icon badge number.

--- a/website/versioned_docs/version-0.73/appregistry.md
+++ b/website/versioned_docs/version-0.73/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/website/versioned_docs/version-0.73/linking.md
+++ b/website/versioned_docs/version-0.73/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/website/versioned_docs/version-0.73/native-debugging.md
+++ b/website/versioned_docs/version-0.73/native-debugging.md
@@ -6,10 +6,8 @@ title: Native Debugging
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 <div className="banner-native-code-required">
-  <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <h3>Projects with Native Code Only</h3><p>
+    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing native logs

--- a/website/versioned_docs/version-0.73/permissionsandroid.md
+++ b/website/versioned_docs/version-0.73/permissionsandroid.md
@@ -5,9 +5,7 @@ title: PermissionsAndroid
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/website/versioned_docs/version-0.73/pushnotificationios.md
+++ b/website/versioned_docs/version-0.73/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle push notifications for your app, including permission handling and icon badge number.

--- a/website/versioned_docs/version-0.74/appregistry.md
+++ b/website/versioned_docs/version-0.74/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/website/versioned_docs/version-0.74/linking.md
+++ b/website/versioned_docs/version-0.74/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/website/versioned_docs/version-0.74/native-debugging.md
+++ b/website/versioned_docs/version-0.74/native-debugging.md
@@ -6,10 +6,8 @@ title: Native Debugging
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 <div className="banner-native-code-required">
-  <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <h3>Projects with Native Code Only</h3><p>
+    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing native logs

--- a/website/versioned_docs/version-0.74/permissionsandroid.md
+++ b/website/versioned_docs/version-0.74/permissionsandroid.md
@@ -5,9 +5,7 @@ title: PermissionsAndroid
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/website/versioned_docs/version-0.74/pushnotificationios.md
+++ b/website/versioned_docs/version-0.74/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle notifications for your app, including scheduling and permissions.

--- a/website/versioned_docs/version-0.75/appregistry.md
+++ b/website/versioned_docs/version-0.75/appregistry.md
@@ -5,9 +5,7 @@ title: AppRegistry
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.
-  </p>
+  <p>If you are using the managed Expo workflow there is only ever one entry component registered with <code>AppRegistry</code> and it is handled automatically (or through <a href="https://docs.expo.dev/versions/latest/sdk/register-root-component/">registerRootComponent</a>). You do not need to use this API.</p>
 </div>
 
 `AppRegistry` is the JS entry point to running all React Native apps. App root components should register themselves with `AppRegistry.registerComponent`, then the native system can load the bundle for the app and then actually run the app when it's ready by invoking `AppRegistry.runApplication`.

--- a/website/versioned_docs/version-0.75/debugging-native-code.md
+++ b/website/versioned_docs/version-0.75/debugging-native-code.md
@@ -6,10 +6,8 @@ title: Debugging Native Code
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
 <div className="banner-native-code-required">
-  <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.
-  </p>
+  <h3>Projects with Native Code Only</h3><p>
+    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/workflow/prebuild/" target="_blank">prebuild</a> to use this API.</p>
 </div>
 
 ## Accessing Logs

--- a/website/versioned_docs/version-0.75/linking.md
+++ b/website/versioned_docs/version-0.75/linking.md
@@ -30,9 +30,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/linking/">Linking</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 If you want to enable deep links in your app, please read the below guide:

--- a/website/versioned_docs/version-0.75/permissionsandroid.md
+++ b/website/versioned_docs/version-0.75/permissionsandroid.md
@@ -5,9 +5,7 @@ title: PermissionsAndroid
 
 <div className="banner-native-code-required">
   <h3>Project with Native Code Required</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/guides/permissions/">Permissions</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 `PermissionsAndroid` provides access to Android M's new permissions model. The so-called "normal" permissions are granted by default when the application is installed as long as they appear in `AndroidManifest.xml`. However, "dangerous" permissions require a dialog prompt. You should use this module for those permissions.

--- a/website/versioned_docs/version-0.75/pushnotificationios.md
+++ b/website/versioned_docs/version-0.75/pushnotificationios.md
@@ -7,9 +7,7 @@ title: '🚧 PushNotificationIOS'
 
 <div className="banner-native-code-required">
   <h3>Projects with Native Code Only</h3>
-  <p>
-    The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.
-  </p>
+  <p>The following section only applies to projects with native code exposed. If you are using the managed Expo workflow, see the guide on <a href="https://docs.expo.dev/versions/latest/sdk/notifications/">Notifications</a> in the Expo documentation for the appropriate alternative.</p>
 </div>
 
 Handle notifications for your app, including scheduling and permissions.


### PR DESCRIPTION
Docusaurus v3.6 (https://github.com/facebook/react-native-website/pull/4268) will have a new HTML minifier. 

It has the ability to report some markup errors, such as `<p>` inside `<p>` which is not valid HTML.

We probably missed that during the MDX v2+ upgrade, but the usage of `<p>` + line breaks lead to duplicate paragraphs. The solution is to either use fragments or remove the line breaks.

See MDX playground:

![CleanShot 2024-10-10 at 12 39 56](https://github.com/user-attachments/assets/168037c1-18cf-4d12-9714-0af98a6115de)


cc @Simek this shouldn't have any meaningful impact of the site but fixes the markup and will avoid printing another upcoming build warning.


