### PR TITLE
fix: incorrect link for opting out of deep imports deprecation warning

### DIFF
--- a/website/blog/2025-06-12-react-native-0.80.md
+++ b/website/blog/2025-06-12-react-native-0.80.md
@@ -30,7 +30,7 @@ Moreover, the Legacy Architecture of React Native is now officially frozen, and 
 
 In this release, we are making moves to improve and stabilize React Native's public JavaScript API. The first step towards this is better scoping of which of our APIs are importable by apps and frameworks. In line with this, we are formally deprecating deep imports from React Native ([see RFC](https://github.com/react-native-community/discussions-and-proposals/pull/894)), and are introducing warnings via ESLint and the JS console.
 
-These warnings are scoped to imports from within your project's source code, and can be [opted out from](/docs/strict-typescript-api). However, please bear in mind that we aim to remove deep imports from React Native's API in a future release, and these should instead be updated to the root import.
+These warnings are scoped to imports from within your project's source code, and can be [opted out from](https://reactnative.dev/blog/2025/06/12/moving-towards-a-stable-javascript-api#deprecating-deep-imports-from-react-native). However, please bear in mind that we aim to remove deep imports from React Native's API in a future release, and these should instead be updated to the root import.
 
 ```js
 // Before - import from subpath


### PR DESCRIPTION
**The opt-out link provided in the React Native 0.80 release blog post is currently not working.**
(https://reactnative.dev/docs/strict-typescript-api)

I found a section in the “Moving Towards a Stable JavaScript API” blog post that explains how to opt out of the ESLint warning.
**I’ve replaced the broken link with the link to that section.**

In my opinion, this replacement isn’t ideal since the link doesn’t directly jump to the opt-out instructions.
However, it seems to be the best available alternative for now.