### PR TITLE
Enable caching on pre-merge jobs

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -9,11 +9,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --no-progress --non-interactive
@@ -25,11 +27,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --no-progress --non-interactive


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Should save a decent amount of time (10-20s) on pre-merge jobs if we take advantage of setup-node's built-in caching. The yarn install step drops from ~45s to ~25s 