### PR TITLE
[docs] Update troubleshooting.md to replace dead link

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,7 +139,7 @@ yarn android --verbose
 
 ### Case 1: Error "code":"ENOSPC","errno":"ENOSPC"
 
-Issue caused by the number of directories [inotify](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers) (used by watchman on Linux) can monitor. To solve it, run this command in your terminal window
+Issue caused by the number of directories [inotify](https://github.com/guard/listen/blob/master/README.md#increasing-the-amount-of-inotify-watchers) (used by watchman on Linux) can monitor. To solve it, run this command in your terminal window
 
 ```shell
 echo fs.inotify.max_user_watches=582222 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p


### PR DESCRIPTION
The [Listen](https://github.com/guard/listen) gem's documentation moved from the [wiki](https://github.com/guard/listen/wiki) section to its [README](https://github.com/guard/listen/blob/master/README.md).

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
