### PR TITLE
fix Snacks preview appearance, allow customizing, tweak few examples

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -65,12 +65,10 @@ const MultilineTextInputExample = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={[
-          styles.container,
-          {
-            backgroundColor: value,
-          },
-        ]}>
+        style={{
+          flex: 1,
+          backgroundColor: value.toLowerCase(),
+        }}>
         <TextInput
           editable
           multiline
@@ -86,12 +84,11 @@ const MultilineTextInputExample = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderBottomColor: '#000',
-    borderBottomWidth: 1,
-  },
   textInput: {
     padding: 10,
+    borderColor: '#000',
+    borderWidth: 1,
+    margin: 12,
   },
 });
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -17,9 +17,9 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 const ViewBoxesWithColorAndText = () => {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
-        <View style={{backgroundColor: 'blue', flex: 0.2}} />
-        <View style={{backgroundColor: 'red', flex: 0.4}} />
+      <SafeAreaView style={{flexDirection: 'row'}}>
+        <View style={{height: 100, backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{height: 100, backgroundColor: 'red', flex: 0.4}} />
         <Text>Hello World!</Text>
       </SafeAreaView>
     </SafeAreaProvider>

--- a/plugins/remark-snackplayer/README.md
+++ b/plugins/remark-snackplayer/README.md
@@ -40,6 +40,7 @@ The above code snippet would look like this:
 | supportedPlatforms | Supported platforms                                                                                             | `"ios,android,web"` |
 | theme              | SnackPlayer theme, `"light"` or `"dark"`                                                                        | `"light"`           |
 | preview            | Preview visible, `"true"` or `"false"`                                                                          | `"true"`            |
+| deviceAppearance   | Sets the preview mobile device appearance, `"light"` or `"dark"`                                                | `"light"`           |
 | loading            | iFrame loading attribute, `"auto"`, `"lazy"` or `"eager"`                                                       | `"lazy"`            |
 | deviceAndroid      | Emulator type used for Android, [see Appetize options](https://docs.appetize.io/core-features/playback-options) | `pixel4`            |
 | deviceIos          | Simulator type used for iOS, [see Appetize options](https://docs.appetize.io/core-features/playback-options)    | `iphone12`          |

--- a/plugins/remark-snackplayer/src/index.js
+++ b/plugins/remark-snackplayer/src/index.js
@@ -54,6 +54,7 @@ async function toJsxNode(node) {
   const theme = params.theme ?? 'light';
   const preview = params.preview ?? 'true';
   const loading = params.loading ?? 'lazy';
+  const deviceAppearance = params.deviceAppearance ?? 'light';
 
   // Need help constructing this AST node?
   // Use the MDX Playground and explore what your output mdast should look like
@@ -72,6 +73,7 @@ async function toJsxNode(node) {
       attr('data-snack-theme', theme),
       attr('data-snack-preview', preview),
       attr('data-snack-loading', loading),
+      attr('data-snack-device-appearance', deviceAppearance),
       attr('data-snack-device-frame', 'false'),
     ],
     children: [],

--- a/website/versioned_docs/version-0.77/textinput.md
+++ b/website/versioned_docs/version-0.77/textinput.md
@@ -65,12 +65,10 @@ const MultilineTextInputExample = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={[
-          styles.container,
-          {
-            backgroundColor: value,
-          },
-        ]}>
+        style={{
+          flex: 1,
+          backgroundColor: value.toLowerCase(),
+        }}>
         <TextInput
           editable
           multiline
@@ -86,12 +84,11 @@ const MultilineTextInputExample = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderBottomColor: '#000',
-    borderBottomWidth: 1,
-  },
   textInput: {
     padding: 10,
+    borderColor: '#000',
+    borderWidth: 1,
+    margin: 12,
   },
 });
 

--- a/website/versioned_docs/version-0.77/view.md
+++ b/website/versioned_docs/version-0.77/view.md
@@ -17,9 +17,9 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 const ViewBoxesWithColorAndText = () => {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
-        <View style={{backgroundColor: 'blue', flex: 0.2}} />
-        <View style={{backgroundColor: 'red', flex: 0.4}} />
+      <SafeAreaView style={{flexDirection: 'row'}}>
+        <View style={{height: 100, backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{height: 100, backgroundColor: 'red', flex: 0.4}} />
         <Text>Hello World!</Text>
       </SafeAreaView>
     </SafeAreaProvider>

--- a/website/versioned_docs/version-0.78/textinput.md
+++ b/website/versioned_docs/version-0.78/textinput.md
@@ -65,12 +65,10 @@ const MultilineTextInputExample = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={[
-          styles.container,
-          {
-            backgroundColor: value,
-          },
-        ]}>
+        style={{
+          flex: 1,
+          backgroundColor: value.toLowerCase(),
+        }}>
         <TextInput
           editable
           multiline
@@ -86,12 +84,11 @@ const MultilineTextInputExample = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderBottomColor: '#000',
-    borderBottomWidth: 1,
-  },
   textInput: {
     padding: 10,
+    borderColor: '#000',
+    borderWidth: 1,
+    margin: 12,
   },
 });
 

--- a/website/versioned_docs/version-0.78/view.md
+++ b/website/versioned_docs/version-0.78/view.md
@@ -17,9 +17,9 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 const ViewBoxesWithColorAndText = () => {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
-        <View style={{backgroundColor: 'blue', flex: 0.2}} />
-        <View style={{backgroundColor: 'red', flex: 0.4}} />
+      <SafeAreaView style={{flexDirection: 'row'}}>
+        <View style={{height: 100, backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{height: 100, backgroundColor: 'red', flex: 0.4}} />
         <Text>Hello World!</Text>
       </SafeAreaView>
     </SafeAreaProvider>

--- a/website/versioned_docs/version-0.79/textinput.md
+++ b/website/versioned_docs/version-0.79/textinput.md
@@ -65,12 +65,10 @@ const MultilineTextInputExample = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={[
-          styles.container,
-          {
-            backgroundColor: value,
-          },
-        ]}>
+        style={{
+          flex: 1,
+          backgroundColor: value.toLowerCase(),
+        }}>
         <TextInput
           editable
           multiline
@@ -86,12 +84,11 @@ const MultilineTextInputExample = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderBottomColor: '#000',
-    borderBottomWidth: 1,
-  },
   textInput: {
     padding: 10,
+    borderColor: '#000',
+    borderWidth: 1,
+    margin: 12,
   },
 });
 

--- a/website/versioned_docs/version-0.79/view.md
+++ b/website/versioned_docs/version-0.79/view.md
@@ -17,9 +17,9 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 const ViewBoxesWithColorAndText = () => {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
-        <View style={{backgroundColor: 'blue', flex: 0.2}} />
-        <View style={{backgroundColor: 'red', flex: 0.4}} />
+      <SafeAreaView style={{flexDirection: 'row'}}>
+        <View style={{height: 100, backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{height: 100, backgroundColor: 'red', flex: 0.4}} />
         <Text>Hello World!</Text>
       </SafeAreaView>
     </SafeAreaProvider>

--- a/website/versioned_docs/version-0.80/textinput.md
+++ b/website/versioned_docs/version-0.80/textinput.md
@@ -65,12 +65,10 @@ const MultilineTextInputExample = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={[
-          styles.container,
-          {
-            backgroundColor: value,
-          },
-        ]}>
+        style={{
+          flex: 1,
+          backgroundColor: value.toLowerCase(),
+        }}>
         <TextInput
           editable
           multiline
@@ -86,12 +84,11 @@ const MultilineTextInputExample = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderBottomColor: '#000',
-    borderBottomWidth: 1,
-  },
   textInput: {
     padding: 10,
+    borderColor: '#000',
+    borderWidth: 1,
+    margin: 12,
   },
 });
 

--- a/website/versioned_docs/version-0.80/view.md
+++ b/website/versioned_docs/version-0.80/view.md
@@ -17,9 +17,9 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 const ViewBoxesWithColorAndText = () => {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
-        <View style={{backgroundColor: 'blue', flex: 0.2}} />
-        <View style={{backgroundColor: 'red', flex: 0.4}} />
+      <SafeAreaView style={{flexDirection: 'row'}}>
+        <View style={{height: 100, backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{height: 100, backgroundColor: 'red', flex: 0.4}} />
         <Text>Hello World!</Text>
       </SafeAreaView>
     </SafeAreaProvider>

--- a/website/versioned_docs/version-0.81/textinput.md
+++ b/website/versioned_docs/version-0.81/textinput.md
@@ -65,12 +65,10 @@ const MultilineTextInputExample = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={[
-          styles.container,
-          {
-            backgroundColor: value,
-          },
-        ]}>
+        style={{
+          flex: 1,
+          backgroundColor: value.toLowerCase(),
+        }}>
         <TextInput
           editable
           multiline
@@ -86,12 +84,11 @@ const MultilineTextInputExample = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    borderBottomColor: '#000',
-    borderBottomWidth: 1,
-  },
   textInput: {
     padding: 10,
+    borderColor: '#000',
+    borderWidth: 1,
+    margin: 12,
   },
 });
 

--- a/website/versioned_docs/version-0.81/view.md
+++ b/website/versioned_docs/version-0.81/view.md
@@ -17,9 +17,9 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 const ViewBoxesWithColorAndText = () => {
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={{height: 100, flexDirection: 'row'}}>
-        <View style={{backgroundColor: 'blue', flex: 0.2}} />
-        <View style={{backgroundColor: 'red', flex: 0.4}} />
+      <SafeAreaView style={{flexDirection: 'row'}}>
+        <View style={{height: 100, backgroundColor: 'blue', flex: 0.2}} />
+        <View style={{height: 100, backgroundColor: 'red', flex: 0.4}} />
         <Text>Hello World!</Text>
       </SafeAreaView>
     </SafeAreaProvider>


### PR DESCRIPTION
# Why

So far, the Snack embedded element theme was coupled with preview device appearance which in some cases lead to readability problems in dark mode.

<img width="1680" height="1326" alt="Screenshot 2025-08-28 at 11 01 22" src="https://github.com/user-attachments/assets/611a6e45-cd27-4d89-91d6-fc909c0066ff" />

Refs:
* https://github.com/expo/snack/pull/643

Should address issues bring up in:
* https://github.com/facebook/react-native-website/pull/4639
* https://github.com/facebook/react-native-website/pull/4640

# How

Add support for `deviceAppearance` query param, set it by default to `'light'`, but allow customization on case-by-case base.

In the process, I have also updated few examples, to make sure that they display and work correctly on mobile previews.

# Preview

<img width="1680" height="1326" alt="Screenshot 2025-08-28 at 10 43 28" src="https://github.com/user-attachments/assets/3c08ea42-7cf6-4bbf-ad40-925c5f2ffafd" />
