### PR TITLE
Add missing listitem role do accessibiltiy doc

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with a button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.

--- a/website/versioned_docs/version-0.71/accessibility.md
+++ b/website/versioned_docs/version-0.71/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- - **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.

--- a/website/versioned_docs/version-0.72/accessibility.md
+++ b/website/versioned_docs/version-0.72/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with a button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.

--- a/website/versioned_docs/version-0.73/accessibility.md
+++ b/website/versioned_docs/version-0.73/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with a button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.

--- a/website/versioned_docs/version-0.74/accessibility.md
+++ b/website/versioned_docs/version-0.74/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with a button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.

--- a/website/versioned_docs/version-0.75/accessibility.md
+++ b/website/versioned_docs/version-0.75/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with a button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.

--- a/website/versioned_docs/version-0.76/accessibility.md
+++ b/website/versioned_docs/version-0.76/accessibility.md
@@ -363,6 +363,7 @@ Assign this property to a custom function which will be called when someone perf
 - **img** Used when the element should be treated as an image. Can be combined with a button or link, for example.
 - **link** Used when the element should be treated as a link.
 - **list** Used to identify a list of items.
+- **listitem** Used to itentify an item in a list.
 - **menu** Used when the component is a menu of choices.
 - **menubar** Used when a component is a container of multiple menus.
 - **menuitem** Used to represent an item within a menu.


### PR DESCRIPTION
The accessibility doc seemed to be missing info about the `listitem` role, which is an important complementary role to the `list` role.

I added an entry for it with a simple description of the purpose.
