### PR TITLE
[RN][iOS][Brownfield] Remove warning as we already landed the commit in RC.5

### DIFF
--- a/docs/_integration-with-existing-apps-ios.md
+++ b/docs/_integration-with-existing-apps-ios.md
@@ -490,11 +490,6 @@ Once you reach your React-powered Activity inside the app, it should load the Ja
 
 <center><img src="/docs/assets/EmbeddedAppIOS078.gif" width="300" /></center>
 
-:::note
-We are aware of a small limitation that prevent you to represent a view controller once it is dismissed.
-[This PR](https://github.com/facebook/react-native/pull/49300) fixes this issue and the limitation will be lifted in React Native 0.78.1.
-:::
-
 ### Creating a release build in Xcode
 
 You can use Xcode to create your release builds too! The only additional step is to add a script that is executed when the app is built to package your JS and images into the iOS application.


### PR DESCRIPTION
This change removes the warning box from the brownfield guide because we did an extra RC (RC.5) that includes the commit that lift the limitation expressed in the warning box.
