### PR TITLE
port `onPressMove` addition to the versioned doc

### DIFF
--- a/website/versioned_docs/version-0.80/pressable.md
+++ b/website/versioned_docs/version-0.80/pressable.md
@@ -204,6 +204,14 @@ Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 | ------------------------------------------------------ |
 | `md ({nativeEvent: [PressEvent](pressevent)}) => void` |
 
+### `onPressMove`
+
+Called when the press location moves.
+
+| Type                                                   |
+| ------------------------------------------------------ |
+| `md ({nativeEvent: [PressEvent](pressevent)}) => void` |
+
 ### `onPressOut`
 
 Called when a touch is released.


### PR DESCRIPTION
# Why

Follow up to:
* #4543

Port `onPressMove` addition to the versioned doc for 0.80.