### PR TITLE
Add script for generating `llms.txt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ website/build/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+
+# Generated file(s) for llms
+llms.txt

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const readline = require('readline');
 const https = require('https');
 const url = require('url');
 const path = require('path');

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -226,10 +226,8 @@ function generateMarkdown(sidebarConfig) {
     });
   });
 
-  // Add newlines after all markdown headers
-  markdown = markdown.replace(/(#+ .*)\n/g, '\n$1\n');
-
-  return markdown;
+  // Format and cleanup whitespaces
+  return markdown.replace(/(#+ .*)\n/g, '\n$1\n').replace(/\n(\n)+/g, '\n\n');
 }
 
 const inputFilePath = './sidebars.ts';

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -246,7 +246,7 @@ if (sidebarConfig) {
       if (result.unavailableUrls.length === 0) {
         // Only generate documentation if all URLs are valid
         const markdown = generateMarkdown(sidebarConfig);
-        fs.writeFileSync(path.join('static/', OUTPUT_FILENAME), markdown);
+        fs.writeFileSync(path.join('build/', OUTPUT_FILENAME), markdown);
         console.log(
           `Successfully generated documentation to: ${OUTPUT_FILENAME}`
         );

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -43,8 +43,8 @@ function extractUrlsFromSidebar(sidebarConfig) {
   const urls = [];
 
   // Process each section (docs, api, components)
-  Object.entries(sidebarConfig).forEach(([section, categories]) => {
-    Object.entries(categories).forEach(([categoryName, items]) => {
+  Object.entries(sidebarConfig).forEach(([_, categories]) => {
+    Object.entries(categories).forEach(([_, items]) => {
       processItemsForUrls(items, urls);
     });
   });

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -1,0 +1,265 @@
+const fs = require('fs');
+const readline = require('readline');
+const https = require('https');
+const url = require('url');
+const path = require('path');
+
+const OUTPUT_FILENAME = 'llms.txt';
+const TITLE = 'React Native Documentation';
+const DESCRIPTION =
+  'React Native is a framework for building native apps using React. It lets you create mobile apps using only JavaScript and React.';
+const URL_PREFIX = 'https://reactnative.dev/docs/';
+const DOCS_PATH = '../docs/';
+
+// Function to convert the TypeScript sidebar config to JSON
+function convertSidebarConfigToJson(filePath) {
+  const fileContent = fs.readFileSync(filePath, 'utf8');
+
+  // Simple regex to extract the object between curly braces
+  const exportPattern =
+    /export default\s*({[\s\S]*?})\s*satisfies\s*SidebarsConfig;/;
+  const match = fileContent.match(exportPattern);
+
+  if (!match) {
+    console.error('Could not find the sidebar configuration object');
+    return null;
+  }
+
+  let configText = match[1];
+
+  // Manual transformation approach
+  try {
+    // First, convert the TypeScript object to a JavaScript object using Function constructor
+    const tempFn = new Function(`return ${configText}`);
+    const jsObject = tempFn();
+    return jsObject;
+  } catch (error) {
+    console.error('Error evaluating the configuration:', error);
+    return null;
+  }
+}
+
+// Function to extract URLs from sidebar config
+function extractUrlsFromSidebar(sidebarConfig) {
+  const urls = [];
+
+  // Process each section (docs, api, components)
+  Object.entries(sidebarConfig).forEach(([section, categories]) => {
+    Object.entries(categories).forEach(([categoryName, items]) => {
+      processItemsForUrls(items, urls);
+    });
+  });
+
+  return urls;
+}
+
+// Recursive function to process items and extract URLs
+function processItemsForUrls(items, urls) {
+  items.forEach(item => {
+    if (typeof item === 'string') {
+      urls.push(`${URL_PREFIX}${item}`);
+    } else if (typeof item === 'object') {
+      if (item.type === 'doc' && item.id) {
+        urls.push(`${URL_PREFIX}${item.id}`);
+      } else if (item.type === 'category' && Array.isArray(item.items)) {
+        processItemsForUrls(item.items, urls);
+      }
+    }
+  });
+}
+
+// Function to check URL status
+function checkUrl(urlString) {
+  return new Promise(resolve => {
+    const parsedUrl = url.parse(urlString);
+
+    const options = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.path,
+      method: 'HEAD',
+      timeout: 5000,
+    };
+
+    const req = https.request(options, res => {
+      resolve({
+        url: urlString,
+        status: res.statusCode,
+        is404: res.statusCode === 404,
+      });
+    });
+
+    req.on('error', error => {
+      resolve({
+        url: urlString,
+        status: 'Error',
+        is404: false,
+        error: error.message,
+      });
+    });
+
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({
+        url: urlString,
+        status: 'Timeout',
+        is404: false,
+      });
+    });
+
+    req.end();
+  });
+}
+
+// Process each URL
+async function processUrls(urls) {
+  const unavailableUrls = [];
+
+  for (const urlToCheck of urls) {
+    const result = await checkUrl(urlToCheck);
+    if (
+      result.is404 ||
+      result.status === 'Error' ||
+      result.status === 'Timeout'
+    ) {
+      unavailableUrls.push({
+        url: urlToCheck,
+        status: result.status,
+        error: result.error || null,
+      });
+    }
+  }
+
+  const result = {
+    totalUrls: urls.length,
+    unavailableUrls: unavailableUrls,
+  };
+
+  if (unavailableUrls.length > 0) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+
+  return result;
+}
+
+// Function to extract title from markdown frontmatter
+function extractTitleFromMarkdown(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const frontmatterMatch = content.match(/---\n([\s\S]*?)\n---/);
+    if (frontmatterMatch) {
+      const frontmatter = frontmatterMatch[1];
+      const titleMatch = frontmatter.match(/title:\s*(.*)/);
+      if (titleMatch) {
+        return titleMatch[1].trim();
+      }
+    }
+    // If no title found, use the filename
+    return filePath.split('/').pop().replace('.md', '');
+  } catch (error) {
+    console.error(`Error reading file ${filePath}:`, error);
+    return filePath.split('/').pop().replace('.md', '');
+  }
+}
+
+// Function to map special cases for file names that don't match the sidebar
+function mapDocPath(item) {
+  const specialCases = {
+    'environment-setup': 'getting-started.md',
+    'native-platform': 'native-platforms.md',
+    'turbo-native-modules-introduction': 'turbo-native-modules.md',
+    'fabric-native-components-introduction': 'fabric-native-components.md',
+  };
+
+  if (typeof item === 'string') {
+    return specialCases[item] || `${item}.md`;
+  } else if (item.type === 'doc' && item.id) {
+    return specialCases[item.id] || `${item.id}.md`;
+  }
+  return `${item}.md`;
+}
+
+// Function to generate markdown documentation
+function generateMarkdown(sidebarConfig) {
+  let markdown = `# ${TITLE}\n\n`;
+  markdown += `> ${DESCRIPTION}\n\n`;
+  markdown += `This documentation covers all aspects of using React Native, from installation to advanced usage.\n\n`;
+
+  // Process each section (docs, api, components)
+  Object.entries(sidebarConfig).forEach(([section, categories]) => {
+    markdown += `## ${section.charAt(0).toUpperCase() + section.slice(1)}\n\n`;
+
+    // Process each category within the section
+    Object.entries(categories).forEach(([categoryName, items]) => {
+      markdown += `### ${categoryName}\n\n`;
+
+      // Process each item in the category
+      items.forEach(item => {
+        if (typeof item === 'string') {
+          // This is a direct page reference
+          const docPath = `${DOCS_PATH}${mapDocPath(item)}`;
+          const title = extractTitleFromMarkdown(docPath);
+          markdown += `- [${title}](${URL_PREFIX}${item})\n`;
+        } else if (typeof item === 'object') {
+          if (item.type === 'doc' && item.id) {
+            // This is a doc reference with an explicit ID
+            const docPath = `${DOCS_PATH}${mapDocPath(item)}`;
+            const title = extractTitleFromMarkdown(docPath);
+            markdown += `- [${title}](${URL_PREFIX}${item.id})\n`;
+          } else if (item.type === 'category' && Array.isArray(item.items)) {
+            // This is a category with nested items
+            markdown += `#### ${item.label}\n\n`;
+            item.items.forEach(nestedItem => {
+              if (typeof nestedItem === 'string') {
+                const docPath = `${DOCS_PATH}${mapDocPath(nestedItem)}`;
+                const title = extractTitleFromMarkdown(docPath);
+                markdown += `- [${title}](${URL_PREFIX}${nestedItem})\n`;
+              } else if (nestedItem.type === 'doc' && nestedItem.id) {
+                const docPath = `${DOCS_PATH}${mapDocPath(nestedItem)}`;
+                const title = extractTitleFromMarkdown(docPath);
+                markdown += `- [${title}](${URL_PREFIX}${nestedItem.id})\n`;
+              }
+            });
+          }
+        }
+      });
+    });
+  });
+
+  // Add newlines after all markdown headers
+  markdown = markdown.replace(/(#+ .*)\n/g, '\n$1\n');
+
+  return markdown;
+}
+
+const inputFilePath = './sidebars.ts';
+const outputFilePath = inputFilePath.replace(/\.tsx?$/, '-urls.txt');
+
+const sidebarConfig = convertSidebarConfigToJson(inputFilePath);
+if (sidebarConfig) {
+  const urls = extractUrlsFromSidebar(sidebarConfig);
+
+  // First check URLs for 404 errors
+  processUrls(urls)
+    .then(result => {
+      if (result.unavailableUrls.length === 0) {
+        // Only generate documentation if all URLs are valid
+        const markdown = generateMarkdown(sidebarConfig);
+        fs.writeFileSync(path.join('static/', OUTPUT_FILENAME), markdown);
+        console.log(
+          `Successfully generated documentation to: ${OUTPUT_FILENAME}`
+        );
+      } else {
+        console.error('Documentation generation skipped due to broken links');
+        process.exit(1);
+      }
+    })
+    .catch(err => {
+      console.error('Error processing URLs:', err);
+      process.exit(1);
+    });
+} else {
+  console.error('Failed to convert sidebar config to JSON');
+  process.exit(1);
+}

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -314,7 +314,6 @@ const generateOutput = () => {
 
   for (const {name, docPath, prefix} of inputFilePaths) {
     const inputFilePath = `./${name}`;
-    const outputFilePath = inputFilePath.replace(/\.tsx?$/, '-urls.txt');
 
     const sidebarConfig = convertSidebarConfigToJson(inputFilePath);
     if (sidebarConfig) {
@@ -326,7 +325,7 @@ const generateOutput = () => {
           if (result.unavailableUrls.length === 0) {
             // Only generate documentation if all URLs are valid
             const markdown = generateMarkdown(sidebarConfig, docPath, prefix);
-            results.push({ markdown, prefix });
+            results.push({markdown, prefix});
             console.log(`Successfully generated output from ${inputFilePath}`);
           } else {
             console.error(
@@ -359,7 +358,7 @@ const generateOutput = () => {
 
       // Combine all markdown content in the correct order
       output += results.map(r => r.markdown).join('\n');
-      
+
       fs.writeFileSync(path.join('build/', OUTPUT_FILENAME), output);
       console.log(
         `Successfully generated documentation to: ${OUTPUT_FILENAME}`

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build && yarn run update-redirect ./build/_redirects ./versions.json && node ../scripts/generate-llms-txt.js",
+    "build": "docusaurus build && yarn run update-redirect ./build/_redirects ./versions.json && yarn run generate-llms-txt",
     "build:fast": "PREVIEW_DEPLOY=true yarn run build",
     "tsc": "npx tsc --noEmit",
     "swizzle": "docusaurus swizzle",
@@ -35,7 +35,8 @@
     "language:lint": "cd ../ && alex && case-police 'docs/*.md' -d ./website/react-native-dict.json --disable SDK,URI",
     "language:lint:versioned": "cd ../ && alex . && case-police '**/*.md' -d ./website/react-native-dict.json --disable SDK,URI",
     "ci:lint": "yarn lint && yarn lint:examples && yarn lint:versioned && yarn language:lint:versioned && yarn lint:markdown && yarn lint:format",
-    "pwa:generate": "npx pwa-asset-generator ./static/img/header_logo.svg ./static/img/pwa --padding '40px' --background 'rgb(32, 35, 42)' --icon-only --opaque true"
+    "pwa:generate": "npx pwa-asset-generator ./static/img/header_logo.svg ./static/img/pwa --padding '40px' --background 'rgb(32, 35, 42)' --icon-only --opaque true",
+    "generate-llms-txt": "node ../scripts/generate-llms-txt.js"
   },
   "browserslist": {
     "production": [

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build && yarn run update-redirect ./build/_redirects ./versions.json",
+    "build": "docusaurus build && yarn run update-redirect ./build/_redirects ./versions.json && node ../scripts/generate-llms-txt.js",
     "build:fast": "PREVIEW_DEPLOY=true yarn run build",
     "tsc": "npx tsc --noEmit",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## What
Adds a script that generates [`llms.txt`](https://llms.txt) - a single file containing all React Native documentation in a format optimized for LLMs. The file is generated during the website build process.

## Why
- Makes it easier for LLMs to understand and reference React Native documentation
- Provides a single, clean source of truth for documentation
- Helps LLMs give more accurate and up-to-date answers about React Native

## How
- New script `scripts/generate-llms-txt.js` that:
  - Parses sidebar config
  - Validates all doc URLs
  - Generates a clean markdown file
- Added to build process
- Added to `.gitignore`

## Testing
- Verified all URLs are valid
- Checked generated markdown structure
- Tested build process