### PR TITLE
Android typo

### DIFF
--- a/website/architecture/landing-page.md
+++ b/website/architecture/landing-page.md
@@ -215,7 +215,7 @@ If, for any reasons, you can't use the New Architecture, you can still opt-out f
 
 ### Android
 
-1. Open the `andorid/gradle.properties` file
+1. Open the `android/gradle.properties` file
 2. Toggle the `newArchEnabled` flag from `true` to `false`
 
 ```diff title="gradle.properties"


### PR DESCRIPTION
There was a typo in the manual on enabling the new architecture for Android.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
