### PR TITLE
expand Alex check allowed terms list

### DIFF
--- a/.alexrc.js
+++ b/.alexrc.js
@@ -24,6 +24,13 @@ exports.allow = [
 
   // allowing this term, since it seems to be used not in insensitive cases
   'straightforward',
+
+  // allowing those terms, since they refer to colors and the surname of one of core contributors
+  'black',
+  'white',
+
+  // allowing this term, since we use it for expressing gratitude for certain contributors
+  'special',
 ];
 
 // Use a "maybe" level of profanity instead of the default "unlikely".

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/blog/2020-07-06-version-0.63.md
+++ b/website/blog/2020-07-06-version-0.63.md
@@ -136,8 +136,6 @@ At the same time, we are dropping support for Node 8. [Its LTS maintenance cycle
 
 Thank you to the hundreds of contributors that helped make 0.63 possible!
 
-<!--alex ignore special white-->
-
 > Special thanks to [Rick Hanlon](https://twitter.com/rickhanlonii) for authoring the section on `LogBox` and [Eli White](https://twitter.com/Eli_White) for authoring the `Pressable` part of this article.
 
 To see all the updates, take a look at the [0.63 changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#v0630).

--- a/website/blog/2021-08-26-many-platform-vision.md
+++ b/website/blog/2021-08-26-many-platform-vision.md
@@ -47,8 +47,6 @@ As another example, our research into user perception of speed on the web led to
 
 In addition to domain-specific engineers and meetups and conferences, each platform also brings other unique players solving similar problems. On the web, React (which directly powers React Native) frequently draws inspiration from other open source web frameworks like [Vue](https://vuejs.org/), [Preact](https://preactjs.com/), and [Svelte](https://svelte.dev/). On mobile, React Native has been inspired by other open source mobile frameworks, and we have been learning from other mobile frameworks built inside Facebook.
 
-<!-- alex ignore special -->
-
 **We believe that competition leads to better outcomes for everyone in the long run.** By studying what makes other players on each platform great, we can learn lessons that may apply to other platforms. For example, the race to simplify complex websites influenced the development of React and gave React Native a head start to offer a declarative framework for mobile apps. The demand for faster iteration cycles and build times for the web also led to the development of Fast Refresh which significantly benefited React Native. Similarly, performance optimizations in our internal mobile frameworks — especially around data fetching and parallelization — challenged us to improve React Native in a way that has also influenced React when we built the new [Facebook.com](https://facebook.com/) website.
 
 <figure>

--- a/website/blog/2021-10-26-toward-hermes-being-the-default.md
+++ b/website/blog/2021-10-26-toward-hermes-being-the-default.md
@@ -81,6 +81,4 @@ It’s extremely important for us to prepare the ecosystem for a smooth adoption
 
 We’d love to thank the Hermes team, the React Native team, and the many contributors from the React Native community for their work to improve Hermes.
 
-<!-- alex ignore white -->
-
 I’d also love to personally thank (in alphabetic order) Eli White, Luna Wei, Neil Dhar, Tim Yung, Tzvetan Mikov, and many others for their help during the writing.

--- a/website/blog/2024-10-23-release-0.76-new-architecture.md
+++ b/website/blog/2024-10-23-release-0.76-new-architecture.md
@@ -91,8 +91,6 @@ The [previous shadow functionality](https://reactnative.dev/docs/shadow-props) h
 
 #### Limitations & Spec Deviations
 
-<!--alex ignore black -->
-
 - The default shadow color is black, not the parent’s color
 - Android normal shadows are supported on **Android 9+**
 - Android inset shadows are supported on **Android 10+**

--- a/website/blog/2025-01-21-version-0.77.md
+++ b/website/blog/2025-01-21-version-0.77.md
@@ -124,9 +124,7 @@ To help have more granular control about what is blending together, we also adde
 - `overlay`: Multiplies or screens the colors, depending on the backdrop color value.
 - `darken`: Selects the darker of the backdrop and source colors.
 - `lighten`: Selects the lighter of the backdrop and source colors.
-<!--alex ignore black-->
 - `color-dodge`: Brightens the backdrop color to reflect the source color. Painting with black produces no changes.
-<!--alex ignore white-->
 - `color-burn`: Darkens the backdrop color to reflect the source color. Painting with white produces no change.
 - `hard-light`: Multiplies or screens the colors, depending on the source color value. The effect is similar to shining a harsh spotlight on the backdrop.
 - `soft-light`: Darkens or lightens the colors, depending on the source color value. The effect is similar to shining a diffused spotlight on the backdrop.

--- a/website/blog/2025-06-12-react-native-0.80.md
+++ b/website/blog/2025-06-12-react-native-0.80.md
@@ -205,8 +205,6 @@ Further smaller breaking changes are listed [in the CHANGELOG for 0.80](https://
 
 React Native 0.80 contains over 1167 commits from 127 contributors. Thanks for all your hard work!
 
-<!--alex ignore special white-->
-
 We want to send a special thank you to those community members that shipped significant contributions in this release:
 
 - [Christian Falch](https://github.com/chrfalch) for the work on the iOS prebuilds for React Native Dependencies

--- a/website/versioned_docs/version-0.73/colors.md
+++ b/website/versioned_docs/version-0.73/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.74/colors.md
+++ b/website/versioned_docs/version-0.74/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.75/colors.md
+++ b/website/versioned_docs/version-0.75/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.76/colors.md
+++ b/website/versioned_docs/version-0.76/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.77/colors.md
+++ b/website/versioned_docs/version-0.77/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.78/colors.md
+++ b/website/versioned_docs/version-0.78/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.79/colors.md
+++ b/website/versioned_docs/version-0.79/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/website/versioned_docs/version-0.80/colors.md
+++ b/website/versioned_docs/version-0.80/colors.md
@@ -74,8 +74,6 @@ This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/T
 
 Named colors implementation follows the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color):
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)


### PR DESCRIPTION
# Why

Alex word check could be a bit too strict in some case.

# How

Expand Alex check allowed terms list to allow `black`, `white` and `special` terms commonly used in doc pages and blog posts, to reduce the friction when landing new content.
