### PR TITLE
docs: Updated _getting-started-macos-android.md for Finder commands in MacOS + android environment

### DIFF
--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -34,7 +34,7 @@ brew info --cask zulu@17
 # Installed using the formulae.brew.sh API on 2024-06-06 at 10:00:00
 
 # Navigate to the folder
-finder /opt/homebrew/Caskroom/zulu@17/<version number> # or /usr/local/Caskroom/zulu@17/<version number>
+open /opt/homebrew/Caskroom/zulu@17/<version number> # or /usr/local/Caskroom/zulu@17/<version number>
 ```
 
 After opening Finder, double click the `Double-Click to Install Azul Zulu JDK 17.pkg` package to install the JDK.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

If you simply follow the process in a MacOS + Android environment, this command seems correct to open the finder.
