### PR TITLE
chore: suggest adding flag in Podfile instead of console

### DIFF
--- a/website/architecture/landing-page.md
+++ b/website/architecture/landing-page.md
@@ -231,7 +231,13 @@ If, for any reasons, you can't use the New Architecture, you can still opt-out f
 ### iOS
 
 1. Open the `ios/Podfile` file
-2. Add `ENV['RCT_NEW_ARCH_ENABLED'] = '0'` in the main scope of the file
+2. Add `ENV['RCT_NEW_ARCH_ENABLED'] = '0'` in the main scope of the Podfile ([reference Podfile](https://github.com/react-native-community/template/blob/0.76-stable/template/ios/Podfile) in the template)
+```diff
++ ENV['RCT_NEW_ARCH_ENABLED'] = '0'
+# Resolve react_native_pods.rb with node to allow for hoisting
+require Pod::Executable.execute_command('node', ['-p',
+  'require.resolve(
+```
 3. Install your CocoaPods dependencies with the command:
 
 ```shell

--- a/website/architecture/landing-page.md
+++ b/website/architecture/landing-page.md
@@ -230,8 +230,10 @@ If, for any reasons, you can't use the New Architecture, you can still opt-out f
 
 ### iOS
 
-1. Install your CocoaPods dependencies with the command:
+1. Open the `ios/Podfile` file
+2. Add `ENV['RCT_NEW_ARCH_ENABLED'] = '0'` in the main scope of the file
+3. Install your CocoaPods dependencies with the command:
 
 ```shell
-RCT_NEW_ARCH_ENABLED=0 bundle exec pod install
+bundle exec pod install
 ```


### PR DESCRIPTION
PR changing the suggested way of switching the new/old arch on `iOS` so it is similar to `Android`. Also, it seems more reasonable to have it in the `Podfile`, otherwise you (and your whole team) would have to remember about doing it every time.

