### PR TITLE
collapsable is not Android only prop in new architecture

### DIFF
--- a/docs/view.md
+++ b/docs/view.md
@@ -361,7 +361,7 @@ Represents the textual description of the component. Has precedence over the `te
 
 ---
 
-### `collapsable` <div class="label android">Android</div>
+### `collapsable`
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 

--- a/website/versioned_docs/version-0.76/view.md
+++ b/website/versioned_docs/version-0.76/view.md
@@ -361,7 +361,7 @@ Represents the textual description of the component. Has precedence over the `te
 
 ---
 
-### `collapsable` <div class="label android">Android</div>
+### `collapsable`
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 


### PR DESCRIPTION
Before:
<img width="828" alt="Screenshot 2024-11-21 at 14 45 05" src="https://github.com/user-attachments/assets/23fa6a98-1f46-4e21-8748-f264e7badf1e">

After:
<img width="812" alt="Screenshot 2024-11-21 at 14 45 00" src="https://github.com/user-attachments/assets/0c83de84-b885-4447-bfd8-e0562ae3cabc">
