### PR TITLE
Fix typo: "reccomend" → "recommend"

### DIFF
--- a/website/contributing/contributing-overview.md
+++ b/website/contributing/contributing-overview.md
@@ -22,7 +22,7 @@ As a reminder, all contributors are expected to adhere to the [Code of Conduct](
 
 ## Versioning Policy
 
-In order to fully understand the versioning of React Native, we reccomend you to check out the [Versioning Policy](/contributing/versioning-policy) page.
+In order to fully understand the versioning of React Native, we recommend you to check out the [Versioning Policy](/contributing/versioning-policy) page.
 In that page we describe which versions of React Native are supported, how often they're released and which one you should use based on your circumstances.
 
 ## Ways to Contribute


### PR DESCRIPTION
- Fixed a typo: reccomend → recommend in the Versioning Policy.

Note:  This is my first contribution to open-source 😄