### PR TITLE
docs: update LayoutAnimation guide for RN 0.79+ (fixes #4600)

### DIFF
--- a/docs/layoutanimation.md
+++ b/docs/layoutanimation.md
@@ -9,13 +9,18 @@ A common way to use this API is to call it before updating the state hook in fun
 
 Note that in order to get this to work on **Android** you need to set the following flags via `UIManager`:
 
+> ⚠️ **Note (React Native 0.79+)**:  
+> `UIManager.setLayoutAnimationEnabledExperimental(true)` is **no longer needed** in React Native 0.79+ and above. It is enabled by default now.
+
+If you're using an older version (before 0.79), you can still use:
+
 ```js
 if (Platform.OS === 'android') {
   if (UIManager.setLayoutAnimationEnabledExperimental) {
     UIManager.setLayoutAnimationEnabledExperimental(true);
   }
 }
-```
+
 
 ## Example
 


### PR DESCRIPTION
### Summary
The PR is an update of the documentation of the LayoutAnimation in accordance with the changes in React Native v.0.79+.

What has been changing:
Added a warning that `UIManager.setLayoutAnimationEnabledExperimental(true)` is not required anymore in RN 0.79+.
Kept the piece of code on account of those who used earlier releases.

### Reference
According to issue #4600.