### PR TITLE
Add Instagram and Facebook VR to showcase links

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -5,7 +5,14 @@
       "icon": "facebook.webp",
       "linkAppStore": "https://apps.apple.com/app/facebook/id284882215",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.katana",
+      "linkMetaQuest": "https://www.meta.com/experiences/facebook/7495711360547796/",
       "pinned": true
+    },
+    {
+      "name": "Instagram",
+      "icon": "instagram.png",
+      "linkMetaQuest": "https://www.meta.com/experiences/instagram/6894135610696226/",
+      "infoLink": "https://engineering.fb.com/2024/10/02/android/react-at-meta-connect-2024/"
     },
     {
       "name": "Facebook Ads Manager",

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -92,7 +92,7 @@ const renderLinks = app => {
     .flatMap((link, i) =>
       i === 0 ? [link] : [<span key={i}> • </span>, link]
     );
-  
+
   if (links.length === 0) {
     return <p />;
   }

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -83,7 +83,7 @@ const renderLinks = app => {
       </a>
     ) : null,
     app.linkMetaQuest ? (
-      <a key="quest" href={app.linkDesktop} target="_blank">
+      <a key="quest" href={app.linkMetaQuest} target="_blank">
         Meta Quest
       </a>
     ) : null,

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -86,6 +86,11 @@ const renderLinks = app => {
         Desktop
       </a>
     ) : null,
+    app.linkMetaQuest ? (
+      <a key="quest" href={app.linkDesktop} target="_blank">
+        Meta Quest
+      </a>
+    ) : null,
   ]
     .filter(Boolean)
     .flatMap((link, i) =>

--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -66,10 +66,6 @@ const AppBox = ({app}) => {
 };
 
 const renderLinks = app => {
-  if (!app.linkAppStore && !app.linkPlayStore && !app.linkDesktop) {
-    return <p />;
-  }
-
   const links = [
     app.linkAppStore ? (
       <a key="ios" href={app.linkAppStore} target="_blank">
@@ -96,6 +92,10 @@ const renderLinks = app => {
     .flatMap((link, i) =>
       i === 0 ? [link] : [<span key={i}> • </span>, link]
     );
+  
+  if (links.length === 0) {
+    return <p />;
+  }
 
   return <p className="showcaseLinks">{links}</p>;
 };


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

The new Facebook and Instagram apps were written entirely in React Native. This change updates the showcase page to include links to each on the Meta Quest store, as well as an information link to one of Meta's recent blog posts on the topic