### PR TITLE
[RNW]Fix missing license in css files

### DIFF
--- a/website/src/theme/Blog/Components/Author/styles.module.css
+++ b/website/src/theme/Blog/Components/Author/styles.module.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .authorImage {
   background: var(--home-hero-grid-icon);
   --ifm-avatar-photo-size: 3.6rem;

--- a/website/src/theme/DocItem/Footer/styles.module.css
+++ b/website/src/theme/DocItem/Footer/styles.module.css
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 .lastUpdated {
   margin-top: 0.2rem;
   font-style: italic;


### PR DESCRIPTION
Our internal system noticed a couple of .css files that were missing the license.

This change adds the licenses to those files
