### PR TITLE
[docs] Fix debugging /docs/next/ redirects following 0.76 cut

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -5,10 +5,10 @@
 /docs/building-for-apple-tv     /docs/building-for-tv
 /docs/building-from-source      /contributing/how-to-build-from-source
 /docs/contributing              /contributing/overview
-/docs/next/sourcemaps           /docs/next/debugging-release-builds
-/docs/next/symbolication        /docs/next/debugging-release-builds
+/docs/sourcemaps                /docs/debugging-release-builds
+/docs/symbolication             /docs/debugging-release-builds
 /docs/publishing-forks          /contributing/how-to-build-from-source#publish-your-own-version-of-react-native
-/docs/next/react-devtools       /docs/next/react-native-devtools
+/docs/react-devtools            /docs/react-native-devtools
 /docs/testing                   /contributing/how-to-run-and-write-tests
 /docs/understanding-cli         https://github.com/react-native-community/cli#react-native-cli
 


### PR DESCRIPTION
Updates redirects following https://github.com/facebook/react-native-website/pull/4294. Removed routes under `/docs/next` have now shipped under `/docs`.

<img width="671" alt="image" src="https://github.com/user-attachments/assets/7d508df8-9526-4282-9580-6b7c0f3c23d6">
