### PR TITLE
Fix wrong syntax using Kotlin enum class

### DIFF
--- a/docs/fabric-native-components-android.md
+++ b/docs/fabric-native-components-android.md
@@ -163,9 +163,9 @@ class ReactWebView: WebView {
     eventDispatcher?.dispatchEvent(event)
   }
 
-  enum class OnScriptLoadedEventResult() {
-    success(),
-    error()
+  enum class OnScriptLoadedEventResult {
+    success,
+    error;
   }
 
   inner class OnScriptLoadedEvent(


### PR DESCRIPTION
# Issue

- close #4327 
- Fix wrong syntax using enum class in Fabric Native Component


<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
