### PR TITLE
Add documentation for `isolation`

### DIFF
--- a/docs/layout-props.md
+++ b/docs/layout-props.md
@@ -661,6 +661,21 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 ---
 
+### `isolation`
+
+`isolation` lets you form a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). This prop is only available on the [New Architecture](/architecture/landing-page).
+
+There are two values:
+
+* `auto` (default): Does nothing.
+* `isolate`: Forms a stacking context.
+
+| Type                    | Required |
+| ----------------------- | -------- |
+| enum('auto', 'isolate') | No       |
+
+---
+
 ### `justifyContent`
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.

--- a/website/versioned_docs/version-0.76/layout-props.md
+++ b/website/versioned_docs/version-0.76/layout-props.md
@@ -651,6 +651,21 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 ---
 
+### `isolation`
+
+`isolation` lets you form a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). This prop is only available on the [New Architecture](/architecture/landing-page).
+
+There are two values:
+
+* `auto` (default): Does nothing.
+* `isolate`: Forms a stacking context.
+
+| Type                    | Required |
+| ----------------------- | -------- |
+| enum('auto', 'isolate') | No       |
+
+---
+
 ### `justifyContent`
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.

--- a/website/versioned_docs/version-0.77/layout-props.md
+++ b/website/versioned_docs/version-0.77/layout-props.md
@@ -661,6 +661,21 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 ---
 
+### `isolation`
+
+`isolation` lets you form a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). This prop is only available on the [New Architecture](/architecture/landing-page).
+
+There are two values:
+
+* `auto` (default): Does nothing.
+* `isolate`: Forms a stacking context.
+
+| Type                    | Required |
+| ----------------------- | -------- |
+| enum('auto', 'isolate') | No       |
+
+---
+
 ### `justifyContent`
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.

--- a/website/versioned_docs/version-0.78/layout-props.md
+++ b/website/versioned_docs/version-0.78/layout-props.md
@@ -661,6 +661,21 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 ---
 
+### `isolation`
+
+`isolation` lets you form a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). This prop is only available on the [New Architecture](/architecture/landing-page).
+
+There are two values:
+
+* `auto` (default): Does nothing.
+* `isolate`: Forms a stacking context.
+
+| Type                    | Required |
+| ----------------------- | -------- |
+| enum('auto', 'isolate') | No       |
+
+---
+
 ### `justifyContent`
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.

--- a/website/versioned_docs/version-0.79/layout-props.md
+++ b/website/versioned_docs/version-0.79/layout-props.md
@@ -661,6 +661,21 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 ---
 
+### `isolation`
+
+`isolation` lets you form a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). This prop is only available on the [New Architecture](/architecture/landing-page).
+
+There are two values:
+
+* `auto` (default): Does nothing.
+* `isolate`: Forms a stacking context.
+
+| Type                    | Required |
+| ----------------------- | -------- |
+| enum('auto', 'isolate') | No       |
+
+---
+
 ### `justifyContent`
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.

--- a/website/versioned_docs/version-0.80/layout-props.md
+++ b/website/versioned_docs/version-0.80/layout-props.md
@@ -661,6 +661,21 @@ It works similarly to `height` in CSS, but in React Native you must use points o
 
 ---
 
+### `isolation`
+
+`isolation` lets you form a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context). This prop is only available on the [New Architecture](/architecture/landing-page).
+
+There are two values:
+
+* `auto` (default): Does nothing.
+* `isolate`: Forms a stacking context.
+
+| Type                    | Required |
+| ----------------------- | -------- |
+| enum('auto', 'isolate') | No       |
+
+---
+
 ### `justifyContent`
 
 `justifyContent` aligns children in the main direction. For example, if children are flowing vertically, `justifyContent` controls how they align vertically. It works like `justify-content` in CSS (default: flex-start). See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content for more details.


### PR DESCRIPTION
This was added way back in 0.76 in https://github.com/facebook/react-native/commit/17017d2b8181acf6e1ce6543f333cd6653b6945b. The isn't much to this prop. We should add a guide on stacking context though probably, but the CSS definition is pretty good and similar enough for now.
