### PR TITLE
docs: update Fresco version in Image component

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -102,14 +102,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.6.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.6.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 }
 ```
 


### PR DESCRIPTION
## Problem
- On Android devices with 16KB page size, the current Fresco version used by the Image component does not provide proper support.

## Solution
- Update Fresco to version `3.6.0`
- Fresco has supported 16KB page size since version `3.4.0`
- Version `3.6.0` is chosen as it is the latest stable release

## Reference
- [Fresco v3.4.0 Release Notes](https://github.com/facebook/fresco/releases/tag/v3.4.0)
- [React-native Commit 819b5c2](https://github.com/facebook/react-native/commit/819b5c2c8dfad620152b159838575b6c03e18ffe)
