### PR TITLE
Temporarily change onBrokenLinks severity to warning

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -71,7 +71,7 @@ const config: Config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   presets: [
     [
       '@docusaurus/preset-classic',


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Seeing some build failures in https://github.com/facebook/react-native-website/pull/4450 while attempting to cut a new docs version. These failures are falsy reporting a broken link, so let's temporarily disable `onBrokenLinks`
