### PR TITLE
Better contrast for component grid component header

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1707,8 +1707,8 @@ article .component-grid {
       font-weight: 600;
       margin: 0;
       padding: 0 10px;
-      background-color: #357da1;
-      color: white;
+      background-color: var(--home-button-primary);
+      color: var(--home-button-primary-text);
       line-height: 36px;
 
       a {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1707,7 +1707,7 @@ article .component-grid {
       font-weight: 600;
       margin: 0;
       padding: 0 10px;
-      background-color: var(--ifm-color-primary);
+      background-color: #357da1;
       color: white;
       line-height: 36px;
 


### PR DESCRIPTION
Change the background color of the component grid to enhance the contrast.

before
![image](https://github.com/user-attachments/assets/1d3b86a4-c982-4354-9194-ec8bdf056756)

![image](https://github.com/user-attachments/assets/78530f9c-01e4-4a7b-8585-5a835c0f62b0)

after
![image](https://github.com/user-attachments/assets/ae21cbf9-4c37-4d33-8246-12b673a1c051)

![image](https://github.com/user-attachments/assets/538f3b33-490e-43de-ada3-5d434de4324a)
