### PR TITLE
Update colors for table of contents to be more in line with the theme

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1107,7 +1107,7 @@ div[class^="tableOfContents"] {
 
     code {
       color: var(--ifm-font-color-base);
-      font-weight: 900;
+      font-weight: 700;
     }
 
     &:hover {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1102,20 +1102,19 @@ div[class^="tableOfContents"] {
     font-weight: 500;
     margin-left: -16px;
     padding-left: 12px;
-    color: var(--ifm-font-color-base);
-    border-left: 4px solid var(--brand);
+    color: var(--ifm-link-color);
+    border-left: 4px solid var(--ifm-link-color);
 
     code {
-      font-weight: 600;
-      color: var(--ifm-font-color-base);
-      white-space: nowrap;
+      color: var(--ifm-link-color);
+      font-weight: 900;
     }
 
     &:hover {
-      color: var(--ifm-font-color-base);
+      color: var(--ifm-link-color);
 
       code {
-        color: var(--ifm-font-color-base);
+        color: var(--ifm-link-color);
       }
     }
   }

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1102,19 +1102,35 @@ div[class^="tableOfContents"] {
     font-weight: 500;
     margin-left: -16px;
     padding-left: 12px;
-    color: var(--ifm-link-color);
+    color: var(--ifm-font-color-base);
     border-left: 4px solid var(--ifm-link-color);
 
     code {
-      color: var(--ifm-link-color);
+      color: var(--ifm-font-color-base);
       font-weight: 900;
     }
 
     &:hover {
-      color: var(--ifm-link-color);
+      color: var(--ifm-font-color-base);
 
       code {
+        color: var(--ifm-font-color-base);
+      }
+    }
+  }
+}
+
+html[data-theme="dark"] {
+  .table-of-contents {
+    .table-of-contents__link--active {
+      color: var(--ifm-link-color);
+
+      &:hover {
         color: var(--ifm-link-color);
+
+        code {
+          color: var(--ifm-link-color);
+        }
       }
     }
   }

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1108,6 +1108,7 @@ div[class^="tableOfContents"] {
     code {
       color: var(--ifm-font-color-base);
       font-weight: 700;
+      white-space: nowrap;
     }
 
     &:hover {


### PR DESCRIPTION
Revise the custom theme colors to enhance the appearance of the table of contents and code elements.

before
![image](https://github.com/user-attachments/assets/784986da-7fb4-4788-9ed2-a9ae6830a8f6)

after
![image](https://github.com/user-attachments/assets/71476794-ff64-47f6-a8e1-1445b5780613)

![image](https://github.com/user-attachments/assets/3fc54ec2-ad2d-414f-8a1e-8a46a534aa62)


before
![image](https://github.com/user-attachments/assets/21fc91db-1d2e-48be-99fd-5939c2c540d2)

after
![image](https://github.com/user-attachments/assets/dd8db037-f19f-4f19-90dc-49100f9d5727)

![image](https://github.com/user-attachments/assets/5edbffc2-a056-4bc9-bacb-eecf59db677b)

