### PR TITLE
Make table border thicker and easier to see

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -40,7 +40,6 @@
   --ifm-alert-border-radius: 0;
   --ifm-alert-color: var(--ifm-font-color-base);
   --ifm-pagination-nav-color-hover: var(--ifm-color-emphasis-300);
-  --ifm-table-border-width: 0.005rem;
   --ifm-navbar-sidebar-width: 100%;
   --ifm-hr-border-color: var(--docusaurus-collapse-button-bg-hover);
   --docusaurus-blog-social-icon-size: 16px;


### PR DESCRIPTION
Use the default width and eliminate the redundant table border width setting in the custom theme to streamline the styling.

before
![image](https://github.com/user-attachments/assets/9fa43c11-c3d9-4fa9-9c28-b4cb4d27b8c7)

after
![image](https://github.com/user-attachments/assets/750209a2-cb8c-48d0-a22f-37929a43eece)

before
![image](https://github.com/user-attachments/assets/81c97a85-2a14-40b2-afe6-44825bd74f7f)

after
![image](https://github.com/user-attachments/assets/7ede4e14-9369-41ed-beb9-dc38dcbbefd2)
