### PR TITLE
align admonitions style with react.dev

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -518,7 +518,11 @@ html[data-theme="dark"] article .badge {
 .admonition,
 .theme-admonition {
   font-size: var(--ifm-blockquote-font-size);
-  margin-bottom: 1.5rem !important;
+  margin-bottom: var(--ifm-paragraph-margin-bottom);
+  padding: 28px;
+  border-radius: 20px;
+  border: 1px solid var(--ifm-alert-background-color-highlight);
+  box-shadow: none;
 
   div[class^="admonitionContent"] {
     a {
@@ -531,23 +535,40 @@ html[data-theme="dark"] article .badge {
     }
   }
 
+  span[class^="admonitionIcon"] svg {
+    max-width: 20px;
+    max-height: 20px;
+    fill: hsl(from var(--ifm-alert-border-color) h calc(s + 30) calc(l - 20));
+  }
+
   div[class^="admonitionHeading"] {
-    font-size: 14px;
+    font-size: 18px;
+    margin-bottom: 12px;
+    color: hsl(from var(--ifm-alert-border-color) h calc(s + 30) calc(l - 20));
   }
 }
 
-.alert--warning {
-  background-color: var(--rn-note-background);
-}
-
 .alert--secondary {
+  --ifm-alert-border-color: hsl(from var(--light) h calc(s - 20) calc(l + 30));
   --ifm-alert-background-color: var(--ifm-color-secondary-lightest);
   --ifm-alert-background-color-highlight: rgba(225, 227, 230, 0.7);
 }
 
-html[data-theme="dark"] .alert--secondary {
-  --ifm-alert-background-color: var(--ifm-color-secondary-contrast-background);
-  --ifm-alert-background-color-highlight: rgba(225, 227, 230, 0.15);
+html[data-theme="dark"] {
+  span[class^="admonitionIcon"] svg {
+    fill: hsl(from var(--ifm-alert-border-color) h calc(s + 10) calc(l + 10));
+  }
+
+  div[class^="admonitionHeading"] {
+    color: hsl(from var(--ifm-alert-border-color) h calc(s + 10) calc(l + 10));
+  }
+
+  .alert--secondary {
+    --ifm-alert-background-color: var(
+      --ifm-color-secondary-contrast-background
+    );
+    --ifm-alert-background-color-highlight: rgba(225, 227, 230, 0.15);
+  }
 }
 
 /* Home page */


### PR DESCRIPTION
# Why

An another small chunk of styling changes to align RN website appearance more with React.dev.

This one was suggested by @joevilches.

# How

Alter the default Docusaurus admonitions styling to match a bit closer in-content notes on React website.

# Preview

<img width="1728" height="388" alt="Screenshot 2025-08-28 at 12 02 53" src="https://github.com/user-attachments/assets/7e361854-13bd-40cb-ba9f-eda5ccf2e052" />
<img width="1728" height="388" alt="Screenshot 2025-08-28 at 12 02 45" src="https://github.com/user-attachments/assets/0b910ef1-0974-4bee-bb81-f2a7c1c87b82" />
<img width="1728" height="432" alt="Screenshot 2025-08-28 at 11 54 23" src="https://github.com/user-attachments/assets/a15bf4f0-7703-441f-bb9b-713ca2041b11" />
<img width="1728" height="432" alt="Screenshot 2025-08-28 at 11 54 31" src="https://github.com/user-attachments/assets/c11f7223-04c8-46fd-8bb5-9d60cadbb8ee" />
<img width="1728" height="1102" alt="Screenshot 2025-08-28 at 11 54 03" src="https://github.com/user-attachments/assets/cccb75fc-89c6-4543-9967-79b6cf911a0e" />
<img width="1728" height="1102" alt="Screenshot 2025-08-28 at 11 53 53" src="https://github.com/user-attachments/assets/adc35a94-4f9a-4b55-a823-48859f6015e8" />
