### PR TITLE
[Native Components] Remove warning box as all the issues have been solved now.

### DIFF
--- a/docs/fabric-native-components-ios.md
+++ b/docs/fabric-native-components-ios.md
@@ -220,12 +220,3 @@ To link the WebKit framework in your app, follow these steps:
 7. Click on Add.
 
 <img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
-
-:::warning
-We are aware of a couple of issues with iOS that would create some problem when building the app with a custom iOS component.
-
-1. The component requires access to the `yoga/style/Style.h` header which is not currently available for the application. To fix this, add the `$(PODS_ROOT)/Headers/Private/Yoga` path to the header search paths build settings of the app.
-2. Codegen is generating a line in the `RCTThirdPartyFabricComponentsProvider` that it should not generate. Remove the lines with the `WebViewCls` symbol in the `RCTThirdPartyFabricComponentsProvider.h` and `RCTThirdPartyFabricComponentsProvider.mm` files.
-
-We have already fixed those issues and they will be released in React Native 0.76.2.
-:::

--- a/website/versioned_docs/version-0.76/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.76/fabric-native-components-ios.md
@@ -259,12 +259,3 @@ To link the WebKit framework in your app, follow these steps:
 7. Click on Add.
 
 <img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
-
-:::warning
-We are aware of a couple of issues with iOS that would create some problem when building the app with a custom iOS component.
-
-1. The component requires access to the `yoga/style/Style.h` header which is not currently available for the application. To fix this, add the `$(PODS_ROOT)/Headers/Private/Yoga` path to the header search paths build settings of the app.
-2. Codegen is generating a line in the `RCTThirdPartyFabricComponentsProvider` that it should not generate. Remove the lines with the `WebViewCls` symbol in the `RCTThirdPartyFabricComponentsProvider.h` and `RCTThirdPartyFabricComponentsProvider.mm` files.
-
-We have already fixed those issues and they will be released in React Native 0.76.2.
-:::

--- a/website/versioned_docs/version-0.77/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.77/fabric-native-components-ios.md
@@ -220,12 +220,3 @@ To link the WebKit framework in your app, follow these steps:
 7. Click on Add.
 
 <img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
-
-:::warning
-We are aware of a couple of issues with iOS that would create some problem when building the app with a custom iOS component.
-
-1. The component requires access to the `yoga/style/Style.h` header which is not currently available for the application. To fix this, add the `$(PODS_ROOT)/Headers/Private/Yoga` path to the header search paths build settings of the app.
-2. Codegen is generating a line in the `RCTThirdPartyFabricComponentsProvider` that it should not generate. Remove the lines with the `WebViewCls` symbol in the `RCTThirdPartyFabricComponentsProvider.h` and `RCTThirdPartyFabricComponentsProvider.mm` files.
-
-We have already fixed those issues and they will be released in React Native 0.76.2.
-:::


### PR DESCRIPTION
When releasing 0.76, we were aware of a couple of issues that were affecting the Native Components, and we added a warning box for the users. Now those issues are solved and we can remove the warning. 
