### PR TITLE
 fixed: kotlin SoLoader.init params to fix "library 'libhermes_executor.so' not found

### DIFF
--- a/docs/_integration-with-existing-apps-kotlin.md
+++ b/docs/_integration-with-existing-apps-kotlin.md
@@ -338,6 +338,7 @@ import android.app.Application
 +import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 +import com.facebook.react.defaults.DefaultReactNativeHost
 +import com.facebook.soloader.SoLoader
++import com.facebook.react.soloader.OpenSourceMergedSoMapping
 
 -class MainApplication : Application() {
 +class MainApplication : Application(), ReactApplication {
@@ -356,7 +357,7 @@ import android.app.Application
 
   override fun onCreate() {
     super.onCreate()
-+   SoLoader.init(this, false)
++   SoLoader.init(this, OpenSourceMergedSoMapping)
 +   if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
 +     load()
 +   }

--- a/website/versioned_docs/version-0.76/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.76/_integration-with-existing-apps-kotlin.md
@@ -338,6 +338,7 @@ import android.app.Application
 +import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 +import com.facebook.react.defaults.DefaultReactNativeHost
 +import com.facebook.soloader.SoLoader
++import com.facebook.react.soloader.OpenSourceMergedSoMapping
 
 -class MainApplication : Application() {
 +class MainApplication : Application(), ReactApplication {
@@ -356,7 +357,7 @@ import android.app.Application
 
   override fun onCreate() {
     super.onCreate()
-+   SoLoader.init(this, false)
++   SoLoader.init(this, OpenSourceMergedSoMapping)
 +   if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
 +     load()
 +   }


### PR DESCRIPTION
As per react native 0.76 release breaking changes documentation updated kotlin integration.

Kotlin integration code example missed the changes.

[0.76 breaking changes](https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture#breaking-changes-1) 


**Issue**
#4430 