### PR TITLE
Have column reverse below column instead of on the diagonal

### DIFF
--- a/docs/flexbox.md
+++ b/docs/flexbox.md
@@ -78,7 +78,7 @@ const FlexDirectionBasics = () => {
   return (
     <PreviewLayout
       label="flexDirection"
-      values={['column', 'row', 'row-reverse', 'column-reverse']}
+      values={['column', 'row', 'column-reverse', 'row-reverse']}
       selectedValue={flexDirection}
       setSelectedValue={setflexDirection}>
       <View style={[styles.box, {backgroundColor: 'powderblue'}]} />
@@ -178,7 +178,7 @@ const FlexDirectionBasics = () => {
   return (
     <PreviewLayout
       label="flexDirection"
-      values={['column', 'row', 'row-reverse', 'column-reverse']}
+      values={['column', 'row', 'column-reverse', 'row-reverse']}
       selectedValue={flexDirection}
       setSelectedValue={setflexDirection}>
       <View style={[styles.box, {backgroundColor: 'powderblue'}]} />

--- a/website/versioned_docs/version-0.78/flexbox.md
+++ b/website/versioned_docs/version-0.78/flexbox.md
@@ -178,7 +178,7 @@ const FlexDirectionBasics = () => {
   return (
     <PreviewLayout
       label="flexDirection"
-      values={['column', 'row', 'row-reverse', 'column-reverse']}
+      values={['column', 'row', 'column-reverse', 'row-reverse']}
       selectedValue={flexDirection}
       setSelectedValue={setflexDirection}>
       <View style={[styles.box, {backgroundColor: 'powderblue'}]} />

--- a/website/versioned_docs/version-0.78/flexbox.md
+++ b/website/versioned_docs/version-0.78/flexbox.md
@@ -78,7 +78,7 @@ const FlexDirectionBasics = () => {
   return (
     <PreviewLayout
       label="flexDirection"
-      values={['column', 'row', 'row-reverse', 'column-reverse']}
+      values={['column', 'row', 'column-reverse', 'row-reverse']}
       selectedValue={flexDirection}
       setSelectedValue={setflexDirection}>
       <View style={[styles.box, {backgroundColor: 'powderblue'}]} />


### PR DESCRIPTION
Having `column-reverse` below `column` felt more natural to try it when compared to on the diagonal.

<img width="819" alt="image" src="https://github.com/user-attachments/assets/88ab47ae-6ea7-4f9f-8d1b-f401ef54e103" />
