### PR TITLE
docs: fix grammar in Getting started with macOS / iOS

### DIFF
--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -33,7 +33,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 To install a simulator, open **Xcode > Settings... (or Preferences...)** and select the **Platforms (or Components)** tab. Select a simulator with the corresponding version of iOS you wish to use.
 
-If you are using Xcode version 14.0 or greater than to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
+If you are using Xcode version 14.0 or greater to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
 
 #### CocoaPods
 

--- a/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.71/_getting-started-macos-ios.md
@@ -64,7 +64,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 To install a simulator, open <strong>Xcode > Preferences...</strong> and select the <strong>Components</strong> tab. Select a simulator with the corresponding version of iOS you wish to use.
 
-If you are using Xcode version 14.0 or greater than to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
+If you are using Xcode version 14.0 or greater to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
 
 #### CocoaPods
 

--- a/website/versioned_docs/version-0.73/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.73/_getting-started-macos-ios.md
@@ -36,7 +36,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 To install a simulator, open **Xcode > Settings... (or Preferences...)** and select the **Platforms (or Components)** tab. Select a simulator with the corresponding version of iOS you wish to use.
 
-If you are using Xcode version 14.0 or greater than to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
+If you are using Xcode version 14.0 or greater to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
 
 #### CocoaPods
 

--- a/website/versioned_docs/version-0.74/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.74/_getting-started-macos-ios.md
@@ -33,7 +33,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 To install a simulator, open **Xcode > Settings... (or Preferences...)** and select the **Platforms (or Components)** tab. Select a simulator with the corresponding version of iOS you wish to use.
 
-If you are using Xcode version 14.0 or greater than to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
+If you are using Xcode version 14.0 or greater to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
 
 #### CocoaPods
 

--- a/website/versioned_docs/version-0.75/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.75/_getting-started-macos-ios.md
@@ -33,7 +33,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 To install a simulator, open **Xcode > Settings... (or Preferences...)** and select the **Platforms (or Components)** tab. Select a simulator with the corresponding version of iOS you wish to use.
 
-If you are using Xcode version 14.0 or greater than to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
+If you are using Xcode version 14.0 or greater to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
 
 #### CocoaPods
 

--- a/website/versioned_docs/version-0.76/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.76/_getting-started-macos-ios.md
@@ -33,7 +33,7 @@ You will also need to install the Xcode Command Line Tools. Open Xcode, then cho
 
 To install a simulator, open **Xcode > Settings... (or Preferences...)** and select the **Platforms (or Components)** tab. Select a simulator with the corresponding version of iOS you wish to use.
 
-If you are using Xcode version 14.0 or greater than to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
+If you are using Xcode version 14.0 or greater to install a simulator, open **Xcode > Settings > Platforms** tab, then click "+" icon and select **iOS…** option.
 
 #### CocoaPods
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

**Summary:** Fix the incorrect grammatical construction "If you are using version XX or greater than to install ...`

**Changelog:**

 - [General] [Fixed] - Fix grammar mistake in docs about Getting started with macOS / iOS