### PR TITLE
ViewStyleProps: add `borderBlock*` props

### DIFF
--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -79,6 +79,30 @@ export default App;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |

--- a/website/versioned_docs/version-0.73/view-style-props.md
+++ b/website/versioned_docs/version-0.73/view-style-props.md
@@ -79,6 +79,30 @@ export default ViewStyleProps;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type   |

--- a/website/versioned_docs/version-0.74/view-style-props.md
+++ b/website/versioned_docs/version-0.74/view-style-props.md
@@ -79,6 +79,30 @@ export default ViewStyleProps;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type   |

--- a/website/versioned_docs/version-0.75/view-style-props.md
+++ b/website/versioned_docs/version-0.75/view-style-props.md
@@ -79,6 +79,30 @@ export default ViewStyleProps;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |

--- a/website/versioned_docs/version-0.76/view-style-props.md
+++ b/website/versioned_docs/version-0.76/view-style-props.md
@@ -79,6 +79,30 @@ export default App;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |

--- a/website/versioned_docs/version-0.77/view-style-props.md
+++ b/website/versioned_docs/version-0.77/view-style-props.md
@@ -79,6 +79,30 @@ export default App;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |

--- a/website/versioned_docs/version-0.78/view-style-props.md
+++ b/website/versioned_docs/version-0.78/view-style-props.md
@@ -79,6 +79,30 @@ export default App;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |

--- a/website/versioned_docs/version-0.79/view-style-props.md
+++ b/website/versioned_docs/version-0.79/view-style-props.md
@@ -79,6 +79,30 @@ export default App;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |

--- a/website/versioned_docs/version-0.80/view-style-props.md
+++ b/website/versioned_docs/version-0.80/view-style-props.md
@@ -79,6 +79,30 @@ export default App;
 
 ---
 
+### `borderBlockColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockEndColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
+### `borderBlockStartColor`
+
+| Type               |
+| ------------------ |
+| [color](colors.md) |
+
+---
+
 ### `borderBottomEndRadius`
 
 | Type                              |


### PR DESCRIPTION
# Why

Supersedes:
* #3554

Looks like only the `borderBlock*` part has been merged in the core, and contribution adding `borderInline*` has become stale and closed.

# How

Add `borderBlock*` props to View Style Props list.
