### PR TITLE
Add danger text to feature flag section of the Pointer Events blog post

### DIFF
--- a/website/blog/2022-12-13-pointer-events-in-react-native.md
+++ b/website/blog/2022-12-13-pointer-events-in-react-native.md
@@ -106,6 +106,12 @@ Our Pointer Events implementation is still experimental but we’re interested i
 
 ### Enable Feature Flags
 
+:::danger
+
+Enabling these feature flags may break your setup soon as we are working to phase them out in order for us to roll Pointer Events out more broadly.
+
+:::
+
 :::note
 
 Pointer Events are only implemented for the [New Architecture (Fabric)](https://reactnative.dev/docs/the-new-architecture/use-app-template) and are only available for React Native 0.71+ which at the time of writing is a release candidate.


### PR DESCRIPTION

As we get closer to enabling Pointer Events by default we want to ensure that people understand that utilizing these feature flags will cause breakages when we phase them out.
