### PR TITLE
Fix: Use correct parameter names in ReactModuleInfo constructor

### DIFF
--- a/docs/turbo-native-modules-android.md
+++ b/docs/turbo-native-modules-android.md
@@ -180,10 +180,10 @@ class NativeLocalStoragePackage : BaseReactPackage() {
   override fun getReactModuleInfoProvider() = ReactModuleInfoProvider {
     mapOf(
       NativeLocalStorageModule.NAME to ReactModuleInfo(
-        _name = NativeLocalStorageModule.NAME,
-        _className = NativeLocalStorageModule.NAME,
-        _canOverrideExistingModule = false,
-        _needsEagerInit = false,
+        name = NativeLocalStorageModule.NAME,
+        className = NativeLocalStorageModule.NAME,
+        canOverrideExistingModule = false,
+        needsEagerInit = false,
         isCxxModule = false,
         isTurboModule = true
       )

--- a/website/versioned_docs/version-0.78/turbo-native-modules-android.md
+++ b/website/versioned_docs/version-0.78/turbo-native-modules-android.md
@@ -180,10 +180,10 @@ class NativeLocalStoragePackage : BaseReactPackage() {
   override fun getReactModuleInfoProvider() = ReactModuleInfoProvider {
     mapOf(
       NativeLocalStorageModule.NAME to ReactModuleInfo(
-        _name = NativeLocalStorageModule.NAME,
-        _className = NativeLocalStorageModule.NAME,
-        _canOverrideExistingModule = false,
-        _needsEagerInit = false,
+        name = NativeLocalStorageModule.NAME,
+        className = NativeLocalStorageModule.NAME,
+        canOverrideExistingModule = false,
+        needsEagerInit = false,
         isCxxModule = false,
         isTurboModule = true
       )


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

This PR fixes the parameter names in the `ReactModuleInfo` of `NativeLocalStoragePackage` constructor call in the example code provided in the [React Native documentation](https://reactnative.dev/docs/turbo-native-modules-introduction). Previously, the parameters were passed using incorrect names (`_name`, `_className`, `_canOverrideExistingModule`, and `_needsEagerInit`), which do not match the actual parameter names expected by the constructor.

This issue was reported in: https://github.com/facebook/react-native/issues/49573