### PR TITLE
[gha] tweaks for the pre-merge workflows

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: "20"
           cache: "yarn"
 
       - name: Install dependencies
@@ -27,16 +28,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: "20"
           cache: "yarn"
 
       - name: Install dependencies

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Set up Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,6 +29,8 @@ jobs:
     steps:
       - name: Set up Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,4 +42,4 @@ jobs:
         run: yarn build
         working-directory: website
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=8192"


### PR DESCRIPTION
# Why

In recent PR CI we can see an unexpected build failure.

# How

Bump used Node 18->20 and increase the amount of RAM which can be reserved by Node during the build process. Since public Ubuntu runners have 16GB of RAM this should be fine:
* https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

# Test plan

Run the CI.