### PR TITLE
Add missing syntax highlighting in View

### DIFF
--- a/docs/view.md
+++ b/docs/view.md
@@ -676,10 +676,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -687,10 +687,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -674,7 +674,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -685,7 +685,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.70/view.md
+++ b/website/versioned_docs/version-0.70/view.md
@@ -539,7 +539,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -550,7 +550,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.70/view.md
+++ b/website/versioned_docs/version-0.70/view.md
@@ -541,10 +541,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -552,10 +552,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.71/view.md
+++ b/website/versioned_docs/version-0.71/view.md
@@ -703,10 +703,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -714,10 +714,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.71/view.md
+++ b/website/versioned_docs/version-0.71/view.md
@@ -701,7 +701,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -712,7 +712,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.72/view.md
+++ b/website/versioned_docs/version-0.72/view.md
@@ -666,7 +666,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -677,7 +677,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.72/view.md
+++ b/website/versioned_docs/version-0.72/view.md
@@ -668,10 +668,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -679,10 +679,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.73/view.md
+++ b/website/versioned_docs/version-0.73/view.md
@@ -666,7 +666,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -677,7 +677,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.73/view.md
+++ b/website/versioned_docs/version-0.73/view.md
@@ -668,10 +668,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -679,10 +679,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.74/view.md
+++ b/website/versioned_docs/version-0.74/view.md
@@ -666,7 +666,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -677,7 +677,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.74/view.md
+++ b/website/versioned_docs/version-0.74/view.md
@@ -668,10 +668,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -679,10 +679,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.75/view.md
+++ b/website/versioned_docs/version-0.75/view.md
@@ -666,7 +666,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -677,7 +677,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }

--- a/website/versioned_docs/version-0.75/view.md
+++ b/website/versioned_docs/version-0.75/view.md
@@ -668,10 +668,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -679,10 +679,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.76/view.md
+++ b/website/versioned_docs/version-0.76/view.md
@@ -676,10 +676,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-none {
-     pointer-events: none;
+  pointer-events: none;
 }
 .box-none * {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 ```
 
@@ -687,10 +687,10 @@ Controls whether the `View` can be the target of touch events.
 
 ```css
 .box-only {
-     pointer-events: auto;
+  pointer-events: auto;
 }
 .box-only * {
-     pointer-events: none;
+  pointer-events: none;
 }
 ```
 

--- a/website/versioned_docs/version-0.76/view.md
+++ b/website/versioned_docs/version-0.76/view.md
@@ -674,7 +674,7 @@ Controls whether the `View` can be the target of touch events.
 - `'none'`: The View is never the target of touch events.
 - `'box-none'`: The View is never the target of touch events but its subviews can be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-none {
      pointer-events: none;
 }
@@ -685,7 +685,7 @@ Controls whether the `View` can be the target of touch events.
 
 - `'box-only'`: The view can be the target of touch events but its subviews cannot be. It behaves like if the view had the following classes in CSS:
 
-```
+```css
 .box-only {
      pointer-events: auto;
 }


### PR DESCRIPTION
This PR adds missing syntax highlighting and fixes indentation in the View's pointerEvents property.