### PR TITLE
fix: double colon in 2024-10-23-release-0.76-new-architecture.md

### DIFF
--- a/website/blog/2024-10-23-release-0.76-new-architecture.md
+++ b/website/blog/2024-10-23-release-0.76-new-architecture.md
@@ -81,7 +81,7 @@ As a result, you can look up the web documentation to fully understand how these
 
 `boxShadow` can take either a string, which mimics the CSS syntax, or JS objects which can embed variables. For example the string `‘5 5 5 0 rgba(255, 0, 0, 0.5)’` and the object `{offsetX: 5, offsetY: 5, blurRadius: 5, spreadDistance: 0, color: ‘rgba(255, 0, 0, 0.5)’}` would yield the same box shadow.
 
-The [previous shadow functionality](https://reactnative.dev/docs/shadow-props) had some shortcomings addressed now addressed by `boxShadow`::
+The [previous shadow functionality](https://reactnative.dev/docs/shadow-props) had some shortcomings addressed now addressed by `boxShadow`:
 
 - Does not work on Android
 - Cannot be [inset](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#inset)


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Fixes small typo with a double colon next to boxShadow.