### PR TITLE
[scripts] LLMS: skip non-existing yet URLs instead of failing

### DIFF
--- a/website/sidebarsArchitecture.ts
+++ b/website/sidebarsArchitecture.ts
@@ -20,6 +20,7 @@ export default {
             'xplat-implementation',
             'view-flattening',
             'threading-model',
+            'test-123',
           ],
         },
         {

--- a/website/sidebarsArchitecture.ts
+++ b/website/sidebarsArchitecture.ts
@@ -20,7 +20,6 @@ export default {
             'xplat-implementation',
             'view-flattening',
             'threading-model',
-            'test-123',
           ],
         },
         {


### PR DESCRIPTION
# Why

We spotted that LLMS generation script fails  in PR preview deployments when contributor adds a new page, which is not yet in the PROD.

Refs: 
* https://github.com/facebook/react-native-website/pull/4626#issuecomment-2918132359

# How

Instead of failing whole build, skip non-existing URLs and warn about them in logs. All path defined in sidebar should exist, so if there is sth random added the build will still fail, but in the cases when the problem is just with fresh pages missing on PROD this should help, and unblock contributions.

# Tests plan

1. Add random, non existing section, make sure that generation scripts works
2. Remove the bogus sidebar entry before merging.

## Preview

![Screenshot 2025-06-03 at 17 49 13](https://github.com/user-attachments/assets/dae28f5d-ab9b-4ce5-914a-c82343b27f19)
