### PR TITLE
Fix heading in codegen-cli.md

### DIFF
--- a/docs/the-new-architecture/codegen-cli.md
+++ b/docs/the-new-architecture/codegen-cli.md
@@ -39,7 +39,7 @@ npx @react-native-community/cli codegen \
     --outputPath third-party/some-library/android/generated
 ```
 
-# Including Generated Code into Libraries
+## Including Generated Code into Libraries
 
 The Codegen CLI is a great tool for library developers. It can be used to take a sneak-peek at the generated code to see which interfaces you need to implement.
 


### PR DESCRIPTION
Using an H1 here causes the TOC to entirely skip this section. See it here: https://reactnative.dev/docs/the-new-architecture/codegen-cli

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
