### PR TITLE
port `enterKeyHint` to versioned docs

### DIFF
--- a/website/versioned_docs/version-0.74/textinput.md
+++ b/website/versioned_docs/version-0.74/textinput.md
@@ -349,11 +349,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -361,9 +361,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 

--- a/website/versioned_docs/version-0.75/textinput.md
+++ b/website/versioned_docs/version-0.75/textinput.md
@@ -349,11 +349,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -361,9 +361,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 

--- a/website/versioned_docs/version-0.76/textinput.md
+++ b/website/versioned_docs/version-0.76/textinput.md
@@ -366,11 +366,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -378,9 +378,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 

--- a/website/versioned_docs/version-0.77/textinput.md
+++ b/website/versioned_docs/version-0.77/textinput.md
@@ -368,11 +368,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -380,9 +380,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 

--- a/website/versioned_docs/version-0.78/textinput.md
+++ b/website/versioned_docs/version-0.78/textinput.md
@@ -368,11 +368,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -380,9 +380,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 

--- a/website/versioned_docs/version-0.79/textinput.md
+++ b/website/versioned_docs/version-0.79/textinput.md
@@ -368,11 +368,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -380,9 +380,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 

--- a/website/versioned_docs/version-0.80/textinput.md
+++ b/website/versioned_docs/version-0.80/textinput.md
@@ -368,11 +368,11 @@ Determines what text should be shown to the return key. Has precedence over the 
 
 The following values work across platforms:
 
-- `enter`
 - `done`
 - `next`
 - `search`
 - `send`
+- `go`
 
 _Android Only_
 
@@ -380,9 +380,15 @@ The following values work on Android only:
 
 - `previous`
 
-| Type                                                        |
-| ----------------------------------------------------------- |
-| enum('enter', 'done', 'next', 'previous', 'search', 'send') |
+_iOS Only_
+
+The following values work on iOS only:
+
+- `enter`
+
+| Type                                                              |
+| ----------------------------------------------------------------- |
+| enum('enter', 'done', 'next', 'previous', 'search', 'send', 'go') |
 
 ---
 


### PR DESCRIPTION
# Why

Follow up to:
* #3739

# How

Port recent `enterKeyHint` prop values update to the versioned docs.