### PR TITLE
fix: minor issue on how-to-open-a-pull-request.md

### DIFF
--- a/website/contributing/how-to-open-a-pull-request.md
+++ b/website/contributing/how-to-open-a-pull-request.md
@@ -28,6 +28,7 @@ You will now have a fork of React Native on GitHub at https://github.com/your_us
 
 ```bash
 git clone https://github.com/facebook/react-native.git
+cd react-native
 git remote add fork https://github.com/your_username/react-native.git
 ```
 


### PR DESCRIPTION
Just saw this while cloning the project fresh for another PR. When you clone the repo, you have to go into the directory before you add a new origin to it.