### PR TITLE
fix(docs): typo in hermes docs

### DIFF
--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -15,7 +15,7 @@ Hermes is used by default by React Native and no additional configuration is req
 ## Bundled Hermes
 
 React Native comes with a **bundled version** of Hermes.
-We building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
+We are building a version of Hermes for you whenever we release a new version of React Native. This will make sure you're consuming a version of Hermes which is fully compatible with the version of React Native you're using.
 
 This change is fully transparent to users of React Native. You can still disable Hermes using the command described in this page.
 You can [read more about the technical implementation on this page](/architecture/bundled-hermes).


### PR DESCRIPTION
Hi team,
I just found a small typo in the [hermes docs](https://reactnative.dev/docs/hermes). I tested it locally as well. If you require me to do anything further, just let me know.
