### PR TITLE
Update _integration-with-existing-apps-kotlin Metro bundler URL

### DIFF
--- a/docs/_integration-with-existing-apps-kotlin.md
+++ b/docs/_integration-with-existing-apps-kotlin.md
@@ -157,7 +157,7 @@ Then you need to enable [cleartext traffic](https://developer.android.com/traini
 
 As usual, here the AndroidManifest.xml file from the Community template to use as a reference: [main](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/main/AndroidManifest.xml) and [debug](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/debug/AndroidManifest.xml)
 
-This is needed as your application will communicate with your local bundler, [Metro][https://metrobundler.dev/], via HTTP.
+This is needed as your application will communicate with your local bundler, [Metro](https://metrobundler.dev/), via HTTP.
 
 Make sure you add this only to your **debug** manifest.
 


### PR DESCRIPTION
Fixed Markdown link syntax for Metro bundler URL
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
