### PR TITLE
fix: added platform label annotation of onAccessibilityTap prop

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -522,7 +522,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.70/accessibility.md
+++ b/website/versioned_docs/version-0.70/accessibility.md
@@ -228,7 +228,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.70/view.md
+++ b/website/versioned_docs/version-0.70/view.md
@@ -397,7 +397,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.71/accessibility.md
+++ b/website/versioned_docs/version-0.71/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.71/view.md
+++ b/website/versioned_docs/version-0.71/view.md
@@ -559,7 +559,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.72/accessibility.md
+++ b/website/versioned_docs/version-0.72/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.72/view.md
+++ b/website/versioned_docs/version-0.72/view.md
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.73/accessibility.md
+++ b/website/versioned_docs/version-0.73/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.73/view.md
+++ b/website/versioned_docs/version-0.73/view.md
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.74/accessibility.md
+++ b/website/versioned_docs/version-0.74/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.74/view.md
+++ b/website/versioned_docs/version-0.74/view.md
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.75/accessibility.md
+++ b/website/versioned_docs/version-0.75/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.75/view.md
+++ b/website/versioned_docs/version-0.75/view.md
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 

--- a/website/versioned_docs/version-0.76/accessibility.md
+++ b/website/versioned_docs/version-0.76/accessibility.md
@@ -340,7 +340,7 @@ In the above example, the `yellow` layout and its descendants are completely inv
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 

--- a/website/versioned_docs/version-0.76/view.md
+++ b/website/versioned_docs/version-0.76/view.md
@@ -522,7 +522,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap`
+### `onAccessibilityTap` <div class="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 


### PR DESCRIPTION
**What did I change?**
I added a platform label for the `onAccessibilityTap` prop on the [React Native documentation page](https://reactnative.dev/docs/accessibility#onaccessibilitytap).

**Why did I change it?**
An issue was reported regarding `onAccessibilityTap` not working on Android, but this prop is only intended for the iOS platform. This change will help clarify platform-specific behaviour and prevent future confusion among users.

**Reported issue** - https://github.com/facebook/react-native/issues/47149
**Action item** - https://github.com/facebook/react-native/issues/47149#issuecomment-2442379424