### PR TITLE
[RNW][Deps] Bump babel dependencies to solve vulnerability issues

### DIFF
--- a/scripts/lint-examples/package.json
+++ b/scripts/lint-examples/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.4",
-    "@babel/runtime": "^7.25.6",
+    "@babel/runtime": "^7.26.10",
     "@react-native-community/slider": "^4.5.3",
     "@react-native/babel-preset": "^0.76.0-rc.2",
     "@react-native/eslint-config": "^0.76.0-rc.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,12 +1877,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.6, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
-  version: 7.26.7
-  resolution: "@babel/runtime@npm:7.26.7"
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.25.9, @babel/runtime@npm:^7.26.10, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+  version: 7.27.0
+  resolution: "@babel/runtime@npm:7.27.0"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
-  checksum: 10c0/60199c049f90e5e41c687687430052a370aca60bac7859ff4ee761c5c1739b8ba1604d391d01588c22dc0e93828cbadb8ada742578ad1b1df240746bce98729a
+  checksum: 10c0/35091ea9de48bd7fd26fb177693d64f4d195eb58ab2b142b893b7f3fa0f1d7c677604d36499ae0621a3703f35ba0c6a8f6c572cc8f7dc0317213841e493cf663
   languageName: node
   linkType: hard
 
@@ -3849,7 +3849,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.4"
-    "@babel/runtime": "npm:^7.25.6"
+    "@babel/runtime": "npm:^7.26.10"
     "@react-native-community/slider": "npm:^4.5.3"
     "@react-native/babel-preset": "npm:^0.76.0-rc.2"
     "@react-native/eslint-config": "npm:^0.76.0-rc.2"


### PR DESCRIPTION
Our internal tools detected that versions <7.26.10 of @babel/runtime, @babel/runtime-core3j and @babel/helpers suffers from some vulnerability.

This change bumps those packages to ensure that the minimum version we are using is 7.26.10 that fixes those vulnerabilities.

## Changelog:
[Security] - Bump @babel dependencies to fix vulnerabilities.
