### PR TITLE
FabricNativeComponents: Update codegen imports

### DIFF
--- a/docs/fabric-native-components.md
+++ b/docs/fabric-native-components.md
@@ -60,9 +60,8 @@ Use this specification for our WebView Component:
 <TabItem value="typescript">
 
 ```typescript title="Demo/specs/WebViewNativeComponent.ts"
-import type {HostComponent, ViewProps} from 'react-native';
-import type {BubblingEventHandler} from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type {CodegenTypes, HostComponent, ViewProps} from 'react-native';
+import {codegenNativeComponent} from 'react-native';
 
 type WebViewScriptLoadedEvent = {
   result: 'success' | 'error';
@@ -70,7 +69,7 @@ type WebViewScriptLoadedEvent = {
 
 export interface NativeProps extends ViewProps {
   sourceURL?: string;
-  onScriptLoaded?: BubblingEventHandler<WebViewScriptLoadedEvent> | null;
+  onScriptLoaded?: CodegenTypes.BubblingEventHandler<WebViewScriptLoadedEvent> | null;
 }
 
 export default codegenNativeComponent<NativeProps>(
@@ -84,9 +83,8 @@ export default codegenNativeComponent<NativeProps>(
 ```ts title="Demo/RCTWebView/js/RCTWebViewNativeComponent.js":
 // @flow strict-local
 
-import type {HostComponent, ViewProps} from 'react-native';
-import type {BubblingEventHandler} from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type {CodegenTypes, HostComponent, ViewProps} from 'react-native';
+import {codegenNativeComponent} from 'react-native';
 
 type WebViewScriptLoadedEvent = $ReadOnly<{|
   result: "success" | "error",
@@ -95,7 +93,7 @@ type WebViewScriptLoadedEvent = $ReadOnly<{|
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
   sourceURL?: string;
-  onScriptLoaded?: BubblingEventHandler<WebViewScriptLoadedEvent>?;
+  onScriptLoaded?: CodegenTypes.BubblingEventHandler<WebViewScriptLoadedEvent>?;
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(

--- a/docs/fabric-native-components.md
+++ b/docs/fabric-native-components.md
@@ -60,7 +60,11 @@ Use this specification for our WebView Component:
 <TabItem value="typescript">
 
 ```typescript title="Demo/specs/WebViewNativeComponent.ts"
-import type {CodegenTypes, HostComponent, ViewProps} from 'react-native';
+import type {
+  CodegenTypes,
+  HostComponent,
+  ViewProps,
+} from 'react-native';
 import {codegenNativeComponent} from 'react-native';
 
 type WebViewScriptLoadedEvent = {


### PR DESCRIPTION
> [!WARNING]
Pull requests mentioned here will **not** be included in React Native 0.79

Following https://github.com/facebook/react-native/pull/49854 and https://github.com/facebook/react-native/pull/49950, it's no longer recommended to use deep imports when using codegen types and functions. Instead, they should be imported from the root `react-native` package.
