### PR TITLE
turbo-native-modules: specify that Native prefix is needed

### DIFF
--- a/docs/turbo-native-modules.md
+++ b/docs/turbo-native-modules.md
@@ -45,6 +45,8 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/appendix.md) documentation.
 :::
 
+:::info If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. NativeStorage or NativeUsersDefault). :::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>


### PR DESCRIPTION
Apparently without Native prefix, the spec file Codegen generates is *empty*

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
