### PR TITLE
Clarify specific CLI and RN versions in init command

### DIFF
--- a/docs/get-started-without-a-framework.md
+++ b/docs/get-started-without-a-framework.md
@@ -41,10 +41,10 @@ If you are having trouble with iOS, try to reinstall the dependencies by running
 
 #### [Optional] Using a specific version or template
 
-If you want to start a new project with a specific React Native version, you can use the `--version` argument:
+If you want to start a new project with a specific CLI and React Native version, you can use the `--version` argument:
 
 ```shell
-npx @react-native-community/cli@X.XX.X init AwesomeProject --version X.XX.X
+npx @react-native-community/cli@X.XX.X init AwesomeProject --version Y.YY.Y
 ```
 
 You can also start a project with a custom React Native template with the `--template` argument, read more [here](https://github.com/react-native-community/cli/blob/main/docs/init.md#initializing-project-with-custom-template).


### PR DESCRIPTION
Clarify specific CLI and RN versions. Previously, it was not super clear that X.XX.X and X.XX.X were not supposed to be the same versions.