### PR TITLE
Remove platform distinction on snapToAlignment

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -640,7 +640,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.70/scrollview.md
+++ b/website/versioned_docs/version-0.70/scrollview.md
@@ -641,7 +641,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.71/scrollview.md
+++ b/website/versioned_docs/version-0.71/scrollview.md
@@ -647,7 +647,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.72/scrollview.md
+++ b/website/versioned_docs/version-0.72/scrollview.md
@@ -647,7 +647,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.73/scrollview.md
+++ b/website/versioned_docs/version-0.73/scrollview.md
@@ -647,7 +647,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.74/scrollview.md
+++ b/website/versioned_docs/version-0.74/scrollview.md
@@ -645,7 +645,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.75/scrollview.md
+++ b/website/versioned_docs/version-0.75/scrollview.md
@@ -645,7 +645,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.76/scrollview.md
+++ b/website/versioned_docs/version-0.76/scrollview.md
@@ -640,7 +640,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.77/scrollview.md
+++ b/website/versioned_docs/version-0.77/scrollview.md
@@ -640,7 +640,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 

--- a/website/versioned_docs/version-0.78/scrollview.md
+++ b/website/versioned_docs/version-0.78/scrollview.md
@@ -640,7 +640,7 @@ When `true`, shows a vertical scroll indicator.
 
 ---
 
-### `snapToAlignment` <div class="label ios">iOS</div>
+### `snapToAlignment`
 
 When `snapToInterval` is set, `snapToAlignment` will define the relationship of the snapping to the scroll view.
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

The `snapToAlignment` prop has been supported in Android since 0.67 (added https://github.com/facebook/react-native/commit/c6e5640e87e7cb5b514ded2c8d4cbb039bd02c5f for vertical, https://github.com/facebook/react-native/commit/deec1db9fdf2848941326ba5bebc11f3592a301e for horizontal) so this updates all of our active docs to remove the distinction that it's only on iOS