### PR TITLE
Fix env variable configuration in 0.80 release blog post

### DIFF
--- a/website/blog/2025-06-12-react-native-0.80.md
+++ b/website/blog/2025-06-12-react-native-0.80.md
@@ -130,7 +130,7 @@ if linkage != nil
   use_frameworks! :linkage => linkage.to_sym
 end
 
-+ENV[‘`RCT_USE_RN_DEP`’] = ‘1’
++ENV['RCT_USE_RN_DEP'] = '1'
 
 target 'HelloWorld' do
   config = use_native_modules!


### PR DESCRIPTION
This PR fixes the Podfile syntax to setting the `RCT_USE_RN_DEP` env variable in the 0.80 release blog post.