### PR TITLE
Update React's web address

### DIFF
--- a/website/versioned_docs/version-0.79/intro-react-native-components.md
+++ b/website/versioned_docs/version-0.79/intro-react-native-components.md
@@ -6,7 +6,7 @@ description: 'React Native lets you compose app interfaces using Native Componen
 
 import ThemedImage from '@theme/ThemedImage';
 
-React Native is an open source framework for building Android and iOS applications using [React](https://reactjs.org/) and the app platform’s native capabilities. With React Native, you use JavaScript to access your platform’s APIs as well as to describe the appearance and behavior of your UI using React components: bundles of reusable, nestable code. You can learn more about React in the next section. But first, let’s cover how components work in React Native.
+React Native is an open source framework for building Android and iOS applications using [React](https://react.dev/) and the app platform’s native capabilities. With React Native, you use JavaScript to access your platform’s APIs as well as to describe the appearance and behavior of your UI using React components: bundles of reusable, nestable code. You can learn more about React in the next section. But first, let’s cover how components work in React Native.
 
 ## Views and mobile development
 


### PR DESCRIPTION
Updated the React web address to https://react.dev/ from the old and non-functional reactjs.org.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
