### PR TITLE
Change default language from 'jsx' to 'tsx' in Docusaurus config

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -223,7 +223,7 @@ const config: Config = {
       isCloseable: false,
     },
     prism: {
-      defaultLanguage: 'jsx',
+      defaultLanguage: 'tsx',
       theme: require('./core/PrismTheme'),
       additionalLanguages: [
         'diff',


### PR DESCRIPTION
Update the default language setting in the Docusaurus configuration to take into account snippets with TypeScript.