### PR TITLE
Add targetevent to current versioned doc

### DIFF
--- a/website/versioned_docs/version-0.79/targetevent.md
+++ b/website/versioned_docs/version-0.79/targetevent.md
@@ -1,0 +1,29 @@
+---
+id: targetevent
+title: TargetEvent Object Type
+---
+
+`TargetEvent` object is returned in the callback as a result of focus change, for example `onFocus` or `onBlur` in the [TextInput](textinput) component.
+
+## Example
+
+```
+{
+    target: 1127
+}
+```
+
+## Keys and values
+
+### `target`
+
+The node id of the element receiving the TargetEvent.
+
+| Type                        | Optional |
+| --------------------------- | -------- |
+| number, `null`, `undefined` | No       |
+
+## Used by
+
+- [`TextInput`](textinput)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback)


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

The URL checker that's failing in #4622 is for the current version of docs (0.79), not the *next* version of docs. This copies the `targetevent` file event though it's not being referenced in 0.79 to satisfy a build step
