### PR TITLE
Add support for TargetEvent type in focus, blur callbacks

### DIFF
--- a/docs/layoutevent.md
+++ b/docs/layoutevent.md
@@ -55,7 +55,7 @@ Component Y coordinate inside the parent component.
 
 ### `target`
 
-The node id of the element receiving the PressEvent.
+The node id of the element receiving the LayoutEvent.
 
 | Type                        | Optional |
 | --------------------------- | -------- |

--- a/docs/targetevent.md
+++ b/docs/targetevent.md
@@ -1,0 +1,29 @@
+---
+id: targetevent
+title: TargetEvent Object Type
+---
+
+`TargetEvent` object is returned in the callback as a result of focus change, for example `onFocus` or `onBlur` in the [TextInput](textinput) component.
+
+## Example
+
+```js
+{
+    target: 1127
+}
+```
+
+## Keys and values
+
+### `target`
+
+The node id of the element receiving the TargetEvent.
+
+| Type                        | Optional |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |
+
+## Used by
+
+- [`TextInput`](textinput)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback)

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -565,9 +565,9 @@ Callback that is called when the text input is blurred.
 
 > Note: If you are attempting to access the `text` value from `nativeEvent` keep in mind that the resulting value you get can be `undefined` which can cause unintended errors. If you are trying to find the last value of TextInput, you can use the [`onEndEditing`](textinput#onendediting) event, which is fired upon completion of editing.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| `md ({nativeEvent: [TargetEvent](targetevent)}) => void` |
 
 ---
 
@@ -639,7 +639,7 @@ Callback that is called when the text input is focused.
 
 | Type                                                     |
 | -------------------------------------------------------- |
-| `md ({nativeEvent: [LayoutEvent](layoutevent)}) => void` |
+| `md ({nativeEvent: [TargetEvent](targetevent)}) => void` |
 
 ---
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -424,9 +424,9 @@ Used to locate this view from native code. Has precedence over `nativeID` prop.
 
 Invoked when the item loses focus.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| `md ({nativeEvent: [TargetEvent](targetevent)}) => void` |
 
 ---
 
@@ -434,9 +434,9 @@ Invoked when the item loses focus.
 
 Invoked when the item receives focus.
 
-| Type     |
-| -------- |
-| function |
+| Type                                                     |
+| -------------------------------------------------------- |
+| `md ({nativeEvent: [TargetEvent](targetevent)}) => void` |
 
 ---
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -299,6 +299,7 @@ export default {
       'pressevent',
       'react-node',
       'rect',
+      'targetevent',
       'viewtoken',
     ],
   },


### PR DESCRIPTION
## Summary
The documentation for `onBlur` and `onFocus` events either omits the native event type or incorrectly points to `LayoutEvent` as the event type. This should fix the issue

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
