### PR TITLE
Add packageManager field to package.json for Yarn version specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,6 @@
     "trim": "^1.0.1",
     "update-notifier": "^6.0.2",
     "@sideway/formula": ">=3.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Include the packageManager field in package.json to specify the version of Yarn used for the project.
Corepack will use the specified version to ensure consistency across environments.
https://nodejs.org/api/corepack.html

closes #4378
