### PR TITLE
fix: override getTaskConfig method signature

### DIFF
--- a/docs/headless-js-android.md
+++ b/docs/headless-js-android.md
@@ -76,7 +76,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 
 class MyTaskService : HeadlessJsTaskService() {
-    override fun getTaskConfig(intent: Intent): HeadlessJsTaskConfig? {
+    override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig? {
         return intent.extras?.let {
             HeadlessJsTaskConfig(
                 "SomeTaskName",


### PR DESCRIPTION
- The original sample code signature doesn't match the HeadlessJsTaskService rewritten in Kotlin: https://github.com/facebook/react-native/blob/1156c08ac4d1fd9f782c87864d63c3f152f93734/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt#L56

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
