### PR TITLE
[docs] Remove Remote JavaScript Debugging

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -47,7 +47,7 @@ React Native DevTools is only available with the Hermes engine, and requires eit
 
 React Native DevTools replaces the previous Flipper, Experimental Debugger, and Hermes debugger (Chrome) frontends. If you are on an older version of React Native, please go to the docs [for your version](/versions).
 
-We continue to offer legacy debugging methods such as Direct JSC Debugging and Remote JS Debugging (deprecated) (see [Other Debugging Methods](./other-debugging-methods)).
+For apps using JavaScriptCore instead of Hermes, Direct JSC Debugging is still available (see [Other Debugging Methods](./other-debugging-methods)).
 
 React Native DevTools is designed for debugging React app concerns, and not to replace native tools. If you want to inspect React Native’s underlying platform layers (for example, while developing a Native Module), please use the debugging tools available in Xcode and Android Studio (see [Debugging Native Code](/docs/next/debugging-native-code)).
 

--- a/docs/other-debugging-methods.md
+++ b/docs/other-debugging-methods.md
@@ -25,71 +25,12 @@ While source maps may not be enabled by default, you can follow [this guide](htt
 Every time the app is reloaded, a new JSContext is created. Choosing "Automatically Show Web Inspectors for JSContexts" saves you from having to select the latest JSContext manually.
 :::
 
-## Remote JavaScript Debugging (deprecated)
+## Remote JavaScript Debugging (removed)
 
-:::warning
-Remote JavaScript Debugging is deprecated in React Native 0.73 and will be removed in a future release.
+:::warning Important
+Remote JavaScript Debugging has been removed as of React Native 0.79. See the original [deprecation announcement](https://github.com/react-native-community/discussions-and-proposals/discussions/734).
+
+If you are on an older version of React Native, please go to the docs [for your version](/versions).
 :::
-
-Remote JavaScript Debugging connects an external web browser (Chrome) to your app and runs your JavaScript code inside a web page. This allows you to use Chrome's debugger as you would with any web app. Note that the browser environment can be very different, and not all React Native modules will work when debugging this way.
-
-### Setup
-
-Since React Native 0.73, Remote JavaScript Debugging must be **manually enabled** using the `NativeDevSettings` module.
-
-```js
-import NativeDevSettings from 'react-native/Libraries/NativeModules/specs/NativeDevSettings';
-
-function MyApp() {
-  // Assign this to a dev-only button or useEffect call
-  const connectToRemoteDebugger = () => {
-    NativeDevSettings.setIsDebuggingRemotely(true);
-  };
-}
-```
-
-When `NativeDevSettings.setIsDebuggingRemotely(true)` is invoked, this will open a new tab at [http://localhost:8081/debugger-ui](http://localhost:8081/debugger-ui).
-
-From this page, open Chrome DevTools via:
-
-- View > Developer > Developer Tools
-- <kbd>⌥ Option</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>I</kbd> (macOS) / <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> (Windows and Linux).
-
-The Console and Sources panels will allow you to inspect your React Native code.
 
 ![The remote debugger window in Chrome](/docs/assets/debugging-chrome-remote-debugger.jpg)
-
-:::info
-Under Remote JavaScript Debugging, the web version of React DevTools in Chrome will not work with React Native. See the [React Native DevTools](./react-native-devtools) guide to explore how to use React DevTools in our integrated debugger.
-:::
-
-:::note
-On Android, if the times between the debugger and device have drifted, things such as animations and event behavior might not work properly. This can be fixed by running ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"``. Root access is required if using a physical device.
-:::
-
-### Debugging on a physical device
-
-:::info
-If you're using Expo CLI, this is configured for you already.
-:::
-
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
-<TabItem value="ios">
-
-On iOS devices, open the file [`RCTWebSocketExecutor.mm`](https://github.com/facebook/react-native/blob/master/packages/react-native/React/CoreModules/RCTWebSocketExecutor.mm) and change "localhost" to the IP address of your computer.
-
-</TabItem>
-<TabItem value="android">
-
-On Android 5.0+ devices connected via USB, you can use the [`adb` command line tool](http://developer.android.com/tools/help/adb.html) to set up port forwarding from the device to your computer:
-
-```sh
-adb reverse tcp:8081 tcp:8081
-```
-
-</TabItem>
-</Tabs>
-
-:::note
-If you run into any issues, it may be possible that one of your Chrome extensions is interacting in unexpected ways with the debugger. Try disabling all of your extensions and re-enabling them one-by-one until you find the problematic extension.
-:::


### PR DESCRIPTION
Accompanies https://github.com/react-native-community/discussions-and-proposals/discussions/872, landing in React Native 0.79.

<img width="1318" alt="image" src="https://github.com/user-attachments/assets/190f5696-bcf6-46a7-bbee-644d9d8bd204" />
