### PR TITLE
Enable Docusaurus native CSS transitions

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -33,8 +33,6 @@
   --ifm-table-head-color: var(--subtle);
   --ifm-link-hover-decoration: none;
   --ifm-navbar-background-color: var(--deepdark);
-  --ifm-transition-fast: 0;
-  --ifm-transition-slow: 0;
   --ifm-pre-line-height: 1.5;
   --ifm-tabs-padding-vertical: 6px;
   --ifm-color-warning: #ffe564;
@@ -955,8 +953,6 @@ aside[class^="theme-doc-sidebar-container"] {
 
 .menu__list {
   margin-bottom: 8px;
-  transition: none !important;
-  height: auto !important;
 
   &.blog-menu__list {
     font-size: 14px;
@@ -1045,12 +1041,6 @@ aside[class^="theme-doc-sidebar-container"] {
 
   .menu__list-item--collapsed .menu__list {
     margin-bottom: 0;
-  }
-}
-
-.menu__list-item.menu__list-item--collapsed {
-  .menu__list {
-    height: 0 !important;
   }
 }
 

--- a/website/src/css/index.scss
+++ b/website/src/css/index.scss
@@ -447,7 +447,6 @@
   stroke-opacity: 0;
   transform: scale(2.25, 1.33) rotate(0);
   opacity: 1;
-  transition: none;
 }
 
 .LogoAnimation.mobile .screen {


### PR DESCRIPTION
Remove restrictions on CSS transitions to allow for native transitions in Docusaurus components.

this brings back things like: 

- sidebar menu transition in and out of view
- sidebar menu list expand and collapse animation
- link and button hover animation
- popover in and out animation


https://github.com/user-attachments/assets/ee3d5f03-37bc-4635-bd9b-9a17a2d97db6

closes #4379