### PR TITLE
Update Fresco to 3.6.0 to fix Android 16KB page issue

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -102,14 +102,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.6.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.6.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 }
 ```
 

--- a/website/versioned_docs/version-0.77/image.md
+++ b/website/versioned_docs/version-0.77/image.md
@@ -100,14 +100,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.4.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.4.0'
+  implementation 'com.facebook.fresco:webpsupport:3.4.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.4.0'
 }
 ```
 

--- a/website/versioned_docs/version-0.78/image.md
+++ b/website/versioned_docs/version-0.78/image.md
@@ -100,14 +100,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.6.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.6.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 }
 ```
 

--- a/website/versioned_docs/version-0.79/image.md
+++ b/website/versioned_docs/version-0.79/image.md
@@ -100,14 +100,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.6.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.6.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 }
 ```
 

--- a/website/versioned_docs/version-0.80/image.md
+++ b/website/versioned_docs/version-0.80/image.md
@@ -100,14 +100,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.6.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.6.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 }
 ```
 

--- a/website/versioned_docs/version-0.81/image.md
+++ b/website/versioned_docs/version-0.81/image.md
@@ -100,14 +100,14 @@ dependencies {
   implementation 'com.facebook.fresco:animated-base-support:1.3.0'
 
   // For animated GIF support
-  implementation 'com.facebook.fresco:animated-gif:3.2.0'
+  implementation 'com.facebook.fresco:animated-gif:3.6.0'
 
   // For WebP support, including animated WebP
-  implementation 'com.facebook.fresco:animated-webp:3.2.0'
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:animated-webp:3.6.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 
   // For WebP support, without animations
-  implementation 'com.facebook.fresco:webpsupport:3.2.0'
+  implementation 'com.facebook.fresco:webpsupport:3.6.0'
 }
 ```
 


### PR DESCRIPTION
### Summary
Update the Fresco version used in the Image component to properly support 16KB pages on Android.

### Details
- Fresco added explicit support for 16KB page sizes starting from version 3.4.0 ([release notes](https://github.com/facebook/fresco/releases/tag/v3.4.0)).
- This PR updates Fresco to **3.6.0** for React Native 0.78 and above ([release notes](https://github.com/facebook/react-native/releases/tag/v0.78.0)).
- For versions prior to 0.78, Fresco remains at 3.4.0 to maintain stability.

### Related Issues / References
- Android 16KB page issue in Image component