### PR TITLE
Add supportedPlatforms=ios,android to SnackPlayer in animations.md

### DIFF
--- a/website/versioned_docs/version-0.81/animations.md
+++ b/website/versioned_docs/version-0.81/animations.md
@@ -73,7 +73,7 @@ export default () => {
 </TabItem>
 <TabItem value="typescript">
 
-```SnackPlayer ext=tsx
+```SnackPlayer ext=tsx&supportedPlatforms=ios,android
 import React, {useEffect} from 'react';
 import {Animated, Text, View, useAnimatedValue} from 'react-native';
 import type {PropsWithChildren} from 'react';


### PR DESCRIPTION
### issue

The preview for Animated API is not rendered correctly for TypeScript+Web.
https://reactnative.dev/docs/animations

This is because `useAnimatedValue` is undefined in `react-native` on Web.

### Changes

Sets supportedPlatforms=ios,android to SnackPlayer in animations.md since web is not supported.
It was already set for the `ext=js` version.

|before|after|
|---|---|
|<img width="1509" height="735" alt="スクリーンショット 2025-08-19 19 47 10" src="https://github.com/user-attachments/assets/dcaa7c98-f016-4f7a-a28c-9abe4cefdb91" />|<img width="1512" height="744" alt="スクリーンショット 2025-08-19 19 48 32" src="https://github.com/user-attachments/assets/a683281b-032d-48d3-a92e-dd0605a887ef" />|


