### PR TITLE
Add deprecation note for Statusbar backgroundcolor prop

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -387,6 +387,10 @@ static setBackgroundColor(color: ColorValue, animated?: boolean);
 
 Set the background color for the status bar.
 
+:::warning
+Due to edge-to-edge enforcement introduced in Android 15, setting background color of the status bar is deprecated in API level 35.
+:::
+
 **Parameters:**
 
 | Name                                                   | Type    | Description               |

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -263,7 +263,10 @@ If the transition between status bar property changes should be animated. Suppor
 
 ### `backgroundColor` <div class="label android">Android</div>
 
-The background color of the status bar. This was deprecated in API level 35.
+The background color of the status bar.
+
+:::warning
+Due to edge-to-edge enforcement introduced in Android 15, setting background color of the status bar is deprecated in API level 35.
 
 | Type            | Required | Default                                                                |
 | --------------- | -------- | ---------------------------------------------------------------------- |

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -267,6 +267,7 @@ The background color of the status bar.
 
 :::warning
 Due to edge-to-edge enforcement introduced in Android 15, setting background color of the status bar is deprecated in API level 35.
+:::
 
 | Type            | Required | Default                                                                |
 | --------------- | -------- | ---------------------------------------------------------------------- |

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -263,7 +263,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ### `backgroundColor` <div class="label android">Android</div>
 
-The background color of the status bar.
+The background color of the status bar. This was deprecated in API level 35.
 
 | Type            | Required | Default                                                                |
 | --------------- | -------- | ---------------------------------------------------------------------- |


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Add deprecation note as Android API backing Statusbar backgroundcolor prop is deprecated.