### PR TITLE
add missing `key` to the blog sidebar components

### DIFF
--- a/website/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/website/src/theme/BlogSidebar/Desktop/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {Fragment} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {translate} from '@docusaurus/Translate';
@@ -34,7 +34,7 @@ export default function BlogSidebarDesktop({sidebar}: Props) {
             );
             cachedYear = postYear;
             return (
-              <>
+              <Fragment key={item.permalink}>
                 {yearHeader}
                 <li key={item.permalink} className={styles.sidebarItem}>
                   <Link
@@ -45,7 +45,7 @@ export default function BlogSidebarDesktop({sidebar}: Props) {
                     {item.title}
                   </Link>
                 </li>
-              </>
+              </Fragment>
             );
           })}
         </ul>

--- a/website/src/theme/BlogSidebar/Mobile/index.tsx
+++ b/website/src/theme/BlogSidebar/Mobile/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, {Fragment} from 'react';
 import Link from '@docusaurus/Link';
 import {NavbarSecondaryMenuFiller} from '@docusaurus/theme-common';
 import styles from './styles.module.css';
@@ -22,7 +22,7 @@ function BlogSidebarMobileSecondaryMenu({sidebar}: Props) {
         );
         cachedYear = postYear;
         return (
-          <>
+          <Fragment key={item.permalink}>
             {yearHeader}
             <li key={item.permalink} className="menu__list-item">
               <Link
@@ -33,7 +33,7 @@ function BlogSidebarMobileSecondaryMenu({sidebar}: Props) {
                 {item.title}
               </Link>
             </li>
-          </>
+          </Fragment>
         );
       })}
     </ul>


### PR DESCRIPTION
# Why

Spotted a warning in the dev console about missing `key` in the blog sidebars.

<img width="1734" height="460" alt="Screenshot 2025-08-12 at 07 59 03" src="https://github.com/user-attachments/assets/a8b4655e-ad87-4576-aef0-f1a754eb3e9c" />

# How

Add missing `key` to the blog sidebar link in Desktop and Mobile components.