### PR TITLE
Update turbo-native-modules-android.md

### DIFF
--- a/docs/turbo-native-modules-android.md
+++ b/docs/turbo-native-modules-android.md
@@ -22,7 +22,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 
 public class NativeLocalStorageModule extends NativeLocalStorageSpec {
 
-  private static final String NAME = "NativeLocalStorage";
+  public static final String NAME = "NativeLocalStorage";
 
   public NativeLocalStorageModule(ReactApplicationContext reactContext) {
     super(reactContext);


### PR DESCRIPTION
On app build, compiler throws an error since we're using this property as `NativeLocalStorageModule.NAME` in another file `NativeLocalStorageModule.java`

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
