### PR TITLE
Fix broken examples in Animated API docs

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 

--- a/website/versioned_docs/version-0.71/animations.md
+++ b/website/versioned_docs/version-0.71/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect, useAnimatedValue} from 'react';
 import {Animated, Text, View} from 'react-native';
 

--- a/website/versioned_docs/version-0.72/animations.md
+++ b/website/versioned_docs/version-0.72/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 

--- a/website/versioned_docs/version-0.73/animations.md
+++ b/website/versioned_docs/version-0.73/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 

--- a/website/versioned_docs/version-0.74/animations.md
+++ b/website/versioned_docs/version-0.74/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 

--- a/website/versioned_docs/version-0.75/animations.md
+++ b/website/versioned_docs/version-0.75/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 

--- a/website/versioned_docs/version-0.76/animations.md
+++ b/website/versioned_docs/version-0.76/animations.md
@@ -20,7 +20,7 @@ For example, a container view that fades in when it is mounted may look like thi
 <Tabs groupId="language" queryString defaultValue={constants.defaultSnackLanguage} values={constants.snackLanguages}>
 <TabItem value="javascript">
 
-```SnackPlayer ext=js
+```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 


### PR DESCRIPTION

I missed a few examples in #4200 where the example expo sandboxes were broken due to useAnimatedValue not being exported on web.
