### PR TITLE
[blog] Fix bullets and re-expand RNDT section in 0.76 post

### DIFF
--- a/website/blog/2024-10-23-release-0.76-new-architecture.md
+++ b/website/blog/2024-10-23-release-0.76-new-architecture.md
@@ -38,14 +38,17 @@ This change is a milestone in the evolution of React Native, and we invite you t
 
 ![React Native DevTools front-end](../static/blog/assets/0.76-react-native-devtools.jpg)
 
-We're releasing the first stable version of React Native DevTools, a reliable and familiar debugging tool. Key features include:
+We're releasing the first stable version of React Native DevTools, our new default debugging experience.
 
-• **Familiar, web-aligned tooling**: A fully featured debugger based on Chrome DevTools with reliable breakpoints, watch values, step-through debugging, stack inspection, and a rich JavaScript console.
-• **Improved and integrated React DevTools**: The built-in React Components Inspector and Profiler work seamlessly, with faster and more reliable component highlighting.
-• **Improved UX**: A new Paused in Debugger overlay, summary warnings in LogBox, and fixed reconnection behavior.
-• **Instant launch**: React Native DevTools is ready by default with zero config, and can be opened from the in-app Dev Menu or via <kbd>j</kbd> to debug in the CLI server.
+We want the tooling you use to debug React across all platforms to be reliable, familiar, simple, and cohesive. React Native DevTools delivers on these principles — browser-aligned developer tools that are deeply integrated with React Native. Key features include:
 
-This new debugging experience is fundamentally different from previous options and [has changed](https://github.com/react-native-community/discussions-and-proposals/discussions/819#:~:text=announcement%20talk%20%F0%9F%8E%AC.-,Compatibility,-React%20Native%20DevTools) compatibility. It's built on a new backend debugging stack, rebuilt from the ground up, and will support future feature additions like Performance and Network panels.
+- **Familiar, web-aligned tooling** — A fully featured debugger based on Chrome DevTools with reliable breakpoints, watch values, step-through debugging, stack inspection, and a rich JavaScript console. These core features now work reliably and across reloads.
+- **Improved and integrated React DevTools** — The built-in React Components Inspector and Profiler work seamlessly, with faster and more reliable component highlighting.
+- **Improved UX** — See a new _Paused in Debugger_ overlay, making it clear when your app is paused on a breakpoint. Warnings in LogBox are now displayed as a summary, and hidden when DevTools is attached.
+- **Fixed reconnection behaviour** — JavaScript breakpoints now work reliably across reloads and when DevTools is disconnected and reattached. DevTools can even reconnect to the same app after a native rebuild.
+- **Instant launch** — React Native DevTools is ready by default with zero config. Open it from the in-app Dev Menu or via <kbd>j</kbd> to debug in the CLI server, which now supports multiple emulators and devices.
+
+React Native DevTools is fundamentally different from our previous debugging options, including being different from the Experimental Debugger experience first shipped in 0.73. It switches to a new backend debugging stack that we’ve rebuilt over the last year. This means that compatibility with previous tooling [has changed](https://github.com/react-native-community/discussions-and-proposals/discussions/819#:~:text=announcement%20talk%20%F0%9F%8E%AC.-,Compatibility,-React%20Native%20DevTools), and you should also expect a much more reliable experience end-to-end. We intend to build upon this new stack to allow us to reliably implement more features in future, such as the Performance and Network panels.
 
 #### Phasing out logs in Metro
 


### PR DESCRIPTION
Implements pending feedback I had on the 0.76 blog post: https://github.com/facebook/react-native-website/pull/4279#pullrequestreview-2390663521.

**Changes**

- Fix list formatting.
- I've added back some RNDT detail (this **_is_** shorter than the original v1!). Just don't want things to be cut quite as heavily, to preserve initial impressions and correctness — the AI shortening was too aggressive & don't quite have time to shorten further accurately.
