### PR TITLE
Remove outdated entries in React Native showcase 

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -3,6 +3,7 @@
     {
       "name": "Facebook",
       "icon": "facebook.webp",
+      "linkAppStore": "https://apps.apple.com/app/facebook/id284882215",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.katana",
       "linkMetaQuest": "https://www.meta.com/experiences/facebook/7495711360547796/",
       "pinned": true
@@ -65,14 +66,6 @@
       "icon": "xboxgamepass.png",
       "linkAppStore": "https://apps.apple.com/gb/app/xbox-game-pass/id1374542474",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.gamepass",
-      "infoLink": "https://devblogs.microsoft.com/react-native/",
-      "pinned": true
-    },
-    {
-      "name": "Skype",
-      "icon": "skype.webp",
-      "linkAppStore": "https://apps.apple.com/us/app/skype-for-iphone/id304878510",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.skype.raider",
       "infoLink": "https://devblogs.microsoft.com/react-native/",
       "pinned": true
     }

--- a/website/showcase.json
+++ b/website/showcase.json
@@ -75,7 +75,8 @@
       "name": "Amazon Shopping",
       "icon": "amazon-shopping.png",
       "linkAppStore": "https://apps.apple.com/us/app/amazon-shopping/id297606951",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.amazon.mShop.android.shopping"
+      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.amazon.mShop.android.shopping",
+      "pinned": true
     },
     {
       "name": "Amazon Alexa",

--- a/website/showcase.json
+++ b/website/showcase.json
@@ -3,7 +3,6 @@
     {
       "name": "Facebook",
       "icon": "facebook.webp",
-      "linkAppStore": "https://apps.apple.com/app/facebook/id284882215",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.katana",
       "linkMetaQuest": "https://www.meta.com/experiences/facebook/7495711360547796/",
       "pinned": true
@@ -18,7 +17,8 @@
       "name": "Facebook Ads Manager",
       "icon": "adsmanager.png",
       "linkAppStore": "https://apps.apple.com/us/app/facebook-ads-manager/id964397083",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.adsmanager"
+      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.facebook.adsmanager",
+      "pinned": true
     },
     {
       "name": "Meta Horizon",
@@ -101,12 +101,6 @@
       "icon": "amazon-kindle.png",
       "infoLink": "https://www.amazon.com/b/?node=6669702011",
       "infoTitle": "Purpose-built for reading, Kindle e-readers let you take your stories wherever you go"
-    },
-    {
-      "name": "Amazon Appstore",
-      "icon": "amazon-appstore.png",
-      "infoLink": "https://www.amazon.com/gp/mas/get/amazonapp",
-      "infoTitle": "Amazon Appstore is an app store for Android devices, all Amazon Fire tablets, and Windows 11 devices"
     }
   ],
   "shopify": [
@@ -263,15 +257,6 @@
       "pinned": true
     },
     {
-      "name": "Pinterest",
-      "icon": "pinterest.webp",
-      "linkAppStore": "https://apps.apple.com/us/app/pinterest/id429047995",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.pinterest",
-      "infoLink": "https://medium.com/@Pinterest_Engineering/supporting-react-native-at-pinterest-f8c2233f90e6",
-      "infoTitle": "Supporting React Native at Pinterest",
-      "pinned": true
-    },
-    {
       "name": "Tesla",
       "icon": "tesla.png",
       "linkAppStore": "https://apps.apple.com/us/app/tesla/id582007913",
@@ -279,31 +264,6 @@
       "infoLink": "https://www.tesla.com/blog",
       "infoTitle": "Tesla Blog",
       "pinned": true
-    },
-    {
-      "name": "Walmart Shopping & Grocery",
-      "icon": "walmart.webp",
-      "linkAppStore": "https://apps.apple.com/us/app/walmart-app-shopping-savings/id338137227",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.walmart.android",
-      "infoLink": " https://medium.com/walmartlabs/react-native-at-walmartlabs-cdd140589560#.ueonqqloc",
-      "infoTitle": "React Native at Walmart Labs",
-      "pinned": true
-    },
-    {
-      "name": "Words with Friends 2",
-      "icon": "words2.png",
-      "linkAppStore": "https://apps.apple.com/app/words-with-friends-2-word-game/id1196764367",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.zynga.words3&hl=en_US&gl=US",
-      "infoLink": "https://medium.com/zynga-engineering/why-how-words-with-friends-is-adopting-react-native-b24a405f421c",
-      "infoTitle": "Why & How Words With Friends Is Adopting React Native"
-    },
-    {
-      "name": "Call of Duty Companion App",
-      "icon": "callofduty_companion.png",
-      "linkAppStore": "https://apps.apple.com/us/app/call-of-duty-companion-app/id1405837628",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.activision.callofduty.companion",
-      "infoLink": "https://www.callofduty.com/app",
-      "infoTitle": ""
     },
     {
       "name": "Foreca",
@@ -349,7 +309,6 @@
       "name": "Gyroscope",
       "icon": "gyroscope.png",
       "linkAppStore": "https://itunes.apple.com/app/apple-store/id1104085053?pt=117927205&ct=website&mt=8",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.gyroscope.gyroscope",
       "infoLink": "https://blog.gyrosco.pe/building-the-app-1dac1a97d253",
       "infoTitle": "Building a visualization experience with React Native"
     },
@@ -362,19 +321,12 @@
       "infoTitle": "JD.com is China’s largest ecommerce company by revenue and a member of the Fortune Global 500."
     },
     {
-      "name": "Tencent QQ",
-      "icon": "qq.webp",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.tencent.mobileqq&hl=en&gl=US",
-      "infoLink": "https://www.tencent.com/en-us/business.html",
-      "infoTitle": "QQ is China's largest messaging platform, with over 829 million active accounts",
-      "pinned": true
-    },
-    {
       "name": "Bolt Food: Delivery & Takeaway",
       "icon": "bolt.png",
       "linkAppStore": "https://apps.apple.com/us/app/bolt-food/id1451492388",
       "linkPlayStore": "https://play.google.com/store/apps/details?id=com.bolt.deliveryclient",
-      "infoLink": "https://medium.com/bolt-labs/how-we-built-a-react-native-app-in-2-months-aeadf210a764"
+      "infoLink": "https://medium.com/bolt-labs/how-we-built-a-react-native-app-in-2-months-aeadf210a764",
+      "pinned": true
     },
     {
       "name": "Mattermost",
@@ -388,7 +340,8 @@
       "name": "Klarna | Shop now. Pay later.",
       "icon": "klarna.jpg",
       "linkAppStore": "https://apps.apple.com/us/app/klarna-shop-now-pay-later/id1115120118",
-      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.myklarnamobile"
+      "linkPlayStore": "https://play.google.com/store/apps/details?id=com.myklarnamobile",
+      "pinned": true
     },
     {
       "name": "NFL",


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native-website/issues/4588 

This PR removes several apps that no longer use React Native or are no longer available including:
- Skype ([Shutting Down May 2025](https://support.microsoft.com/en-us/skype/skype-is-retiring-in-may-2025-what-you-need-to-know-2a7d2501-427f-485e-8be0-2068a9f90472#:~:text=As%20of%20May%205th%2C%202025,same%20core%20features%20and%20more.))
- Amazon App Store ([deprecated](https://www.amazon.com/gp/mas/appstore/android/faq))
- Pinterest - No longer uses React Native
- Walmart Shopping & Grocery - Walmart uses React Native in other areas of the business, but not in the main grocery app. 
- Words with Friends 2 - uses Unity
- Call of Duty Companion App - No longer available
- Tencent QQ
- Gyroscope (Android)


Thank you to @ginnyTheCat for the [Original PR](https://github.com/facebook/react-native-website/pull/4586) which I based this on
(Note: I verified with Meta that all of the information on the existing Meta apps in the showcase is correct, so I'm leaving in the Facebook iOS app. )

# Visuals

![CleanShot 2025-05-12 at 13 44 03@2x](https://github.com/user-attachments/assets/1b3d12f3-ded3-4b6d-89c6-e9cf9717c5ed)


![CleanShot 2025-05-12 at 13 44 09@2x](https://github.com/user-attachments/assets/06000b27-509c-4a3d-aba8-bc260f24d227)

![CleanShot 2025-05-12 at 13 45 32@2x](https://github.com/user-attachments/assets/7954bee5-4970-4279-abda-10f24f7bf074)

