### PR TITLE
docs: replace usage of react-native-fast-image

### DIFF
--- a/website/versioned_docs/version-0.78/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.78/optimizing-flatlist-configuration.md
@@ -119,7 +119,7 @@ In this example, we have determined that MyListItem should be re-rendered only w
 
 ### Use cached optimized images
 
-You can use the community packages (such as [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) from [@DylanVann](https://github.com/DylanVann)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
+You can use the community packages (such as [@d11/react-native-fast-image](https://github.com/dream-sports-labs/react-native-fast-image) from [@dream-sports-labs](https://github.com/dream-sports-labs)) for more performant images. Every image in your list is a `new Image()` instance. The faster it reaches the `loaded` hook, the faster your JavaScript thread will be free again.
 
 ### Use getItemLayout
 


### PR DESCRIPTION
The maintenance of `react-native-fast-image` is not in good condition, the last commit is 3 years old and the maintainer is not very active in the community currently. Now dream-lab-sports forked it and maintains this and added support for the new architecture, so I think it's good for everyone to update this

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
