### PR TITLE
fix: enable linking docs swift codeblock

### DIFF
--- a/website/versioned_docs/version-0.80/linking.md
+++ b/website/versioned_docs/version-0.80/linking.md
@@ -84,7 +84,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -92,7 +92,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.81/linking.md
+++ b/website/versioned_docs/version-0.81/linking.md
@@ -84,7 +84,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -92,7 +92,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

#4748

The linking documentation instructs the user to add code that errors in the community cli template

I believe the `override` to not be necessary/useful for users trying to add deep/universal links since in the default template it will give you errors

before this change
<img width="1689" height="649" alt="image" src="https://github.com/user-attachments/assets/39fa01e7-b410-483b-9068-2c83d18a72ff" />

after this change
<img width="831" height="652" alt="image" src="https://github.com/user-attachments/assets/3f5c06b1-537f-4a8a-93db-676409bb8a9d" />

Not 100% sure but for me it only works without `override` happy to close if I'm mistaken
