### PR TITLE
add collapsableChildren to docs and add default value for collapsable

### DIFF
--- a/docs/view.md
+++ b/docs/view.md
@@ -365,9 +365,19 @@ Represents the textual description of the component. Has precedence over the `te
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 
-| Type |
-| ---- |
-| bool |
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
+
+---
+
+### `collapsableChildren`
+
+Setting to false prevents direct children of the view from being removed from the native view hierarchy, similar to the effect of setting `collapsable={false}` on each child.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
 
 ---
 

--- a/website/versioned_docs/version-0.76/view.md
+++ b/website/versioned_docs/version-0.76/view.md
@@ -365,9 +365,19 @@ Represents the textual description of the component. Has precedence over the `te
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 
-| Type |
-| ---- |
-| bool |
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
+
+---
+
+### `collapsableChildren`
+
+Setting to false prevents direct children of the view from being removed from the native view hierarchy, similar to the effect of setting `collapsable={false}` on each child.
+
+| Type    | Default |
+| ------- | ------- |
+| boolean | true    |
 
 ---
 


### PR DESCRIPTION
[collapsableChildren](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/View/ViewPropTypes.js#L582) is not documented on the website. Let's add it.

In this PR, I also add default value column to `collapsable`.

<img width="811" alt="Screenshot 2024-11-21 at 14 55 27" src="https://github.com/user-attachments/assets/d8738120-2820-4798-9b22-f4175a47f33e">
