### PR TITLE
Fix: update FadeInView example to use Animated.Value

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -21,11 +21,11 @@ For example, a container view that fades in when it is mounted may look like thi
 <TabItem value="javascript">
 
 ```SnackPlayer ext=js&supportedPlatforms=ios,android
-import React, {useRef, useEffect} from 'react';
-import {Animated, Text, View} from 'react-native';
+import React, {useEffect} from 'react';
+import {Animated, Text, View, useAnimatedValue} from 'react-native';
 
 const FadeInView = props => {
-  const fadeAnim = useRef(new Animated.Value(0)).current // Initial value for opacity: 0
+  const fadeAnim = useAnimatedValue(0); // Initial value for opacity: 0
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -74,15 +74,15 @@ export default () => {
 <TabItem value="typescript">
 
 ```SnackPlayer ext=tsx
-import React, {useEffect} from 'react';
-import {Animated, Text, View, useAnimatedValue} from 'react-native';
+import React, {useRef, useEffect} from 'react';
+import {Animated, Text, View} from 'react-native';
 import type {PropsWithChildren} from 'react';
 import type {ViewStyle} from 'react-native';
 
 type FadeInViewProps = PropsWithChildren<{style: ViewStyle}>;
 
 const FadeInView: React.FC<FadeInViewProps> = props => {
-  const fadeAnim = useAnimatedValue(0); // Initial value for opacity: 0
+  const fadeAnim = useRef(new Animated.Value(0)).current // Initial value for opacity: 0
 
   useEffect(() => {
     Animated.timing(fadeAnim, {

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -22,10 +22,10 @@ For example, a container view that fades in when it is mounted may look like thi
 
 ```SnackPlayer ext=js&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
-import {Animated, Text, View, useAnimatedValue} from 'react-native';
+import {Animated, Text, View} from 'react-native';
 
 const FadeInView = props => {
-  const fadeAnim = useAnimatedValue(0); // Initial value for opacity: 0
+  const fadeAnim = new Animated.Value(0); // Initial value for opacity: 0
 
   useEffect(() => {
     Animated.timing(fadeAnim, {

--- a/docs/animations.md
+++ b/docs/animations.md
@@ -21,11 +21,11 @@ For example, a container view that fades in when it is mounted may look like thi
 <TabItem value="javascript">
 
 ```SnackPlayer ext=js&supportedPlatforms=ios,android
-import React, {useEffect} from 'react';
+import React, {useRef, useEffect} from 'react';
 import {Animated, Text, View} from 'react-native';
 
 const FadeInView = props => {
-  const fadeAnim = new Animated.Value(0); // Initial value for opacity: 0
+  const fadeAnim = useRef(new Animated.Value(0)).current // Initial value for opacity: 0
 
   useEffect(() => {
     Animated.timing(fadeAnim, {


### PR DESCRIPTION
Addressed #4654 
- The animation example for TypeScript uses `const fadeAnim = useAnimatedValue(0);` which is not a real function in the React Native API.
- `TypeError: (0 , _reactNative.useAnimatedValue) is not a function`
- Replaced `const fadeAnim = useAnimatedValue(0);` with `const fadeAnim = new Animated.Value(0);`
- Removed useAnimatedValue import
- However the original code does work when scanning the QR code for Expo - perhaps due to some internal support? However the code changes still works and fixes the error.
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
