### PR TITLE
Improved code example in layout-measurements.md

### DIFF
--- a/docs/the-new-architecture/layout-measurements.md
+++ b/docs/the-new-architecture/layout-measurements.md
@@ -13,8 +13,8 @@ function AComponent(children) {
   const targetRef = React.useRef(null)
 
   useLayoutEffect(() => {
-    targetRef.current?.measure(({measurements}) => {
-      //do something with the `measurements`
+    targetRef.current?.measure((x, y, width, height, pageX, pageY) => {
+      //do something with the measurements
     });
   }, [ /* add dependencies here */]);
 


### PR DESCRIPTION
The parameters of the `MeasureOnSuccessCallback` are spread out across `x`, `y`, `width`, `height`, etc, instead of being in a variable called `measurements`. I've updated to the code example to reflect that.