### PR TITLE
TextInput: update `numberOfLines` section

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -545,9 +545,13 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines`
 
-Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
+:::note
+`numberOfLines` on iOS is only available on the [New Architecture](/architecture/landing-page)
+:::
+
+Sets the maximum number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
 | Type   |
 | ------ |


### PR DESCRIPTION
https://github.com/facebook/react-native/pull/49549 Added support for the `numberOfLines` prop on iOS on the new architecture.

This PR also changes the description to say `maximum number of lines` to more accurately reflect that the behavior on the new architecture (TextInput expanding until it reaches the set limit) is the correct one.