### PR TITLE
Update sectionlist.md for keyExtractor

### DIFF
--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -179,7 +179,7 @@ Rendered in between each item, but not at the top or bottom. By default, `highli
 
 ### `keyExtractor`
 
-Used to extract a unique key for a given item at the specified index. Key is used for caching and as the React key to track item re-ordering. The default extractor checks `item.key`, then falls back to using the index, like React does. Note that this sets keys for each item, but each overall section still needs its own key.
+Used to extract a unique key for a given item at the specified index. Key is used for caching and as the React key to track item re-ordering. The default extractor checks `item.key`, then `item.id`, and then falls back to using the index, like React does. Note that this sets keys for each item, but each overall section still needs its own key.
 
 | Type                                    |
 | --------------------------------------- |


### PR DESCRIPTION
keyExtractor in sectionlist checks for item.key first. If it is not present it checks for item.id. If item.id is not present then it falls back to index.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
