### PR TITLE
Update the version of React Native used in the create application script to 0.79.0 from 0.76.0

### DIFF
--- a/docs/the-new-architecture/pure-cxx-modules.md
+++ b/docs/the-new-architecture/pure-cxx-modules.md
@@ -15,7 +15,7 @@ In this guide, we will go through the creation of a pure C++ Turbo Native Module
 The rest of this guide assume that you have created your application running the command:
 
 ```shell
-npx @react-native-community/cli@latest init SampleApp --version 0.76.0
+npx @react-native-community/cli@latest init SampleApp --version 0.79.0
 ```
 
 ## 1. Create the JS specs

--- a/website/versioned_docs/version-0.79/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.79/the-new-architecture/pure-cxx-modules.md
@@ -15,7 +15,7 @@ In this guide, we will go through the creation of a pure C++ Turbo Native Module
 The rest of this guide assume that you have created your application running the command:
 
 ```shell
-npx @react-native-community/cli@latest init SampleApp --version 0.76.0
+npx @react-native-community/cli@latest init SampleApp --version 0.79.0
 ```
 
 ## 1. Create the JS specs


### PR DESCRIPTION
In version 0.79.0 of [Cross-Platform Native Modules (C++)](https://reactnative.dev/docs/the-new-architecture/pure-cxx-modules#ios) the documentation tells you to create a React Native app running version 0.76.0 whereas it should be version 0.79.0

https://github.com/facebook/react-native-website/issues/4577
