### PR TITLE
Fix `AccessibilityInfo.announceForAccessibilityWithOptions()`'s declaration

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -118,7 +118,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.71/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.71/accessibilityinfo.md
@@ -273,7 +273,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.72/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.72/accessibilityinfo.md
@@ -115,7 +115,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.73/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.73/accessibilityinfo.md
@@ -115,7 +115,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.74/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.74/accessibilityinfo.md
@@ -115,7 +115,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.75/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.75/accessibilityinfo.md
@@ -115,7 +115,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.76/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.76/accessibilityinfo.md
@@ -118,7 +118,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.77/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.77/accessibilityinfo.md
@@ -118,7 +118,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 


### PR DESCRIPTION
The current declaration is invalid syntax in TypeScript.