### PR TITLE
[DOC] Use CodegenTypes without deep import

### DIFF
--- a/docs/the-new-architecture/native-modules-custom-events.md
+++ b/docs/the-new-architecture/native-modules-custom-events.md
@@ -23,7 +23,7 @@ The first step would be to update the specs of the `NativeLocalStorage` specs to
 Open the `NativeLocalStorage.ts` file and update it as it follows:
 
 ```diff title="NativeLocalStorage.ts"
-import type {TurboModule, CodegenTypes} from 'react-native';
++import type {TurboModule, CodegenTypes} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
 
 +export type KeyValuePair = {
@@ -53,7 +53,7 @@ Open the `NativeLocalStorage.js` file and update it as it follows:
 ```diff title="NativeLocalStorage.js"
 
 // @flow
-import type {TurboModule, CodegenTypes} from 'react-native';
++import type {TurboModule, CodegenTypes} from 'react-native';
 import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 +export type KeyValuePair = {
@@ -76,7 +76,7 @@ export default (TurboModuleRegistry.get<Spec>(
 </TabItem>
 </Tabs>
 
-With the `import type` statement, you are importing the `EventEmitter` type that is required to then add the `onKeyAdded` property.
+With the `import type` statement, you are importing the `CodegenTypes` from `react-native`, which includes the `EventEmitter` type. This allows you to define the `onKeyAdded` property using `CodegenTypes.EventEmitter<KeyValuePair>`, specifying that the event will emit a payload of type `KeyValuePair`.
 
 When the event is emitted, you expect for it to receive a parameter of type `string`.
 

--- a/docs/the-new-architecture/native-modules-custom-events.md
+++ b/docs/the-new-architecture/native-modules-custom-events.md
@@ -23,9 +23,8 @@ The first step would be to update the specs of the `NativeLocalStorage` specs to
 Open the `NativeLocalStorage.ts` file and update it as it follows:
 
 ```diff title="NativeLocalStorage.ts"
-import type {TurboModule} from 'react-native';
+import type {TurboModule, CodegenTypes} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
-+import type {EventEmitter} from 'react-native/Libraries/Types/CodegenTypes';
 
 +export type KeyValuePair = {
 +  key: string,
@@ -38,7 +37,7 @@ export interface Spec extends TurboModule {
   removeItem(key: string): void;
   clear(): void;
 
-+ readonly onKeyAdded: EventEmitter<KeyValuePair>;
++ readonly onKeyAdded: CodegenTypes.EventEmitter<KeyValuePair>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(
@@ -54,9 +53,8 @@ Open the `NativeLocalStorage.js` file and update it as it follows:
 ```diff title="NativeLocalStorage.js"
 
 // @flow
-import type {TurboModule} from 'react-native';
+import type {TurboModule, CodegenTypes} from 'react-native';
 import {TurboModule, TurboModuleRegistry} from 'react-native';
-+import type {EventEmitter} from 'react-native/Libraries/Types/CodegenTypes';
 
 +export type KeyValuePair = {
 +  key: string,
@@ -68,7 +66,7 @@ export interface Spec extends TurboModule {
   getItem(key: string): ?string;
   removeItem(key: string): void;
   clear(): void;
-+ onKeyAdded: EventEmitter<KeyValuePair>
++ onKeyAdded: CodegenTypes.EventEmitter<KeyValuePair>
 }
 export default (TurboModuleRegistry.get<Spec>(
   'NativeLocalStorage'

--- a/website/versioned_docs/version-0.80/the-new-architecture/native-modules-custom-events.md
+++ b/website/versioned_docs/version-0.80/the-new-architecture/native-modules-custom-events.md
@@ -76,7 +76,7 @@ export default (TurboModuleRegistry.get<Spec>(
 </TabItem>
 </Tabs>
 
-With the `import type` statement, you are importing the `CodegenTypes` from react-native, which includes the `EventEmitter` type. This allows you to define the `onKeyAdded` property using `CodegenTypes.EventEmitter<KeyValuePair>`, specifying that the event will emit a payload of type `KeyValuePair`.
+With the `import type` statement, you are importing the `CodegenTypes` from `react-native`, which includes the `EventEmitter` type. This allows you to define the `onKeyAdded` property using `CodegenTypes.EventEmitter<KeyValuePair>`, specifying that the event will emit a payload of type `KeyValuePair`.
 
 When the event is emitted, you expect for it to receive a parameter of type `string`.
 

--- a/website/versioned_docs/version-0.80/the-new-architecture/native-modules-custom-events.md
+++ b/website/versioned_docs/version-0.80/the-new-architecture/native-modules-custom-events.md
@@ -23,9 +23,8 @@ The first step would be to update the specs of the `NativeLocalStorage` specs to
 Open the `NativeLocalStorage.ts` file and update it as it follows:
 
 ```diff title="NativeLocalStorage.ts"
-import type {TurboModule} from 'react-native';
++import type {TurboModule, CodegenTypes} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
-+import type {EventEmitter} from 'react-native/Libraries/Types/CodegenTypes';
 
 +export type KeyValuePair = {
 +  key: string,
@@ -38,7 +37,7 @@ export interface Spec extends TurboModule {
   removeItem(key: string): void;
   clear(): void;
 
-+ readonly onKeyAdded: EventEmitter<KeyValuePair>;
++ readonly onKeyAdded: CodegenTypes.EventEmitter<KeyValuePair>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(
@@ -54,9 +53,8 @@ Open the `NativeLocalStorage.js` file and update it as it follows:
 ```diff title="NativeLocalStorage.js"
 
 // @flow
-import type {TurboModule} from 'react-native';
++import type {TurboModule, CodegenTypes} from 'react-native';
 import {TurboModule, TurboModuleRegistry} from 'react-native';
-+import type {EventEmitter} from 'react-native/Libraries/Types/CodegenTypes';
 
 +export type KeyValuePair = {
 +  key: string,
@@ -68,7 +66,7 @@ export interface Spec extends TurboModule {
   getItem(key: string): ?string;
   removeItem(key: string): void;
   clear(): void;
-+ onKeyAdded: EventEmitter<KeyValuePair>
++ onKeyAdded: CodegenTypes.EventEmitter<KeyValuePair>
 }
 export default (TurboModuleRegistry.get<Spec>(
   'NativeLocalStorage'
@@ -78,7 +76,7 @@ export default (TurboModuleRegistry.get<Spec>(
 </TabItem>
 </Tabs>
 
-With the `import type` statement, you are importing the `EventEmitter` type that is required to then add the `onKeyAdded` property.
+With the `import type` statement, you are importing the `CodegenTypes` from react-native, which includes the `EventEmitter` type. This allows you to define the `onKeyAdded` property using `CodegenTypes.EventEmitter<KeyValuePair>`, specifying that the event will emit a payload of type `KeyValuePair`.
 
 When the event is emitted, you expect for it to receive a parameter of type `string`.
 


### PR DESCRIPTION
Fix the doc to use EventEmitter from CodegenTypes without deep import

