### PR TITLE
Fix default value of removeClippedSubviews on Android

### DIFF
--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -23,11 +23,11 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 ### removeClippedSubviews
 
-| Type    | Default |
-| ------- | ------- |
-| Boolean | False   |
+| Type    | Default                       |
+| ------- | ----------------------------- |
+| Boolean | True (Android)<br>False (iOS) |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 


### PR DESCRIPTION
Align docs with https://reactnative.dev/docs/flatlist#removeclippedsubviews