### PR TITLE
improve docs footer layout on smaller screens

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1221,22 +1221,30 @@ button[class*="tocCollapsibleButton"] {
   .theme-last-updated {
     line-height: 18px;
   }
+
+  .theme-doc-footer-edit-meta-row {
+    padding: 0 var(--ifm-spacing-horizontal);
+    grid-row-gap: 8px;
+  }
 }
 
-@media only screen and (min-width: 540px) and (max-width: 996px) {
-  .theme-doc-footer .col {
-    flex-basis: 50% !important;
-    max-width: 50% !important;
+@media only screen and (max-width: 1320px) {
+  .theme-doc-footer-edit-meta-row {
+    flex-direction: column;
+  }
+}
+
+@media only screen and (max-width: 996px) {
+  div[class^="lastUpdated"] {
+    text-align: end;
   }
 }
 
 @media only screen and (max-width: 539px) {
-  .theme-doc-footer .col {
+  .theme-doc-footer-edit-meta-row div[class^="editButtons"] {
+    flex-direction: column;
+    grid-row-gap: 8px;
     text-align: center;
-
-    &:first-child {
-      margin-bottom: 16px;
-    }
   }
 }
 


### PR DESCRIPTION
# Why

I have spotted that docs footer components (edit buttons, last modification date) look a bit off on smaller screens.

<img width="854" height="1224" alt="Screenshot 2025-08-11 at 18 35 26" src="https://github.com/user-attachments/assets/838c7b88-02bb-4a3b-8a44-89bbdfe99ef1" />

<img width="1234" height="1234" alt="Screenshot 2025-08-11 at 18 36 28" src="https://github.com/user-attachments/assets/08b15713-8c2f-4eb7-bc6b-f167bda9ca51" />

# How

Adjust custom styles, alter layout on small screens and add missing horizontal padding for the container.

# Preview

<img width="830" height="1250" alt="Screenshot 2025-08-11 at 18 43 11" src="https://github.com/user-attachments/assets/9bb68442-e7ed-4ca5-a2b4-d84c1069227e" />

<img width="1234" height="1268" alt="Screenshot 2025-08-11 at 18 35 58" src="https://github.com/user-attachments/assets/a7f16bdb-6062-49c0-90d6-1d14c4b5340a" />
