### PR TITLE
Use `&nbsp;` in "Meta Quest"

### DIFF
--- a/website/src/pages/showcase.js
+++ b/website/src/pages/showcase.js
@@ -84,7 +84,7 @@ const renderLinks = app => {
     ) : null,
     app.linkMetaQuest ? (
       <a key="quest" href={app.linkMetaQuest} target="_blank">
-        Meta Quest
+        Meta&nbsp;Quest
       </a>
     ) : null,
   ]


### PR DESCRIPTION
This minor change prevents word wrapping from splitting up "Meta" and "Quest" in the Showcase.

# Before

![CleanShot 2024-11-04 at 10 40 24](https://github.com/user-attachments/assets/fe5b16b5-432c-4a9c-8f0c-a03a3ea239f4)

# After

![CleanShot 2024-11-04 at 10 40 25](https://github.com/user-attachments/assets/8c6c8feb-9866-471b-bb55-4713c4f05537)
