### PR TITLE
Style property 'top' is not supported by native animated module

### DIFF
--- a/docs/animatedvaluexy.md
+++ b/docs/animatedvaluexy.md
@@ -17,18 +17,21 @@ const DraggableView = () => {
 
   const panResponder = PanResponder.create({
     onStartShouldSetPanResponder: () => true,
-    onPanResponderMove: Animated.event([
-      null,
-      {
-        dx: pan.x, // x,y are Animated.Value
-        dy: pan.y,
-      },
-    ]),
+    onPanResponderMove: Animated.event(
+      [
+        null,
+        {
+          dx: pan.x, // x,y are Animated.Value
+          dy: pan.y,
+        },
+      ],
+      {useNativeDriver: false} // Set to false for PanResponder to work
+    ),
     onPanResponderRelease: () => {
-      Animated.spring(
-        pan, // Auto-multiplexed
-        {toValue: {x: 0, y: 0}, useNativeDriver: true}, // Back to zero
-      ).start();
+      Animated.spring(pan, {
+        toValue: {x: 0, y: 0},
+        useNativeDriver: true, // Keep this for better performance
+      }).start();
     },
   });
 
@@ -37,7 +40,12 @@ const DraggableView = () => {
       <SafeAreaView style={styles.container}>
         <Animated.View
           {...panResponder.panHandlers}
-          style={[pan.getLayout(), styles.box]}
+          style={[
+            {
+              transform: pan.getTranslateTransform(), // Use transform instead of left/top
+            },
+            styles.box,
+          ]}
         />
       </SafeAreaView>
     </SafeAreaProvider>


### PR DESCRIPTION
Replace pan.getLayout() with pan.getTranslateTransform() and use the transform property, which is compatible with useNativeDriver.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
