### PR TITLE
Core Components and APIs: list Pressable

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -44,6 +44,12 @@ Most apps will end up using one or more of these basic components.
     </a>
   </div>
   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A wrapper component that can detect various stages of press interactions on any of its children.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1770,8 +1770,9 @@ td .label {
 /* Components grid */
 
 article .component-grid {
-  max-width: 800px;
   margin-bottom: 22px;
+  display: grid;
+  grid-column-gap: 22px;
 
   .component {
     border: 1px solid var(--ifm-color-emphasis-500);
@@ -1783,13 +1784,14 @@ article .component-grid {
     overflow: hidden;
 
     &:hover {
-      transform: scale(1.05);
+      transform: scale(1.033);
     }
 
     > a {
       display: block;
       height: 100%;
       border-bottom: none;
+      background: none !important;
     }
 
     h3 {
@@ -1797,7 +1799,7 @@ article .component-grid {
       font-weight: 600;
       margin: 0;
       padding: 0 10px;
-      background-color: var(--home-button-primary);
+      background-color: var(--ifm-color-info-darkest);
       color: var(--home-button-primary-text);
       line-height: 36px;
 
@@ -1807,7 +1809,7 @@ article .component-grid {
     }
 
     p {
-      padding: 10px;
+      padding: 6px 10px 8px;
       font-size: 15px;
       margin: 2px;
       color: var(--ifm-font-color-base);
@@ -1815,6 +1817,7 @@ article .component-grid {
       code {
         font-size: 15px;
         padding: 0 1px;
+        top: 0;
       }
     }
   }
@@ -1822,13 +1825,6 @@ article .component-grid {
 
 html[data-theme="dark"] .component {
   border: 1px solid var(--ifm-color-emphasis-200);
-}
-
-@supports (display: grid) {
-  article .component-grid {
-    display: grid;
-    grid-column-gap: 22px;
-  }
 }
 
 @media only screen and (min-width: 768px) {
@@ -1843,22 +1839,20 @@ html[data-theme="dark"] .component {
     vertical-align: top;
   }
 
-  @supports (display: grid) {
+  article .component-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media only screen and (min-width: 1440px) {
     article .component-grid {
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(3, 1fr);
     }
+  }
 
-    @media only screen and (min-width: 1440px) {
-      article .component-grid {
-        grid-template-columns: repeat(3, 1fr);
-      }
-    }
-
-    article .component {
-      width: auto;
-      height: auto;
-      margin: 0;
-    }
+  article .component {
+    width: auto;
+    height: auto;
+    margin: 0;
   }
 }
 

--- a/website/versioned_docs/version-0.77/components-and-apis.md
+++ b/website/versioned_docs/version-0.77/components-and-apis.md
@@ -44,6 +44,12 @@ Most apps will end up using one or more of these basic components.
     </a>
   </div>
   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A wrapper component that can detect various stages of press interactions on any of its children.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>

--- a/website/versioned_docs/version-0.78/components-and-apis.md
+++ b/website/versioned_docs/version-0.78/components-and-apis.md
@@ -44,6 +44,12 @@ Most apps will end up using one or more of these basic components.
     </a>
   </div>
   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A wrapper component that can detect various stages of press interactions on any of its children.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>

--- a/website/versioned_docs/version-0.79/components-and-apis.md
+++ b/website/versioned_docs/version-0.79/components-and-apis.md
@@ -44,6 +44,12 @@ Most apps will end up using one or more of these basic components.
     </a>
   </div>
   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A wrapper component that can detect various stages of press interactions on any of its children.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>

--- a/website/versioned_docs/version-0.80/components-and-apis.md
+++ b/website/versioned_docs/version-0.80/components-and-apis.md
@@ -44,6 +44,12 @@ Most apps will end up using one or more of these basic components.
     </a>
   </div>
   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A wrapper component that can detect various stages of press interactions on any of its children.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>

--- a/website/versioned_docs/version-0.81/components-and-apis.md
+++ b/website/versioned_docs/version-0.81/components-and-apis.md
@@ -44,6 +44,12 @@ Most apps will end up using one or more of these basic components.
     </a>
   </div>
   <div className="component">
+    <a href="./pressable">
+      <h3>Pressable</h3>
+      <p>A wrapper component that can detect various stages of press interactions on any of its children.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./scrollview">
       <h3>ScrollView</h3>
       <p>Provides a scrolling container that can host multiple components and views.</p>


### PR DESCRIPTION
# Why

Supersedes:
* #4049

Unfortunately, author of original PR did not follow up on review, but I agree that this would be a nice addition!

# How

List Pressable on Core Components and APIs intro page. Tweak styles a bit for a better readability.

# Preview

<img width="1708" height="1152" alt="Screenshot 2025-08-11 at 15 33 42" src="https://github.com/user-attachments/assets/e800f169-7477-461c-9923-813e8afb705f" />

