### PR TITLE
fix: give credit to Oskar for Swift template

### DIFF
--- a/website/blog/2025-01-21-version-0.77.md
+++ b/website/blog/2025-01-21-version-0.77.md
@@ -374,7 +374,7 @@ Thanks to all the additional authors that worked on documenting features in this
 - [Jakub Piasecki](https://github.com/j-piasecki) for contributing to the `display: contents` feature
 - [Nick Gerleman](https://github.com/NickGerleman), [Joe Vilches](https://github.com/joevilches) and [Jorge Cabiedes Acosta](https://github.com/jorge-cab) for releasing the new styling features
 - [Alan Lee](https://github.com/alanleedev) for the Android 16Kb page support content
-- [Riccardo Cipolleschi](https://github.com/cipolleschi) for supporting the migration of the template to Swift
+- [Riccardo Cipolleschi](https://github.com/cipolleschi) and [Oskar Kwaśniewski](https://github.com/okwasniewski) for supporting the migration of the template to Swift
 - [Nicola Corti](https://github.com/cortinico) for the `react-native init` deprecation cycle content
 - [Alex Hunt](https://github.com/huntie) for the content on the removal of `console.log` from metro
 


### PR DESCRIPTION
I noticed that the work on the Swift template is credited to Riccardo only in 0.77 blog post. Since the bulk of work and prior art in React Native visionOS project was done by Oskar, I believe he deserves a little credit in that blog post :) 