### PR TITLE
fix few typos in doc files

### DIFF
--- a/docs/fabric-native-components-ios.md
+++ b/docs/fabric-native-components-ios.md
@@ -46,7 +46,7 @@ open Demo.xcworkspace
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 

--- a/docs/virtualview.md
+++ b/docs/virtualview.md
@@ -164,6 +164,6 @@ const HiddenVirtualView = createHiddenVirtualView(100);
 
 **Parameters:**
 
-| Name                                                    | Type   | Description                                            |
-| ------------------------------------------------------- | ------ | ------------------------------------------------------ |
-| height <div class="label basic required">Required</div> | number | Estimated height of initially rendering `VirtualView`. |
+| Name                                                        | Type   | Description                                            |
+| ----------------------------------------------------------- | ------ | ------------------------------------------------------ |
+| height <div className="label basic required">Required</div> | number | Estimated height of initially rendering `VirtualView`. |

--- a/website/blog/2025-02-19-react-native-0.78.md
+++ b/website/blog/2025-02-19-react-native-0.78.md
@@ -37,7 +37,7 @@ After the migration, you’ll be able to leverage all the new features of React,
 - **[useActionState](https://react.dev/reference/react/useActionState):** a utility hook built on top of Actions. It takes a function and returns a wrapped Action to call. When the action is called, it will return the last result of the Action and its `pending` state.
 - **[useOptimistic](https://react.dev/reference/react/useOptimistic):** a new hook that simplifies showing the final state of an update optimistically while the async request is underway. If the request errors, React will switch back to the previous value automatically.
 - **[`use`](https://react.dev/reference/react/use):** this is a new API that allows access to resources during render. You can now read a promise or a context with `use` and React will Suspend until they resolve.
-- **[`ref` as `props`](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop):** you can now pass `ref`as a `prop` like you do with any other prop. Function components will no longer need `forwardRef` and you can migrate your components now.
+- **[`ref` as `props`](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop):** you can now pass `ref` as a `prop` like you do with any other prop. Function components will no longer need `forwardRef` and you can migrate your components now.
 - And many others
 
 For a complete list of the new available features, have a look at the [React 19 release blog post](https://react.dev/blog/2024/12/05/react-19).

--- a/website/versioned_docs/version-0.77/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.77/fabric-native-components-ios.md
@@ -46,7 +46,7 @@ open Demo.xcworkspace
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 

--- a/website/versioned_docs/version-0.78/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.78/fabric-native-components-ios.md
@@ -46,7 +46,7 @@ open Demo.xcworkspace
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 

--- a/website/versioned_docs/version-0.79/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.79/fabric-native-components-ios.md
@@ -46,7 +46,7 @@ open Demo.xcworkspace
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 

--- a/website/versioned_docs/version-0.80/fabric-native-components-ios.md
+++ b/website/versioned_docs/version-0.80/fabric-native-components-ios.md
@@ -46,7 +46,7 @@ open Demo.xcworkspace
 
 3. In the `WebView` group, create <code>New</code>→<code>File from Template</code>.
 
-<img className="half-size" alt="Create a new file using the Cocoa Touch Classs template" src="/docs/assets/fabric-native-components/3.webp" />
+<img className="half-size" alt="Create a new file using the Cocoa Touch Class template" src="/docs/assets/fabric-native-components/3.webp" />
 
 4. Use the <code>Objective-C File</code> template, and name it <code>RCTWebView</code>.
 


### PR DESCRIPTION
# Why

When performing recent updates and follow ups on old PR I have spotted few typos.

Aslo refs: https://github.com/facebook/react-native-website/pull/4526#issuecomment-3199455869

# How

Correct few typos before regenerating 0.81 docs.