### PR TITLE
Update the JSON provided in the modification of the package.json file step

### DIFF
--- a/docs/the-new-architecture/pure-cxx-modules.md
+++ b/docs/the-new-architecture/pure-cxx-modules.md
@@ -388,12 +388,13 @@ Modify the `package.json` as it follows:
      "jsSrcsDir": "specs",
      "android": {
        "javaPackageName": "com.sampleapp.specs"
-     }
      // highlight-add-start
-     "ios":
+     },
+     "ios": {
         "modulesProvider": {
           "NativeSampleModule":  "NativeSampleModuleProvider"
         }
+     }
      // highlight-add-end
    },
 

--- a/website/versioned_docs/version-0.79/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.79/the-new-architecture/pure-cxx-modules.md
@@ -388,12 +388,13 @@ Modify the `package.json` as it follows:
      "jsSrcsDir": "specs",
      "android": {
        "javaPackageName": "com.sampleapp.specs"
-     }
      // highlight-add-start
-     "ios":
+     },
+     "ios": {
         "modulesProvider": {
           "NativeSampleModule":  "NativeSampleModuleProvider"
         }
+     }
      // highlight-add-end
    },
 


### PR DESCRIPTION
In version 0.79.0 of [Cross-Platform Native Modules (C++)](https://reactnative.dev/docs/the-new-architecture/pure-cxx-modules#ios) the documentation for registering the module in the platform for iOS gives malformed JSON when explaining how to modify the `package.json` file.

https://github.com/facebook/react-native-website/issues/4579