### PR TITLE
port `announceForAccessibilityWithOptions` fix to the versioned docs

### DIFF
--- a/website/versioned_docs/version-0.78/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.78/accessibilityinfo.md
@@ -118,7 +118,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.79/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.79/accessibilityinfo.md
@@ -118,7 +118,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 

--- a/website/versioned_docs/version-0.80/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.80/accessibilityinfo.md
@@ -118,7 +118,7 @@ Post a string to be announced by the screen reader.
 ```tsx
 static announceForAccessibilityWithOptions(
   announcement: string,
-  options: options: {queue?: boolean},
+  options: {queue?: boolean},
 );
 ```
 


### PR DESCRIPTION
# Why

Follow up to:
* #4501

Since we have released new versions since the PR has been created, we need to backport those changes to the newest, versioned docs.

