### PR TITLE
[blog] Truncate preview for CC Summit 2024 post

### DIFF
--- a/website/blog/2025-02-03-react-native-core-contributor-summit-2024.md
+++ b/website/blog/2025-02-03-react-native-core-contributor-summit-2024.md
@@ -12,6 +12,8 @@ Last year was no different—with small exception. We usually meet a day before 
 
 ![all-participants](../static/blog/assets/react-native-core-contributor-summit-2024-1.jpeg)
 
+<!--truncate-->
+
 This annual tradition has become a valuable opportunity for contributors to share insights and voice their concerns, and for the core team to share their plans and gather feedback from key contributors to the React Native ecosystem—including partner companies, individual library authors and friends.
 
 We divided the Summit into two tracks covering following topics:


### PR DESCRIPTION
Previously showed entire post in the blog index page. Now correctly displays an excerpt.

<img width="737" alt="image" src="https://github.com/user-attachments/assets/736c0f84-d327-4c83-b423-319b8db60ee4" />