### PR TITLE
Add display: 'contents'

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -547,11 +547,11 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 `display` sets the display type of this component.
 
-It works similarly to `display` in CSS but only supports 'flex' and 'none'. 'flex' is the default.
+It works similarly to `display` in CSS but only supports the values 'flex', 'none', and 'contents'. The default is `flex`.
 
-| Type                 | Required |
-| -------------------- | -------- |
-| enum('none', 'flex') | No       |
+| Type                             | Required |
+| -------------------------------- | -------- |
+| enum('none', 'flex', 'contents') | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.77/layout-props.md
+++ b/website/versioned_docs/version-0.77/layout-props.md
@@ -547,11 +547,11 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 `display` sets the display type of this component.
 
-It works similarly to `display` in CSS but only supports 'flex' and 'none'. 'flex' is the default.
+It works similarly to `display` in CSS but only supports the values 'flex', 'none', and 'contents'. The default is `flex`.
 
-| Type                 | Required |
-| -------------------- | -------- |
-| enum('none', 'flex') | No       |
+| Type                             | Required |
+| -------------------------------- | -------- |
+| enum('none', 'flex', 'contents') | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.78/layout-props.md
+++ b/website/versioned_docs/version-0.78/layout-props.md
@@ -547,11 +547,11 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 `display` sets the display type of this component.
 
-It works similarly to `display` in CSS but only supports 'flex' and 'none'. 'flex' is the default.
+It works similarly to `display` in CSS but only supports the values 'flex', 'none', and 'contents'. The default is `flex`.
 
-| Type                 | Required |
-| -------------------- | -------- |
-| enum('none', 'flex') | No       |
+| Type                             | Required |
+| -------------------------------- | -------- |
+| enum('none', 'flex', 'contents') | No       |
 
 ---
 

--- a/website/versioned_docs/version-0.79/layout-props.md
+++ b/website/versioned_docs/version-0.79/layout-props.md
@@ -547,11 +547,11 @@ See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom for more details of 
 
 `display` sets the display type of this component.
 
-It works similarly to `display` in CSS but only supports 'flex' and 'none'. 'flex' is the default.
+It works similarly to `display` in CSS but only supports the values 'flex', 'none', and 'contents'. The default is `flex`.
 
-| Type                 | Required |
-| -------------------- | -------- |
-| enum('none', 'flex') | No       |
+| Type                             | Required |
+| -------------------------------- | -------- |
+| enum('none', 'flex', 'contents') | No       |
 
 ---
 


### PR DESCRIPTION
Adds the missing `contents` value to the `display` property.
https://reactnative.dev/blog/2025/01/21/version-0.77#simpler-layouts-with-display-contents


#4616 

