### PR TITLE
Use "build configuration" instead of "scheme"

### DIFF
--- a/docs/publishing-to-app-store.md
+++ b/docs/publishing-to-app-store.md
@@ -11,9 +11,9 @@ If you are using Expo, read the Expo guide for [Deploying to App Stores](https:/
 
 ### 1. Configure release scheme
 
-Building an app for distribution in the App Store requires using the `Release` scheme in Xcode. Apps built for `Release` will automatically disable the in-app Dev Menu, which will prevent your users from inadvertently accessing the menu in production. It will also bundle the JavaScript locally, so you can put the app on a device and test whilst not connected to the computer.
+Building an app for distribution in the App Store requires using the `Release` build configuration in Xcode. Apps built for `Release` will automatically disable the in-app Dev Menu, which will prevent your users from inadvertently accessing the menu in production. It will also bundle the JavaScript locally, so you can put the app on a device and test whilst not connected to the computer.
 
-To configure your app to be built using the `Release` scheme, go to **Product** → **Scheme** → **Edit Scheme**. Select the **Run** tab in the sidebar, then set the Build Configuration dropdown to `Release`.
+To configure your app to be built using the `Release` build configuration, go to **Product** → **Scheme** → **Edit Scheme**. Select the **Run** tab in the sidebar, then set the Build Configuration dropdown to `Release`.
 
 ![](/docs/assets/ConfigureReleaseScheme.png)
 


### PR DESCRIPTION
The screenshot on the page https://reactnative.dev/docs/publishing-to-app-store clearly shows that the correct term would be "build configuration", as scheme in XCode is something different.