### PR TITLE
Add targetevent to sidebar

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -299,6 +299,7 @@ export default {
       'pressevent',
       'react-node',
       'rect',
+      'targetevent',
       'viewtoken',
     ],
   },


### PR DESCRIPTION
Without landing https://github.com/facebook/react-native-website/pull/4618, adding this sidebar link resolves to a 404 and the build fails

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
