### PR TITLE
Enhance component grid link clickability for better usability

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1702,6 +1702,12 @@ article .component-grid {
       transform: scale(1.05);
     }
 
+    > a {
+      display: block;
+      height: 100%;
+      border-bottom: none;
+    }
+
     h3 {
       font-size: 16px;
       font-weight: 600;


### PR DESCRIPTION
Improved link styling to take full height within the component grid to enhance usability and accessibility.

before

https://github.com/user-attachments/assets/a3c9d975-a1c6-4fc8-960b-a199375f4eb8

after

https://github.com/user-attachments/assets/cdb9c826-99d1-420b-a261-18c6dc4f7c73

the background color is apparently an existing style of the a tag that was auto enabled but it looks good actually