### PR TITLE
fix `class` attr warning for SnackPlayer and on multiple pages

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -48,7 +48,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -83,15 +83,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -104,11 +104,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -165,13 +165,13 @@ In the above example method `addOne` changes the state variable `count`. When th
 - **toolbar** Used to represent a toolbar (a container of action buttons or components).
 - **grid** Used with ScrollView, VirtualizedList, FlatList, or SectionList to represent a grid. Adds the in/out of grid announcements to Android's GridView.
 
-### `accessibilityShowsLargeContentViewer` <div class="label ios">iOS</div>
+### `accessibilityShowsLargeContentViewer` <div className="label ios">iOS</div>
 
 A boolean value that determines whether the large content viewer is shown when the user performs a long press on the element.
 
 Available in iOS 13.0 and later.
 
-### `accessibilityLargeContentTitle` <div class="label ios">iOS</div>
+### `accessibilityLargeContentTitle` <div className="label ios">iOS</div>
 
 A string that will be used as the title of the large content viewer when it is shown.
 
@@ -214,13 +214,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -292,7 +292,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -307,7 +307,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -321,7 +321,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -337,7 +337,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -358,15 +358,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -464,7 +464,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -479,7 +479,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -499,7 +499,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -90,16 +90,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -126,14 +126,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -144,13 +144,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -162,7 +162,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -172,7 +172,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -182,7 +182,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -202,7 +202,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -222,7 +222,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/docs/activityindicator.md
+++ b/docs/activityindicator.md
@@ -62,13 +62,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -82,6 +82,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -78,7 +78,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -143,16 +143,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -169,21 +169,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -201,7 +201,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -230,12 +230,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -247,8 +247,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -86,11 +86,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/docs/button.md
+++ b/docs/button.md
@@ -112,7 +112,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -122,7 +122,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -212,7 +212,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -222,7 +222,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -232,7 +232,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -242,7 +242,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -252,7 +252,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -262,7 +262,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -282,7 +282,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/docs/fabric-native-components-ios.md
+++ b/docs/fabric-native-components-ios.md
@@ -38,19 +38,19 @@ cd ios
 open Demo.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `WebView`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 
-<img class="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
+<img className="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
 
 5. Repeat step 4 and create a header file named `RCTWebView.h`.
 
@@ -213,10 +213,10 @@ To link the WebKit framework in your app, follow these steps:
 3. Select the General tab
 4. Scroll down until you find the _"Frameworks, Libraries, and Embedded Contents"_ section, and press the `+` button
 
-<img class="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
+<img className="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
 
 5. In the search bar, filter for WebKit
 6. Select the WebKit framework
 7. Click on Add.
 
-<img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
+<img className="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />

--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -356,7 +356,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -416,7 +416,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/docs/image-style-props.md
+++ b/docs/image-style-props.md
@@ -312,7 +312,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -167,7 +167,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -202,7 +202,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -286,7 +286,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -306,7 +306,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -326,7 +326,7 @@ A string indicating which referrer to use when fetching the resource. Sets the v
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -368,7 +368,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 ---
 
-### `resizeMultiplier` <div class="label android">Android</div>
+### `resizeMultiplier` <div className="label android">Android</div>
 
 When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
 
@@ -464,7 +464,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -474,9 +474,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -492,9 +492,9 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>               | Type   | Description                |
-| ---------------------------------------------------- | ------ | -------------------------- |
-| uri <div class="label basic required">Required</div> | string | The location of the image. |
+| <div className="wideColumn">Name</div>                   | Type   | Description                |
+| -------------------------------------------------------- | ------ | -------------------------- |
+| uri <div className="label basic required">Required</div> | string | The location of the image. |
 
 ---
 
@@ -513,10 +513,10 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type   | Description                  |
-| -------------------------------------------------------- | ------ | ---------------------------- |
-| uri <div class="label basic required">Required</div>     | string | The location of the image.   |
-| headers <div class="label basic required">Required</div> | object | The headers for the request. |
+| <div className="wideColumn">Name</div>                       | Type   | Description                  |
+| ------------------------------------------------------------ | ------ | ---------------------------- |
+| uri <div className="label basic required">Required</div>     | string | The location of the image.   |
+| headers <div className="label basic required">Required</div> | object | The headers for the request. |
 
 ---
 
@@ -530,10 +530,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -549,9 +549,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -570,13 +570,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -621,17 +621,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -652,7 +652,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -136,7 +136,7 @@ The `backdropColor` of the modal (or background color of the modal's container.)
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -146,7 +146,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `navigationBarTranslucent` <div class="label android">Android</div>
+### `navigationBarTranslucent` <div className="label android">Android</div>
 
 The `navigationBarTranslucent` prop determines whether your modal should go under the system navigation bar. However, `statusBarTranslucent` also needs to be set to `true` to make navigation bar translucent.
 
@@ -156,7 +156,7 @@ The `navigationBarTranslucent` prop determines whether your modal should go unde
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -166,7 +166,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -176,7 +176,7 @@ The `onOrientationChange` callback is called when the orientation changes while 
 
 ---
 
-### `allowSwipeDismissal` <div class="label ios">iOS</div>
+### `allowSwipeDismissal` <div className="label ios">iOS</div>
 
 Controls whether the modal can be dismissed by swiping down on iOS.
 This requires you to implement the `onRequestClose` prop to handle the dismissal.
@@ -208,7 +208,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -225,7 +225,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -235,7 +235,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/docs/platform-specific-code.md
+++ b/docs/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -89,7 +89,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/docs/pressable.md
+++ b/docs/pressable.md
@@ -108,7 +108,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -116,7 +116,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/docs/pressevent.md
+++ b/docs/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/docs/refreshcontrol.md
+++ b/docs/refreshcontrol.md
@@ -66,7 +66,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -76,7 +76,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -86,7 +86,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -106,7 +106,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -126,7 +126,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -136,7 +136,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -146,7 +146,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -156,7 +156,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -83,7 +83,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -93,7 +93,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -103,7 +103,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -113,7 +113,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -123,7 +123,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -133,7 +133,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -143,7 +143,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -153,7 +153,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -163,7 +163,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -206,7 +206,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -239,7 +239,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -269,7 +269,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -279,7 +279,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -301,7 +301,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -374,7 +374,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -384,7 +384,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -394,7 +394,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -480,7 +480,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -490,7 +490,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -516,7 +516,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -526,7 +526,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -580,7 +580,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -590,7 +590,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -600,7 +600,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -610,7 +610,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -716,7 +716,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/docs/sectionlist.md
+++ b/docs/sectionlist.md
@@ -105,7 +105,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -127,7 +127,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -293,13 +293,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -331,9 +331,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -355,10 +355,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/docs/shadow-props.md
+++ b/docs/shadow-props.md
@@ -240,7 +240,7 @@ Both `boxShadow` and `dropShadow` are generally more capable than the `shadow` p
 
 See [View Style Props](./view-style-props#boxshadow) for documentation.
 
-### `dropShadow` <div class="label android">Android</div>
+### `dropShadow` <div className="label android">Android</div>
 
 See [View Style Props](./view-style-props#filter) for documentation.
 
@@ -256,7 +256,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -266,7 +266,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -276,7 +276,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/docs/share.md
+++ b/docs/share.md
@@ -108,10 +108,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -127,7 +127,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -243,7 +243,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -261,7 +261,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -297,7 +297,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -307,7 +307,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -317,7 +317,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -341,9 +341,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -357,9 +357,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -376,14 +376,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -397,10 +397,10 @@ Due to edge-to-edge enforcement introduced in Android 15, setting background col
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -414,10 +414,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -431,14 +431,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -448,13 +448,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -468,9 +468,9 @@ Due to edge-to-edge enforcement introduced in Android 15, setting the status bar
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -66,7 +66,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -805,7 +805,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -855,7 +855,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -863,7 +863,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -879,7 +879,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -919,7 +919,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -927,7 +927,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/docs/text.md
+++ b/docs/text.md
@@ -215,7 +215,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -319,7 +319,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -387,7 +387,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -399,7 +399,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -409,7 +409,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -462,7 +462,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -656,7 +656,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -674,7 +674,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -694,7 +694,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -704,7 +704,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -174,7 +174,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -188,7 +188,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -261,7 +261,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -271,7 +271,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -291,7 +291,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -322,7 +322,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -332,7 +332,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -352,7 +352,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -392,7 +392,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -408,7 +408,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -424,7 +424,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -434,7 +434,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -444,7 +444,7 @@ An optional identifier which links a custom [InputAccessoryView](inputaccessoryv
 
 ---
 
-### `inputAccessoryViewButtonLabel` <div class="label ios">iOS</div>
+### `inputAccessoryViewButtonLabel` <div className="label ios">iOS</div>
 
 An optional label that overrides the default [InputAccessoryView](inputaccessoryview.md) button label.
 
@@ -477,7 +477,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -743,7 +743,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -789,7 +789,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -799,7 +799,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -809,7 +809,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -849,7 +849,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -879,7 +879,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -930,7 +930,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -996,7 +996,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -1032,7 +1032,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -1042,7 +1042,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1062,7 +1062,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -1072,7 +1072,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 
@@ -1082,7 +1082,7 @@ Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, 
 
 ---
 
-### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
 
 If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
 

--- a/docs/the-new-architecture/create-module-library.md
+++ b/docs/the-new-architecture/create-module-library.md
@@ -38,7 +38,7 @@ npx create-react-native-library@latest <Name of Your Library>
 
 Once the interactive prompt is done, the tool creates a folder whose structure looks like this in Visual Studio Code:
 
-<img class="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
+<img className="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
 
 Feel free to explore the code that has been created for you. However, the most important parts:
 

--- a/docs/touchablehighlight.md
+++ b/docs/touchablehighlight.md
@@ -138,7 +138,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -148,7 +148,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -158,7 +158,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -168,7 +168,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -178,7 +178,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -188,7 +188,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/docs/touchablenativefeedback.md
+++ b/docs/touchablenativefeedback.md
@@ -104,7 +104,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -144,7 +144,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -154,7 +154,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/docs/touchableopacity.md
+++ b/docs/touchableopacity.md
@@ -84,7 +84,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -94,7 +94,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -104,7 +104,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -84,7 +84,7 @@ export default TouchableWithoutFeedbackExample;
 
 ## Props
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -116,7 +116,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -264,7 +264,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -278,7 +278,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -518,7 +518,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/docs/turbo-native-modules-ios.md
+++ b/docs/turbo-native-modules-ios.md
@@ -18,27 +18,27 @@ cd ios
 open TurboModuleExample.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `NativeLocalStorage`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
 
 3. In the `NativeLocalStorage` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
 
 4. Use the <code>Cocoa Touch Class</code>.
 
-<img class="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
+<img className="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
 
 5. Name the Cocoa Touch Class <code>RCTNativeLocalStorage</code> with the <code>Objective-C</code> language.
 
-<img class="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
+<img className="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
 
 6. Rename <code>RCTNativeLocalStorage.m</code> → <code>RCTNativeLocalStorage.mm</code> making it an Objective-C++ file.
 
-<img class="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
+<img className="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
 
 ## Implement localStorage with NSUserDefaults
 

--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -159,7 +159,7 @@ export default App;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -304,7 +304,7 @@ These shadows can be composed together so that a single `boxShadow` can be compr
 | --------------------------- |
 | array of BoxShadowValue ojects \| string |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -314,7 +314,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 
@@ -341,7 +341,7 @@ The following filter functions work across all platforms:
 Due to issues with performance and spec compliance, these are the only two filter functions available on iOS. There are plans to explore some potential workarounds using SwiftUI instead of UIKit for this implementation.
 :::
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following filter functions work on Android only:
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -55,7 +55,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -77,7 +77,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -89,7 +89,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -111,7 +111,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -192,7 +192,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -383,7 +383,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -419,7 +419,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -462,7 +462,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -502,7 +502,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -524,7 +524,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -534,7 +534,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -556,7 +556,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -712,7 +712,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -734,7 +734,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -756,7 +756,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -166,7 +166,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -180,7 +180,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -194,7 +194,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -62,7 +62,7 @@ async function toJsxNode(node) {
     type: 'mdxJsxTextElement',
     name: 'div',
     attributes: [
-      attr('class', 'snack-player'),
+      attr('className', 'snack-player'),
       attr('data-snack-name', name),
       attr('data-snack-description', description),
       attr('data-snack-files', files),

--- a/website/versioned_docs/version-0.73/accessibility.md
+++ b/website/versioned_docs/version-0.73/accessibility.md
@@ -46,7 +46,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -81,15 +81,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -102,11 +102,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -192,13 +192,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -270,7 +270,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -285,7 +285,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -299,7 +299,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -315,7 +315,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -336,15 +336,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -440,7 +440,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -455,7 +455,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -475,7 +475,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.73/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.73/accessibilityinfo.md
@@ -87,16 +87,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -123,14 +123,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -141,13 +141,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -159,7 +159,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -169,7 +169,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -179,7 +179,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -199,7 +199,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -219,7 +219,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.73/activityindicator.md
+++ b/website/versioned_docs/version-0.73/activityindicator.md
@@ -59,13 +59,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -79,6 +79,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.73/alert.md
+++ b/website/versioned_docs/version-0.73/alert.md
@@ -75,7 +75,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -137,16 +137,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -163,21 +163,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -195,7 +195,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -224,12 +224,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -241,8 +241,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.73/appstate.md
+++ b/website/versioned_docs/version-0.73/appstate.md
@@ -83,11 +83,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.73/button.md
+++ b/website/versioned_docs/version-0.73/button.md
@@ -116,7 +116,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -126,7 +126,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -146,7 +146,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -216,7 +216,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -226,7 +226,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -236,7 +236,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -246,7 +246,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -256,7 +256,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -266,7 +266,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -286,7 +286,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.73/flatlist.md
+++ b/website/versioned_docs/version-0.73/flatlist.md
@@ -364,7 +364,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -424,7 +424,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.73/image-style-props.md
+++ b/website/versioned_docs/version-0.73/image-style-props.md
@@ -328,7 +328,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.73/image.md
+++ b/website/versioned_docs/version-0.73/image.md
@@ -165,7 +165,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -200,7 +200,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -284,7 +284,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -304,7 +304,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -314,7 +314,7 @@ When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/pro
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -444,7 +444,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -454,9 +454,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -476,11 +476,11 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -501,12 +501,12 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| headers <div class="label basic required">Required</div> | object   | The headers for the request.                                                                         |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| headers <div className="label basic required">Required</div> | object   | The headers for the request.                                                                         |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -520,10 +520,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -539,9 +539,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -560,13 +560,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -611,17 +611,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.73/linking.md
+++ b/website/versioned_docs/version-0.73/linking.md
@@ -636,7 +636,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.73/modal.md
+++ b/website/versioned_docs/version-0.73/modal.md
@@ -124,7 +124,7 @@ Possible values:
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -134,7 +134,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -144,7 +144,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -175,7 +175,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -192,7 +192,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -202,7 +202,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.73/platform.md
+++ b/website/versioned_docs/version-0.73/platform.md
@@ -84,7 +84,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.73/pressable.md
+++ b/website/versioned_docs/version-0.73/pressable.md
@@ -105,7 +105,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -113,7 +113,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.73/pressevent.md
+++ b/website/versioned_docs/version-0.73/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.73/refreshcontrol.md
+++ b/website/versioned_docs/version-0.73/refreshcontrol.md
@@ -69,7 +69,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -79,7 +79,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -89,7 +89,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -109,7 +109,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -129,7 +129,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -139,7 +139,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -149,7 +149,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -159,7 +159,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.73/scrollview.md
+++ b/website/versioned_docs/version-0.73/scrollview.md
@@ -88,7 +88,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -98,7 +98,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -108,7 +108,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -118,7 +118,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -128,7 +128,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -138,7 +138,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -148,7 +148,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -158,7 +158,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -168,7 +168,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -211,7 +211,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -244,7 +244,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -274,7 +274,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -284,7 +284,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -306,7 +306,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -379,7 +379,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -389,7 +389,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -399,7 +399,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -485,7 +485,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -495,7 +495,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -523,7 +523,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -533,7 +533,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -587,7 +587,7 @@ This controls how often the scroll event will be fired while scrolling (as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -597,7 +597,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -607,7 +607,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -617,7 +617,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -723,7 +723,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.73/sectionlist.md
+++ b/website/versioned_docs/version-0.73/sectionlist.md
@@ -109,7 +109,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -131,7 +131,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -297,13 +297,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -335,9 +335,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -359,10 +359,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.73/shadow-props.md
+++ b/website/versioned_docs/version-0.73/shadow-props.md
@@ -226,7 +226,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -236,7 +236,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -246,7 +246,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.73/share.md
+++ b/website/versioned_docs/version-0.73/share.md
@@ -102,10 +102,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -121,7 +121,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.73/statusbar.md
+++ b/website/versioned_docs/version-0.73/statusbar.md
@@ -227,7 +227,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -245,7 +245,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -277,7 +277,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -287,7 +287,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -297,7 +297,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -317,9 +317,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -333,9 +333,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -352,14 +352,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -369,10 +369,10 @@ Set the background color for the status bar.
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -386,10 +386,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -403,14 +403,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -420,13 +420,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -436,9 +436,9 @@ Control the translucency of the status bar.
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.73/switch.md
+++ b/website/versioned_docs/version-0.73/switch.md
@@ -63,7 +63,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.73/text-style-props.md
+++ b/website/versioned_docs/version-0.73/text-style-props.md
@@ -804,7 +804,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -854,7 +854,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -862,7 +862,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -878,7 +878,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -918,7 +918,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -926,7 +926,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.73/text.md
+++ b/website/versioned_docs/version-0.73/text.md
@@ -201,7 +201,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -305,7 +305,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -373,7 +373,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -385,7 +385,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -395,7 +395,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -448,7 +448,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -642,7 +642,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -660,7 +660,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -680,7 +680,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -690,7 +690,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.73/textinput.md
+++ b/website/versioned_docs/version-0.73/textinput.md
@@ -157,7 +157,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -171,7 +171,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -242,7 +242,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -252,7 +252,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -272,7 +272,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -303,7 +303,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -313,7 +313,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -333,7 +333,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -373,7 +373,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -389,7 +389,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -405,7 +405,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -415,7 +415,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -446,7 +446,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -532,7 +532,7 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -708,7 +708,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -754,7 +754,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -764,7 +764,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -774,7 +774,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -834,7 +834,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -860,7 +860,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -926,7 +926,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -964,7 +964,7 @@ see [Issue#7070](https://github.com/facebook/react-native/issues/7070) for more 
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -974,7 +974,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -994,7 +994,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.73/touchablehighlight.md
+++ b/website/versioned_docs/version-0.73/touchablehighlight.md
@@ -135,7 +135,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -145,7 +145,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -155,7 +155,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -165,7 +165,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -175,7 +175,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -185,7 +185,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.73/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.73/touchablenativefeedback.md
@@ -100,7 +100,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -110,7 +110,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -120,7 +120,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -130,7 +130,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -140,7 +140,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -150,7 +150,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.73/touchableopacity.md
+++ b/website/versioned_docs/version-0.73/touchableopacity.md
@@ -81,7 +81,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `tvParallaxProperties` <div class="label ios">IOS</div>
+### `tvParallaxProperties` <div className="label ios">IOS</div>
 
 _(Apple TV only)_ Object with properties to control Apple TV parallax effects.
 
@@ -100,7 +100,7 @@ _(Apple TV only)_ Object with properties to control Apple TV parallax effects.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -110,7 +110,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -120,7 +120,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -130,7 +130,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -140,7 +140,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -150,7 +150,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.73/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.73/touchablewithoutfeedback.md
@@ -109,7 +109,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -257,7 +257,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -271,7 +271,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -511,7 +511,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.73/view-style-props.md
+++ b/website/versioned_docs/version-0.73/view-style-props.md
@@ -159,7 +159,7 @@ export default ViewStyleProps;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -291,7 +291,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 

--- a/website/versioned_docs/version-0.73/view.md
+++ b/website/versioned_docs/version-0.73/view.md
@@ -57,7 +57,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -79,7 +79,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -91,7 +91,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -113,7 +113,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -194,7 +194,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -363,7 +363,7 @@ Represents the textual description of the component. Has precedence over the `te
 
 ---
 
-### `collapsable` <div class="label android">Android</div>
+### `collapsable` <div className="label android">Android</div>
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 
@@ -373,7 +373,7 @@ Views that are only used to layout their children or otherwise don't draw anythi
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -409,7 +409,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -452,7 +452,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -462,7 +462,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -514,7 +514,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -546,7 +546,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -702,7 +702,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -724,7 +724,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -746,7 +746,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.73/virtualizedlist.md
+++ b/website/versioned_docs/version-0.73/virtualizedlist.md
@@ -178,7 +178,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -192,7 +192,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -206,7 +206,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.74/accessibility.md
+++ b/website/versioned_docs/version-0.74/accessibility.md
@@ -46,7 +46,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -81,15 +81,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -102,11 +102,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -192,13 +192,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -270,7 +270,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -285,7 +285,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -299,7 +299,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -315,7 +315,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -336,15 +336,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -440,7 +440,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -455,7 +455,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -475,7 +475,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.74/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.74/accessibilityinfo.md
@@ -87,16 +87,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -123,14 +123,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -141,13 +141,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -159,7 +159,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -169,7 +169,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -179,7 +179,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -199,7 +199,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -219,7 +219,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.74/activityindicator.md
+++ b/website/versioned_docs/version-0.74/activityindicator.md
@@ -59,13 +59,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -79,6 +79,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.74/alert.md
+++ b/website/versioned_docs/version-0.74/alert.md
@@ -75,7 +75,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -137,16 +137,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -163,21 +163,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -195,7 +195,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -224,12 +224,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -241,8 +241,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.74/appstate.md
+++ b/website/versioned_docs/version-0.74/appstate.md
@@ -83,11 +83,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.74/button.md
+++ b/website/versioned_docs/version-0.74/button.md
@@ -116,7 +116,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -126,7 +126,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -146,7 +146,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -216,7 +216,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -226,7 +226,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -236,7 +236,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -246,7 +246,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -256,7 +256,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -266,7 +266,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -286,7 +286,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.74/flatlist.md
+++ b/website/versioned_docs/version-0.74/flatlist.md
@@ -364,7 +364,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -424,7 +424,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.74/image-style-props.md
+++ b/website/versioned_docs/version-0.74/image-style-props.md
@@ -328,7 +328,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.74/image.md
+++ b/website/versioned_docs/version-0.74/image.md
@@ -165,7 +165,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -200,7 +200,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -284,7 +284,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -304,7 +304,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -314,7 +314,7 @@ When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/pro
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -444,7 +444,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -454,9 +454,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -476,11 +476,11 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -501,12 +501,12 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| headers <div class="label basic required">Required</div> | object   | The headers for the request.                                                                         |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| headers <div className="label basic required">Required</div> | object   | The headers for the request.                                                                         |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -520,10 +520,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -539,9 +539,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -560,13 +560,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -611,17 +611,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.74/linking.md
+++ b/website/versioned_docs/version-0.74/linking.md
@@ -636,7 +636,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.74/modal.md
+++ b/website/versioned_docs/version-0.74/modal.md
@@ -124,7 +124,7 @@ Possible values:
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -134,7 +134,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -144,7 +144,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -175,7 +175,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -192,7 +192,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -202,7 +202,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.74/platform-specific-code.md
+++ b/website/versioned_docs/version-0.74/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.74/platform.md
+++ b/website/versioned_docs/version-0.74/platform.md
@@ -84,7 +84,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.74/pressable.md
+++ b/website/versioned_docs/version-0.74/pressable.md
@@ -105,7 +105,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -113,7 +113,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.74/pressevent.md
+++ b/website/versioned_docs/version-0.74/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.74/refreshcontrol.md
+++ b/website/versioned_docs/version-0.74/refreshcontrol.md
@@ -69,7 +69,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -79,7 +79,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -89,7 +89,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -109,7 +109,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -129,7 +129,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -139,7 +139,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -149,7 +149,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -159,7 +159,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.74/scrollview.md
+++ b/website/versioned_docs/version-0.74/scrollview.md
@@ -88,7 +88,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -98,7 +98,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -108,7 +108,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -118,7 +118,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -128,7 +128,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -138,7 +138,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -148,7 +148,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -158,7 +158,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -168,7 +168,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -211,7 +211,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -244,7 +244,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -274,7 +274,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -284,7 +284,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -306,7 +306,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -379,7 +379,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -389,7 +389,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -399,7 +399,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -485,7 +485,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -495,7 +495,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -521,7 +521,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -531,7 +531,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -585,7 +585,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -595,7 +595,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -605,7 +605,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -615,7 +615,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -721,7 +721,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.74/sectionlist.md
+++ b/website/versioned_docs/version-0.74/sectionlist.md
@@ -109,7 +109,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -131,7 +131,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -297,13 +297,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -335,9 +335,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -359,10 +359,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.74/shadow-props.md
+++ b/website/versioned_docs/version-0.74/shadow-props.md
@@ -226,7 +226,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -236,7 +236,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -246,7 +246,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.74/share.md
+++ b/website/versioned_docs/version-0.74/share.md
@@ -102,10 +102,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -121,7 +121,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.74/statusbar.md
+++ b/website/versioned_docs/version-0.74/statusbar.md
@@ -227,7 +227,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -245,7 +245,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -277,7 +277,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -287,7 +287,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -297,7 +297,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -317,9 +317,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -333,9 +333,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -352,14 +352,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -369,10 +369,10 @@ Set the background color for the status bar.
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -386,10 +386,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -403,14 +403,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -420,13 +420,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -436,9 +436,9 @@ Control the translucency of the status bar.
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.74/switch.md
+++ b/website/versioned_docs/version-0.74/switch.md
@@ -63,7 +63,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.74/text-style-props.md
+++ b/website/versioned_docs/version-0.74/text-style-props.md
@@ -804,7 +804,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -854,7 +854,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -862,7 +862,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -878,7 +878,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -918,7 +918,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -926,7 +926,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.74/text.md
+++ b/website/versioned_docs/version-0.74/text.md
@@ -201,7 +201,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -305,7 +305,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -373,7 +373,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -385,7 +385,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -395,7 +395,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -448,7 +448,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -642,7 +642,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -660,7 +660,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -680,7 +680,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -690,7 +690,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.74/textinput.md
+++ b/website/versioned_docs/version-0.74/textinput.md
@@ -157,7 +157,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -171,7 +171,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -242,7 +242,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -252,7 +252,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -272,7 +272,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -303,7 +303,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -313,7 +313,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -333,7 +333,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -373,7 +373,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -389,7 +389,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -405,7 +405,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -415,7 +415,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -446,7 +446,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -532,7 +532,7 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -708,7 +708,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -754,7 +754,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -764,7 +764,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -774,7 +774,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -814,7 +814,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -844,7 +844,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -870,7 +870,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -936,7 +936,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -972,7 +972,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -982,7 +982,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1002,7 +1002,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.74/touchablehighlight.md
+++ b/website/versioned_docs/version-0.74/touchablehighlight.md
@@ -135,7 +135,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -145,7 +145,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -155,7 +155,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -165,7 +165,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -175,7 +175,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -185,7 +185,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.74/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.74/touchablenativefeedback.md
@@ -100,7 +100,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -110,7 +110,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -120,7 +120,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -130,7 +130,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -140,7 +140,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -150,7 +150,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.74/touchableopacity.md
+++ b/website/versioned_docs/version-0.74/touchableopacity.md
@@ -81,7 +81,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `tvParallaxProperties` <div class="label ios">IOS</div>
+### `tvParallaxProperties` <div className="label ios">IOS</div>
 
 _(Apple TV only)_ Object with properties to control Apple TV parallax effects.
 
@@ -100,7 +100,7 @@ _(Apple TV only)_ Object with properties to control Apple TV parallax effects.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -110,7 +110,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -120,7 +120,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -130,7 +130,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -140,7 +140,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -150,7 +150,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.74/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.74/touchablewithoutfeedback.md
@@ -109,7 +109,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -257,7 +257,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -271,7 +271,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -511,7 +511,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.74/view-style-props.md
+++ b/website/versioned_docs/version-0.74/view-style-props.md
@@ -159,7 +159,7 @@ export default ViewStyleProps;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -289,7 +289,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 | ------ |
 | number |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -299,7 +299,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 

--- a/website/versioned_docs/version-0.74/view.md
+++ b/website/versioned_docs/version-0.74/view.md
@@ -57,7 +57,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -79,7 +79,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -91,7 +91,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -113,7 +113,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -194,7 +194,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -363,7 +363,7 @@ Represents the textual description of the component. Has precedence over the `te
 
 ---
 
-### `collapsable` <div class="label android">Android</div>
+### `collapsable` <div className="label android">Android</div>
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 
@@ -373,7 +373,7 @@ Views that are only used to layout their children or otherwise don't draw anythi
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -409,7 +409,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -452,7 +452,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -462,7 +462,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -514,7 +514,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -546,7 +546,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -702,7 +702,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -724,7 +724,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -746,7 +746,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.74/virtualizedlist.md
+++ b/website/versioned_docs/version-0.74/virtualizedlist.md
@@ -178,7 +178,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -192,7 +192,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -206,7 +206,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.75/accessibility.md
+++ b/website/versioned_docs/version-0.75/accessibility.md
@@ -46,7 +46,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -81,15 +81,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -102,11 +102,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -192,13 +192,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -270,7 +270,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -285,7 +285,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -299,7 +299,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -315,7 +315,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -336,15 +336,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -440,7 +440,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -455,7 +455,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -475,7 +475,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.75/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.75/accessibilityinfo.md
@@ -87,16 +87,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -123,14 +123,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -141,13 +141,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -159,7 +159,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -169,7 +169,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -179,7 +179,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -199,7 +199,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -219,7 +219,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.75/activityindicator.md
+++ b/website/versioned_docs/version-0.75/activityindicator.md
@@ -59,13 +59,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -79,6 +79,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.75/alert.md
+++ b/website/versioned_docs/version-0.75/alert.md
@@ -75,7 +75,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -137,16 +137,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -163,21 +163,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -195,7 +195,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -224,12 +224,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -241,8 +241,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.75/appstate.md
+++ b/website/versioned_docs/version-0.75/appstate.md
@@ -83,11 +83,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.75/button.md
+++ b/website/versioned_docs/version-0.75/button.md
@@ -116,7 +116,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -126,7 +126,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -146,7 +146,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -216,7 +216,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -226,7 +226,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -236,7 +236,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -246,7 +246,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -256,7 +256,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -266,7 +266,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -286,7 +286,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.75/flatlist.md
+++ b/website/versioned_docs/version-0.75/flatlist.md
@@ -364,7 +364,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -424,7 +424,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.75/image-style-props.md
+++ b/website/versioned_docs/version-0.75/image-style-props.md
@@ -328,7 +328,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.75/image.md
+++ b/website/versioned_docs/version-0.75/image.md
@@ -165,7 +165,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -200,7 +200,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -284,7 +284,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -304,7 +304,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -314,7 +314,7 @@ When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/pro
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -444,7 +444,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -454,9 +454,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -476,11 +476,11 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -501,12 +501,12 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| headers <div class="label basic required">Required</div> | object   | The headers for the request.                                                                         |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| headers <div className="label basic required">Required</div> | object   | The headers for the request.                                                                         |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -520,10 +520,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -539,9 +539,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -560,13 +560,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -611,17 +611,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.75/linking.md
+++ b/website/versioned_docs/version-0.75/linking.md
@@ -636,7 +636,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.75/modal.md
+++ b/website/versioned_docs/version-0.75/modal.md
@@ -124,7 +124,7 @@ Possible values:
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -134,7 +134,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -144,7 +144,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -175,7 +175,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -192,7 +192,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -202,7 +202,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.75/platform-specific-code.md
+++ b/website/versioned_docs/version-0.75/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.75/platform.md
+++ b/website/versioned_docs/version-0.75/platform.md
@@ -84,7 +84,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.75/pressable.md
+++ b/website/versioned_docs/version-0.75/pressable.md
@@ -105,7 +105,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -113,7 +113,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.75/pressevent.md
+++ b/website/versioned_docs/version-0.75/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.75/refreshcontrol.md
+++ b/website/versioned_docs/version-0.75/refreshcontrol.md
@@ -69,7 +69,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -79,7 +79,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -89,7 +89,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -109,7 +109,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -129,7 +129,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -139,7 +139,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -149,7 +149,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -159,7 +159,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.75/scrollview.md
+++ b/website/versioned_docs/version-0.75/scrollview.md
@@ -88,7 +88,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -98,7 +98,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -108,7 +108,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -118,7 +118,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -128,7 +128,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -138,7 +138,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -148,7 +148,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -158,7 +158,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -168,7 +168,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -211,7 +211,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -244,7 +244,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -274,7 +274,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -284,7 +284,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -306,7 +306,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -379,7 +379,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -389,7 +389,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -399,7 +399,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -485,7 +485,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -495,7 +495,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -521,7 +521,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -531,7 +531,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -585,7 +585,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -595,7 +595,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -605,7 +605,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -615,7 +615,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -721,7 +721,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.75/sectionlist.md
+++ b/website/versioned_docs/version-0.75/sectionlist.md
@@ -109,7 +109,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -131,7 +131,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -297,13 +297,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -335,9 +335,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -359,10 +359,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.75/shadow-props.md
+++ b/website/versioned_docs/version-0.75/shadow-props.md
@@ -226,7 +226,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -236,7 +236,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -246,7 +246,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.75/share.md
+++ b/website/versioned_docs/version-0.75/share.md
@@ -102,10 +102,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -121,7 +121,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.75/statusbar.md
+++ b/website/versioned_docs/version-0.75/statusbar.md
@@ -227,7 +227,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -245,7 +245,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -277,7 +277,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -287,7 +287,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -297,7 +297,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -317,9 +317,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -333,9 +333,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -352,14 +352,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -369,10 +369,10 @@ Set the background color for the status bar.
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -386,10 +386,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -403,14 +403,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -420,13 +420,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -436,9 +436,9 @@ Control the translucency of the status bar.
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.75/switch.md
+++ b/website/versioned_docs/version-0.75/switch.md
@@ -63,7 +63,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.75/text-style-props.md
+++ b/website/versioned_docs/version-0.75/text-style-props.md
@@ -804,7 +804,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -854,7 +854,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -862,7 +862,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -878,7 +878,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -918,7 +918,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -926,7 +926,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.75/text.md
+++ b/website/versioned_docs/version-0.75/text.md
@@ -201,7 +201,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -305,7 +305,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -373,7 +373,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -385,7 +385,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -395,7 +395,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -448,7 +448,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -642,7 +642,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -660,7 +660,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -680,7 +680,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -690,7 +690,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.75/textinput.md
+++ b/website/versioned_docs/version-0.75/textinput.md
@@ -157,7 +157,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -171,7 +171,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -242,7 +242,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -252,7 +252,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -272,7 +272,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -303,7 +303,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -313,7 +313,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -333,7 +333,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -373,7 +373,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -389,7 +389,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -405,7 +405,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -415,7 +415,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -446,7 +446,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -532,7 +532,7 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -708,7 +708,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -754,7 +754,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -764,7 +764,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -774,7 +774,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -814,7 +814,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -844,7 +844,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -870,7 +870,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -936,7 +936,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -972,7 +972,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -982,7 +982,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1002,7 +1002,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.75/touchablehighlight.md
+++ b/website/versioned_docs/version-0.75/touchablehighlight.md
@@ -135,7 +135,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -145,7 +145,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -155,7 +155,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -165,7 +165,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -175,7 +175,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -185,7 +185,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.75/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.75/touchablenativefeedback.md
@@ -100,7 +100,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -110,7 +110,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -120,7 +120,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -130,7 +130,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -140,7 +140,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -150,7 +150,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.75/touchableopacity.md
+++ b/website/versioned_docs/version-0.75/touchableopacity.md
@@ -81,7 +81,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -91,7 +91,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -101,7 +101,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -111,7 +111,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -121,7 +121,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -131,7 +131,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.75/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.75/touchablewithoutfeedback.md
@@ -109,7 +109,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -257,7 +257,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -271,7 +271,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -511,7 +511,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.75/view-style-props.md
+++ b/website/versioned_docs/version-0.75/view-style-props.md
@@ -159,7 +159,7 @@ export default ViewStyleProps;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -289,7 +289,7 @@ If the rounded border is not visible, try applying `overflow: 'hidden'` as well.
 | ------ |
 | number |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -299,7 +299,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 

--- a/website/versioned_docs/version-0.75/view.md
+++ b/website/versioned_docs/version-0.75/view.md
@@ -57,7 +57,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -79,7 +79,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -91,7 +91,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -113,7 +113,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -194,7 +194,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -363,7 +363,7 @@ Represents the textual description of the component. Has precedence over the `te
 
 ---
 
-### `collapsable` <div class="label android">Android</div>
+### `collapsable` <div className="label android">Android</div>
 
 Views that are only used to layout their children or otherwise don't draw anything may be automatically removed from the native hierarchy as an optimization. Set this property to `false` to disable this optimization and ensure that this `View` exists in the native view hierarchy.
 
@@ -373,7 +373,7 @@ Views that are only used to layout their children or otherwise don't draw anythi
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -409,7 +409,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -452,7 +452,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -462,7 +462,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -514,7 +514,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -524,7 +524,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -546,7 +546,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -702,7 +702,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -724,7 +724,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -746,7 +746,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.75/virtualizedlist.md
+++ b/website/versioned_docs/version-0.75/virtualizedlist.md
@@ -178,7 +178,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -192,7 +192,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -206,7 +206,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.76/accessibility.md
+++ b/website/versioned_docs/version-0.76/accessibility.md
@@ -46,7 +46,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -81,15 +81,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -102,11 +102,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -163,13 +163,13 @@ In the above example method `addOne` changes the state variable `count`. When th
 - **toolbar** Used to represent a toolbar (a container of action buttons or components).
 - **grid** Used with ScrollView, VirtualizedList, FlatList, or SectionList to represent a grid. Adds the in/out of grid announcements to Android's GridView.
 
-### `accessibilityShowsLargeContentViewer` <div class="label ios">iOS</div>
+### `accessibilityShowsLargeContentViewer` <div className="label ios">iOS</div>
 
 A boolean value that determines whether the large content viewer is shown when the user performs a long press on the element.
 
 Available in iOS 13.0 and later.
 
-### `accessibilityLargeContentTitle` <div class="label ios">iOS</div>
+### `accessibilityLargeContentTitle` <div className="label ios">iOS</div>
 
 A string that will be used as the title of the large content viewer when it is shown.
 
@@ -212,13 +212,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -290,7 +290,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -305,7 +305,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -319,7 +319,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -335,7 +335,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -356,15 +356,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -460,7 +460,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -475,7 +475,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -495,7 +495,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.76/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.76/accessibilityinfo.md
@@ -90,16 +90,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -126,14 +126,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -144,13 +144,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -162,7 +162,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -172,7 +172,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -182,7 +182,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -202,7 +202,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -222,7 +222,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.76/activityindicator.md
+++ b/website/versioned_docs/version-0.76/activityindicator.md
@@ -62,13 +62,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -82,6 +82,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.76/alert.md
+++ b/website/versioned_docs/version-0.76/alert.md
@@ -78,7 +78,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -143,16 +143,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -169,21 +169,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -201,7 +201,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -230,12 +230,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -247,8 +247,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.76/appstate.md
+++ b/website/versioned_docs/version-0.76/appstate.md
@@ -86,11 +86,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.76/button.md
+++ b/website/versioned_docs/version-0.76/button.md
@@ -112,7 +112,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -122,7 +122,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -212,7 +212,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -222,7 +222,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -232,7 +232,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -242,7 +242,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -252,7 +252,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -262,7 +262,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -282,7 +282,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.76/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.76/fabric-native-components-ios.md
@@ -38,19 +38,19 @@ cd ios
 open Demo.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `WebView`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 
-<img class="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
+<img className="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
 
 5. Rename <code>RCTWebView.m</code> → <code>RCTWebView.mm</code> making it an Objective-C++ file
 
@@ -252,10 +252,10 @@ To link the WebKit framework in your app, follow these steps:
 3. Select the General tab
 4. Scroll down until you find the _"Frameworks, Libraries, and Embedded Contents"_ section, and press the `+` button
 
-<img class="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
+<img className="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
 
 5. In the search bar, filter for WebKit
 6. Select the WebKit framework
 7. Click on Add.
 
-<img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
+<img className="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />

--- a/website/versioned_docs/version-0.76/flatlist.md
+++ b/website/versioned_docs/version-0.76/flatlist.md
@@ -356,7 +356,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -416,7 +416,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.76/image-style-props.md
+++ b/website/versioned_docs/version-0.76/image-style-props.md
@@ -312,7 +312,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.76/image.md
+++ b/website/versioned_docs/version-0.76/image.md
@@ -167,7 +167,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -202,7 +202,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -286,7 +286,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -306,7 +306,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -326,7 +326,7 @@ A string indicating which referrer to use when fetching the resource. Sets the v
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -368,7 +368,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 ---
 
-### `resizeMultiplier` <div class="label android">Android</div>
+### `resizeMultiplier` <div className="label android">Android</div>
 
 When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
 
@@ -464,7 +464,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -474,9 +474,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -496,11 +496,11 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -521,12 +521,12 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type     | Description                                                                                          |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| uri <div class="label basic required">Required</div>     | string   | The location of the image.                                                                           |
-| headers <div class="label basic required">Required</div> | object   | The headers for the request.                                                                         |
-| success <div class="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
-| failure                                                  | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
+| <div className="wideColumn">Name</div>                       | Type     | Description                                                                                          |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| uri <div className="label basic required">Required</div>     | string   | The location of the image.                                                                           |
+| headers <div className="label basic required">Required</div> | object   | The headers for the request.                                                                         |
+| success <div className="label basic required">Required</div> | function | The function that will be called if the image was successfully found and width and height retrieved. |
+| failure                                                      | function | The function that will be called if there was an error, such as failing to retrieve the image.       |
 
 ---
 
@@ -540,10 +540,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -559,9 +559,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -580,13 +580,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -631,17 +631,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.76/linking.md
+++ b/website/versioned_docs/version-0.76/linking.md
@@ -636,7 +636,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.76/modal.md
+++ b/website/versioned_docs/version-0.76/modal.md
@@ -126,7 +126,7 @@ Possible values:
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -136,7 +136,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -146,7 +146,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -177,7 +177,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -194,7 +194,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -204,7 +204,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.76/platform-specific-code.md
+++ b/website/versioned_docs/version-0.76/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.76/platform.md
+++ b/website/versioned_docs/version-0.76/platform.md
@@ -89,7 +89,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.76/pressable.md
+++ b/website/versioned_docs/version-0.76/pressable.md
@@ -108,7 +108,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -116,7 +116,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.76/pressevent.md
+++ b/website/versioned_docs/version-0.76/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.76/refreshcontrol.md
+++ b/website/versioned_docs/version-0.76/refreshcontrol.md
@@ -66,7 +66,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -76,7 +76,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -86,7 +86,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -106,7 +106,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -126,7 +126,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -136,7 +136,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -146,7 +146,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -156,7 +156,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.76/scrollview.md
+++ b/website/versioned_docs/version-0.76/scrollview.md
@@ -83,7 +83,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -93,7 +93,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -103,7 +103,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -113,7 +113,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -123,7 +123,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -133,7 +133,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -143,7 +143,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -153,7 +153,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -163,7 +163,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -206,7 +206,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -239,7 +239,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -269,7 +269,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -279,7 +279,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -301,7 +301,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -374,7 +374,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -384,7 +384,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -394,7 +394,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -480,7 +480,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -490,7 +490,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -516,7 +516,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -526,7 +526,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -580,7 +580,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -590,7 +590,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -600,7 +600,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -610,7 +610,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -716,7 +716,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.76/sectionlist.md
+++ b/website/versioned_docs/version-0.76/sectionlist.md
@@ -105,7 +105,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -127,7 +127,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -293,13 +293,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -331,9 +331,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -355,10 +355,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.76/shadow-props.md
+++ b/website/versioned_docs/version-0.76/shadow-props.md
@@ -240,7 +240,7 @@ Both `boxShadow` and `dropShadow` are generally more capable than the `shadow` p
 
 See [View Style Props](./view-style-props#boxshadow) for documentation.
 
-### `dropShadow` <div class="label android">Android</div>
+### `dropShadow` <div className="label android">Android</div>
 
 See [View Style Props](./view-style-props#filter) for documentation.
 
@@ -256,7 +256,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -266,7 +266,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -276,7 +276,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.76/share.md
+++ b/website/versioned_docs/version-0.76/share.md
@@ -108,10 +108,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -127,7 +127,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.76/statusbar.md
+++ b/website/versioned_docs/version-0.76/statusbar.md
@@ -243,7 +243,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -261,7 +261,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -297,7 +297,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -307,7 +307,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -317,7 +317,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -341,9 +341,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -357,9 +357,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -376,14 +376,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -397,10 +397,10 @@ Due to edge-to-edge enforcement introduced in Android 15, setting background col
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -414,10 +414,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -431,14 +431,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -448,13 +448,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -468,9 +468,9 @@ Due to edge-to-edge enforcement introduced in Android 15, setting the status bar
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.76/switch.md
+++ b/website/versioned_docs/version-0.76/switch.md
@@ -66,7 +66,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.76/text-style-props.md
+++ b/website/versioned_docs/version-0.76/text-style-props.md
@@ -805,7 +805,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -855,7 +855,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -863,7 +863,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -879,7 +879,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -919,7 +919,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -927,7 +927,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.76/text.md
+++ b/website/versioned_docs/version-0.76/text.md
@@ -215,7 +215,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -319,7 +319,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -387,7 +387,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -399,7 +399,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -409,7 +409,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -462,7 +462,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -656,7 +656,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -674,7 +674,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -694,7 +694,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -704,7 +704,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.76/textinput.md
+++ b/website/versioned_docs/version-0.76/textinput.md
@@ -174,7 +174,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -188,7 +188,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -259,7 +259,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -269,7 +269,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -289,7 +289,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -320,7 +320,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -330,7 +330,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -350,7 +350,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -390,7 +390,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -406,7 +406,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -422,7 +422,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -432,7 +432,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -463,7 +463,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -549,7 +549,7 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -725,7 +725,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -771,7 +771,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -781,7 +781,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -791,7 +791,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -831,7 +831,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -861,7 +861,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -887,7 +887,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -953,7 +953,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -989,7 +989,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -999,7 +999,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1019,7 +1019,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -1029,7 +1029,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 

--- a/website/versioned_docs/version-0.76/the-new-architecture/create-module-library.md
+++ b/website/versioned_docs/version-0.76/the-new-architecture/create-module-library.md
@@ -38,7 +38,7 @@ npx create-react-native-library@latest <Name of Your Library>
 
 Once the interactive prompt is done, the tool creates a folder whose structure looks like this in Visual Studio Code:
 
-<img class="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
+<img className="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
 
 Feel free to explore the code that has been created for you. However, the most important parts:
 

--- a/website/versioned_docs/version-0.76/touchablehighlight.md
+++ b/website/versioned_docs/version-0.76/touchablehighlight.md
@@ -138,7 +138,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -148,7 +148,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -158,7 +158,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -168,7 +168,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -178,7 +178,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -188,7 +188,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.76/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.76/touchablenativefeedback.md
@@ -104,7 +104,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -144,7 +144,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -154,7 +154,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.76/touchableopacity.md
+++ b/website/versioned_docs/version-0.76/touchableopacity.md
@@ -84,7 +84,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -94,7 +94,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -104,7 +104,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.76/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.76/touchablewithoutfeedback.md
@@ -112,7 +112,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -260,7 +260,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -274,7 +274,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -514,7 +514,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.76/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.76/turbo-native-modules-ios.md
@@ -18,27 +18,27 @@ cd ios
 open TurboModuleExample.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `NativeLocalStorage`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
 
 3. In the `NativeLocalStorage` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
 
 4. Use the <code>Cocoa Touch Class</code>.
 
-<img class="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
+<img className="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
 
 5. Name the Cocoa Touch Class <code>RCTNativeLocalStorage</code> with the <code>Objective-C</code> language.
 
-<img class="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
+<img className="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
 
 6. Rename <code>RCTNativeLocalStorage.m</code> → <code>RCTNativeLocalStorage.mm</code> making it an Objective-C++ file.
 
-<img class="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
+<img className="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
 
 ## Implement localStorage with NSUserDefaults
 

--- a/website/versioned_docs/version-0.76/view-style-props.md
+++ b/website/versioned_docs/version-0.76/view-style-props.md
@@ -159,7 +159,7 @@ export default App;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -304,7 +304,7 @@ These shadows can be composed together so that a single `boxShadow` can be compr
 | --------------------------- |
 | array of BoxShadowValue ojects \| string |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -314,7 +314,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 
@@ -341,7 +341,7 @@ The following filter functions work across all platforms:
 Due to issues with performance and spec compliance, these are the only two filter functions available on iOS. There are plans to explore some potential workarounds using SwiftUI instead of UIKit for this implementation.
 :::
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following filter functions work on Android only:
 

--- a/website/versioned_docs/version-0.76/view.md
+++ b/website/versioned_docs/version-0.76/view.md
@@ -55,7 +55,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -77,7 +77,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -89,7 +89,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -111,7 +111,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -192,7 +192,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -272,7 +272,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -289,7 +289,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -303,7 +303,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -381,7 +381,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -417,7 +417,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -460,7 +460,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -470,7 +470,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -480,7 +480,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -490,7 +490,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -500,7 +500,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -522,7 +522,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -532,7 +532,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -554,7 +554,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -710,7 +710,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -732,7 +732,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -754,7 +754,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.76/virtualizedlist.md
+++ b/website/versioned_docs/version-0.76/virtualizedlist.md
@@ -166,7 +166,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -180,7 +180,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -194,7 +194,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.77/accessibility.md
+++ b/website/versioned_docs/version-0.77/accessibility.md
@@ -46,7 +46,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -81,15 +81,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -102,11 +102,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -163,13 +163,13 @@ In the above example method `addOne` changes the state variable `count`. When th
 - **toolbar** Used to represent a toolbar (a container of action buttons or components).
 - **grid** Used with ScrollView, VirtualizedList, FlatList, or SectionList to represent a grid. Adds the in/out of grid announcements to Android's GridView.
 
-### `accessibilityShowsLargeContentViewer` <div class="label ios">iOS</div>
+### `accessibilityShowsLargeContentViewer` <div className="label ios">iOS</div>
 
 A boolean value that determines whether the large content viewer is shown when the user performs a long press on the element.
 
 Available in iOS 13.0 and later.
 
-### `accessibilityLargeContentTitle` <div class="label ios">iOS</div>
+### `accessibilityLargeContentTitle` <div className="label ios">iOS</div>
 
 A string that will be used as the title of the large content viewer when it is shown.
 
@@ -212,13 +212,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -290,7 +290,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -305,7 +305,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -319,7 +319,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -335,7 +335,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -356,15 +356,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -460,7 +460,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -475,7 +475,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -495,7 +495,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.77/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.77/accessibilityinfo.md
@@ -90,16 +90,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -126,14 +126,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -144,13 +144,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -162,7 +162,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -172,7 +172,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -182,7 +182,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -202,7 +202,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -222,7 +222,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.77/activityindicator.md
+++ b/website/versioned_docs/version-0.77/activityindicator.md
@@ -62,13 +62,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -82,6 +82,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.77/alert.md
+++ b/website/versioned_docs/version-0.77/alert.md
@@ -78,7 +78,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -143,16 +143,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -169,21 +169,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -201,7 +201,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -230,12 +230,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -247,8 +247,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.77/appstate.md
+++ b/website/versioned_docs/version-0.77/appstate.md
@@ -86,11 +86,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.77/button.md
+++ b/website/versioned_docs/version-0.77/button.md
@@ -112,7 +112,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -122,7 +122,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -212,7 +212,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -222,7 +222,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -232,7 +232,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -242,7 +242,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -252,7 +252,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -262,7 +262,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -282,7 +282,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.77/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.77/fabric-native-components-ios.md
@@ -38,19 +38,19 @@ cd ios
 open Demo.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `WebView`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 
-<img class="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
+<img className="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
 
 5. Repeat step 4 and create a header file named `RCTWebView.h`.
 
@@ -213,10 +213,10 @@ To link the WebKit framework in your app, follow these steps:
 3. Select the General tab
 4. Scroll down until you find the _"Frameworks, Libraries, and Embedded Contents"_ section, and press the `+` button
 
-<img class="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
+<img className="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
 
 5. In the search bar, filter for WebKit
 6. Select the WebKit framework
 7. Click on Add.
 
-<img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
+<img className="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />

--- a/website/versioned_docs/version-0.77/flatlist.md
+++ b/website/versioned_docs/version-0.77/flatlist.md
@@ -356,7 +356,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -416,7 +416,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.77/image-style-props.md
+++ b/website/versioned_docs/version-0.77/image-style-props.md
@@ -312,7 +312,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.77/image.md
+++ b/website/versioned_docs/version-0.77/image.md
@@ -167,7 +167,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -202,7 +202,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -286,7 +286,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -306,7 +306,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -326,7 +326,7 @@ A string indicating which referrer to use when fetching the resource. Sets the v
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -368,7 +368,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 ---
 
-### `resizeMultiplier` <div class="label android">Android</div>
+### `resizeMultiplier` <div className="label android">Android</div>
 
 When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
 
@@ -464,7 +464,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -474,9 +474,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -492,9 +492,9 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>               | Type   | Description                |
-| ---------------------------------------------------- | ------ | -------------------------- |
-| uri <div class="label basic required">Required</div> | string | The location of the image. |
+| <div className="wideColumn">Name</div>                   | Type   | Description                |
+| -------------------------------------------------------- | ------ | -------------------------- |
+| uri <div className="label basic required">Required</div> | string | The location of the image. |
 
 ---
 
@@ -513,10 +513,10 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type   | Description                  |
-| -------------------------------------------------------- | ------ | ---------------------------- |
-| uri <div class="label basic required">Required</div>     | string | The location of the image.   |
-| headers <div class="label basic required">Required</div> | object | The headers for the request. |
+| <div className="wideColumn">Name</div>                       | Type   | Description                  |
+| ------------------------------------------------------------ | ------ | ---------------------------- |
+| uri <div className="label basic required">Required</div>     | string | The location of the image.   |
+| headers <div className="label basic required">Required</div> | object | The headers for the request. |
 
 ---
 
@@ -530,10 +530,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -549,9 +549,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -570,13 +570,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -621,17 +621,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.77/linking.md
+++ b/website/versioned_docs/version-0.77/linking.md
@@ -636,7 +636,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.77/modal.md
+++ b/website/versioned_docs/version-0.77/modal.md
@@ -136,7 +136,7 @@ The `backdropColor` of the modal (or background color of the modal's container.)
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -146,7 +146,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `navigationBarTranslucent` <div class="label android">Android</div>
+### `navigationBarTranslucent` <div className="label android">Android</div>
 
 The `navigationBarTranslucent` prop determines whether your modal should go under the system navigation bar. However, `statusBarTranslucent` also needs to be set to `true` to make navigation bar translucent.
 
@@ -156,7 +156,7 @@ The `navigationBarTranslucent` prop determines whether your modal should go unde
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -166,7 +166,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -197,7 +197,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -214,7 +214,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -224,7 +224,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.77/platform-specific-code.md
+++ b/website/versioned_docs/version-0.77/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.77/platform.md
+++ b/website/versioned_docs/version-0.77/platform.md
@@ -89,7 +89,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.77/pressable.md
+++ b/website/versioned_docs/version-0.77/pressable.md
@@ -108,7 +108,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -116,7 +116,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.77/pressevent.md
+++ b/website/versioned_docs/version-0.77/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.77/refreshcontrol.md
+++ b/website/versioned_docs/version-0.77/refreshcontrol.md
@@ -66,7 +66,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -76,7 +76,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -86,7 +86,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -106,7 +106,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -126,7 +126,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -136,7 +136,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -146,7 +146,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -156,7 +156,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.77/scrollview.md
+++ b/website/versioned_docs/version-0.77/scrollview.md
@@ -83,7 +83,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -93,7 +93,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -103,7 +103,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -113,7 +113,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -123,7 +123,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -133,7 +133,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -143,7 +143,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -153,7 +153,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -163,7 +163,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -206,7 +206,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -239,7 +239,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -269,7 +269,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -279,7 +279,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -301,7 +301,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -374,7 +374,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -384,7 +384,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -394,7 +394,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -480,7 +480,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -490,7 +490,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -516,7 +516,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -526,7 +526,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -580,7 +580,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -590,7 +590,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -600,7 +600,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -610,7 +610,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -716,7 +716,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.77/sectionlist.md
+++ b/website/versioned_docs/version-0.77/sectionlist.md
@@ -105,7 +105,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -127,7 +127,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -293,13 +293,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -331,9 +331,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -355,10 +355,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.77/shadow-props.md
+++ b/website/versioned_docs/version-0.77/shadow-props.md
@@ -240,7 +240,7 @@ Both `boxShadow` and `dropShadow` are generally more capable than the `shadow` p
 
 See [View Style Props](./view-style-props#boxshadow) for documentation.
 
-### `dropShadow` <div class="label android">Android</div>
+### `dropShadow` <div className="label android">Android</div>
 
 See [View Style Props](./view-style-props#filter) for documentation.
 
@@ -256,7 +256,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -266,7 +266,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -276,7 +276,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.77/share.md
+++ b/website/versioned_docs/version-0.77/share.md
@@ -108,10 +108,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -127,7 +127,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.77/statusbar.md
+++ b/website/versioned_docs/version-0.77/statusbar.md
@@ -243,7 +243,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -261,7 +261,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -297,7 +297,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -307,7 +307,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -317,7 +317,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -341,9 +341,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -357,9 +357,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -376,14 +376,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -397,10 +397,10 @@ Due to edge-to-edge enforcement introduced in Android 15, setting background col
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -414,10 +414,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -431,14 +431,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -448,13 +448,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -468,9 +468,9 @@ Due to edge-to-edge enforcement introduced in Android 15, setting the status bar
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.77/switch.md
+++ b/website/versioned_docs/version-0.77/switch.md
@@ -66,7 +66,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.77/text-style-props.md
+++ b/website/versioned_docs/version-0.77/text-style-props.md
@@ -805,7 +805,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -855,7 +855,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -863,7 +863,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -879,7 +879,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -919,7 +919,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -927,7 +927,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.77/text.md
+++ b/website/versioned_docs/version-0.77/text.md
@@ -215,7 +215,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -319,7 +319,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -387,7 +387,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -399,7 +399,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -409,7 +409,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -462,7 +462,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -656,7 +656,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -674,7 +674,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -694,7 +694,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -704,7 +704,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.77/textinput.md
+++ b/website/versioned_docs/version-0.77/textinput.md
@@ -174,7 +174,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -188,7 +188,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -261,7 +261,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -271,7 +271,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -291,7 +291,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -322,7 +322,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -332,7 +332,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -352,7 +352,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -392,7 +392,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -408,7 +408,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -424,7 +424,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -434,7 +434,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -444,7 +444,7 @@ An optional identifier which links a custom [InputAccessoryView](inputaccessoryv
 
 ---
 
-### `inputAccessoryViewButtonLabel` <div class="label ios">iOS</div>
+### `inputAccessoryViewButtonLabel` <div className="label ios">iOS</div>
 
 An optional label that overrides the default [InputAccessoryView](inputaccessoryview.md) button label.
 
@@ -477,7 +477,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -563,7 +563,7 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -739,7 +739,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -785,7 +785,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -795,7 +795,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -805,7 +805,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -845,7 +845,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -875,7 +875,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -926,7 +926,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -992,7 +992,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -1028,7 +1028,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -1038,7 +1038,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1058,7 +1058,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -1068,7 +1068,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 
@@ -1078,7 +1078,7 @@ Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, 
 
 ---
 
-### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
 
 If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
 

--- a/website/versioned_docs/version-0.77/the-new-architecture/create-module-library.md
+++ b/website/versioned_docs/version-0.77/the-new-architecture/create-module-library.md
@@ -38,7 +38,7 @@ npx create-react-native-library@latest <Name of Your Library>
 
 Once the interactive prompt is done, the tool creates a folder whose structure looks like this in Visual Studio Code:
 
-<img class="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
+<img className="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
 
 Feel free to explore the code that has been created for you. However, the most important parts:
 

--- a/website/versioned_docs/version-0.77/touchablehighlight.md
+++ b/website/versioned_docs/version-0.77/touchablehighlight.md
@@ -138,7 +138,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -148,7 +148,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -158,7 +158,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -168,7 +168,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -178,7 +178,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -188,7 +188,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.77/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.77/touchablenativefeedback.md
@@ -104,7 +104,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -144,7 +144,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -154,7 +154,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.77/touchableopacity.md
+++ b/website/versioned_docs/version-0.77/touchableopacity.md
@@ -84,7 +84,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -94,7 +94,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -104,7 +104,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.77/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.77/touchablewithoutfeedback.md
@@ -84,7 +84,7 @@ export default TouchableWithoutFeedbackExample;
 
 ## Props
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -116,7 +116,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -264,7 +264,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -278,7 +278,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -518,7 +518,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.77/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.77/turbo-native-modules-ios.md
@@ -18,27 +18,27 @@ cd ios
 open TurboModuleExample.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `NativeLocalStorage`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
 
 3. In the `NativeLocalStorage` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
 
 4. Use the <code>Cocoa Touch Class</code>.
 
-<img class="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
+<img className="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
 
 5. Name the Cocoa Touch Class <code>RCTNativeLocalStorage</code> with the <code>Objective-C</code> language.
 
-<img class="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
+<img className="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
 
 6. Rename <code>RCTNativeLocalStorage.m</code> → <code>RCTNativeLocalStorage.mm</code> making it an Objective-C++ file.
 
-<img class="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
+<img className="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
 
 ## Implement localStorage with NSUserDefaults
 

--- a/website/versioned_docs/version-0.77/view-style-props.md
+++ b/website/versioned_docs/version-0.77/view-style-props.md
@@ -159,7 +159,7 @@ export default App;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -304,7 +304,7 @@ These shadows can be composed together so that a single `boxShadow` can be compr
 | --------------------------- |
 | array of BoxShadowValue ojects \| string |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -314,7 +314,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 
@@ -341,7 +341,7 @@ The following filter functions work across all platforms:
 Due to issues with performance and spec compliance, these are the only two filter functions available on iOS. There are plans to explore some potential workarounds using SwiftUI instead of UIKit for this implementation.
 :::
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following filter functions work on Android only:
 

--- a/website/versioned_docs/version-0.77/view.md
+++ b/website/versioned_docs/version-0.77/view.md
@@ -55,7 +55,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -77,7 +77,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -89,7 +89,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -111,7 +111,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -192,7 +192,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -272,7 +272,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -289,7 +289,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -303,7 +303,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -381,7 +381,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -417,7 +417,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -460,7 +460,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -470,7 +470,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -480,7 +480,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -490,7 +490,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -500,7 +500,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -522,7 +522,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -532,7 +532,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -554,7 +554,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -710,7 +710,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -732,7 +732,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -754,7 +754,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.77/virtualizedlist.md
+++ b/website/versioned_docs/version-0.77/virtualizedlist.md
@@ -166,7 +166,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -180,7 +180,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -194,7 +194,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.78/accessibility.md
+++ b/website/versioned_docs/version-0.78/accessibility.md
@@ -48,7 +48,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -83,15 +83,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -104,11 +104,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -165,13 +165,13 @@ In the above example method `addOne` changes the state variable `count`. When th
 - **toolbar** Used to represent a toolbar (a container of action buttons or components).
 - **grid** Used with ScrollView, VirtualizedList, FlatList, or SectionList to represent a grid. Adds the in/out of grid announcements to Android's GridView.
 
-### `accessibilityShowsLargeContentViewer` <div class="label ios">iOS</div>
+### `accessibilityShowsLargeContentViewer` <div className="label ios">iOS</div>
 
 A boolean value that determines whether the large content viewer is shown when the user performs a long press on the element.
 
 Available in iOS 13.0 and later.
 
-### `accessibilityLargeContentTitle` <div class="label ios">iOS</div>
+### `accessibilityLargeContentTitle` <div className="label ios">iOS</div>
 
 A string that will be used as the title of the large content viewer when it is shown.
 
@@ -214,13 +214,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -292,7 +292,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -307,7 +307,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -321,7 +321,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -337,7 +337,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -358,15 +358,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -462,7 +462,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -477,7 +477,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -497,7 +497,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.78/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.78/accessibilityinfo.md
@@ -90,16 +90,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -126,14 +126,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -144,13 +144,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -162,7 +162,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -172,7 +172,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -182,7 +182,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -202,7 +202,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -222,7 +222,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.78/activityindicator.md
+++ b/website/versioned_docs/version-0.78/activityindicator.md
@@ -62,13 +62,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -82,6 +82,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.78/alert.md
+++ b/website/versioned_docs/version-0.78/alert.md
@@ -78,7 +78,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -143,16 +143,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -169,21 +169,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -201,7 +201,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -230,12 +230,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -247,8 +247,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.78/appstate.md
+++ b/website/versioned_docs/version-0.78/appstate.md
@@ -86,11 +86,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.78/button.md
+++ b/website/versioned_docs/version-0.78/button.md
@@ -112,7 +112,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -122,7 +122,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -212,7 +212,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -222,7 +222,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -232,7 +232,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -242,7 +242,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -252,7 +252,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -262,7 +262,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -282,7 +282,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.78/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.78/fabric-native-components-ios.md
@@ -38,19 +38,19 @@ cd ios
 open Demo.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `WebView`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 
-<img class="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
+<img className="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
 
 5. Repeat step 4 and create a header file named `RCTWebView.h`.
 
@@ -213,10 +213,10 @@ To link the WebKit framework in your app, follow these steps:
 3. Select the General tab
 4. Scroll down until you find the _"Frameworks, Libraries, and Embedded Contents"_ section, and press the `+` button
 
-<img class="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
+<img className="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
 
 5. In the search bar, filter for WebKit
 6. Select the WebKit framework
 7. Click on Add.
 
-<img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
+<img className="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />

--- a/website/versioned_docs/version-0.78/flatlist.md
+++ b/website/versioned_docs/version-0.78/flatlist.md
@@ -356,7 +356,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -416,7 +416,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.78/image-style-props.md
+++ b/website/versioned_docs/version-0.78/image-style-props.md
@@ -312,7 +312,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.78/image.md
+++ b/website/versioned_docs/version-0.78/image.md
@@ -167,7 +167,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -202,7 +202,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -286,7 +286,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -306,7 +306,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -326,7 +326,7 @@ A string indicating which referrer to use when fetching the resource. Sets the v
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -368,7 +368,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 ---
 
-### `resizeMultiplier` <div class="label android">Android</div>
+### `resizeMultiplier` <div className="label android">Android</div>
 
 When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
 
@@ -464,7 +464,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -474,9 +474,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -492,9 +492,9 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>               | Type   | Description                |
-| ---------------------------------------------------- | ------ | -------------------------- |
-| uri <div class="label basic required">Required</div> | string | The location of the image. |
+| <div className="wideColumn">Name</div>                   | Type   | Description                |
+| -------------------------------------------------------- | ------ | -------------------------- |
+| uri <div className="label basic required">Required</div> | string | The location of the image. |
 
 ---
 
@@ -513,10 +513,10 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type   | Description                  |
-| -------------------------------------------------------- | ------ | ---------------------------- |
-| uri <div class="label basic required">Required</div>     | string | The location of the image.   |
-| headers <div class="label basic required">Required</div> | object | The headers for the request. |
+| <div className="wideColumn">Name</div>                       | Type   | Description                  |
+| ------------------------------------------------------------ | ------ | ---------------------------- |
+| uri <div className="label basic required">Required</div>     | string | The location of the image.   |
+| headers <div className="label basic required">Required</div> | object | The headers for the request. |
 
 ---
 
@@ -530,10 +530,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -549,9 +549,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -570,13 +570,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -621,17 +621,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.78/linking.md
+++ b/website/versioned_docs/version-0.78/linking.md
@@ -636,7 +636,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.78/modal.md
+++ b/website/versioned_docs/version-0.78/modal.md
@@ -136,7 +136,7 @@ The `backdropColor` of the modal (or background color of the modal's container.)
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -146,7 +146,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `navigationBarTranslucent` <div class="label android">Android</div>
+### `navigationBarTranslucent` <div className="label android">Android</div>
 
 The `navigationBarTranslucent` prop determines whether your modal should go under the system navigation bar. However, `statusBarTranslucent` also needs to be set to `true` to make navigation bar translucent.
 
@@ -156,7 +156,7 @@ The `navigationBarTranslucent` prop determines whether your modal should go unde
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -166,7 +166,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -197,7 +197,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -214,7 +214,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -224,7 +224,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.78/platform-specific-code.md
+++ b/website/versioned_docs/version-0.78/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.78/platform.md
+++ b/website/versioned_docs/version-0.78/platform.md
@@ -89,7 +89,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.78/pressable.md
+++ b/website/versioned_docs/version-0.78/pressable.md
@@ -108,7 +108,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -116,7 +116,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.78/pressevent.md
+++ b/website/versioned_docs/version-0.78/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.78/refreshcontrol.md
+++ b/website/versioned_docs/version-0.78/refreshcontrol.md
@@ -66,7 +66,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -76,7 +76,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -86,7 +86,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -106,7 +106,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -126,7 +126,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -136,7 +136,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -146,7 +146,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -156,7 +156,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.78/scrollview.md
+++ b/website/versioned_docs/version-0.78/scrollview.md
@@ -83,7 +83,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -93,7 +93,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -103,7 +103,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -113,7 +113,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -123,7 +123,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -133,7 +133,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -143,7 +143,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -153,7 +153,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -163,7 +163,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -206,7 +206,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -239,7 +239,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -269,7 +269,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -279,7 +279,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -301,7 +301,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -374,7 +374,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -384,7 +384,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -394,7 +394,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -480,7 +480,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -490,7 +490,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -516,7 +516,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -526,7 +526,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -580,7 +580,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -590,7 +590,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -600,7 +600,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -610,7 +610,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -716,7 +716,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.78/sectionlist.md
+++ b/website/versioned_docs/version-0.78/sectionlist.md
@@ -105,7 +105,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -127,7 +127,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -293,13 +293,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -331,9 +331,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -355,10 +355,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.78/shadow-props.md
+++ b/website/versioned_docs/version-0.78/shadow-props.md
@@ -240,7 +240,7 @@ Both `boxShadow` and `dropShadow` are generally more capable than the `shadow` p
 
 See [View Style Props](./view-style-props#boxshadow) for documentation.
 
-### `dropShadow` <div class="label android">Android</div>
+### `dropShadow` <div className="label android">Android</div>
 
 See [View Style Props](./view-style-props#filter) for documentation.
 
@@ -256,7 +256,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -266,7 +266,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -276,7 +276,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.78/share.md
+++ b/website/versioned_docs/version-0.78/share.md
@@ -108,10 +108,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -127,7 +127,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.78/statusbar.md
+++ b/website/versioned_docs/version-0.78/statusbar.md
@@ -243,7 +243,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -261,7 +261,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -297,7 +297,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -307,7 +307,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -317,7 +317,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -341,9 +341,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -357,9 +357,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -376,14 +376,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -397,10 +397,10 @@ Due to edge-to-edge enforcement introduced in Android 15, setting background col
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -414,10 +414,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -431,14 +431,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -448,13 +448,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -468,9 +468,9 @@ Due to edge-to-edge enforcement introduced in Android 15, setting the status bar
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.78/switch.md
+++ b/website/versioned_docs/version-0.78/switch.md
@@ -66,7 +66,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.78/text-style-props.md
+++ b/website/versioned_docs/version-0.78/text-style-props.md
@@ -805,7 +805,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -855,7 +855,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -863,7 +863,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -879,7 +879,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -919,7 +919,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -927,7 +927,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.78/text.md
+++ b/website/versioned_docs/version-0.78/text.md
@@ -215,7 +215,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -319,7 +319,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -387,7 +387,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -399,7 +399,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -409,7 +409,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -462,7 +462,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -656,7 +656,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -674,7 +674,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -694,7 +694,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -704,7 +704,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.78/textinput.md
+++ b/website/versioned_docs/version-0.78/textinput.md
@@ -174,7 +174,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -188,7 +188,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -261,7 +261,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -271,7 +271,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -291,7 +291,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -322,7 +322,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -332,7 +332,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -352,7 +352,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -392,7 +392,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -408,7 +408,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -424,7 +424,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -434,7 +434,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -444,7 +444,7 @@ An optional identifier which links a custom [InputAccessoryView](inputaccessoryv
 
 ---
 
-### `inputAccessoryViewButtonLabel` <div class="label ios">iOS</div>
+### `inputAccessoryViewButtonLabel` <div className="label ios">iOS</div>
 
 An optional label that overrides the default [InputAccessoryView](inputaccessoryview.md) button label.
 
@@ -477,7 +477,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -563,7 +563,7 @@ It is important to note that this aligns the text to the top on iOS, and centers
 
 ---
 
-### `numberOfLines` <div class="label android">Android</div>
+### `numberOfLines` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -739,7 +739,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -785,7 +785,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -795,7 +795,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -805,7 +805,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -845,7 +845,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -875,7 +875,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -926,7 +926,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -992,7 +992,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -1028,7 +1028,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -1038,7 +1038,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1058,7 +1058,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -1068,7 +1068,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 
@@ -1078,7 +1078,7 @@ Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, 
 
 ---
 
-### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
 
 If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
 

--- a/website/versioned_docs/version-0.78/the-new-architecture/create-module-library.md
+++ b/website/versioned_docs/version-0.78/the-new-architecture/create-module-library.md
@@ -38,7 +38,7 @@ npx create-react-native-library@latest <Name of Your Library>
 
 Once the interactive prompt is done, the tool creates a folder whose structure looks like this in Visual Studio Code:
 
-<img class="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
+<img className="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
 
 Feel free to explore the code that has been created for you. However, the most important parts:
 

--- a/website/versioned_docs/version-0.78/touchablehighlight.md
+++ b/website/versioned_docs/version-0.78/touchablehighlight.md
@@ -138,7 +138,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -148,7 +148,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -158,7 +158,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -168,7 +168,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -178,7 +178,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -188,7 +188,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.78/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.78/touchablenativefeedback.md
@@ -104,7 +104,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -144,7 +144,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -154,7 +154,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.78/touchableopacity.md
+++ b/website/versioned_docs/version-0.78/touchableopacity.md
@@ -84,7 +84,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -94,7 +94,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -104,7 +104,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.78/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.78/touchablewithoutfeedback.md
@@ -84,7 +84,7 @@ export default TouchableWithoutFeedbackExample;
 
 ## Props
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -116,7 +116,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -264,7 +264,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -278,7 +278,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -518,7 +518,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.78/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.78/turbo-native-modules-ios.md
@@ -18,27 +18,27 @@ cd ios
 open TurboModuleExample.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `NativeLocalStorage`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
 
 3. In the `NativeLocalStorage` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
 
 4. Use the <code>Cocoa Touch Class</code>.
 
-<img class="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
+<img className="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
 
 5. Name the Cocoa Touch Class <code>RCTNativeLocalStorage</code> with the <code>Objective-C</code> language.
 
-<img class="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
+<img className="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
 
 6. Rename <code>RCTNativeLocalStorage.m</code> → <code>RCTNativeLocalStorage.mm</code> making it an Objective-C++ file.
 
-<img class="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
+<img className="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
 
 ## Implement localStorage with NSUserDefaults
 

--- a/website/versioned_docs/version-0.78/view-style-props.md
+++ b/website/versioned_docs/version-0.78/view-style-props.md
@@ -159,7 +159,7 @@ export default App;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -304,7 +304,7 @@ These shadows can be composed together so that a single `boxShadow` can be compr
 | --------------------------- |
 | array of BoxShadowValue ojects \| string |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -314,7 +314,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 
@@ -341,7 +341,7 @@ The following filter functions work across all platforms:
 Due to issues with performance and spec compliance, these are the only two filter functions available on iOS. There are plans to explore some potential workarounds using SwiftUI instead of UIKit for this implementation.
 :::
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following filter functions work on Android only:
 

--- a/website/versioned_docs/version-0.78/view.md
+++ b/website/versioned_docs/version-0.78/view.md
@@ -55,7 +55,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -77,7 +77,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -89,7 +89,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -111,7 +111,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -192,7 +192,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -383,7 +383,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -419,7 +419,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -462,7 +462,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -502,7 +502,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -524,7 +524,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -534,7 +534,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -556,7 +556,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -712,7 +712,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -734,7 +734,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -756,7 +756,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.78/virtualizedlist.md
+++ b/website/versioned_docs/version-0.78/virtualizedlist.md
@@ -166,7 +166,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -180,7 +180,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -194,7 +194,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.79/accessibility.md
+++ b/website/versioned_docs/version-0.79/accessibility.md
@@ -48,7 +48,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -83,15 +83,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -104,11 +104,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -165,13 +165,13 @@ In the above example method `addOne` changes the state variable `count`. When th
 - **toolbar** Used to represent a toolbar (a container of action buttons or components).
 - **grid** Used with ScrollView, VirtualizedList, FlatList, or SectionList to represent a grid. Adds the in/out of grid announcements to Android's GridView.
 
-### `accessibilityShowsLargeContentViewer` <div class="label ios">iOS</div>
+### `accessibilityShowsLargeContentViewer` <div className="label ios">iOS</div>
 
 A boolean value that determines whether the large content viewer is shown when the user performs a long press on the element.
 
 Available in iOS 13.0 and later.
 
-### `accessibilityLargeContentTitle` <div class="label ios">iOS</div>
+### `accessibilityLargeContentTitle` <div className="label ios">iOS</div>
 
 A string that will be used as the title of the large content viewer when it is shown.
 
@@ -214,13 +214,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -292,7 +292,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -307,7 +307,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -321,7 +321,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -337,7 +337,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -358,15 +358,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -462,7 +462,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -477,7 +477,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -497,7 +497,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.79/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.79/accessibilityinfo.md
@@ -90,16 +90,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -126,14 +126,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -144,13 +144,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -162,7 +162,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -172,7 +172,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -182,7 +182,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -202,7 +202,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -222,7 +222,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.79/activityindicator.md
+++ b/website/versioned_docs/version-0.79/activityindicator.md
@@ -62,13 +62,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -82,6 +82,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.79/alert.md
+++ b/website/versioned_docs/version-0.79/alert.md
@@ -78,7 +78,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -143,16 +143,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -169,21 +169,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -201,7 +201,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -230,12 +230,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -247,8 +247,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.79/appstate.md
+++ b/website/versioned_docs/version-0.79/appstate.md
@@ -86,11 +86,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.79/button.md
+++ b/website/versioned_docs/version-0.79/button.md
@@ -112,7 +112,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -122,7 +122,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -212,7 +212,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -222,7 +222,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -232,7 +232,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -242,7 +242,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -252,7 +252,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -262,7 +262,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -282,7 +282,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.79/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.79/fabric-native-components-ios.md
@@ -38,19 +38,19 @@ cd ios
 open Demo.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `WebView`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 
-<img class="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
+<img className="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
 
 5. Repeat step 4 and create a header file named `RCTWebView.h`.
 
@@ -213,10 +213,10 @@ To link the WebKit framework in your app, follow these steps:
 3. Select the General tab
 4. Scroll down until you find the _"Frameworks, Libraries, and Embedded Contents"_ section, and press the `+` button
 
-<img class="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
+<img className="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
 
 5. In the search bar, filter for WebKit
 6. Select the WebKit framework
 7. Click on Add.
 
-<img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
+<img className="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />

--- a/website/versioned_docs/version-0.79/flatlist.md
+++ b/website/versioned_docs/version-0.79/flatlist.md
@@ -356,7 +356,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -416,7 +416,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.79/image-style-props.md
+++ b/website/versioned_docs/version-0.79/image-style-props.md
@@ -312,7 +312,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.79/image.md
+++ b/website/versioned_docs/version-0.79/image.md
@@ -167,7 +167,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -202,7 +202,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -286,7 +286,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -306,7 +306,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -326,7 +326,7 @@ A string indicating which referrer to use when fetching the resource. Sets the v
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -368,7 +368,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 ---
 
-### `resizeMultiplier` <div class="label android">Android</div>
+### `resizeMultiplier` <div className="label android">Android</div>
 
 When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
 
@@ -464,7 +464,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -474,9 +474,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -492,9 +492,9 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>               | Type   | Description                |
-| ---------------------------------------------------- | ------ | -------------------------- |
-| uri <div class="label basic required">Required</div> | string | The location of the image. |
+| <div className="wideColumn">Name</div>                   | Type   | Description                |
+| -------------------------------------------------------- | ------ | -------------------------- |
+| uri <div className="label basic required">Required</div> | string | The location of the image. |
 
 ---
 
@@ -513,10 +513,10 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type   | Description                  |
-| -------------------------------------------------------- | ------ | ---------------------------- |
-| uri <div class="label basic required">Required</div>     | string | The location of the image.   |
-| headers <div class="label basic required">Required</div> | object | The headers for the request. |
+| <div className="wideColumn">Name</div>                       | Type   | Description                  |
+| ------------------------------------------------------------ | ------ | ---------------------------- |
+| uri <div className="label basic required">Required</div>     | string | The location of the image.   |
+| headers <div className="label basic required">Required</div> | object | The headers for the request. |
 
 ---
 
@@ -530,10 +530,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -549,9 +549,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -570,13 +570,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -621,17 +621,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.79/linking.md
+++ b/website/versioned_docs/version-0.79/linking.md
@@ -652,7 +652,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.79/modal.md
+++ b/website/versioned_docs/version-0.79/modal.md
@@ -136,7 +136,7 @@ The `backdropColor` of the modal (or background color of the modal's container.)
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -146,7 +146,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `navigationBarTranslucent` <div class="label android">Android</div>
+### `navigationBarTranslucent` <div className="label android">Android</div>
 
 The `navigationBarTranslucent` prop determines whether your modal should go under the system navigation bar. However, `statusBarTranslucent` also needs to be set to `true` to make navigation bar translucent.
 
@@ -156,7 +156,7 @@ The `navigationBarTranslucent` prop determines whether your modal should go unde
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -166,7 +166,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -197,7 +197,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -214,7 +214,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -224,7 +224,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.79/platform-specific-code.md
+++ b/website/versioned_docs/version-0.79/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.79/platform.md
+++ b/website/versioned_docs/version-0.79/platform.md
@@ -89,7 +89,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.79/pressable.md
+++ b/website/versioned_docs/version-0.79/pressable.md
@@ -108,7 +108,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -116,7 +116,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.79/pressevent.md
+++ b/website/versioned_docs/version-0.79/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.79/refreshcontrol.md
+++ b/website/versioned_docs/version-0.79/refreshcontrol.md
@@ -66,7 +66,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -76,7 +76,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -86,7 +86,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -106,7 +106,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -126,7 +126,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -136,7 +136,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -146,7 +146,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -156,7 +156,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.79/scrollview.md
+++ b/website/versioned_docs/version-0.79/scrollview.md
@@ -83,7 +83,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -93,7 +93,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -103,7 +103,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -113,7 +113,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -123,7 +123,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -133,7 +133,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -143,7 +143,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -153,7 +153,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -163,7 +163,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -206,7 +206,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -239,7 +239,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -269,7 +269,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -279,7 +279,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -301,7 +301,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -374,7 +374,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -384,7 +384,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -394,7 +394,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -480,7 +480,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -490,7 +490,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -516,7 +516,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -526,7 +526,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -580,7 +580,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -590,7 +590,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -600,7 +600,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -610,7 +610,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -716,7 +716,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.79/sectionlist.md
+++ b/website/versioned_docs/version-0.79/sectionlist.md
@@ -105,7 +105,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -127,7 +127,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -293,13 +293,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -331,9 +331,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -355,10 +355,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.79/shadow-props.md
+++ b/website/versioned_docs/version-0.79/shadow-props.md
@@ -240,7 +240,7 @@ Both `boxShadow` and `dropShadow` are generally more capable than the `shadow` p
 
 See [View Style Props](./view-style-props#boxshadow) for documentation.
 
-### `dropShadow` <div class="label android">Android</div>
+### `dropShadow` <div className="label android">Android</div>
 
 See [View Style Props](./view-style-props#filter) for documentation.
 
@@ -256,7 +256,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -266,7 +266,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -276,7 +276,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.79/share.md
+++ b/website/versioned_docs/version-0.79/share.md
@@ -108,10 +108,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -127,7 +127,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.79/statusbar.md
+++ b/website/versioned_docs/version-0.79/statusbar.md
@@ -243,7 +243,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -261,7 +261,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -297,7 +297,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -307,7 +307,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -317,7 +317,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -341,9 +341,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -357,9 +357,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -376,14 +376,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -397,10 +397,10 @@ Due to edge-to-edge enforcement introduced in Android 15, setting background col
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -414,10 +414,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -431,14 +431,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -448,13 +448,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -468,9 +468,9 @@ Due to edge-to-edge enforcement introduced in Android 15, setting the status bar
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.79/switch.md
+++ b/website/versioned_docs/version-0.79/switch.md
@@ -66,7 +66,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.79/text-style-props.md
+++ b/website/versioned_docs/version-0.79/text-style-props.md
@@ -805,7 +805,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -855,7 +855,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -863,7 +863,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -879,7 +879,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -919,7 +919,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -927,7 +927,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.79/text.md
+++ b/website/versioned_docs/version-0.79/text.md
@@ -215,7 +215,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -319,7 +319,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -387,7 +387,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -399,7 +399,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -409,7 +409,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -462,7 +462,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -656,7 +656,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -674,7 +674,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -694,7 +694,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -704,7 +704,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.79/textinput.md
+++ b/website/versioned_docs/version-0.79/textinput.md
@@ -174,7 +174,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -188,7 +188,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -261,7 +261,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -271,7 +271,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -291,7 +291,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -322,7 +322,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -332,7 +332,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -352,7 +352,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -392,7 +392,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -408,7 +408,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -424,7 +424,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -434,7 +434,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -444,7 +444,7 @@ An optional identifier which links a custom [InputAccessoryView](inputaccessoryv
 
 ---
 
-### `inputAccessoryViewButtonLabel` <div class="label ios">iOS</div>
+### `inputAccessoryViewButtonLabel` <div className="label ios">iOS</div>
 
 An optional label that overrides the default [InputAccessoryView](inputaccessoryview.md) button label.
 
@@ -477,7 +477,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -743,7 +743,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -789,7 +789,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -799,7 +799,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -809,7 +809,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -849,7 +849,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -879,7 +879,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -930,7 +930,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -996,7 +996,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -1032,7 +1032,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -1042,7 +1042,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1062,7 +1062,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 
@@ -1072,7 +1072,7 @@ Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -1082,7 +1082,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
 
 If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
 

--- a/website/versioned_docs/version-0.79/the-new-architecture/create-module-library.md
+++ b/website/versioned_docs/version-0.79/the-new-architecture/create-module-library.md
@@ -38,7 +38,7 @@ npx create-react-native-library@latest <Name of Your Library>
 
 Once the interactive prompt is done, the tool creates a folder whose structure looks like this in Visual Studio Code:
 
-<img class="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
+<img className="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
 
 Feel free to explore the code that has been created for you. However, the most important parts:
 

--- a/website/versioned_docs/version-0.79/touchablehighlight.md
+++ b/website/versioned_docs/version-0.79/touchablehighlight.md
@@ -138,7 +138,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -148,7 +148,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -158,7 +158,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -168,7 +168,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -178,7 +178,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -188,7 +188,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.79/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.79/touchablenativefeedback.md
@@ -104,7 +104,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -144,7 +144,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -154,7 +154,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.79/touchableopacity.md
+++ b/website/versioned_docs/version-0.79/touchableopacity.md
@@ -84,7 +84,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -94,7 +94,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -104,7 +104,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.79/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.79/touchablewithoutfeedback.md
@@ -84,7 +84,7 @@ export default TouchableWithoutFeedbackExample;
 
 ## Props
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -116,7 +116,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -264,7 +264,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -278,7 +278,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -518,7 +518,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.79/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.79/turbo-native-modules-ios.md
@@ -18,27 +18,27 @@ cd ios
 open TurboModuleExample.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `NativeLocalStorage`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
 
 3. In the `NativeLocalStorage` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
 
 4. Use the <code>Cocoa Touch Class</code>.
 
-<img class="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
+<img className="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
 
 5. Name the Cocoa Touch Class <code>RCTNativeLocalStorage</code> with the <code>Objective-C</code> language.
 
-<img class="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
+<img className="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
 
 6. Rename <code>RCTNativeLocalStorage.m</code> → <code>RCTNativeLocalStorage.mm</code> making it an Objective-C++ file.
 
-<img class="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
+<img className="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
 
 ## Implement localStorage with NSUserDefaults
 

--- a/website/versioned_docs/version-0.79/view-style-props.md
+++ b/website/versioned_docs/version-0.79/view-style-props.md
@@ -159,7 +159,7 @@ export default App;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -304,7 +304,7 @@ These shadows can be composed together so that a single `boxShadow` can be compr
 | --------------------------- |
 | array of BoxShadowValue ojects \| string |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -314,7 +314,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 
@@ -341,7 +341,7 @@ The following filter functions work across all platforms:
 Due to issues with performance and spec compliance, these are the only two filter functions available on iOS. There are plans to explore some potential workarounds using SwiftUI instead of UIKit for this implementation.
 :::
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following filter functions work on Android only:
 

--- a/website/versioned_docs/version-0.79/view.md
+++ b/website/versioned_docs/version-0.79/view.md
@@ -55,7 +55,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -77,7 +77,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -89,7 +89,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -111,7 +111,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -192,7 +192,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -383,7 +383,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -419,7 +419,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -462,7 +462,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -502,7 +502,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -524,7 +524,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -534,7 +534,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -556,7 +556,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -712,7 +712,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -734,7 +734,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -756,7 +756,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.79/virtualizedlist.md
+++ b/website/versioned_docs/version-0.79/virtualizedlist.md
@@ -166,7 +166,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -180,7 +180,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -194,7 +194,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>

--- a/website/versioned_docs/version-0.80/accessibility.md
+++ b/website/versioned_docs/version-0.80/accessibility.md
@@ -48,7 +48,7 @@ To use, set the `accessibilityLabel` property to a custom string on your View, T
 
 In the above example, the `accessibilityLabel` on the TouchableOpacity element would default to "Press me!". The label is constructed by concatenating all Text node children separated by spaces.
 
-### `accessibilityLabelledBy` <div class="label android">Android</div>
+### `accessibilityLabelledBy` <div className="label android">Android</div>
 
 A reference to another element [nativeID](view.md#nativeid) used to build complex forms.
 The value of `accessibilityLabelledBy` should match the `nativeID` of the related element:
@@ -83,15 +83,15 @@ Provide the `accessibilityHint` property a custom string on your View, Text, or 
 </TouchableOpacity>
 ```
 
-<div class="label ios basic">iOS</div>
+<div className="label ios basic">iOS</div>
 
 In the above example, VoiceOver will read the hint after the label, if the user has hints enabled in the device's VoiceOver settings. Read more about guidelines for `accessibilityHint` in the [iOS Developer Docs](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)
 
-<div class="label android basic">Android</div>
+<div className="label android basic">Android</div>
 
 In the above example, TalkBack will read the hint after the label. At this time, hints cannot be turned off on Android.
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 By using the `accessibilityLanguage` property, the screen reader will understand which language to use while reading the element's **label**, **value**, and **hint**. The provided string value must follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -104,11 +104,11 @@ By using the `accessibilityLanguage` property, the screen reader will understand
 </View>
 ```
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 Inverting screen colors is an accessibility feature available in iOS and iPadOS for people with color blindness, low vision, or vision impairment. If there's a view you don't want to invert when this setting is on, possibly a photo, set this property to `true`.
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 When components dynamically change, we want TalkBack to alert the end user. This is made possible by the `accessibilityLiveRegion` property. It can be set to `none`, `polite`, and `assertive`:
 
@@ -165,13 +165,13 @@ In the above example method `addOne` changes the state variable `count`. When th
 - **toolbar** Used to represent a toolbar (a container of action buttons or components).
 - **grid** Used with ScrollView, VirtualizedList, FlatList, or SectionList to represent a grid. Adds the in/out of grid announcements to Android's GridView.
 
-### `accessibilityShowsLargeContentViewer` <div class="label ios">iOS</div>
+### `accessibilityShowsLargeContentViewer` <div className="label ios">iOS</div>
 
 A boolean value that determines whether the large content viewer is shown when the user performs a long press on the element.
 
 Available in iOS 13.0 and later.
 
-### `accessibilityLargeContentTitle` <div class="label ios">iOS</div>
+### `accessibilityLargeContentTitle` <div className="label ios">iOS</div>
 
 A string that will be used as the title of the large content viewer when it is shown.
 
@@ -214,13 +214,13 @@ Represents the current value of a component. It can be a textual description of 
 | now  | The current value of this component's range.                                                   | integer | No                        |
 | text | A textual description of this component's value. Will override `min`, `now`, and `max` if set. | string  | No                        |
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A boolean value that indicates whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
 For example, in a window that contains sibling views `A` and `B`, setting `accessibilityViewIsModal` to `true` on view `B` causes VoiceOver to ignore the elements in view `A`. On the other hand, if view `B` contains a child view `C` and you set `accessibilityViewIsModal` to `true` on view `C`, VoiceOver does not ignore the elements in view `A`.
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
 
@@ -292,7 +292,7 @@ Defines a string value that labels an interactive element.
 | ------ |
 | string |
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -307,7 +307,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 | ------ |
 | string |
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -321,7 +321,7 @@ Indicates that an element will be updated and describes the types of updates the
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver.
 
@@ -337,7 +337,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 In the case of two overlapping UI components with the same parent, default accessibility focus can have unpredictable behavior. The `importantForAccessibility` property will resolve this by controlling if a view fires accessibility events and if it is reported to accessibility services. It can be set to `auto`, `yes`, `no` and `no-hide-descendants` (the last value will force accessibility services to ignore the component and all of its children).
 
@@ -358,15 +358,15 @@ In the case of two overlapping UI components with the same parent, default acces
 
 In the above example, the `yellow` layout and its descendants are completely invisible to TalkBack and all other accessibility services. So we can use overlapping views with the same parent without confusing TalkBack.
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "escape" gesture, which is a two finger Z shaped gesture. An escape function should move back hierarchically in the user interface. This can mean moving up or back in a navigation hierarchy or dismissing a modal user interface. If the selected element does not have an `onAccessibilityEscape` function, the system will attempt to traverse up the view hierarchy until it finds a view that does or bonk to indicate it was unable to find one.
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 Use this property to assign a custom function to be called when someone activates an accessible element by double tapping on it while it's selected.
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 Assign this property to a custom function which will be called when someone performs the "magic tap" gesture, which is a double-tap with two fingers. A magic tap function should perform the most relevant action a user could take on a component. In the Phone app on iPhone, a magic tap answers a phone call or ends the current one. If the selected element does not have an `onMagicTap` function, the system will traverse up the view hierarchy until it finds a view that does.
 
@@ -464,7 +464,7 @@ To handle action requests, a component must implement an `onAccessibilityAction`
 
 The `AccessibilityInfo` API allows you to determine whether or not a screen reader is currently active. See the [AccessibilityInfo documentation](accessibilityinfo) for details.
 
-## Sending Accessibility Events <div class="label android">Android</div>
+## Sending Accessibility Events <div className="label android">Android</div>
 
 Sometimes it is useful to trigger an accessibility event on a UI component (i.e. when a custom view appears on a screen or set accessibility focus to a view). Native UIManager module exposes a method ‘sendAccessibilityEvent’ for this purpose. It takes two arguments: a view tag and a type of event. The supported event types are `typeWindowStateChanged`, `typeViewFocused`, and `typeViewClicked`.
 
@@ -479,7 +479,7 @@ if (Platform.OS === 'android') {
 }
 ```
 
-## Testing TalkBack Support <div class="label android">Android</div>
+## Testing TalkBack Support <div className="label android">Android</div>
 
 To enable TalkBack, go to the Settings app on your Android device or emulator. Tap Accessibility, then TalkBack. Toggle the "Use service" switch to enable or disable it.
 
@@ -499,7 +499,7 @@ adb shell settings put secure enabled_accessibility_services com.android.talkbac
 adb shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
 ```
 
-## Testing VoiceOver Support <div class="label ios">iOS</div>
+## Testing VoiceOver Support <div className="label ios">iOS</div>
 
 To enable VoiceOver on your iOS or iPadOS device, go to the Settings app, tap General, then Accessibility. There you will find many tools available for people to enable their devices to be more usable, including VoiceOver. To enable VoiceOver, tap on VoiceOver under "Vision" and toggle the switch that appears at the top.
 

--- a/website/versioned_docs/version-0.80/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.80/accessibilityinfo.md
@@ -90,16 +90,16 @@ static addEventListener(
 
 Add an event handler. Supported events:
 
-| Event name                                                                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accessibilityServiceChanged`<br/><div class="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
-| `announcementFinished`<br/><div class="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
-| `boldTextChanged`<br/><div class="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
-| `grayscaleChanged`<br/><div class="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
-| `invertColorsChanged`<br/><div class="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
-| `reduceMotionChanged`                                                                | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
-| `reduceTransparencyChanged`<br/><div class="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
-| `screenReaderChanged`                                                                | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
+| Event name                                                                               | Description                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accessibilityServiceChanged`<br/><div className="label two-lines android">Android</div> | Fires when some services such as TalkBack, other Android assistive technologies, and third-party accessibility services are enabled. The argument to the event handler is a boolean. The boolean is `true` when a some accessibility services is enabled and `false` otherwise.                          |
+| `announcementFinished`<br/><div className="label two-lines ios">iOS</div>                | Fires when the screen reader has finished making an announcement. The argument to the event handler is a dictionary with these keys:<ul><li>`announcement`: The string announced by the screen reader.</li><li>`success`: A boolean indicating whether the announcement was successfully made.</li></ul> |
+| `boldTextChanged`<br/><div className="label two-lines ios">iOS</div>                     | Fires when the state of the bold text toggle changes. The argument to the event handler is a boolean. The boolean is `true` when bold text is enabled and `false` otherwise.                                                                                                                             |
+| `grayscaleChanged`<br/><div className="label two-lines ios">iOS</div>                    | Fires when the state of the gray scale toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a gray scale is enabled and `false` otherwise.                                                                                                                         |
+| `invertColorsChanged`<br/><div className="label two-lines ios">iOS</div>                 | Fires when the state of the invert colors toggle changes. The argument to the event handler is a boolean. The boolean is `true` when invert colors is enabled and `false` otherwise.                                                                                                                     |
+| `reduceMotionChanged`                                                                    | Fires when the state of the reduce motion toggle changes. The argument to the event handler is a boolean. The boolean is `true` when a reduce motion is enabled (or when "Transition Animation Scale" in "Developer options" is "Animation off") and `false` otherwise.                                  |
+| `reduceTransparencyChanged`<br/><div className="label two-lines ios">iOS</div>           | Fires when the state of the reduce transparency toggle changes. The argument to the event handler is a boolean. The boolean is `true` when reduce transparency is enabled and `false` otherwise.                                                                                                         |
+| `screenReaderChanged`                                                                    | Fires when the state of the screen reader changes. The argument to the event handler is a boolean. The boolean is `true` when a screen reader is enabled and `false` otherwise.                                                                                                                          |
 
 ---
 
@@ -126,14 +126,14 @@ Post a string to be announced by the screen reader with modification options. By
 
 **Parameters:**
 
-| Name                                                          | Type   | Description                                                                              |
-| ------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| announcement <div class="label basic required">Required</div> | string | The string to be announced                                                               |
-| options <div class="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div class="label ios">iOS</div> |
+| Name                                                              | Type   | Description                                                                                  |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| announcement <div className="label basic required">Required</div> | string | The string to be announced                                                                   |
+| options <div className="label basic required">Required</div>      | object | `queue` - queue the announcement behind existing speech <div className="label ios">iOS</div> |
 
 ---
 
-### `getRecommendedTimeoutMillis()` <div class="label android">Android</div>
+### `getRecommendedTimeoutMillis()` <div className="label android">Android</div>
 
 ```tsx
 static getRecommendedTimeoutMillis(originalTimeout: number): Promise<number>;
@@ -144,13 +144,13 @@ This value is set in "Time to take action (Accessibility timeout)" of "Accessibi
 
 **Parameters:**
 
-| Name                                                             | Type   | Description                                                                           |
-| ---------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| originalTimeout <div class="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
+| Name                                                                 | Type   | Description                                                                           |
+| -------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| originalTimeout <div className="label basic required">Required</div> | number | The timeout to return if "Accessibility timeout" is not set. Specify in milliseconds. |
 
 ---
 
-### `isAccessibilityServiceEnabled()` <div class="label android">Android</div>
+### `isAccessibilityServiceEnabled()` <div className="label android">Android</div>
 
 ```tsx
 static isAccessibilityServiceEnabled(): Promise<boolean>;
@@ -162,7 +162,7 @@ Check whether any accessibility service is enabled. This includes TalkBack but a
 
 ---
 
-### `isBoldTextEnabled()` <div class="label ios">iOS</div>
+### `isBoldTextEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isBoldTextEnabled(): Promise<boolean>:
@@ -172,7 +172,7 @@ Query whether a bold text is currently enabled. Returns a promise which resolves
 
 ---
 
-### `isGrayscaleEnabled()` <div class="label ios">iOS</div>
+### `isGrayscaleEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isGrayscaleEnabled(): Promise<boolean>;
@@ -182,7 +182,7 @@ Query whether grayscale is currently enabled. Returns a promise which resolves t
 
 ---
 
-### `isInvertColorsEnabled()` <div class="label ios">iOS</div>
+### `isInvertColorsEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isInvertColorsEnabled(): Promise<boolean>;
@@ -202,7 +202,7 @@ Query whether reduce motion is currently enabled. Returns a promise which resolv
 
 ---
 
-### `isReduceTransparencyEnabled()` <div class="label ios">iOS</div>
+### `isReduceTransparencyEnabled()` <div className="label ios">iOS</div>
 
 ```tsx
 static isReduceTransparencyEnabled(): Promise<boolean>;
@@ -222,7 +222,7 @@ Query whether a screen reader is currently enabled. Returns a promise which reso
 
 ---
 
-### `prefersCrossFadeTransitions()` <div class="label ios">iOS</div>
+### `prefersCrossFadeTransitions()` <div className="label ios">iOS</div>
 
 ```tsx
 static prefersCrossFadeTransitions(): Promise<boolean>;

--- a/website/versioned_docs/version-0.80/activityindicator.md
+++ b/website/versioned_docs/version-0.80/activityindicator.md
@@ -62,13 +62,13 @@ Whether to show the indicator (`true`) or hide it (`false`).
 
 The foreground color of the spinner.
 
-| Type            | Default                                                                                                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [color](colors) | `null` (system accent default color)<div class="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
+| Type            | Default                                                                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [color](colors) | `null` (system accent default color)<div className="label android">Android</div><hr/><ins style={{background: '#999'}} className="color-box" />`'#999999'` <div className="label ios">iOS</div> |
 
 ---
 
-### `hidesWhenStopped` <div class="label ios">iOS</div>
+### `hidesWhenStopped` <div className="label ios">iOS</div>
 
 Whether the indicator should hide when not animating.
 
@@ -82,6 +82,6 @@ Whether the indicator should hide when not animating.
 
 Size of the indicator.
 
-| Type                                                                           | Default   |
-| ------------------------------------------------------------------------------ | --------- |
-| enum(`'small'`, `'large'`)<hr/>number <div class="label android">Android</div> | `'small'` |
+| Type                                                                               | Default   |
+| ---------------------------------------------------------------------------------- | --------- |
+| enum(`'small'`, `'large'`)<hr/>number <div className="label android">Android</div> | `'small'` |

--- a/website/versioned_docs/version-0.80/alert.md
+++ b/website/versioned_docs/version-0.80/alert.md
@@ -78,7 +78,7 @@ Alerts on Android can be dismissed by tapping outside of the alert box. It is di
 
 The cancel event can be handled by providing an `onDismiss` callback property inside the `options` parameter.
 
-### Example <div class="label android">Android</div>
+### Example <div className="label android">Android</div>
 
 ```SnackPlayer name=Alert%20Android%20Dissmissable%20Example&supportedPlatforms=android
 import React from 'react';
@@ -143,16 +143,16 @@ static alert (
 
 **Parameters:**
 
-| Name                                                   | Type                               | Description                                                             |
-| ------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
-| message                                                | string                             | An optional message that appears below the dialog's title.              |
-| buttons                                                | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
-| options                                                | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
+| Name                                                       | Type                               | Description                                                             |
+| ---------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                             | The dialog's title. Passing `null` or empty string will hide the title. |
+| message                                                    | string                             | An optional message that appears below the dialog's title.              |
+| buttons                                                    | [AlertButton](alert#alertbutton)[] | An optional array containing buttons configuration.                     |
+| options                                                    | [AlertOptions](alert#alertoptions) | An optional Alert configuration.                                        |
 
 ---
 
-### `prompt()` <div class="label ios">iOS</div>
+### `prompt()` <div className="label ios">iOS</div>
 
 ```tsx
 static prompt: (
@@ -169,21 +169,21 @@ Create and display a prompt to enter some text in form of Alert.
 
 **Parameters:**
 
-| Name                                                   | Type                                            | Description                                                                                                                                                                                           |
-| ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title <div class="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
-| message                                                | string                                          | An optional message that appears above the text input.                                                                                                                                                |
-| callbackOrButtons                                      | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
-| type                                                   | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
-| defaultValue                                           | string                                          | The default text in text input.                                                                                                                                                                       |
-| keyboardType                                           | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
-| options                                                | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
+| Name                                                       | Type                                            | Description                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title <div className="label basic required">Required</div> | string                                          | The dialog's title.                                                                                                                                                                                   |
+| message                                                    | string                                          | An optional message that appears above the text input.                                                                                                                                                |
+| callbackOrButtons                                          | function<hr/>[AlertButton](alert#alertButton)[] | If passed a function, it will be called with the prompt's value<br/>`(text: string) => void`, when the user taps 'OK'.<hr/>If passed an array, buttons will be configured based on the array content. |
+| type                                                       | [AlertType](alert#alerttype-ios)                | This configures the text input.                                                                                                                                                                       |
+| defaultValue                                               | string                                          | The default text in text input.                                                                                                                                                                       |
+| keyboardType                                               | string                                          | The keyboard type of first text field (if exists). One of TextInput [keyboardTypes](textinput#keyboardtype).                                                                                          |
+| options                                                    | [AlertOptions](alert#alertoptions)              | An optional Alert configuration.                                                                                                                                                                      |
 
 ---
 
 ## Type Definitions
 
-### AlertButtonStyle <div class="label ios">iOS</div>
+### AlertButtonStyle <div className="label ios">iOS</div>
 
 An iOS Alert button style.
 
@@ -201,7 +201,7 @@ An iOS Alert button style.
 
 ---
 
-### AlertType <div class="label ios">iOS</div>
+### AlertType <div className="label ios">iOS</div>
 
 An iOS Alert type.
 
@@ -230,12 +230,12 @@ An object describing the configuration of a button in the alert.
 
 **Objects properties:**
 
-| Name                                         | Type                                           | Description                                                                    |
-| -------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| text                                         | string                                         | Button label.                                                                  |
-| onPress                                      | function                                       | Callback function when button is pressed.                                      |
-| style <div class="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
-| isPreferred <div class="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
+| Name                                             | Type                                           | Description                                                                    |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| text                                             | string                                         | Button label.                                                                  |
+| onPress                                          | function                                       | Callback function when button is pressed.                                      |
+| style <div className="label ios">iOS</div>       | [AlertButtonStyle](alert#alertbuttonstyle-ios) | Button style, on Android this property will be ignored.                        |
+| isPreferred <div className="label ios">iOS</div> | boolean                                        | Whether button should be emphasized, on Android this property will be ignored. |
 
 ---
 
@@ -247,8 +247,8 @@ An object describing the configuration of a button in the alert.
 
 **Properties:**
 
-| Name                                                | Type     | Description                                                                                                               |
-| --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| cancelable <div class="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
-| userInterfaceStyle <div class="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
-| onDismiss <div class="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |
+| Name                                                    | Type     | Description                                                                                                               |
+| ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| cancelable <div className="label android">Android</div> | boolean  | Defines if alert can be dismissed by tapping outside of the alert box.                                                    |
+| userInterfaceStyle <div className="label ios">iOS</div> | string   | The interface style used for the alert, can be set to `light` or `dark`, otherwise the default system style will be used. |
+| onDismiss <div className="label android">Android</div>  | function | Callback function fired when alert has been dismissed.                                                                    |

--- a/website/versioned_docs/version-0.80/appstate.md
+++ b/website/versioned_docs/version-0.80/appstate.md
@@ -86,11 +86,11 @@ This event is received when the app state has changed. The listener is called wi
 
 This event is used in the need of throwing memory warning or releasing it.
 
-### `focus` <div class="label android">Android</div>
+### `focus` <div className="label android">Android</div>
 
 Received when the app gains focus (the user is interacting with the app).
 
-### `blur` <div class="label android">Android</div>
+### `blur` <div className="label android">Android</div>
 
 Received when the user is not actively interacting with the app. Useful in situations when the user pulls down the [notification drawer](https://developer.android.com/guide/topics/ui/notifiers/notifications#bar-and-drawer). `AppState` won't change but the `blur` event will get fired.
 

--- a/website/versioned_docs/version-0.80/button.md
+++ b/website/versioned_docs/version-0.80/button.md
@@ -112,7 +112,7 @@ export default App;
 
 ## Props
 
-### <div class="label required basic">Required</div>**`onPress`**
+### <div className="label required basic">Required</div>**`onPress`**
 
 Handler to be called when the user taps the button.
 
@@ -122,7 +122,7 @@ Handler to be called when the user taps the button.
 
 ---
 
-### <div class="label required basic">Required</div>**`title`**
+### <div className="label required basic">Required</div>**`title`**
 
 Text to display inside the button. On Android the given title will be converted to the uppercased form.
 
@@ -142,7 +142,7 @@ Text to display for blindness accessibility features.
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -212,7 +212,7 @@ If `true`, disable all interactions for this component.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label tv">TV</div>
+### `hasTVPreferredFocus` <div className="label tv">TV</div>
 
 TV preferred focus.
 
@@ -222,7 +222,7 @@ TV preferred focus.
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusDown` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -232,7 +232,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusForward` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -242,7 +242,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusLeft` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -252,7 +252,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusRight` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -262,7 +262,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div><div class="label tv">TV</div>
+### `nextFocusUp` <div className="label android">Android</div><div className="label tv">TV</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -282,7 +282,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If `true`, doesn't play system sound on touch.
 

--- a/website/versioned_docs/version-0.80/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.80/fabric-native-components-ios.md
@@ -38,19 +38,19 @@ cd ios
 open Demo.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/fabric-native-components/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `WebView`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/fabric-native-components/2.webp" />
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 
-<img class="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
+<img className="half-size" alt="Create an Objective-C RCTWebView class" src="/docs/assets/fabric-native-components/4.webp" />
 
 5. Repeat step 4 and create a header file named `RCTWebView.h`.
 
@@ -213,10 +213,10 @@ To link the WebKit framework in your app, follow these steps:
 3. Select the General tab
 4. Scroll down until you find the _"Frameworks, Libraries, and Embedded Contents"_ section, and press the `+` button
 
-<img class="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
+<img className="half-size" alt="Add webkit framework to your app 1" src="/docs/assets/AddWebKitFramework1.png" />
 
 5. In the search bar, filter for WebKit
 6. Select the WebKit framework
 7. Click on Add.
 
-<img class="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />
+<img className="half-size" alt="Add webkit framework to your app 2" src="/docs/assets/AddWebKitFramework2.png" />

--- a/website/versioned_docs/version-0.80/flatlist.md
+++ b/website/versioned_docs/version-0.80/flatlist.md
@@ -356,7 +356,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 renderItem({
@@ -416,7 +416,7 @@ Example usage:
 
 ---
 
-### <div class="label required basic">Required</div> **`data`**
+### <div className="label required basic">Required</div> **`data`**
 
 An array (or array-like list) of items to render. Other data types can be used by targeting [`VirtualizedList`](virtualizedlist.md) directly.
 

--- a/website/versioned_docs/version-0.80/image-style-props.md
+++ b/website/versioned_docs/version-0.80/image-style-props.md
@@ -312,7 +312,7 @@ Set an opacity value for the image. The number should be in the range from `0.0`
 
 ---
 
-### `overlayColor` <div class="label android">Android</div>
+### `overlayColor` <div className="label android">Android</div>
 
 When the image has rounded corners, specifying an overlayColor will cause the remaining space in the corners to be filled with a solid color. This is useful in cases which are not supported by the Android implementation of rounded corners:
 

--- a/website/versioned_docs/version-0.80/image.md
+++ b/website/versioned_docs/version-0.80/image.md
@@ -167,7 +167,7 @@ blurRadius: the blur radius of the blur filter added to the image.
 
 ---
 
-### `capInsets` <div class="label ios">iOS</div>
+### `capInsets` <div className="label ios">iOS</div>
 
 When the image is resized, the corners of the size specified by `capInsets` will stay a fixed size, but the center content and borders of the image will be stretched. This is useful for creating resizable rounded buttons, shadows, and other resizable assets. More info in the [official Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets).
 
@@ -202,7 +202,7 @@ A static image to display while loading the image source.
 
 ---
 
-### `fadeDuration` <div class="label android">Android</div>
+### `fadeDuration` <div className="label android">Android</div>
 
 Fade animation duration in milliseconds.
 
@@ -286,7 +286,7 @@ Invoked on load start.
 
 ---
 
-### `onPartialLoad` <div class="label ios">iOS</div>
+### `onPartialLoad` <div className="label ios">iOS</div>
 
 Invoked when a partial load of the image is complete. The definition of what constitutes a "partial load" is loader specific though this is meant for progressive JPEG loads.
 
@@ -306,7 +306,7 @@ Invoked on download progress.
 
 ---
 
-### `progressiveRenderingEnabled` <div class="label android">Android</div>
+### `progressiveRenderingEnabled` <div className="label android">Android</div>
 
 When `true`, enables progressive jpeg streaming - https://frescolib.org/docs/progressive-jpegs.
 
@@ -326,7 +326,7 @@ A string indicating which referrer to use when fetching the resource. Sets the v
 
 ---
 
-### `resizeMethod` <div class="label android">Android</div>
+### `resizeMethod` <div className="label android">Android</div>
 
 The mechanism that should be used to resize the image when the image's dimensions differ from the image view's dimensions. Defaults to `auto`.
 
@@ -368,7 +368,7 @@ Determines how to resize the image when the frame doesn't match the raw image di
 
 ---
 
-### `resizeMultiplier` <div class="label android">Android</div>
+### `resizeMultiplier` <div className="label android">Android</div>
 
 When the `resizeMethod` is set to `resize`, the destination dimensions are multiplied by this value. The `scale` method is used to perform the remainder of the resize. A default of `1.0` means the bitmap size is designed to fit the destination dimensions. A multiplier greater than `1.0` will set the resize options larger than that of the destination dimensions, and the resulting bitmap will be scaled down from the hardware size. Defaults to `1.0`.
 
@@ -464,7 +464,7 @@ Width of the image component.
 
 ## Methods
 
-### `abortPrefetch()` <div class="label android">Android</div>
+### `abortPrefetch()` <div className="label android">Android</div>
 
 ```tsx
 static abortPrefetch(requestId: number);
@@ -474,9 +474,9 @@ Abort prefetch request.
 
 **Parameters:**
 
-| Name                                                       | Type   | Description                             |
-| ---------------------------------------------------------- | ------ | --------------------------------------- |
-| requestId <div class="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
+| Name                                                           | Type   | Description                             |
+| -------------------------------------------------------------- | ------ | --------------------------------------- |
+| requestId <div className="label basic required">Required</div> | number | Request id as returned by `prefetch()`. |
 
 ---
 
@@ -492,9 +492,9 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>               | Type   | Description                |
-| ---------------------------------------------------- | ------ | -------------------------- |
-| uri <div class="label basic required">Required</div> | string | The location of the image. |
+| <div className="wideColumn">Name</div>                   | Type   | Description                |
+| -------------------------------------------------------- | ------ | -------------------------- |
+| uri <div className="label basic required">Required</div> | string | The location of the image. |
 
 ---
 
@@ -513,10 +513,10 @@ In order to retrieve the image dimensions, the image may first need to be loaded
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                   | Type   | Description                  |
-| -------------------------------------------------------- | ------ | ---------------------------- |
-| uri <div class="label basic required">Required</div>     | string | The location of the image.   |
-| headers <div class="label basic required">Required</div> | object | The headers for the request. |
+| <div className="wideColumn">Name</div>                       | Type   | Description                  |
+| ------------------------------------------------------------ | ------ | ---------------------------- |
+| uri <div className="label basic required">Required</div>     | string | The location of the image.   |
+| headers <div className="label basic required">Required</div> | object | The headers for the request. |
 
 ---
 
@@ -530,10 +530,10 @@ Prefetches a remote image for later use by downloading it to the disk cache. Ret
 
 **Parameters:**
 
-| Name                                                 | Type                                              | Description                                            |
-| ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| url <div class="label basic required">Required</div> | string                                            | The remote location of the image.                      |
-| callback                                             | function <div class="label android">Android</div> | The function that will be called with the `requestId`. |
+| Name                                                     | Type                                                  | Description                                            |
+| -------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| url <div className="label basic required">Required</div> | string                                                | The remote location of the image.                      |
+| callback                                                 | function <div className="label android">Android</div> | The function that will be called with the `requestId`. |
 
 ---
 
@@ -549,9 +549,9 @@ Perform cache interrogation. Returns a promise which resolves to a mapping from 
 
 **Parameters:**
 
-| Name                                                  | Type  | Description                                |
-| ----------------------------------------------------- | ----- | ------------------------------------------ |
-| urls <div class="label basic required">Required</div> | array | List of image URLs to check the cache for. |
+| Name                                                      | Type  | Description                                |
+| --------------------------------------------------------- | ----- | ------------------------------------------ |
+| urls <div className="label basic required">Required</div> | array | List of image URLs to check the cache for. |
 
 ---
 
@@ -570,13 +570,13 @@ Resolves an asset reference into an object which has the properties `uri`, `scal
 
 **Parameters:**
 
-| <div className="wideColumn">Name</div>                  | Type                                     | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| source <div class="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
+| <div className="wideColumn">Name</div>                      | Type                                     | Description                                                                  |
+| ----------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| source <div className="label basic required">Required</div> | [ImageSource](image#imagesource), number | A number (opaque type returned by `require('./foo.png')`) or an ImageSource. |
 
 ## Type Definitions
 
-### ImageCacheEnum <div class="label ios">iOS</div>
+### ImageCacheEnum <div className="label ios">iOS</div>
 
 Enum which can be used to set the cache handling or strategy for the potentially cached responses.
 
@@ -621,17 +621,17 @@ Object returned in the `onLoad` callback.
 
 **Properties (if passing as object or array of objects):**
 
-| <div className="wideColumn">Name</div> | Type                                       | Description                                                                                                                                                                          |
-| -------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri                                    | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
-| width                                  | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| height                                 | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
-| scale                                  | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
-| bundle<div class="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
-| method                                 | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
-| headers                                | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
-| body                                   | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
-| cache<div class="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
+| <div className="wideColumn">Name</div>     | Type                                       | Description                                                                                                                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| uri                                        | string                                     | A string representing the resource identifier for the image, which could be an http address, a local file path, or the name of a static image resource.                              |
+| width                                      | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| height                                     | number                                     | Can be specified if known at build time, in which case the value will be used to set the default `<Image/>` component dimension.                                                     |
+| scale                                      | number                                     | Used to indicate the scale factor of the image. Defaults to `1.0` if unspecified, meaning that one image pixel equates to one display point / DIP.                                   |
+| bundle<div className="label ios">iOS</div> | string                                     | The iOS asset bundle which the image is included in. This will default to `[NSBundle mainBundle]` if not set.                                                                        |
+| method                                     | string                                     | The HTTP Method to use. Defaults to `'GET'` if not specified.                                                                                                                        |
+| headers                                    | object                                     | An object representing the HTTP headers to send along with the request for a remote image.                                                                                           |
+| body                                       | string                                     | The HTTP body to send with the request. This must be a valid UTF-8 string, and will be sent exactly as specified, with no additional encoding (e.g. URL-escaping or base64) applied. |
+| cache<div className="label ios">iOS</div>  | [ImageCacheEnum](image#imagecacheenum-ios) | Determines how the requests handles potentially cached responses.                                                                                                                    |
 
 **If passing a number:**
 

--- a/website/versioned_docs/version-0.80/linking.md
+++ b/website/versioned_docs/version-0.80/linking.md
@@ -652,7 +652,7 @@ The method returns a `Promise` object. If the user confirms the open dialog or t
 
 ---
 
-### `sendIntent()` <div class="label android">Android</div>
+### `sendIntent()` <div className="label android">Android</div>
 
 ```tsx
 static sendIntent(

--- a/website/versioned_docs/version-0.80/modal.md
+++ b/website/versioned_docs/version-0.80/modal.md
@@ -136,7 +136,7 @@ The `backdropColor` of the modal (or background color of the modal's container.)
 
 ---
 
-### `hardwareAccelerated` <div class="label android">Android</div>
+### `hardwareAccelerated` <div className="label android">Android</div>
 
 The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
 
@@ -146,7 +146,7 @@ The `hardwareAccelerated` prop controls whether to force hardware acceleration f
 
 ---
 
-### `navigationBarTranslucent` <div class="label android">Android</div>
+### `navigationBarTranslucent` <div className="label android">Android</div>
 
 The `navigationBarTranslucent` prop determines whether your modal should go under the system navigation bar. However, `statusBarTranslucent` also needs to be set to `true` to make navigation bar translucent.
 
@@ -156,7 +156,7 @@ The `navigationBarTranslucent` prop determines whether your modal should go unde
 
 ---
 
-### `onDismiss` <div class="label ios">iOS</div>
+### `onDismiss` <div className="label ios">iOS</div>
 
 The `onDismiss` prop allows passing a function that will be called once the modal has been dismissed.
 
@@ -166,7 +166,7 @@ The `onDismiss` prop allows passing a function that will be called once the moda
 
 ---
 
-### `onOrientationChange` <div class="label ios">iOS</div>
+### `onOrientationChange` <div className="label ios">iOS</div>
 
 The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed. The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
 
@@ -197,7 +197,7 @@ The `onShow` prop allows passing a function that will be called once the modal h
 
 ---
 
-### `presentationStyle` <div class="label ios">iOS</div>
+### `presentationStyle` <div className="label ios">iOS</div>
 
 The `presentationStyle` prop controls how the modal appears (generally on larger devices such as iPad or plus-sized iPhones). See https://developer.apple.com/reference/uikit/uimodalpresentationstyle for details.
 
@@ -214,7 +214,7 @@ Possible values:
 
 ---
 
-### `statusBarTranslucent` <div class="label android">Android</div>
+### `statusBarTranslucent` <div className="label android">Android</div>
 
 The `statusBarTranslucent` prop determines whether your modal should go under the system statusbar.
 
@@ -224,7 +224,7 @@ The `statusBarTranslucent` prop determines whether your modal should go under th
 
 ---
 
-### `supportedOrientations` <div class="label ios">iOS</div>
+### `supportedOrientations` <div className="label ios">iOS</div>
 
 The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations. On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
 

--- a/website/versioned_docs/version-0.80/platform-specific-code.md
+++ b/website/versioned_docs/version-0.80/platform-specific-code.md
@@ -72,7 +72,7 @@ const Component = Platform.select({
 <Component />;
 ```
 
-### Detecting the Android version <div class="label android" title="This section is related to Android platform">Android</div>
+### Detecting the Android version <div className="label android" title="This section is related to Android platform">Android</div>
 
 On Android, the `Platform` module can also be used to detect the version of the Android Platform in which the app is running:
 
@@ -86,7 +86,7 @@ if (Platform.Version === 25) {
 
 **Note**: `Version` is set to the Android API version not the Android OS version. To find a mapping please refer to [Android Version History](https://en.wikipedia.org/wiki/Android_version_history#Overview).
 
-### Detecting the iOS version <div class="label ios" title="This section is related to iOS platform">iOS</div>
+### Detecting the iOS version <div className="label ios" title="This section is related to iOS platform">iOS</div>
 
 On iOS, the `Version` is a result of `-[UIDevice systemVersion]`, which is a string with the current version of the operating system. An example of the system version is "10.3". For example, to detect the major version number on iOS:
 

--- a/website/versioned_docs/version-0.80/platform.md
+++ b/website/versioned_docs/version-0.80/platform.md
@@ -89,7 +89,7 @@ Returns an object which contains all available common and specific constants rel
 
 ---
 
-### `isPad` <div class="label ios">iOS</div>
+### `isPad` <div className="label ios">iOS</div>
 
 ```tsx
 static isPad: boolean;

--- a/website/versioned_docs/version-0.80/pressable.md
+++ b/website/versioned_docs/version-0.80/pressable.md
@@ -108,7 +108,7 @@ export default App;
 
 ## Props
 
-### `android_disableSound` <div class="label android">Android</div>
+### `android_disableSound` <div className="label android">Android</div>
 
 If true, doesn't play Android system sound on press.
 
@@ -116,7 +116,7 @@ If true, doesn't play Android system sound on press.
 | ------- | ------- |
 | boolean | `false` |
 
-### `android_ripple` <div class="label android">Android</div>
+### `android_ripple` <div className="label android">Android</div>
 
 Enables the Android ripple effect and configures its properties.
 

--- a/website/versioned_docs/version-0.80/pressevent.md
+++ b/website/versioned_docs/version-0.80/pressevent.md
@@ -31,7 +31,7 @@ Array of all PressEvents that have changed since the last event.
 | -------------------- | -------- |
 | array of PressEvents | No       |
 
-### `force` <div class="label ios">iOS</div>
+### `force` <div className="label ios">iOS</div>
 
 Amount of force used during the 3D Touch press. Returns the float value in range from `0.0` to `1.0`.
 

--- a/website/versioned_docs/version-0.80/refreshcontrol.md
+++ b/website/versioned_docs/version-0.80/refreshcontrol.md
@@ -66,7 +66,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`refreshing`**
+### <div className="label required basic">Required</div>**`refreshing`**
 
 Whether the view should be indicating an active refresh.
 
@@ -76,7 +76,7 @@ Whether the view should be indicating an active refresh.
 
 ---
 
-### `colors` <div class="label android">Android</div>
+### `colors` <div className="label android">Android</div>
 
 The colors (at least one) that will be used to draw the refresh indicator.
 
@@ -86,7 +86,7 @@ The colors (at least one) that will be used to draw the refresh indicator.
 
 ---
 
-### `enabled` <div class="label android">Android</div>
+### `enabled` <div className="label android">Android</div>
 
 Whether the pull to refresh functionality is enabled.
 
@@ -106,7 +106,7 @@ Called when the view starts refreshing.
 
 ---
 
-### `progressBackgroundColor` <div class="label android">Android</div>
+### `progressBackgroundColor` <div className="label android">Android</div>
 
 The background color of the refresh indicator.
 
@@ -126,7 +126,7 @@ Progress view top offset.
 
 ---
 
-### `size` <div class="label android">Android</div>
+### `size` <div className="label android">Android</div>
 
 Size of the refresh indicator.
 
@@ -136,7 +136,7 @@ Size of the refresh indicator.
 
 ---
 
-### `tintColor` <div class="label ios">iOS</div>
+### `tintColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator.
 
@@ -146,7 +146,7 @@ The color of the refresh indicator.
 
 ---
 
-### `title` <div class="label ios">iOS</div>
+### `title` <div className="label ios">iOS</div>
 
 The title displayed under the refresh indicator.
 
@@ -156,7 +156,7 @@ The title displayed under the refresh indicator.
 
 ---
 
-### `titleColor` <div class="label ios">iOS</div>
+### `titleColor` <div className="label ios">iOS</div>
 
 The color of the refresh indicator title.
 

--- a/website/versioned_docs/version-0.80/scrollview.md
+++ b/website/versioned_docs/version-0.80/scrollview.md
@@ -83,7 +83,7 @@ A React Component that will be used to render sticky headers, should be used tog
 
 ---
 
-### `alwaysBounceHorizontal` <div class="label ios">iOS</div>
+### `alwaysBounceHorizontal` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces horizontally when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -93,7 +93,7 @@ When true, the scroll view bounces horizontally when it reaches the end even if 
 
 ---
 
-### `alwaysBounceVertical` <div class="label ios">iOS</div>
+### `alwaysBounceVertical` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself.
 
@@ -103,7 +103,7 @@ When true, the scroll view bounces vertically when it reaches the end even if th
 
 ---
 
-### `automaticallyAdjustContentInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustContentInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/toolbar.
 
@@ -113,7 +113,7 @@ Controls whether iOS should automatically adjust the content inset for scroll vi
 
 ---
 
-### `automaticallyAdjustKeyboardInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustKeyboardInsets` <div className="label ios">iOS</div>
 
 Controls whether the ScrollView should automatically adjust its `contentInset` and `scrollViewInsets` when the Keyboard changes its size.
 
@@ -123,7 +123,7 @@ Controls whether the ScrollView should automatically adjust its `contentInset` a
 
 ---
 
-### `automaticallyAdjustsScrollIndicatorInsets` <div class="label ios">iOS</div>
+### `automaticallyAdjustsScrollIndicatorInsets` <div className="label ios">iOS</div>
 
 Controls whether iOS should automatically adjust the scroll indicator insets. See Apple's [documentation on the property](https://developer.apple.com/documentation/uikit/uiscrollview/3198043-automaticallyadjustsscrollindica).
 
@@ -133,7 +133,7 @@ Controls whether iOS should automatically adjust the scroll indicator insets. Se
 
 ---
 
-### `bounces` <div class="label ios">iOS</div>
+### `bounces` <div className="label ios">iOS</div>
 
 When true, the scroll view bounces when it reaches the end of the content if the content is larger than the scroll view along the axis of the scroll direction. When `false`, it disables all bouncing even if the `alwaysBounce*` props are `true`.
 
@@ -143,7 +143,7 @@ When true, the scroll view bounces when it reaches the end of the content if the
 
 ---
 
-### `bouncesZoom` <div class="label ios">iOS</div>
+### `bouncesZoom` <div className="label ios">iOS</div>
 
 When `true`, gestures can drive zoom past min/max and the zoom will animate to the min/max value at gesture end, otherwise the zoom will not exceed the limits.
 
@@ -153,7 +153,7 @@ When `true`, gestures can drive zoom past min/max and the zoom will animate to t
 
 ---
 
-### `canCancelContentTouches` <div class="label ios">iOS</div>
+### `canCancelContentTouches` <div className="label ios">iOS</div>
 
 When `false`, once tracking starts, won't try to drag if the touch moves.
 
@@ -163,7 +163,7 @@ When `false`, once tracking starts, won't try to drag if the touch moves.
 
 ---
 
-### `centerContent` <div class="label ios">iOS</div>
+### `centerContent` <div className="label ios">iOS</div>
 
 When `true`, the scroll view automatically centers the content when the content is smaller than the scroll view bounds; when the content is larger than the scroll view, this property has no effect.
 
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
 
 ---
 
-### `contentInset` <div class="label ios">iOS</div>
+### `contentInset` <div className="label ios">iOS</div>
 
 The amount by which the scroll view content is inset from the edges of the scroll view.
 
@@ -206,7 +206,7 @@ The amount by which the scroll view content is inset from the edges of the scrol
 
 ---
 
-### `contentInsetAdjustmentBehavior` <div class="label ios">iOS</div>
+### `contentInsetAdjustmentBehavior` <div className="label ios">iOS</div>
 
 This property specifies how the safe area insets are used to modify the content area of the scroll view. Available on iOS 11 and later.
 
@@ -239,7 +239,7 @@ A floating-point number that determines how quickly the scroll view decelerates 
 
 ---
 
-### `directionalLockEnabled` <div class="label ios">iOS</div>
+### `directionalLockEnabled` <div className="label ios">iOS</div>
 
 When true, the ScrollView will try to lock to only vertical or horizontal scrolling while dragging.
 
@@ -269,7 +269,7 @@ When true, the default JS pan responder on the ScrollView is disabled, and full 
 
 ---
 
-### `endFillColor` <div class="label android">Android</div>
+### `endFillColor` <div className="label android">Android</div>
 
 Sometimes a scrollview takes up more space than its content fills. When this is the case, this prop will fill the rest of the scrollview with a color to avoid setting a background and creating unnecessary overdraw. This is an advanced optimization that is not needed in the general case.
 
@@ -279,7 +279,7 @@ Sometimes a scrollview takes up more space than its content fills. When this is 
 
 ---
 
-### `fadingEdgeLength` <div class="label android">Android</div>
+### `fadingEdgeLength` <div className="label android">Android</div>
 
 Fades out the edges of the scroll content.
 
@@ -301,7 +301,7 @@ When `true`, the scroll view's children are arranged horizontally in a row inste
 
 ---
 
-### `indicatorStyle` <div class="label ios">iOS</div>
+### `indicatorStyle` <div className="label ios">iOS</div>
 
 The style of the scroll indicators.
 
@@ -374,7 +374,7 @@ Caveat 2: This uses `contentOffset` and `frame.origin` in native code to compute
 
 ---
 
-### `maximumZoomScale` <div class="label ios">iOS</div>
+### `maximumZoomScale` <div className="label ios">iOS</div>
 
 The maximum allowed zoom scale.
 
@@ -384,7 +384,7 @@ The maximum allowed zoom scale.
 
 ---
 
-### `minimumZoomScale` <div class="label ios">iOS</div>
+### `minimumZoomScale` <div className="label ios">iOS</div>
 
 The minimum allowed zoom scale.
 
@@ -394,7 +394,7 @@ The minimum allowed zoom scale.
 
 ---
 
-### `nestedScrollEnabled` <div class="label android">Android</div>
+### `nestedScrollEnabled` <div className="label android">Android</div>
 
 Enables nested scrolling for Android API level 21+.
 
@@ -480,7 +480,7 @@ Called when the user stops dragging the scroll view and it either stops or begin
 
 ---
 
-### `onScrollToTop` <div class="label ios">iOS</div>
+### `onScrollToTop` <div className="label ios">iOS</div>
 
 Fires when the scroll view scrolls to top after the status bar has been tapped.
 
@@ -490,7 +490,7 @@ Fires when the scroll view scrolls to top after the status bar has been tapped.
 
 ---
 
-### `overScrollMode` <div class="label android">Android</div>
+### `overScrollMode` <div className="label android">Android</div>
 
 Used to override default value of overScroll mode.
 
@@ -516,7 +516,7 @@ When true, the scroll view stops on multiples of the scroll view's size when scr
 
 ---
 
-### `persistentScrollbar` <div class="label android">Android</div>
+### `persistentScrollbar` <div className="label android">Android</div>
 
 Causes the scrollbars not to turn transparent when they are not in use.
 
@@ -526,7 +526,7 @@ Causes the scrollbars not to turn transparent when they are not in use.
 
 ---
 
-### `pinchGestureEnabled` <div class="label ios">iOS</div>
+### `pinchGestureEnabled` <div className="label ios">iOS</div>
 
 When true, ScrollView allows use of pinch gestures to zoom in and out.
 
@@ -580,7 +580,7 @@ Limits how often scroll events will be fired while scrolling, specified as a tim
 
 ---
 
-### `scrollIndicatorInsets` <div class="label ios">iOS</div>
+### `scrollIndicatorInsets` <div className="label ios">iOS</div>
 
 The amount by which the scroll view indicators are inset from the edges of the scroll view. This should normally be set to the same value as the `contentInset`.
 
@@ -590,7 +590,7 @@ The amount by which the scroll view indicators are inset from the edges of the s
 
 ---
 
-### `scrollPerfTag` <div class="label android">Android</div>
+### `scrollPerfTag` <div className="label android">Android</div>
 
 Tag used to log scroll performance on this scroll view. Will force momentum events to be turned on (see sendMomentumEvents). This doesn't do anything out of the box and you need to implement a custom native FpsListener for it to be useful.
 
@@ -600,7 +600,7 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
-### `scrollToOverflowEnabled` <div class="label ios">iOS</div>
+### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.
 
@@ -610,7 +610,7 @@ When `true`, the scroll view can be programmatically scrolled beyond its content
 
 ---
 
-### `scrollsToTop` <div class="label ios">iOS</div>
+### `scrollsToTop` <div className="label ios">iOS</div>
 
 When `true`, the scroll view scrolls to top when the status bar is tapped.
 
@@ -716,7 +716,7 @@ An array of child indices determining which children get docked to the top of th
 
 ---
 
-### `zoomScale` <div class="label ios">iOS</div>
+### `zoomScale` <div className="label ios">iOS</div>
 
 The current scale of the scroll view content.
 

--- a/website/versioned_docs/version-0.80/sectionlist.md
+++ b/website/versioned_docs/version-0.80/sectionlist.md
@@ -105,7 +105,7 @@ Inherits [VirtualizedList Props](virtualizedlist.md#props).
 
 ---
 
-### <div class="label required basic">Required</div>**`renderItem`**
+### <div className="label required basic">Required</div>**`renderItem`**
 
 Default renderer for every item in every section. Can be over-ridden on a per-section basis. Should return a React element.
 
@@ -127,7 +127,7 @@ The render function will be passed an object with the following keys:
 
 ---
 
-### <div class="label required basic">Required</div>**`sections`**
+### <div className="label required basic">Required</div>**`sections`**
 
 The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
 
@@ -293,13 +293,13 @@ Rendered at the top and bottom of each section (note this is different from `Ite
 
 Makes section headers stick to the top of the screen until the next one pushes it off. Only enabled by default on iOS because that is the platform standard there.
 
-| Type    | Default                                                                                          |
-| ------- | ------------------------------------------------------------------------------------------------ |
-| boolean | `false` <div class="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
+| Type    | Default                                                                                              |
+| ------- | ---------------------------------------------------------------------------------------------------- |
+| boolean | `false` <div className="label android">Android</div><hr/>`true` <div className="label ios">iOS</div> |
 
 ## Methods
 
-### `flashScrollIndicators()` <div class="label ios">iOS</div>
+### `flashScrollIndicators()` <div className="label ios">iOS</div>
 
 ```tsx
 flashScrollIndicators();
@@ -331,9 +331,9 @@ Scrolls to the item at the specified `sectionIndex` and `itemIndex` (within the 
 
 **Parameters:**
 
-| Name                                                    | Type   |
-| ------------------------------------------------------- | ------ |
-| params <div class="label basic required">Required</div> | object |
+| Name                                                        | Type   |
+| ----------------------------------------------------------- | ------ |
+| params <div className="label basic required">Required</div> | object |
 
 Valid `params` keys are:
 
@@ -355,10 +355,10 @@ An object that identifies the data to be rendered for a given section.
 
 **Properties:**
 
-| Name                                                  | Type               | Description                                                                                                                                                         |
-| ----------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data <div class="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
-| key                                                   | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
-| renderItem                                            | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
-| ItemSeparatorComponent                                | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
-| keyExtractor                                          | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |
+| Name                                                      | Type               | Description                                                                                                                                                         |
+| --------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| data <div className="label basic required">Required</div> | array              | The data for rendering items in this section. Array of objects, much like [`FlatList`'s data prop](flatlist#required-data).                                         |
+| key                                                       | string             | Optional key to keep track of section re-ordering. If you don't plan on re-ordering sections, the array index will be used by default.                              |
+| renderItem                                                | function           | Optionally define an arbitrary item renderer for this section, overriding the default [`renderItem`](sectionlist#renderitem) for the list.                          |
+| ItemSeparatorComponent                                    | component, element | Optionally define an arbitrary item separator for this section, overriding the default [`ItemSeparatorComponent`](sectionlist#itemseparatorcomponent) for the list. |
+| keyExtractor                                              | function           | Optionally define an arbitrary key extractor for this section, overriding the default [`keyExtractor`](sectionlist#keyextractor).                                   |

--- a/website/versioned_docs/version-0.80/shadow-props.md
+++ b/website/versioned_docs/version-0.80/shadow-props.md
@@ -240,7 +240,7 @@ Both `boxShadow` and `dropShadow` are generally more capable than the `shadow` p
 
 See [View Style Props](./view-style-props#boxshadow) for documentation.
 
-### `dropShadow` <div class="label android">Android</div>
+### `dropShadow` <div className="label android">Android</div>
 
 See [View Style Props](./view-style-props#filter) for documentation.
 
@@ -256,7 +256,7 @@ This property will only work on Android API 28 and above. For similar functional
 
 ---
 
-### `shadowOffset` <div class="label ios">iOS</div>
+### `shadowOffset` <div className="label ios">iOS</div>
 
 Sets the drop shadow offset.
 
@@ -266,7 +266,7 @@ Sets the drop shadow offset.
 
 ---
 
-### `shadowOpacity` <div class="label ios">iOS</div>
+### `shadowOpacity` <div className="label ios">iOS</div>
 
 Sets the drop shadow opacity (multiplied by the color's alpha component).
 
@@ -276,7 +276,7 @@ Sets the drop shadow opacity (multiplied by the color's alpha component).
 
 ---
 
-### `shadowRadius` <div class="label ios">iOS</div>
+### `shadowRadius` <div className="label ios">iOS</div>
 
 Sets the drop shadow blur radius.
 

--- a/website/versioned_docs/version-0.80/share.md
+++ b/website/versioned_docs/version-0.80/share.md
@@ -108,10 +108,10 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 **Properties:**
 
-| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div class="label ios">iOS</div><br/>`title` - title of the message <div class="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                              |
-| options                                                      | object | `dialogTitle` <div class="label android">Android</div><br/>`excludedActivityTypes` <div class="label ios">iOS</div><br/>`subject` - a subject to share via email <div class="label ios">iOS</div><br/>`tintColor` <div class="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div class="label ios">iOS</div> |
+| Name                                                         | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content <div className="label basic required">Required</div> | object | `message` - a message to share<br/>`url` - a URL to share <div className="label ios">iOS</div><br/>`title` - title of the message <div className="label android">Android</div><hr/>At least one of `url` and `message` is required.                                                                                                                                                          |
+| options                                                      | object | `dialogTitle` <div className="label android">Android</div><br/>`excludedActivityTypes` <div className="label ios">iOS</div><br/>`subject` - a subject to share via email <div className="label ios">iOS</div><br/>`tintColor` <div className="label ios">iOS</div><br/>`anchor` - the node to which the action sheet should be anchored (used for iPad) <div className="label ios">iOS</div> |
 
 ---
 
@@ -127,7 +127,7 @@ The content was successfully shared.
 
 ---
 
-### `dismissedAction` <div class="label ios">iOS</div>
+### `dismissedAction` <div className="label ios">iOS</div>
 
 ```tsx
 static dismissedAction: 'dismissedAction';

--- a/website/versioned_docs/version-0.80/statusbar.md
+++ b/website/versioned_docs/version-0.80/statusbar.md
@@ -243,7 +243,7 @@ For cases where using a component is not ideal, there is also an imperative API 
 
 ## Constants
 
-### `currentHeight` <div class="label android">Android</div>
+### `currentHeight` <div className="label android">Android</div>
 
 The height of the status bar, which includes the notch height, if present.
 
@@ -261,7 +261,7 @@ If the transition between status bar property changes should be animated. Suppor
 
 ---
 
-### `backgroundColor` <div class="label android">Android</div>
+### `backgroundColor` <div className="label android">Android</div>
 
 The background color of the status bar.
 
@@ -297,7 +297,7 @@ If the status bar is hidden.
 
 ---
 
-### `networkActivityIndicatorVisible` <div class="label ios">iOS</div>
+### `networkActivityIndicatorVisible` <div className="label ios">iOS</div>
 
 If the network activity indicator should be visible.
 
@@ -307,7 +307,7 @@ If the network activity indicator should be visible.
 
 ---
 
-### `showHideTransition` <div class="label ios">iOS</div>
+### `showHideTransition` <div className="label ios">iOS</div>
 
 The transition effect when showing and hiding the status bar using the `hidden` prop.
 
@@ -317,7 +317,7 @@ The transition effect when showing and hiding the status bar using the `hidden` 
 
 ---
 
-### `translucent` <div class="label android">Android</div>
+### `translucent` <div className="label android">Android</div>
 
 If the status bar is translucent. When translucent is set to `true`, the app will draw under the status bar. This is useful when using a semi transparent status bar color.
 
@@ -341,9 +341,9 @@ Get and remove the last StatusBar entry from the stack.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                           |
-| ------------------------------------------------------ | ---- | ------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
+| Name                                                       | Type | Description                           |
+| ---------------------------------------------------------- | ---- | ------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry`. |
 
 ---
 
@@ -357,9 +357,9 @@ Push a StatusBar entry onto the stack. The return value should be passed to `pop
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                      |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------- |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
+| Name                                                       | Type | Description                                                      |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the stack entry. |
 
 ---
 
@@ -376,14 +376,14 @@ Replace an existing StatusBar stack entry with new props.
 
 **Parameters:**
 
-| Name                                                   | Type | Description                                                                  |
-| ------------------------------------------------------ | ---- | ---------------------------------------------------------------------------- |
-| entry <div class="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
-| props <div class="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
+| Name                                                       | Type | Description                                                                  |
+| ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------- |
+| entry <div className="label basic required">Required</div> | any  | Entry returned from `pushStackEntry` to replace.                             |
+| props <div className="label basic required">Required</div> | any  | Object containing the StatusBar props to use in the replacement stack entry. |
 
 ---
 
-### `setBackgroundColor()` <div class="label android">Android</div>
+### `setBackgroundColor()` <div className="label android">Android</div>
 
 ```tsx
 static setBackgroundColor(color: ColorValue, animated?: boolean);
@@ -397,10 +397,10 @@ Due to edge-to-edge enforcement introduced in Android 15, setting background col
 
 **Parameters:**
 
-| Name                                                   | Type    | Description               |
-| ------------------------------------------------------ | ------- | ------------------------- |
-| color <div class="label basic required">Required</div> | string  | Background color.         |
-| animated                                               | boolean | Animate the style change. |
+| Name                                                       | Type    | Description               |
+| ---------------------------------------------------------- | ------- | ------------------------- |
+| color <div className="label basic required">Required</div> | string  | Background color.         |
+| animated                                                   | boolean | Animate the style change. |
 
 ---
 
@@ -414,10 +414,10 @@ Set the status bar style.
 
 **Parameters:**
 
-| Name                                                   | Type                                       | Description               |
-| ------------------------------------------------------ | ------------------------------------------ | ------------------------- |
-| style <div class="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
-| animated                                               | boolean                                    | Animate the style change. |
+| Name                                                       | Type                                       | Description               |
+| ---------------------------------------------------------- | ------------------------------------------ | ------------------------- |
+| style <div className="label basic required">Required</div> | [StatusBarStyle](statusbar#statusbarstyle) | Status bar style to set.  |
+| animated                                                   | boolean                                    | Animate the style change. |
 
 ---
 
@@ -431,14 +431,14 @@ Show or hide the status bar.
 
 **Parameters:**
 
-| Name                                                    | Type                                               | Description                                             |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
-| hidden <div class="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
-| animation <div class="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
+| Name                                                        | Type                                               | Description                                             |
+| ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------- |
+| hidden <div className="label basic required">Required</div> | boolean                                            | Hide the status bar.                                    |
+| animation <div className="label ios">iOS</div>              | [StatusBarAnimation](statusbar#statusbaranimation) | Animation when changing the status bar hidden property. |
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div class="label ios">iOS</div>
+### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);
@@ -448,13 +448,13 @@ Control the visibility of the network activity indicator.
 
 **Parameters:**
 
-| Name                                                     | Type    | Description         |
-| -------------------------------------------------------- | ------- | ------------------- |
-| visible <div class="label basic required">Required</div> | boolean | Show the indicator. |
+| Name                                                         | Type    | Description         |
+| ------------------------------------------------------------ | ------- | ------------------- |
+| visible <div className="label basic required">Required</div> | boolean | Show the indicator. |
 
 ---
 
-### `setTranslucent()` <div class="label android">Android</div>
+### `setTranslucent()` <div className="label android">Android</div>
 
 ```tsx
 static setTranslucent(translucent: boolean);
@@ -468,9 +468,9 @@ Due to edge-to-edge enforcement introduced in Android 15, setting the status bar
 
 **Parameters:**
 
-| Name                                                         | Type    | Description         |
-| ------------------------------------------------------------ | ------- | ------------------- |
-| translucent <div class="label basic required">Required</div> | boolean | Set as translucent. |
+| Name                                                             | Type    | Description         |
+| ---------------------------------------------------------------- | ------- | ------------------- |
+| translucent <div className="label basic required">Required</div> | boolean | Set as translucent. |
 
 ## Type Definitions
 

--- a/website/versioned_docs/version-0.80/switch.md
+++ b/website/versioned_docs/version-0.80/switch.md
@@ -66,7 +66,7 @@ If true the user won't be able to toggle the switch.
 
 ---
 
-### `ios_backgroundColor` <div class="label ios">iOS</div>
+### `ios_backgroundColor` <div className="label ios">iOS</div>
 
 On iOS, custom color for the background. This background color can be seen either when the switch value is `false` or when the switch is disabled (and the switch is translucent).
 

--- a/website/versioned_docs/version-0.80/text-style-props.md
+++ b/website/versioned_docs/version-0.80/text-style-props.md
@@ -805,7 +805,7 @@ Specifies font weight. The values `'normal'` and `'bold'` are supported for most
 
 ---
 
-### `includeFontPadding` <div class="label android">Android</div>
+### `includeFontPadding` <div className="label android">Android</div>
 
 Set to `false` to remove extra font padding intended to make space for certain ascenders / descenders. With some fonts, this padding can make text look slightly misaligned when centered vertically. For best results also set `textAlignVertical` to `center`.
 
@@ -855,7 +855,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textAlignVertical` <div class="label android">Android</div>
+### `textAlignVertical` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -863,7 +863,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationColor` <div class="label ios">iOS</div>
+### `textDecorationColor` <div className="label ios">iOS</div>
 
 | Type               |
 | ------------------ |
@@ -879,7 +879,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `textDecorationStyle` <div class="label ios">iOS</div>
+### `textDecorationStyle` <div className="label ios">iOS</div>
 
 | Type                                                | Default   |
 | --------------------------------------------------- | --------- |
@@ -919,7 +919,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `verticalAlign` <div class="label android">Android</div>
+### `verticalAlign` <div className="label android">Android</div>
 
 | Type                                            | Default  |
 | ----------------------------------------------- | -------- |
@@ -927,7 +927,7 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 
 ---
 
-### `writingDirection` <div class="label ios">iOS</div>
+### `writingDirection` <div className="label ios">iOS</div>
 
 | Type                             | Default  |
 | -------------------------------- | -------- |

--- a/website/versioned_docs/version-0.80/text.md
+++ b/website/versioned_docs/version-0.80/text.md
@@ -215,7 +215,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -319,7 +319,7 @@ Specifies whether fonts should scale to respect Text Size accessibility settings
 
 ---
 
-### `android_hyphenationFrequency` <div class="label android">Android</div>
+### `android_hyphenationFrequency` <div className="label android">Android</div>
 
 Sets the frequency of automatic hyphenation to use when determining word breaks on Android API Level 23+.
 
@@ -387,7 +387,7 @@ Indicates whether a selectable element is currently selected or not.
 | ------- |
 | boolean |
 
-### `dataDetectorType` <div class="label android">Android</div>
+### `dataDetectorType` <div className="label android">Android</div>
 
 Determines the types of data converted to clickable URLs in the text element. By default, no data types are detected.
 
@@ -399,7 +399,7 @@ You can provide only one type.
 
 ---
 
-### `disabled` <div class="label android">Android</div>
+### `disabled` <div className="label android">Android</div>
 
 Specifies the disabled state of the text view for testing purposes.
 
@@ -409,7 +409,7 @@ Specifies the disabled state of the text view for testing purposes.
 
 ---
 
-### `dynamicTypeRamp` <div class="label ios">iOS</div>
+### `dynamicTypeRamp` <div className="label ios">iOS</div>
 
 The [Dynamic Type](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically) ramp to apply to this element on iOS.
 
@@ -462,7 +462,7 @@ Specifies the largest possible scale a font can reach when `allowFontScaling` is
 
 ---
 
-### `minimumFontScale` <div class="label ios">iOS</div>
+### `minimumFontScale` <div className="label ios">iOS</div>
 
 Specifies the smallest possible scale a font can reach when `adjustsFontSizeToFit` is enabled. (values 0.01-1.0).
 
@@ -656,7 +656,7 @@ Lets the user select text, to use the native copy and paste functionality.
 
 ---
 
-### `selectionColor` <div class="label android">Android</div>
+### `selectionColor` <div className="label android">Android</div>
 
 The highlight color of the text.
 
@@ -674,7 +674,7 @@ The highlight color of the text.
 
 ---
 
-### `suppressHighlighting` <div class="label ios">iOS</div>
+### `suppressHighlighting` <div className="label ios">iOS</div>
 
 When `true`, no visual change is made when text is pressed down. By default, a gray oval highlights the text on press down.
 
@@ -694,7 +694,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`.
 
@@ -704,7 +704,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 

--- a/website/versioned_docs/version-0.80/textinput.md
+++ b/website/versioned_docs/version-0.80/textinput.md
@@ -174,7 +174,7 @@ The following values work across platforms:
 - `tel`
 - `username`
 
-<div class="label basic ios">iOS</div>
+<div className="label basic ios">iOS</div>
 
 The following values work on iOS only:
 
@@ -188,7 +188,7 @@ The following values work on iOS only:
 - `organization-title`
 - `url`
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following values work on Android only:
 
@@ -261,7 +261,7 @@ If `true`, caret is hidden. The default value is `false`.
 
 ---
 
-### `clearButtonMode` <div class="label ios">iOS</div>
+### `clearButtonMode` <div className="label ios">iOS</div>
 
 When the clear button should appear on the right side of the text view. This property is supported only for single-line TextInput component. The default value is `never`.
 
@@ -271,7 +271,7 @@ When the clear button should appear on the right side of the text view. This pro
 
 ---
 
-### `clearTextOnFocus` <div class="label ios">iOS</div>
+### `clearTextOnFocus` <div className="label ios">iOS</div>
 
 If `true`, clears the text field automatically when editing begins.
 
@@ -291,7 +291,7 @@ If `true`, context menu is hidden. The default value is `false`.
 
 ---
 
-### `dataDetectorTypes` <div class="label ios">iOS</div>
+### `dataDetectorTypes` <div className="label ios">iOS</div>
 
 Determines the types of data converted to clickable URLs in the text input. Only valid if `multiline={true}` and `editable={false}`. By default no data types are detected.
 
@@ -322,7 +322,7 @@ Provides an initial value that will change when the user starts typing. Useful f
 
 ---
 
-### `cursorColor` <div class="label android">Android</div>
+### `cursorColor` <div className="label android">Android</div>
 
 When provided it will set the color of the cursor (or "caret") in the component. Unlike the behavior of `selectionColor` the cursor color will be set independently from the color of the text selection box.
 
@@ -332,7 +332,7 @@ When provided it will set the color of the cursor (or "caret") in the component.
 
 ---
 
-### `disableFullscreenUI` <div class="label android">Android</div>
+### `disableFullscreenUI` <div className="label android">Android</div>
 
 When `false`, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone), the OS may choose to have the user edit the text inside of a full screen text input mode. When `true`, this feature is disabled and users will always edit the text directly inside of the text input. Defaults to `false`.
 
@@ -352,7 +352,7 @@ If `false`, text is not editable. The default value is `true`.
 
 ---
 
-### `enablesReturnKeyAutomatically` <div class="label ios">iOS</div>
+### `enablesReturnKeyAutomatically` <div className="label ios">iOS</div>
 
 If `true`, the keyboard disables the return key when there is no text and automatically enables it when there is text. The default value is `false`.
 
@@ -392,7 +392,7 @@ The following values work on iOS only:
 
 ---
 
-### `importantForAutofill` <div class="label android">Android</div>
+### `importantForAutofill` <div className="label android">Android</div>
 
 Tells the operating system whether the individual fields in your app should be included in a view structure for autofill purposes on Android API Level 26+. Possible values are `auto`, `no`, `noExcludeDescendants`, `yes`, and `yesExcludeDescendants`. The default value is `auto`.
 
@@ -408,7 +408,7 @@ Tells the operating system whether the individual fields in your app should be i
 
 ---
 
-### `inlineImageLeft` <div class="label android">Android</div>
+### `inlineImageLeft` <div className="label android">Android</div>
 
 If defined, the provided image resource will be rendered on the left. The image resource must be inside `/android/app/src/main/res/drawable` and referenced like
 
@@ -424,7 +424,7 @@ If defined, the provided image resource will be rendered on the left. The image 
 
 ---
 
-### `inlineImagePadding` <div class="label android">Android</div>
+### `inlineImagePadding` <div className="label android">Android</div>
 
 Padding between the inline image, if any, and the text input itself.
 
@@ -434,7 +434,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ---
 
-### `inputAccessoryViewID` <div class="label ios">iOS</div>
+### `inputAccessoryViewID` <div className="label ios">iOS</div>
 
 An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
@@ -444,7 +444,7 @@ An optional identifier which links a custom [InputAccessoryView](inputaccessoryv
 
 ---
 
-### `inputAccessoryViewButtonLabel` <div class="label ios">iOS</div>
+### `inputAccessoryViewButtonLabel` <div className="label ios">iOS</div>
 
 An optional label that overrides the default [InputAccessoryView](inputaccessoryview.md) button label.
 
@@ -477,7 +477,7 @@ Support the following values:
 
 ---
 
-### `keyboardAppearance` <div class="label ios">iOS</div>
+### `keyboardAppearance` <div className="label ios">iOS</div>
 
 Determines the color of the keyboard.
 
@@ -743,7 +743,7 @@ If `true`, text is not editable. The default value is `false`.
 
 ---
 
-### `returnKeyLabel` <div class="label android">Android</div>
+### `returnKeyLabel` <div className="label android">Android</div>
 
 Sets the return key to the label. Use it instead of `returnKeyType`.
 
@@ -789,7 +789,7 @@ The following values work on iOS only:
 | --------------------------------------------------------------------------------------------------------------------------------- |
 | enum('done', 'go', 'next', 'search', 'send', 'none', 'previous', 'default', 'emergency-call', 'google', 'join', 'route', 'yahoo') |
 
-### `rejectResponderTermination` <div class="label ios">iOS</div>
+### `rejectResponderTermination` <div className="label ios">iOS</div>
 
 If `true`, allows TextInput to pass touch events to the parent component. This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, as is the case on Android by default. If `false`, TextInput always asks to handle the input (except when disabled). The default value is `true`.
 
@@ -799,7 +799,7 @@ If `true`, allows TextInput to pass touch events to the parent component. This a
 
 ---
 
-### `rows` <div class="label android">Android</div>
+### `rows` <div className="label android">Android</div>
 
 Sets the number of lines for a `TextInput`. Use it with multiline set to `true` to be able to fill the lines.
 
@@ -809,7 +809,7 @@ Sets the number of lines for a `TextInput`. Use it with multiline set to `true` 
 
 ---
 
-### `scrollEnabled` <div class="label ios">iOS</div>
+### `scrollEnabled` <div className="label ios">iOS</div>
 
 If `false`, scrolling of the text view will be disabled. The default value is `true`. Only works with `multiline={true}`.
 
@@ -849,7 +849,7 @@ The highlight, selection handle and cursor color of the text input.
 
 ---
 
-### `selectionHandleColor` <div class="label android">Android</div>
+### `selectionHandleColor` <div className="label android">Android</div>
 
 Sets the color of the selection handle. Unlike `selectionColor`, it allows the selection handle color to be customized independently of the selection's color.
 
@@ -879,7 +879,7 @@ When `false`, it will prevent the soft keyboard from showing when the field is f
 
 ---
 
-### `spellCheck` <div class="label ios">iOS</div>
+### `spellCheck` <div className="label ios">iOS</div>
 
 If `false`, disables spell-check style (i.e. red underlines). The default value is inherited from `autoCorrect`.
 
@@ -930,7 +930,7 @@ Possible values for `textAlign` are:
 
 ---
 
-### `textContentType` <div class="label ios">iOS</div>
+### `textContentType` <div className="label ios">iOS</div>
 
 Give the keyboard and the system information about the expected semantic meaning for the content that users enter.
 
@@ -996,7 +996,7 @@ Possible values for `textContentType` are:
 
 ---
 
-### `passwordRules` <div class="label ios">iOS</div>
+### `passwordRules` <div className="label ios">iOS</div>
 
 When using `textContentType` as `newPassword` on iOS we can let the OS know the minimum requirements of the password so that it can generate one that will satisfy them. In order to create a valid string for `PasswordRules` take a look to the [Apple Docs](https://developer.apple.com/password-rules/).
 
@@ -1032,7 +1032,7 @@ Note that not all Text styles are supported, an incomplete list of what is not s
 
 ---
 
-### `textBreakStrategy` <div class="label android">Android</div>
+### `textBreakStrategy` <div className="label android">Android</div>
 
 Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced` The default value is `highQuality`.
 
@@ -1042,7 +1042,7 @@ Set text break strategy on Android API Level 23+, possible values are `simple`, 
 
 ---
 
-### `underlineColorAndroid` <div class="label android">Android</div>
+### `underlineColorAndroid` <div className="label android">Android</div>
 
 The color of the `TextInput` underline.
 
@@ -1062,7 +1062,7 @@ The value to show for the text input. `TextInput` is a controlled component, whi
 
 ---
 
-### `lineBreakModeIOS` <div class="label ios">iOS</div>
+### `lineBreakModeIOS` <div className="label ios">iOS</div>
 
 Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, `head`, `middle` and `tail`.
 
@@ -1072,7 +1072,7 @@ Set line break mode on iOS. Possible values are `wordWrapping`, `char`, `clip`, 
 
 ---
 
-### `lineBreakStrategyIOS` <div class="label ios">iOS</div>
+### `lineBreakStrategyIOS` <div className="label ios">iOS</div>
 
 Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `hangul-word` and `push-out`.
 
@@ -1082,7 +1082,7 @@ Set line break strategy on iOS 14+. Possible values are `none`, `standard`, `han
 
 ---
 
-### `disableKeyboardShortcuts` <div class="label ios">iOS</div>
+### `disableKeyboardShortcuts` <div className="label ios">iOS</div>
 
 If `true`, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is `false`.
 

--- a/website/versioned_docs/version-0.80/the-new-architecture/create-module-library.md
+++ b/website/versioned_docs/version-0.80/the-new-architecture/create-module-library.md
@@ -38,7 +38,7 @@ npx create-react-native-library@latest <Name of Your Library>
 
 Once the interactive prompt is done, the tool creates a folder whose structure looks like this in Visual Studio Code:
 
-<img class="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
+<img className="half-size" alt="Folder structure after initializing a new library." src="/docs/assets/turbo-native-modules/c++visualstudiocode.webp" />
 
 Feel free to explore the code that has been created for you. However, the most important parts:
 

--- a/website/versioned_docs/version-0.80/touchablehighlight.md
+++ b/website/versioned_docs/version-0.80/touchablehighlight.md
@@ -138,7 +138,7 @@ The color of the underlay that will show through when the touch is active.
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -148,7 +148,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -158,7 +158,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -168,7 +168,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -178,7 +178,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -188,7 +188,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.80/touchablenativefeedback.md
+++ b/website/versioned_docs/version-0.80/touchablenativefeedback.md
@@ -104,7 +104,7 @@ Check TouchableNativeFeedback.canUseNativeForeground() first, as this is only av
 
 ---
 
-### `hasTVPreferredFocus` <div class="label android">Android</div>
+### `hasTVPreferredFocus` <div className="label android">Android</div>
 
 TV preferred focus (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -144,7 +144,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -154,7 +154,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.80/touchableopacity.md
+++ b/website/versioned_docs/version-0.80/touchableopacity.md
@@ -84,7 +84,7 @@ Determines what the opacity of the wrapped view should be when touch is active. 
 
 ---
 
-### `hasTVPreferredFocus` <div class="label ios">iOS</div>
+### `hasTVPreferredFocus` <div className="label ios">iOS</div>
 
 _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
@@ -94,7 +94,7 @@ _(Apple TV only)_ TV preferred focus (see documentation for the View component).
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 TV next focus down (see documentation for the View component).
 
@@ -104,7 +104,7 @@ TV next focus down (see documentation for the View component).
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 TV next focus forward (see documentation for the View component).
 
@@ -114,7 +114,7 @@ TV next focus forward (see documentation for the View component).
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 TV next focus left (see documentation for the View component).
 
@@ -124,7 +124,7 @@ TV next focus left (see documentation for the View component).
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 TV next focus right (see documentation for the View component).
 
@@ -134,7 +134,7 @@ TV next focus right (see documentation for the View component).
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 TV next focus up (see documentation for the View component).
 

--- a/website/versioned_docs/version-0.80/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.80/touchablewithoutfeedback.md
@@ -84,7 +84,7 @@ export default TouchableWithoutFeedbackExample;
 
 ## Props
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -116,7 +116,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -264,7 +264,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -278,7 +278,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -518,7 +518,7 @@ Used to locate this view in end-to-end tests.
 
 ---
 
-### `touchSoundDisabled` <div class="label android">Android</div>
+### `touchSoundDisabled` <div className="label android">Android</div>
 
 If true, doesn't play a system sound on touch.
 

--- a/website/versioned_docs/version-0.80/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.80/turbo-native-modules-ios.md
@@ -18,27 +18,27 @@ cd ios
 open TurboModuleExample.xcworkspace
 ```
 
-<img class="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
+<img className="half-size" alt="Open Xcode Workspace" src="/docs/assets/turbo-native-modules/xcode/1.webp" />
 
 2. Right click on app and select <code>New Group</code>, call the new group `NativeLocalStorage`.
 
-<img class="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
+<img className="half-size" alt="Right click on app and select New Group" src="/docs/assets/turbo-native-modules/xcode/2.webp" />
 
 3. In the `NativeLocalStorage` group, create <code>New</code>→<code>File from Template</code>.
 
-<img class="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/3.webp" />
 
 4. Use the <code>Cocoa Touch Class</code>.
 
-<img class="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
+<img className="half-size" alt="Use the Cocoa Touch Class template" src="/docs/assets/turbo-native-modules/xcode/4.webp"  />
 
 5. Name the Cocoa Touch Class <code>RCTNativeLocalStorage</code> with the <code>Objective-C</code> language.
 
-<img class="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
+<img className="half-size" alt="Create an Objective-C RCTNativeLocalStorage class" src="/docs/assets/turbo-native-modules/xcode/5.webp" />
 
 6. Rename <code>RCTNativeLocalStorage.m</code> → <code>RCTNativeLocalStorage.mm</code> making it an Objective-C++ file.
 
-<img class="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
+<img className="half-size" alt="Convert to and Objective-C++ file" src="/docs/assets/turbo-native-modules/xcode/6.webp" />
 
 ## Implement localStorage with NSUserDefaults
 

--- a/website/versioned_docs/version-0.80/view-style-props.md
+++ b/website/versioned_docs/version-0.80/view-style-props.md
@@ -159,7 +159,7 @@ export default App;
 
 ---
 
-### `borderCurve` <div class="label ios">iOS</div>
+### `borderCurve` <div className="label ios">iOS</div>
 
 On iOS 13+, it is possible to change the corner curve of borders.
 
@@ -304,7 +304,7 @@ These shadows can be composed together so that a single `boxShadow` can be compr
 | --------------------------- |
 | array of BoxShadowValue ojects \| string |
 
-### `cursor` <div class="label ios">iOS</div>
+### `cursor` <div className="label ios">iOS</div>
 
 On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a trackpad or stylus on iOS, or the users' gaze on visionOS) is over the view.
 
@@ -314,7 +314,7 @@ On iOS 17+, Setting to `pointer` allows hover effects when a pointer (such as a 
 
 ---
 
-### `elevation` <div class="label android">Android</div>
+### `elevation` <div className="label android">Android</div>
 
 Sets the elevation of a view, using Android's underlying [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation). This adds a drop shadow to the item and affects z-order for overlapping views. Only supported on Android 5.0+, has no effect on earlier versions.
 
@@ -341,7 +341,7 @@ The following filter functions work across all platforms:
 Due to issues with performance and spec compliance, these are the only two filter functions available on iOS. There are plans to explore some potential workarounds using SwiftUI instead of UIKit for this implementation.
 :::
 
-<div class="label basic android">Android</div>
+<div className="label basic android">Android</div>
 
 The following filter functions work on Android only:
 

--- a/website/versioned_docs/version-0.80/view.md
+++ b/website/versioned_docs/version-0.80/view.md
@@ -55,7 +55,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `accessibilityElementsHidden` <div class="label ios">iOS</div>
+### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
 A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
 
@@ -77,7 +77,7 @@ An accessibility hint helps users understand what will happen when they perform 
 
 ---
 
-### `accessibilityLanguage` <div class="label ios">iOS</div>
+### `accessibilityLanguage` <div className="label ios">iOS</div>
 
 A value indicating which language should be used by the screen reader when the user interacts with the element. It should follow the [BCP 47 specification](https://www.rfc-editor.org/info/bcp47).
 
@@ -89,7 +89,7 @@ See the [iOS `accessibilityLanguage` doc](https://developer.apple.com/documentat
 
 ---
 
-### `accessibilityIgnoresInvertColors` <div class="label ios">iOS</div>
+### `accessibilityIgnoresInvertColors` <div className="label ios">iOS</div>
 
 A value indicating this view should or should not be inverted when color inversion is turned on. A value of `true` will tell the view to not be inverted even if color inversion is turned on.
 
@@ -111,7 +111,7 @@ Overrides the text that's read by the screen reader when the user interacts with
 
 ---
 
-### `accessibilityLiveRegion` <div class="label android">Android</div>
+### `accessibilityLiveRegion` <div className="label android">Android</div>
 
 Indicates to accessibility services whether the user should be notified when this view changes. Works for Android API >= 19 only. Possible values:
 
@@ -192,7 +192,7 @@ See the [Accessibility guide](accessibility.md#accessibilityvalue-ios-android) f
 
 ---
 
-### `accessibilityViewIsModal` <div class="label ios">iOS</div>
+### `accessibilityViewIsModal` <div className="label ios">iOS</div>
 
 A value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Default is `false`.
 
@@ -274,7 +274,7 @@ Defines a string value that labels an interactive element.
 
 ---
 
-### `aria-labelledby` <div class="label android">Android</div>
+### `aria-labelledby` <div className="label android">Android</div>
 
 Identifies the element that labels the element it is applied to. The value of `aria-labelledby` should match the [`nativeID`](view.md#nativeid) of the related element:
 
@@ -291,7 +291,7 @@ Identifies the element that labels the element it is applied to. The value of `a
 
 ---
 
-### `aria-live` <div class="label android">Android</div>
+### `aria-live` <div className="label android">Android</div>
 
 Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
@@ -305,7 +305,7 @@ Indicates that an element will be updated, and describes the types of updates th
 
 ---
 
-### `aria-modal` <div class="label ios">iOS</div>
+### `aria-modal` <div className="label ios">iOS</div>
 
 Boolean value indicating whether VoiceOver should ignore the elements within views that are siblings of the receiver. Has precedence over the [`accessibilityViewIsModal`](#accessibilityviewismodal-ios) prop.
 
@@ -383,7 +383,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ---
 
-### `focusable` <div class="label android">Android</div>
+### `focusable` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 
@@ -419,7 +419,7 @@ Used to locate this view from native classes. Has precedence over `nativeID` pro
 
 ---
 
-### `importantForAccessibility` <div class="label android">Android</div>
+### `importantForAccessibility` <div className="label android">Android</div>
 
 Controls how view is important for accessibility which is if it fires accessibility events and if it is reported to accessibility services that query the screen. Works for Android only.
 
@@ -462,7 +462,7 @@ Rendering offscreen to preserve correct alpha behavior is extremely expensive an
 
 ---
 
-### `nextFocusDown` <div class="label android">Android</div>
+### `nextFocusDown` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates down. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown).
 
@@ -472,7 +472,7 @@ Designates the next view to receive focus when the user navigates down. See the 
 
 ---
 
-### `nextFocusForward` <div class="label android">Android</div>
+### `nextFocusForward` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates forward. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward).
 
@@ -482,7 +482,7 @@ Designates the next view to receive focus when the user navigates forward. See t
 
 ---
 
-### `nextFocusLeft` <div class="label android">Android</div>
+### `nextFocusLeft` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates left. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft).
 
@@ -492,7 +492,7 @@ Designates the next view to receive focus when the user navigates left. See the 
 
 ---
 
-### `nextFocusRight` <div class="label android">Android</div>
+### `nextFocusRight` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates right. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight).
 
@@ -502,7 +502,7 @@ Designates the next view to receive focus when the user navigates right. See the
 
 ---
 
-### `nextFocusUp` <div class="label android">Android</div>
+### `nextFocusUp` <div className="label android">Android</div>
 
 Designates the next view to receive focus when the user navigates up. See the [Android documentation](https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp).
 
@@ -524,7 +524,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ---
 
-### `onAccessibilityEscape` <div class="label ios">iOS</div>
+### `onAccessibilityEscape` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the escape gesture.
 
@@ -534,7 +534,7 @@ When `accessible` is `true`, the system will invoke this function when the user 
 
 ---
 
-### `onAccessibilityTap` <div class="label ios">iOS</div>
+### `onAccessibilityTap` <div className="label ios">iOS</div>
 
 When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
 
@@ -556,7 +556,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 ---
 
-### `onMagicTap` <div class="label ios">iOS</div>
+### `onMagicTap` <div className="label ios">iOS</div>
 
 When `accessible` is `true`, the system will invoke this function when the user performs the magic tap gesture.
 
@@ -712,7 +712,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 ---
 
-### `renderToHardwareTextureAndroid` <div class="label android">Android</div>
+### `renderToHardwareTextureAndroid` <div className="label android">Android</div>
 
 Whether this `View` should render itself (and all of its children) into a single hardware texture on the GPU.
 
@@ -734,7 +734,7 @@ On Android, this is useful for animations and interactions that only modify opac
 
 ---
 
-### `shouldRasterizeIOS` <div class="label ios">iOS</div>
+### `shouldRasterizeIOS` <div className="label ios">iOS</div>
 
 Whether this `View` should be rendered as a bitmap before compositing.
 
@@ -756,7 +756,7 @@ Rasterization incurs an off-screen drawing pass and the bitmap consumes memory. 
 
 ---
 
-### `tabIndex` <div class="label android">Android</div>
+### `tabIndex` <div className="label android">Android</div>
 
 Whether this `View` should be focusable with a non-touch input device, eg. receive focus with a hardware keyboard.
 Supports the following values:

--- a/website/versioned_docs/version-0.80/virtualizedlist.md
+++ b/website/versioned_docs/version-0.80/virtualizedlist.md
@@ -166,7 +166,7 @@ Opaque data type passed to `getItem` and `getItemCount` to retrieve items.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItem`**
+### <div className="label required basic">Required</div> **`getItem`**
 
 ```tsx
 (data: any, index: number) => any;
@@ -180,7 +180,7 @@ A generic accessor for extracting an item from any sort of data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`getItemCount`**
+### <div className="label required basic">Required</div> **`getItemCount`**
 
 ```tsx
 (data: any) => number;
@@ -194,7 +194,7 @@ Determines how many items are in the data blob.
 
 ---
 
-### <div class="label required basic">Required</div> **`renderItem`**
+### <div className="label required basic">Required</div> **`renderItem`**
 
 ```tsx
 (info: any) => ?React.Element<any>


### PR DESCRIPTION
# Why

Address `class` attr warning spotted in the dev console caused by SnackPlayer and platform tags on multiple pages.

<img width="1734" height="514" alt="Screenshot 2025-08-12 at 08 21 09" src="https://github.com/user-attachments/assets/49447256-03dc-4027-9e92-1e950708b3f3" />

# How

Replace `class` attr with `className` in SnackPlayer component and for all platform tags used in docs content files.