### PR TITLE
port `lineBreakModeIOS` addition to the versioned docs

### DIFF
--- a/website/versioned_docs/version-0.79/textinput.md
+++ b/website/versioned_docs/version-0.79/textinput.md
@@ -1056,6 +1056,16 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
+### `lineBreakModeIOS` <div class="label ios">iOS</div>
+
+Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
+
+| Type                                                                       | Default          |
+| -------------------------------------------------------------------------- | ---------------- |
+| enum(`'wordWrapping'`, `'char'`, `'clip'`, `'head'`, `'middle'`, `'tail'`) | `'wordWrapping'` |
+
+---
+
 ### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.

--- a/website/versioned_docs/version-0.80/textinput.md
+++ b/website/versioned_docs/version-0.80/textinput.md
@@ -1056,6 +1056,16 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
+### `lineBreakModeIOS` <div class="label ios">iOS</div>
+
+Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
+
+| Type                                                                       | Default          |
+| -------------------------------------------------------------------------- | ---------------- |
+| enum(`'wordWrapping'`, `'char'`, `'clip'`, `'head'`, `'middle'`, `'tail'`) | `'wordWrapping'` |
+
+---
+
 ### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.


### PR DESCRIPTION
# Why

Follow up to:
* #4553

Since we have released new versions since the PR has been created, we need to backport those changes to the newest, versioned docs.