### PR TITLE
Fix: update versioned docs for ReactModuleInfo Android Fabric WebView

### DIFF
--- a/website/versioned_docs/version-0.76/fabric-native-components-android.md
+++ b/website/versioned_docs/version-0.76/fabric-native-components-android.md
@@ -425,10 +425,10 @@ class ReactWebViewPackage : TurboReactPackage() {
 
   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
     mapOf(ReactWebViewManager.REACT_CLASS to ReactModuleInfo(
-      _name = ReactWebViewManager.REACT_CLASS,
-      _className = ReactWebViewManager.REACT_CLASS,
-      _canOverrideExistingModule = false,
-      _needsEagerInit = false,
+      name = ReactWebViewManager.REACT_CLASS,
+      className = ReactWebViewManager.REACT_CLASS,
+      canOverrideExistingModule = false,
+      needsEagerInit = false,
       isCxxModule = false,
       isTurboModule = true,
     )

--- a/website/versioned_docs/version-0.77/fabric-native-components-android.md
+++ b/website/versioned_docs/version-0.77/fabric-native-components-android.md
@@ -425,10 +425,10 @@ class ReactWebViewPackage : BaseReactPackage() {
 
   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
     mapOf(ReactWebViewManager.REACT_CLASS to ReactModuleInfo(
-      _name = ReactWebViewManager.REACT_CLASS,
-      _className = ReactWebViewManager.REACT_CLASS,
-      _canOverrideExistingModule = false,
-      _needsEagerInit = false,
+      name = ReactWebViewManager.REACT_CLASS,
+      className = ReactWebViewManager.REACT_CLASS,
+      canOverrideExistingModule = false,
+      needsEagerInit = false,
       isCxxModule = false,
       isTurboModule = true,
     )

--- a/website/versioned_docs/version-0.78/fabric-native-components-android.md
+++ b/website/versioned_docs/version-0.78/fabric-native-components-android.md
@@ -425,10 +425,10 @@ class ReactWebViewPackage : BaseReactPackage() {
 
   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
     mapOf(ReactWebViewManager.REACT_CLASS to ReactModuleInfo(
-      _name = ReactWebViewManager.REACT_CLASS,
-      _className = ReactWebViewManager.REACT_CLASS,
-      _canOverrideExistingModule = false,
-      _needsEagerInit = false,
+      name = ReactWebViewManager.REACT_CLASS,
+      className = ReactWebViewManager.REACT_CLASS,
+      canOverrideExistingModule = false,
+      needsEagerInit = false,
       isCxxModule = false,
       isTurboModule = true,
     )

--- a/website/versioned_docs/version-0.79/fabric-native-components-android.md
+++ b/website/versioned_docs/version-0.79/fabric-native-components-android.md
@@ -425,10 +425,10 @@ class ReactWebViewPackage : BaseReactPackage() {
 
   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
     mapOf(ReactWebViewManager.REACT_CLASS to ReactModuleInfo(
-      _name = ReactWebViewManager.REACT_CLASS,
-      _className = ReactWebViewManager.REACT_CLASS,
-      _canOverrideExistingModule = false,
-      _needsEagerInit = false,
+      name = ReactWebViewManager.REACT_CLASS,
+      className = ReactWebViewManager.REACT_CLASS,
+      canOverrideExistingModule = false,
+      needsEagerInit = false,
       isCxxModule = false,
       isTurboModule = true,
     )

--- a/website/versioned_docs/version-0.80/fabric-native-components-android.md
+++ b/website/versioned_docs/version-0.80/fabric-native-components-android.md
@@ -425,10 +425,10 @@ class ReactWebViewPackage : BaseReactPackage() {
 
   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider = ReactModuleInfoProvider {
     mapOf(ReactWebViewManager.REACT_CLASS to ReactModuleInfo(
-      _name = ReactWebViewManager.REACT_CLASS,
-      _className = ReactWebViewManager.REACT_CLASS,
-      _canOverrideExistingModule = false,
-      _needsEagerInit = false,
+      name = ReactWebViewManager.REACT_CLASS,
+      className = ReactWebViewManager.REACT_CLASS,
+      canOverrideExistingModule = false,
+      needsEagerInit = false,
       isCxxModule = false,
       isTurboModule = true,
     )


### PR DESCRIPTION
Updated the versioned documentation to clarify the ReactModuleInfo setup for the Android Fabric WebView component.
Related to PR #4670
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
