### PR TITLE
Reword accessible prop in accessiblity guide

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -14,18 +14,20 @@ Android and iOS differ slightly in their approaches, and thus the React Native i
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
+When `true`, indicates that the view is discoverable by assistive technologies such as screen readers and hardware keyboards. Note that this does not necessarily mean that the view will be focused by VoiceOver or TalkBack. There are a number of reasons for this, such as VoiceOver disallowing nested acecssibility elements, or TalkBack opting to focus some parent element instead.
 
-On Android, `accessible={true}` property for a react-native View will be translated into native `focusable={true}`.
+By default, all touchable elements are accessible.
+
+On Android, `accessible` will be translated into native [`focusable`](<https://developer.android.com/reference/android/view/View#setFocusable(boolean)>). On iOS, it translates into native [`isAccessibilityElement`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/isaccessibilityelement?language=objc).
 
 ```tsx
-<View accessible={true}>
-  <Text>text one</Text>
-  <Text>text two</Text>
+<View>
+  <View accessible={true} />
+  <View />
 </View>
 ```
 
-In the above example, accessibility focus is only available on the parent view with the `accessible` property, and not individually for 'text one' and 'text two'.
+In the above example, accessibility focus is only available on the first child view with the `accessible` property, and not for the parent or sibling without `accessible`.
 
 ### `accessibilityLabel`
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -206,7 +206,9 @@ See the [Accessibility guide](accessibility.md#accessibilityviewismodal-ios) for
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. By default, all the touchable elements are accessible.
+When `true`, indicates that the view is an accessibility element and discoverable by assistive technologies such as screen readers and hardware keyboards. By default, all the touchable elements are accessible.
+
+See the [Accessibility guide](accessibility.md#accessible) for more information.
 
 ---
 

--- a/website/versioned_docs/version-0.78/accessibility.md
+++ b/website/versioned_docs/version-0.78/accessibility.md
@@ -14,18 +14,20 @@ Android and iOS differ slightly in their approaches, and thus the React Native i
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
+When `true`, indicates that the view is discoverable by assistive technologies such as screen readers and hardware keyboards. Note that this does not necessarily mean that the view will be focused by VoiceOver or TalkBack. There are a number of reasons for this, such as VoiceOver disallowing nested acecssibility elements, or TalkBack opting to focus some parent element instead.
 
-On Android, `accessible={true}` property for a react-native View will be translated into native `focusable={true}`.
+By default, all touchable elements are accessible.
+
+On Android, `accessible` will be translated into native [`focusable`](<https://developer.android.com/reference/android/view/View#setFocusable(boolean)>). On iOS, it translates into native [`isAccessibilityElement`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/isaccessibilityelement?language=objc).
 
 ```tsx
-<View accessible={true}>
-  <Text>text one</Text>
-  <Text>text two</Text>
+<View>
+  <View accessible={true} />
+  <View />
 </View>
 ```
 
-In the above example, accessibility focus is only available on the parent view with the `accessible` property, and not individually for 'text one' and 'text two'.
+In the above example, accessibility focus is only available on the first child view with the `accessible` property, and not for the parent or sibling without `accessible`.
 
 ### `accessibilityLabel`
 

--- a/website/versioned_docs/version-0.78/view.md
+++ b/website/versioned_docs/version-0.78/view.md
@@ -206,7 +206,9 @@ See the [Accessibility guide](accessibility.md#accessibilityviewismodal-ios) for
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. By default, all the touchable elements are accessible.
+When `true`, indicates that the view is an accessibility element and discoverable by assistive technologies such as screen readers and hardware keyboards. By default, all the touchable elements are accessible.
+
+See the [Accessibility guide](accessibility.md#accessible) for more information.
 
 ---
 

--- a/website/versioned_docs/version-0.79/accessibility.md
+++ b/website/versioned_docs/version-0.79/accessibility.md
@@ -14,18 +14,20 @@ Android and iOS differ slightly in their approaches, and thus the React Native i
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
+When `true`, indicates that the view is discoverable by assistive technologies such as screen readers and hardware keyboards. Note that this does not necessarily mean that the view will be focused by VoiceOver or TalkBack. There are a number of reasons for this, such as VoiceOver disallowing nested acecssibility elements, or TalkBack opting to focus some parent element instead.
 
-On Android, `accessible={true}` property for a react-native View will be translated into native `focusable={true}`.
+By default, all touchable elements are accessible.
+
+On Android, `accessible` will be translated into native [`focusable`](<https://developer.android.com/reference/android/view/View#setFocusable(boolean)>). On iOS, it translates into native [`isAccessibilityElement`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/isaccessibilityelement?language=objc).
 
 ```tsx
-<View accessible={true}>
-  <Text>text one</Text>
-  <Text>text two</Text>
+<View>
+  <View accessible={true} />
+  <View />
 </View>
 ```
 
-In the above example, accessibility focus is only available on the parent view with the `accessible` property, and not individually for 'text one' and 'text two'.
+In the above example, accessibility focus is only available on the first child view with the `accessible` property, and not for the parent or sibling without `accessible`.
 
 ### `accessibilityLabel`
 

--- a/website/versioned_docs/version-0.79/view.md
+++ b/website/versioned_docs/version-0.79/view.md
@@ -206,7 +206,9 @@ See the [Accessibility guide](accessibility.md#accessibilityviewismodal-ios) for
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. By default, all the touchable elements are accessible.
+When `true`, indicates that the view is an accessibility element and discoverable by assistive technologies such as screen readers and hardware keyboards. By default, all the touchable elements are accessible.
+
+See the [Accessibility guide](accessibility.md#accessible) for more information.
 
 ---
 

--- a/website/versioned_docs/version-0.80/accessibility.md
+++ b/website/versioned_docs/version-0.80/accessibility.md
@@ -14,18 +14,20 @@ Android and iOS differ slightly in their approaches, and thus the React Native i
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. When a view is an accessibility element, it groups its children into a single selectable component. By default, all touchable elements are accessible.
+When `true`, indicates that the view is discoverable by assistive technologies such as screen readers and hardware keyboards. Note that this does not necessarily mean that the view will be focused by VoiceOver or TalkBack. There are a number of reasons for this, such as VoiceOver disallowing nested acecssibility elements, or TalkBack opting to focus some parent element instead.
 
-On Android, `accessible={true}` property for a react-native View will be translated into native `focusable={true}`.
+By default, all touchable elements are accessible.
+
+On Android, `accessible` will be translated into native [`focusable`](<https://developer.android.com/reference/android/view/View#setFocusable(boolean)>). On iOS, it translates into native [`isAccessibilityElement`](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/isaccessibilityelement?language=objc).
 
 ```tsx
-<View accessible={true}>
-  <Text>text one</Text>
-  <Text>text two</Text>
+<View>
+  <View accessible={true} />
+  <View />
 </View>
 ```
 
-In the above example, accessibility focus is only available on the parent view with the `accessible` property, and not individually for 'text one' and 'text two'.
+In the above example, accessibility focus is only available on the first child view with the `accessible` property, and not for the parent or sibling without `accessible`.
 
 ### `accessibilityLabel`
 

--- a/website/versioned_docs/version-0.80/view.md
+++ b/website/versioned_docs/version-0.80/view.md
@@ -206,7 +206,9 @@ See the [Accessibility guide](accessibility.md#accessibilityviewismodal-ios) for
 
 ### `accessible`
 
-When `true`, indicates that the view is an accessibility element. By default, all the touchable elements are accessible.
+When `true`, indicates that the view is an accessibility element and discoverable by assistive technologies such as screen readers and hardware keyboards. By default, all the touchable elements are accessible.
+
+See the [Accessibility guide](accessibility.md#accessible) for more information.
 
 ---
 


### PR DESCRIPTION
The current description of the accessible prop is misleading and confusing. The current wording implies that this prop mainly "groups its children into a single selectable component", which is a round-about way of saying it can receive focus, I think? I am not really sure what that means.

Regardless, the main point is not hammered home: This prop allows the View to be discoverable by screen readers (and other things).

The example is also a bit misleading, since Text is focusable by default on iOS. It is not wrong, but the example is better for a guide on label co-opting, not basic use of accessible.

Curious how, if at all, I should change this for previous versions.

NOTE: This is the same as https://github.com/facebook/react-native-website/pull/4653, with the requested changes. I had mucked up my fork and wanted to fix it.
