### PR TITLE
docs: Fix link for debugging native code

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -49,7 +49,7 @@ React Native DevTools replaces the previous Flipper, Experimental Debugger, and 
 
 We continue to offer legacy debugging methods such as Direct JSC Debugging and Remote JS Debugging (deprecated) (see [Other Debugging Methods](./other-debugging-methods)).
 
-React Native DevTools is designed for debugging React app concerns, and not to replace native tools. If you want to inspect React Native’s underlying platform layers (for example, while developing a Native Module), please use the debugging tools available in Xcode and Android Studio (see [Debugging Native Code](./next/debugging-native-code)).
+React Native DevTools is designed for debugging React app concerns, and not to replace native tools. If you want to inspect React Native’s underlying platform layers (for example, while developing a Native Module), please use the debugging tools available in Xcode and Android Studio (see [Debugging Native Code](/docs/next/debugging-native-code)).
 
 Other useful links:
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -49,7 +49,7 @@ React Native DevTools replaces the previous Flipper, Experimental Debugger, and 
 
 We continue to offer legacy debugging methods such as Direct JSC Debugging and Remote JS Debugging (deprecated) (see [Other Debugging Methods](./other-debugging-methods)).
 
-React Native DevTools is designed for debugging React app concerns, and not to replace native tools. If you want to inspect React Native’s underlying platform layers (for example, while developing a Native Module), please use the debugging tools available in Xcode and Android Studio (see [Debugging Native Code](http://localhost:3000/docs/next/debugging-native-code)).
+React Native DevTools is designed for debugging React app concerns, and not to replace native tools. If you want to inspect React Native’s underlying platform layers (for example, while developing a Native Module), please use the debugging tools available in Xcode and Android Studio (see [Debugging Native Code](./next/debugging-native-code)).
 
 Other useful links:
 


### PR DESCRIPTION
Remove localhost:3000 from the Debugging doc 