### PR TITLE
Fix versioned docs links in _integration-with-existing-apps-kotlin

### DIFF
--- a/website/versioned_docs/version-0.76/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.76/_integration-with-existing-apps-kotlin.md
@@ -157,7 +157,7 @@ Then you need to enable [cleartext traffic](https://developer.android.com/traini
 
 As usual, here the AndroidManifest.xml file from the Community template to use as a reference: [main](https://github.com/react-native-community/template/blob/0.76-stable/template/android/app/src/main/AndroidManifest.xml) and [debug](https://github.com/react-native-community/template/blob/0.76-stable/template/android/app/src/debug/AndroidManifest.xml)
 
-This is needed as your application will communicate with your local bundler, [Metro][https://metrobundler.dev/], via HTTP.
+This is needed as your application will communicate with your local bundler, [Metro](https://metrobundler.dev/), via HTTP.
 
 Make sure you add this only to your **debug** manifest.
 

--- a/website/versioned_docs/version-0.77/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.77/_integration-with-existing-apps-kotlin.md
@@ -157,7 +157,7 @@ Then you need to enable [cleartext traffic](https://developer.android.com/traini
 
 As usual, here the AndroidManifest.xml file from the Community template to use as a reference: [main](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/main/AndroidManifest.xml) and [debug](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/debug/AndroidManifest.xml)
 
-This is needed as your application will communicate with your local bundler, [Metro][https://metrobundler.dev/], via HTTP.
+This is needed as your application will communicate with your local bundler, [Metro](https://metrobundler.dev/), via HTTP.
 
 Make sure you add this only to your **debug** manifest.
 

--- a/website/versioned_docs/version-0.78/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.78/_integration-with-existing-apps-kotlin.md
@@ -157,7 +157,7 @@ Then you need to enable [cleartext traffic](https://developer.android.com/traini
 
 As usual, here the AndroidManifest.xml file from the Community template to use as a reference: [main](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/main/AndroidManifest.xml) and [debug](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/debug/AndroidManifest.xml)
 
-This is needed as your application will communicate with your local bundler, [Metro][https://metrobundler.dev/], via HTTP.
+This is needed as your application will communicate with your local bundler, [Metro](https://metrobundler.dev/), via HTTP.
 
 Make sure you add this only to your **debug** manifest.
 

--- a/website/versioned_docs/version-0.79/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.79/_integration-with-existing-apps-kotlin.md
@@ -157,7 +157,7 @@ Then you need to enable [cleartext traffic](https://developer.android.com/traini
 
 As usual, here the AndroidManifest.xml file from the Community template to use as a reference: [main](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/main/AndroidManifest.xml) and [debug](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/debug/AndroidManifest.xml)
 
-This is needed as your application will communicate with your local bundler, [Metro][https://metrobundler.dev/], via HTTP.
+This is needed as your application will communicate with your local bundler, [Metro](https://metrobundler.dev/), via HTTP.
 
 Make sure you add this only to your **debug** manifest.
 

--- a/website/versioned_docs/version-0.80/_integration-with-existing-apps-kotlin.md
+++ b/website/versioned_docs/version-0.80/_integration-with-existing-apps-kotlin.md
@@ -157,7 +157,7 @@ Then you need to enable [cleartext traffic](https://developer.android.com/traini
 
 As usual, here the AndroidManifest.xml file from the Community template to use as a reference: [main](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/main/AndroidManifest.xml) and [debug](https://github.com/react-native-community/template/blob/0.77-stable/template/android/app/src/debug/AndroidManifest.xml)
 
-This is needed as your application will communicate with your local bundler, [Metro][https://metrobundler.dev/], via HTTP.
+This is needed as your application will communicate with your local bundler, [Metro](https://metrobundler.dev/), via HTTP.
 
 Make sure you add this only to your **debug** manifest.
 


### PR DESCRIPTION
Fix versioned docs links in _integration-with-existing-apps-kotlin
Related to #4669 

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
