### PR TITLE
Cleanup showcase with outdated users

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -3,7 +3,6 @@
     {
       "name": "Facebook",
       "icon": "facebook.webp",
-      "linkAppStore": "https://apps.apple.com/app/facebook/id284882215",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.katana",
       "linkMetaQuest": "https://www.meta.com/experiences/facebook/7495711360547796/",
       "pinned": true
@@ -18,7 +17,8 @@
       "name": "Facebook Ads Manager",
       "icon": "adsmanager.png",
       "linkAppStore": "https://apps.apple.com/us/app/facebook-ads-manager/id964397083",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.adsmanager"
+      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.adsmanager",
+      "pinned": true
     },
     {
       "name": "Meta Horizon",
@@ -101,12 +101,6 @@
       "icon": "amazon-kindle.png",
       "infoLink": "https://www.amazon.com/b/?node=6669702011",
       "infoTitle": "Purpose-built for reading, Kindle e-readers let you take your stories wherever you go"
-    },
-    {
-      "name": "Amazon Appstore",
-      "icon": "amazon-appstore.png",
-      "infoLink": "https://www.amazon.com/gp/mas/get/amazonapp",
-      "infoTitle": "Amazon Appstore is an app store for Android devices, all Amazon Fire tablets, and Windows 11 devices"
     }
   ],
   "shopify": [
@@ -263,15 +257,6 @@
       "pinned": true
     },
     {
-      "name": "Pinterest",
-      "icon": "pinterest.webp",
-      "linkAppStore": "https://apps.apple.com/us/app/pinterest/id429047995",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.pinterest",
-      "infoLink": "https://medium.com/@Pinterest_Engineering/supporting-react-native-at-pinterest-f8c2233f90e6",
-      "infoTitle": "Supporting React Native at Pinterest",
-      "pinned": true
-    },
-    {
       "name": "Tesla",
       "icon": "tesla.png",
       "linkAppStore": "https://apps.apple.com/us/app/tesla/id582007913",
@@ -279,31 +264,6 @@
       "infoLink": "https://www.tesla.com/blog",
       "infoTitle": "Tesla Blog",
       "pinned": true
-    },
-    {
-      "name": "Walmart Shopping & Grocery",
-      "icon": "walmart.webp",
-      "linkAppStore": "https://apps.apple.com/us/app/walmart-app-shopping-savings/id338137227",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.walmart.android",
-      "infoLink": " https://medium.com/walmartlabs/react-native-at-walmartlabs-cdd140589560#.ueonqqloc",
-      "infoTitle": "React Native at Walmart Labs",
-      "pinned": true
-    },
-    {
-      "name": "Words with Friends 2",
-      "icon": "words2.png",
-      "linkAppStore": "https://apps.apple.com/app/words-with-friends-2-word-game/id1196764367",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.zynga.words3&hl=en_US&gl=US",
-      "infoLink": "https://medium.com/zynga-engineering/why-how-words-with-friends-is-adopting-react-native-b24a405f421c",
-      "infoTitle": "Why & How Words With Friends Is Adopting React Native"
-    },
-    {
-      "name": "Call of Duty Companion App",
-      "icon": "callofduty_companion.png",
-      "linkAppStore": "https://apps.apple.com/us/app/call-of-duty-companion-app/id1405837628",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.activision.callofduty.companion",
-      "infoLink": "https://www.callofduty.com/app",
-      "infoTitle": ""
     },
     {
       "name": "Foreca",
@@ -349,7 +309,6 @@
       "name": "Gyroscope",
       "icon": "gyroscope.png",
       "linkAppStore": "https://itunes.apple.com/app/apple-store/id1104085053?pt=117927205&ct=website&mt=8",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.gyroscope.gyroscope",
       "infoLink": "https://blog.gyrosco.pe/building-the-app-1dac1a97d253",
       "infoTitle": "Building a visualization experience with React Native"
     },
@@ -362,19 +321,12 @@
       "infoTitle": "JD.com is China’s largest ecommerce company by revenue and a member of the Fortune Global 500."
     },
     {
-      "name": "Tencent QQ",
-      "icon": "qq.webp",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.tencent.mobileqq&hl=en&gl=US",
-      "infoLink": "https://www.tencent.com/en-us/business.html",
-      "infoTitle": "QQ is China's largest messaging platform, with over 829 million active accounts",
-      "pinned": true
-    },
-    {
       "name": "Bolt Food: Delivery & Takeaway",
       "icon": "bolt.png",
       "linkAppStore": "https://apps.apple.com/us/app/bolt-food/id1451492388",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.bolt.deliveryclient",
-      "infoLink": "https://medium.com/bolt-labs/how-we-built-a-react-native-app-in-2-months-aeadf210a764"
+      "infoLink": "https://medium.com/bolt-labs/how-we-built-a-react-native-app-in-2-months-aeadf210a764",
+      "pinned": true
     },
     {
       "name": "Mattermost",
@@ -388,7 +340,8 @@
       "name": "Klarna | Shop now. Pay later.",
       "icon": "klarna.jpg",
       "linkAppStore": "https://apps.apple.com/us/app/klarna-shop-now-pay-later/id1115120118",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.myklarnamobile"
+      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.myklarnamobile",
+      "pinned": true
     },
     {
       "name": "NFL",


### PR DESCRIPTION
Inspired by [this videos](https://www.youtube.com/watch?v=E3Yjx0fFeaA) I verified its claims for all the Android apps (i do not have access to a apple device at the moment to verify this on iOS).

- Facebook iOS, uses a different framework according to [a official blogpost](https://engineering.fb.com/2023/02/06/ios/facebook-ios-app-architecture).
- Amazon Appstore, [deprecated](https://www.amazon.com/gp/mas/get/amazonapp)
- Walmart, Pinterest and Tencent QQ, verified by me on Android to not use React Native, iOS claim from video seems believable
- Words with Friends 2, verified to use Unity on Android, unlikely to have a seperate iOS codebase
- Call of Duty Companion App, doesn't exist anymore

I marked some other popular apps as pinned to keep the 5x5 grid on the Home page. 