### PR TITLE
Fix: ReactModuleInfo setup for Android Fabric WebView Component

### DIFF
--- a/docs/fabric-native-components-android.md
+++ b/docs/fabric-native-components-android.md
@@ -425,10 +425,10 @@ class ReactWebViewPackage : BaseReactPackage() {
 
   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
     mapOf(ReactWebViewManager.REACT_CLASS to ReactModuleInfo(
-      _name = ReactWebViewManager.REACT_CLASS,
-      _className = ReactWebViewManager.REACT_CLASS,
-      _canOverrideExistingModule = false,
-      _needsEagerInit = false,
+      name = ReactWebViewManager.REACT_CLASS,
+      className = ReactWebViewManager.REACT_CLASS,
+      canOverrideExistingModule = false,
+      needsEagerInit = false,
       isCxxModule = false,
       isTurboModule = true,
     )


### PR DESCRIPTION
Addresses #4660

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
