### PR TITLE
docs: Update examples in Linking scheme descriptions

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -21,10 +21,10 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 | Scheme           | Description                                | iOS | Android |
 | ---------------- | ------------------------------------------ | --- | ------- |
-| `mailto`         | Open mail app, eg: mailto: support@expo.io | ✅  | ✅      |
+| `mailto`         | Open mail app, eg: mailto: hello@world.dev | ✅  | ✅      |
 | `tel`            | Open phone app, eg: tel:+123456789         | ✅  | ✅      |
 | `sms`            | Open SMS app, eg: sms:+123456789           | ✅  | ✅      |
-| `https` / `http` | Open web browser app, eg: https://expo.io  | ✅  | ✅      |
+| `https` / `http` | Open web browser app, eg: https://expo.dev | ✅  | ✅      |
 
 ### Enabling Deep Links
 

--- a/website/versioned_docs/version-0.77/linking.md
+++ b/website/versioned_docs/version-0.77/linking.md
@@ -21,10 +21,10 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 | Scheme           | Description                                | iOS | Android |
 | ---------------- | ------------------------------------------ | --- | ------- |
-| `mailto`         | Open mail app, eg: mailto: support@expo.io | ✅  | ✅      |
+| `mailto`         | Open mail app, eg: mailto: hello@world.dev | ✅  | ✅      |
 | `tel`            | Open phone app, eg: tel:+123456789         | ✅  | ✅      |
 | `sms`            | Open SMS app, eg: sms:+123456789           | ✅  | ✅      |
-| `https` / `http` | Open web browser app, eg: https://expo.io  | ✅  | ✅      |
+| `https` / `http` | Open web browser app, eg: https://expo.dev | ✅  | ✅      |
 
 ### Enabling Deep Links
 

--- a/website/versioned_docs/version-0.78/linking.md
+++ b/website/versioned_docs/version-0.78/linking.md
@@ -21,10 +21,10 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 | Scheme           | Description                                | iOS | Android |
 | ---------------- | ------------------------------------------ | --- | ------- |
-| `mailto`         | Open mail app, eg: mailto: support@expo.io | ✅  | ✅      |
+| `mailto`         | Open mail app, eg: mailto: hello@world.dev | ✅  | ✅      |
 | `tel`            | Open phone app, eg: tel:+123456789         | ✅  | ✅      |
 | `sms`            | Open SMS app, eg: sms:+123456789           | ✅  | ✅      |
-| `https` / `http` | Open web browser app, eg: https://expo.io  | ✅  | ✅      |
+| `https` / `http` | Open web browser app, eg: https://expo.dev | ✅  | ✅      |
 
 ### Enabling Deep Links
 

--- a/website/versioned_docs/version-0.79/linking.md
+++ b/website/versioned_docs/version-0.79/linking.md
@@ -21,10 +21,10 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 | Scheme           | Description                                | iOS | Android |
 | ---------------- | ------------------------------------------ | --- | ------- |
-| `mailto`         | Open mail app, eg: mailto: support@expo.io | ✅  | ✅      |
+| `mailto`         | Open mail app, eg: mailto: hello@world.dev | ✅  | ✅      |
 | `tel`            | Open phone app, eg: tel:+123456789         | ✅  | ✅      |
 | `sms`            | Open SMS app, eg: sms:+123456789           | ✅  | ✅      |
-| `https` / `http` | Open web browser app, eg: https://expo.io  | ✅  | ✅      |
+| `https` / `http` | Open web browser app, eg: https://expo.dev | ✅  | ✅      |
 
 ### Enabling Deep Links
 

--- a/website/versioned_docs/version-0.80/linking.md
+++ b/website/versioned_docs/version-0.80/linking.md
@@ -21,10 +21,10 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 | Scheme           | Description                                | iOS | Android |
 | ---------------- | ------------------------------------------ | --- | ------- |
-| `mailto`         | Open mail app, eg: mailto: support@expo.io | ✅  | ✅      |
+| `mailto`         | Open mail app, eg: mailto: hello@world.dev | ✅  | ✅      |
 | `tel`            | Open phone app, eg: tel:+123456789         | ✅  | ✅      |
 | `sms`            | Open SMS app, eg: sms:+123456789           | ✅  | ✅      |
-| `https` / `http` | Open web browser app, eg: https://expo.io  | ✅  | ✅      |
+| `https` / `http` | Open web browser app, eg: https://expo.dev | ✅  | ✅      |
 
 ### Enabling Deep Links
 

--- a/website/versioned_docs/version-0.81/linking.md
+++ b/website/versioned_docs/version-0.81/linking.md
@@ -21,10 +21,10 @@ As mentioned in the introduction, there are some URL schemes for core functional
 
 | Scheme           | Description                                | iOS | Android |
 | ---------------- | ------------------------------------------ | --- | ------- |
-| `mailto`         | Open mail app, eg: mailto: support@expo.io | ✅  | ✅      |
+| `mailto`         | Open mail app, eg: mailto: hello@world.dev | ✅  | ✅      |
 | `tel`            | Open phone app, eg: tel:+123456789         | ✅  | ✅      |
 | `sms`            | Open SMS app, eg: sms:+123456789           | ✅  | ✅      |
-| `https` / `http` | Open web browser app, eg: https://expo.io  | ✅  | ✅      |
+| `https` / `http` | Open web browser app, eg: https://expo.dev | ✅  | ✅      |
 
 ### Enabling Deep Links
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

## Why

Currently, the Linking documentation: https://reactnative.dev/docs/linking, uses an outdated Expo domain. This PR replaces the domain name in `mailto` and `https/http` schemes with an appropriate example scheme.

Backported to the versioned docs as well.

## Preview

<img width="854" height="436" alt="CleanShot 2025-08-22 at 00 25 23" src="https://github.com/user-attachments/assets/18a24798-e993-4104-ba6c-619d9e862e0f" />



