### PR TITLE
docs: Fix typos in multiple docs

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -2581,7 +2581,7 @@ The `position` type of an element defines how it is positioned relative to eithe
 
 - `relative` (**default value**) By default, an element is positioned relatively. This means an element is positioned according to the normal flow of the layout, and then offset relative to that position based on the values of `top`, `right`, `bottom`, and `left`. The offset does not affect the position of any sibling or parent elements.
 
-- `absolute` When positioned absolutely, an element doesn't take part in the normal layout flow. It is instead laid out independent of its siblings. The position is determined based on the `top`, `right`, `bottom`, and `left` values. These values will posistion the element relative to its containing block.
+- `absolute` When positioned absolutely, an element doesn't take part in the normal layout flow. It is instead laid out independent of its siblings. The position is determined based on the `top`, `right`, `bottom`, and `left` values. These values will position the element relative to its containing block.
 
 - `static` When positioned statically, an element is positioned according to the normal flow of layout, and will ignore the `top`, `right`, `bottom`, and `left` values. This `position` will also cause the element to not form a containing block for absolute descendants, unless some other superceding style prop is present (e.g. `transform`). This allows `absolute` elements to be positioned to something that is not their parent. Note that **`static` is only available on the New Architecture**.
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -589,7 +589,7 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -107,7 +107,7 @@ export default App;
 ### `create()`
 
 ```tsx
-static create(styles: Object extends Record<string, ViewStyle | ImageStyle | TextSyle>): Object;
+static create(styles: Object extends Record<string, ViewStyle | ImageStyle | TextStyle>): Object;
 ```
 
 An identity function for creating styles. The main practical benefit of creating styles inside `StyleSheet.create()` is static type checking against native style properties.
@@ -117,7 +117,7 @@ An identity function for creating styles. The main practical benefit of creating
 ### `flatten()`
 
 ```tsx
-static flatten(style: Array<Object extends Record<string, ViewStyle | ImageStyle | TextSyle>>): Object;
+static flatten(style: Array<Object extends Record<string, ViewStyle | ImageStyle | TextStyle>>): Object;
 ```
 
 Flattens an array of style objects, into one aggregated style object.

--- a/website/versioned_docs/version-0.70/image.md
+++ b/website/versioned_docs/version-0.70/image.md
@@ -556,7 +556,7 @@ Resolves an asset reference into an object which has the properties `uri`, `widt
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/website/versioned_docs/version-0.71/image.md
+++ b/website/versioned_docs/version-0.71/image.md
@@ -661,7 +661,7 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/website/versioned_docs/version-0.72/image.md
+++ b/website/versioned_docs/version-0.72/image.md
@@ -569,7 +569,7 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/website/versioned_docs/version-0.73/image.md
+++ b/website/versioned_docs/version-0.73/image.md
@@ -569,7 +569,7 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/website/versioned_docs/version-0.74/image.md
+++ b/website/versioned_docs/version-0.74/image.md
@@ -569,7 +569,7 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/website/versioned_docs/version-0.75/image.md
+++ b/website/versioned_docs/version-0.75/image.md
@@ -569,7 +569,7 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 ### ImageCacheEnum <div class="label ios">iOS</div>
 
-Enum which can be used to set the cache handling or stategy for the potentially cached responses.
+Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
 | Type                                                               | Default     |
 | ------------------------------------------------------------------ | ----------- |

--- a/website/versioned_docs/version-0.75/stylesheet.md
+++ b/website/versioned_docs/version-0.75/stylesheet.md
@@ -102,7 +102,7 @@ export default App;
 ### `create()`
 
 ```tsx
-static create(styles: Object extends Record<string, ViewStyle | ImageStyle | TextSyle>): Object;
+static create(styles: Object extends Record<string, ViewStyle | ImageStyle | TextStyle>): Object;
 ```
 
 An identity function for creating styles. The main practical benefit of creating styles inside `StyleSheet.create()` is static type checking against native style properties.
@@ -112,7 +112,7 @@ An identity function for creating styles. The main practical benefit of creating
 ### `flatten()`
 
 ```tsx
-static flatten(style: Array<Object extends Record<string, ViewStyle | ImageStyle | TextSyle>>): Object;
+static flatten(style: Array<Object extends Record<string, ViewStyle | ImageStyle | TextStyle>>): Object;
 ```
 
 Flattens an array of style objects, into one aggregated style object.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

## Why

Found some typos in multiple documents when going through them.

## How

This PR fixes the typos in `/next` and versioned docs (where applicable).
