### PR TITLE
Add redirect to landing page

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -28,6 +28,7 @@
 /docs/the-new-architecture/backward-compatibility          https://github.com/reactwg/react-native-new-architecture#guides
 /docs/the-new-architecture/backward-compatibility-turbomodules https://github.com/reactwg/react-native-new-architecture#guides
 /docs/the-new-architecture/backward-compatibility-fabric-components https://github.com/reactwg/react-native-new-architecture#guides
+/docs/the-new-architecture/landing-page                    /architecture/landing-page
 /docs/new-architecture-intro                               https://github.com/reactwg/react-native-new-architecture#guides
 /docs/new-architecture-library-intro                       https://github.com/reactwg/react-native-new-architecture#guides
 /docs/new-architecture-library-android                     https://github.com/reactwg/react-native-new-architecture#guides


### PR DESCRIPTION
In the past months, we share a New Architecture link that was: https://reactnative.dev/docs/the-new-architecture/landing-page
This page now does not exists and it has to redirect to  https://reactnative.dev/architecture/landing-page
