### PR TITLE
Update XML code block syntax in documentation

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file inside the `application` tag:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.70/headless-js-android.md
+++ b/website/versioned_docs/version-0.70/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.71/headless-js-android.md
+++ b/website/versioned_docs/version-0.71/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.72/headless-js-android.md
+++ b/website/versioned_docs/version-0.72/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.73/headless-js-android.md
+++ b/website/versioned_docs/version-0.73/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file inside the `application` tag:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.74/headless-js-android.md
+++ b/website/versioned_docs/version-0.74/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file inside the `application` tag:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.75/headless-js-android.md
+++ b/website/versioned_docs/version-0.75/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file inside the `application` tag:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 

--- a/website/versioned_docs/version-0.76/headless-js-android.md
+++ b/website/versioned_docs/version-0.76/headless-js-android.md
@@ -96,7 +96,7 @@ class MyTaskService : HeadlessJsTaskService() {
 
 Then add the service to your `AndroidManifest.xml` file inside the `application` tag:
 
-```
+```xml
 <service android:name="com.example.MyTaskService" />
 ```
 


### PR DESCRIPTION
Improve the clarity of the headless-js-android documentation by updating the code block syntax for XML.