### PR TITLE
TextInput: add `smartInsertDelete` prop, reorder props

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -322,6 +322,16 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
+
+If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
+
+---
+
 ### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
@@ -522,6 +532,26 @@ The following values work on Android only:
 | Type                                                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enum('default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter', 'web-search', 'visible-password') |
+
+---
+
+### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+
+Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
+
+| Type                                                        | Default  |
+| ----------------------------------------------------------- | -------- |
+| enum(`'none'`, `'standard'`, `'hangul-word'`, `'push-out'`) | `'none'` |
+
+---
+
+### `lineBreakModeIOS` <div class="label ios">iOS</div>
+
+Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
+
+| Type                                                                       | Default          |
+| -------------------------------------------------------------------------- | ---------------- |
+| enum(`'wordWrapping'`, `'char'`, `'clip'`, `'head'`, `'middle'`, `'tail'`) | `'wordWrapping'` |
 
 ---
 
@@ -879,6 +909,16 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
+### `smartInsertDelete` <div className="label ios">iOS</div>
+
+If `false`, the iOS system will not insert an extra space after a paste operation neither delete one or two spaces after a cut or delete operation.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
@@ -1059,36 +1099,6 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 | Type   |
 | ------ |
 | string |
-
----
-
-### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
-
-Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
-
-| Type                                                        | Default  |
-| ----------------------------------------------------------- | -------- |
-| enum(`'none'`, `'standard'`, `'hangul-word'`, `'push-out'`) | `'none'` |
-
----
-
-### `lineBreakModeIOS` <div className="label ios">iOS</div>
-
-Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
-
-| Type                                                                       | Default          |
-| -------------------------------------------------------------------------- | ---------------- |
-| enum(`'wordWrapping'`, `'char'`, `'clip'`, `'head'`, `'middle'`, `'tail'`) | `'wordWrapping'` |
-
----
-
-### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
-
-If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
-
-| Type |
-| ---- |
-| bool |
 
 ## Methods
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -535,7 +535,7 @@ The following values work on Android only:
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -545,7 +545,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 

--- a/website/versioned_docs/version-0.77/textinput.md
+++ b/website/versioned_docs/version-0.77/textinput.md
@@ -875,6 +875,16 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
+### `smartInsertDelete` <div className="label ios">iOS</div>
+
+If `false`, the iOS system will not insert an extra space after a paste operation neither delete one or two spaces after a cut or delete operation.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.

--- a/website/versioned_docs/version-0.78/textinput.md
+++ b/website/versioned_docs/version-0.78/textinput.md
@@ -875,6 +875,16 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
+### `smartInsertDelete` <div className="label ios">iOS</div>
+
+If `false`, the iOS system will not insert an extra space after a paste operation neither delete one or two spaces after a cut or delete operation.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.

--- a/website/versioned_docs/version-0.79/textinput.md
+++ b/website/versioned_docs/version-0.79/textinput.md
@@ -879,6 +879,16 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
+### `smartInsertDelete` <div className="label ios">iOS</div>
+
+If `false`, the iOS system will not insert an extra space after a paste operation neither delete one or two spaces after a cut or delete operation.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.

--- a/website/versioned_docs/version-0.80/textinput.md
+++ b/website/versioned_docs/version-0.80/textinput.md
@@ -320,7 +320,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 | ------ |
 | string |
 
-### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
 
 If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled.
 
@@ -533,7 +533,7 @@ The following values work on Android only:
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 
@@ -543,7 +543,7 @@ Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.80/textinput.md
+++ b/website/versioned_docs/version-0.80/textinput.md
@@ -320,6 +320,14 @@ Provides an initial value that will change when the user starts typing. Useful f
 | ------ |
 | string |
 
+### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+
+If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `false` |
+
 ---
 
 ### `cursorColor` <div className="label android">Android</div>
@@ -522,6 +530,26 @@ The following values work on Android only:
 | Type                                                                                                                                                                                                    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enum('default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter', 'web-search', 'visible-password') |
+
+---
+
+### `lineBreakModeIOS` <div class="label ios">iOS</div>
+
+Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
+
+| Type                                                                       | Default          |
+| -------------------------------------------------------------------------- | ---------------- |
+| enum(`'wordWrapping'`, `'char'`, `'clip'`, `'head'`, `'middle'`, `'tail'`) | `'wordWrapping'` |
+
+---
+
+### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+
+Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
+
+| Type                                                        | Default  |
+| ----------------------------------------------------------- | -------- |
+| enum(`'none'`, `'standard'`, `'hangul-word'`, `'push-out'`) | `'none'` |
 
 ---
 
@@ -879,6 +907,16 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
+### `smartInsertDelete` <div className="label ios">iOS</div>
+
+If `false`, the iOS system will not insert an extra space after a paste operation neither delete one or two spaces after a cut or delete operation.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
@@ -1059,36 +1097,6 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 | Type   |
 | ------ |
 | string |
-
----
-
-### `lineBreakModeIOS` <div className="label ios">iOS</div>
-
-Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
-
-| Type                                                                       | Default          |
-| -------------------------------------------------------------------------- | ---------------- |
-| enum(`'wordWrapping'`, `'char'`, `'clip'`, `'head'`, `'middle'`, `'tail'`) | `'wordWrapping'` |
-
----
-
-### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
-
-Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
-
-| Type                                                        | Default  |
-| ----------------------------------------------------------- | -------- |
-| enum(`'none'`, `'standard'`, `'hangul-word'`, `'push-out'`) | `'none'` |
-
----
-
-### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
-
-If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
-
-| Type |
-| ---- |
-| bool |
 
 ## Methods
 

--- a/website/versioned_docs/version-0.81/textinput.md
+++ b/website/versioned_docs/version-0.81/textinput.md
@@ -879,6 +879,16 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
+### `smartInsertDelete` <div class="label ios">iOS</div>
+
+If `false`, the iOS system will not insert an extra space after a paste operation neither delete one or two spaces after a cut or delete operation.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `spellCheck` <div class="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.


### PR DESCRIPTION
# Why

Supersedes:
* #3560

# How

Add `smartInsertDelete` prop to the TextInput documentation. List props in alphabetical order in unversioned and 0.80 doc.
