### PR TITLE
Add `build-types` to `how-to-contribute-code` page

### DIFF
--- a/website/contributing/how-to-contribute-code.md
+++ b/website/contributing/how-to-contribute-code.md
@@ -32,7 +32,7 @@ Now you are set up to run several commands:
 - `yarn test-ios` runs the iOS test suite (macOS required).
 - `yarn build` builds all configured packages — in general, this command only needs to be run by CI ahead of publishing.
   - Packages which require a build are configured in [scripts/build/config.js](https://github.com/facebook/react-native/blob/main/scripts/build/config.js).
-- `yarn build-types` builds the TS types for the public API and generates the snapshot.
+- `yarn build-types` generates TypeScript types for the public API and updates the snapshot.
 
 ## Testing your Changes
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

# Summary

This PR adds description of `yarn build-types` command and another step to `Sending a Pull Request` section explaining how to verify whether the code modifies JS public API and how to regenerate the snapshot if it does. 

