### PR TITLE
Fix DocsRating DOM error with browser translation

### DIFF
--- a/website/core/DocsRating.tsx
+++ b/website/core/DocsRating.tsx
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React, {useState} from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
-import {useState} from 'react';
 
 const DocsRating = ({label}) => {
   const isBrowser = useIsBrowser();


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

The `DocsRating` component crashes with a DOM manipulation error when users have browser translation enabled and click the thumbs up/down buttons.


https://github.com/user-attachments/assets/e2969cd5-235b-4200-aee1-baec77ffa1ba


When the component initially renders, the React Fragment causes the text node "Is this page useful?" and SVG elements to be directly attached to the parent div without any wrapper container. The browser's translation feature then detects this text node and directly manipulates the DOM to replace it with translated content, which modifies the DOM structure outside of React's control.

When a user clicks the thumbs up or down button, it triggers `setHaveVoted(true)`, causing React to re-render and attempt to remove the existing Fragment content from the DOM. However, since the translation tool has already altered the DOM structure, the nodes that React expects to find are no longer in their original positions or have been replaced entirely, leading to a mismatch between React's virtual DOM and the actual DOM.

This discrepancy causes React to fail when trying to remove child nodes that are no longer children of their expected parent, ultimately resulting in the "removeChild failed - not a child" error being thrown.

So I replaced `<>` Fragment with `<div>` in DocsRating component. So now, even when translation tools modify the internal text, the div container itself remains intact.


https://github.com/user-attachments/assets/730d4eaf-6d46-4997-8674-3d34e48ed315

