### PR TITLE
Improve sentence structure for past and current docs on Touchables intro

### DIFF
--- a/docs/handling-touches.md
+++ b/docs/handling-touches.md
@@ -69,7 +69,7 @@ export default ButtonBasics;
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.70/handling-touches.md
+++ b/website/versioned_docs/version-0.70/handling-touches.md
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.71/handling-touches.md
+++ b/website/versioned_docs/version-0.71/handling-touches.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.72/handling-touches.md
+++ b/website/versioned_docs/version-0.72/handling-touches.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.73/handling-touches.md
+++ b/website/versioned_docs/version-0.73/handling-touches.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.74/handling-touches.md
+++ b/website/versioned_docs/version-0.74/handling-touches.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.75/handling-touches.md
+++ b/website/versioned_docs/version-0.75/handling-touches.md
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.76/handling-touches.md
+++ b/website/versioned_docs/version-0.76/handling-touches.md
@@ -69,7 +69,7 @@ export default ButtonBasics;
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 

--- a/website/versioned_docs/version-0.77/handling-touches.md
+++ b/website/versioned_docs/version-0.77/handling-touches.md
@@ -69,7 +69,7 @@ export default ButtonBasics;
 
 ## Touchables
 
-If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. The "Touchable" components provide the capability to capture tapping gestures, and can display feedback when a gesture is recognized. These components do not provide any default styling, however, so you will need to do a bit of work to get them looking nicely in your app.
+If the basic button doesn't look right for your app, you can build your own button using any of the "Touchable" components provided by React Native. These components provide the capability to capture tapping gestures and can display feedback when a gesture is recognized. However, these components do not provide any default styling, so you will need to do a bit of work to get them looking nice in your app.
 
 Which "Touchable" component you use will depend on what kind of feedback you want to provide:
 


### PR DESCRIPTION
Previously, the intro paragraph to Touchables read a bit weirdly. This PR improves the flow, word order and fixes incorrect use of a comma. This change has been applied to all versions of docs where Touchables were introduced. 

Doc page and section changed: https://deploy-preview-4500--react-native.netlify.app/docs/handling-touches#touchables
