### PR TITLE
fix: accessibilityElementsHidden & aria-hidden descriptions

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -222,9 +222,9 @@ For example, in a window that contains sibling views `A` and `B`, setting `acces
 
 ### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
-A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
+A boolean value indicating whether the given accessibility element, and any accessibility elements it contains, are hidden.
 
-For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
+For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the `B` view and any elements it contains. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
 ### `aria-valuemax`
 
@@ -276,9 +276,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |
@@ -286,7 +286,7 @@ For example, in a window that contains sibling views `A` and `B`, setting `aria-
 
 ### `aria-label`
 
-Defines a string value that labels an interactive element.
+Defines a string value that can be used to name an element.
 
 | Type   |
 | ------ |

--- a/docs/touchablewithoutfeedback.md
+++ b/docs/touchablewithoutfeedback.md
@@ -246,9 +246,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/docs/view.md
+++ b/docs/view.md
@@ -57,7 +57,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
-A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
+A boolean value indicating whether the given accessibility element, and any accessibility elements it contains, are hidden. Default is `false`.
 
 See the [Accessibility guide](accessibility.md#accessibilityelementshidden-ios) for more information.
 
@@ -254,9 +254,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/website/versioned_docs/version-0.80/accessibility.md
+++ b/website/versioned_docs/version-0.80/accessibility.md
@@ -222,9 +222,9 @@ For example, in a window that contains sibling views `A` and `B`, setting `acces
 
 ### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
-A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
+A boolean value indicating whether the given accessibility element, and any accessibility elements it contains, are hidden.
 
-For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
+For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the `B` view and any elements it contains. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
 ### `aria-valuemax`
 
@@ -276,9 +276,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/website/versioned_docs/version-0.80/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.80/touchablewithoutfeedback.md
@@ -244,9 +244,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/website/versioned_docs/version-0.80/view.md
+++ b/website/versioned_docs/version-0.80/view.md
@@ -57,7 +57,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
-A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
+A boolean value indicating whether the given accessibility element, and any accessibility elements it contains, are hidden. Default is `false`.
 
 See the [Accessibility guide](accessibility.md#accessibilityelementshidden-ios) for more information.
 
@@ -254,9 +254,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/website/versioned_docs/version-0.81/accessibility.md
+++ b/website/versioned_docs/version-0.81/accessibility.md
@@ -222,9 +222,9 @@ For example, in a window that contains sibling views `A` and `B`, setting `acces
 
 ### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
-A boolean value indicating whether the accessibility elements contained within this accessibility element are hidden.
+A boolean value indicating whether the given accessibility element, and any accessibility elements it contains, are hidden.
 
-For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the elements in view `B`. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
+For example, in a window that contains sibling views `A` and `B`, setting `accessibilityElementsHidden` to `true` on view `B` causes VoiceOver to ignore the `B` view and any elements it contains. This is similar to the Android property `importantForAccessibility="no-hide-descendants"`.
 
 ### `aria-valuemax`
 
@@ -276,9 +276,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/website/versioned_docs/version-0.81/touchablewithoutfeedback.md
+++ b/website/versioned_docs/version-0.81/touchablewithoutfeedback.md
@@ -244,9 +244,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |

--- a/website/versioned_docs/version-0.81/view.md
+++ b/website/versioned_docs/version-0.81/view.md
@@ -57,7 +57,7 @@ See the [Accessibility guide](accessibility.md#accessibility-actions) for more i
 
 ### `accessibilityElementsHidden` <div className="label ios">iOS</div>
 
-A value indicating whether the accessibility elements contained within this accessibility element are hidden. Default is `false`.
+A boolean value indicating whether the given accessibility element, and any accessibility elements it contains, are hidden. Default is `false`.
 
 See the [Accessibility guide](accessibility.md#accessibilityelementshidden-ios) for more information.
 
@@ -254,9 +254,9 @@ Indicates whether an expandable element is currently expanded or collapsed.
 
 ### `aria-hidden`
 
-Indicates whether the accessibility elements contained within this accessibility element are hidden.
+Indicates whether whether the element is hidden from assistive technologies.
 
-For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the elements in the view `B`.
+For example, in a window that contains sibling views `A` and `B`, setting `aria-hidden` to `true` on view `B` causes VoiceOver to ignore the `B` element and its children.
 
 | Type    | Default |
 | ------- | ------- |


### PR DESCRIPTION
This PR removes the lack of clarity regarding `accessibilityElementsHidden` and `aria-hidden`. The current documentation is unclear whether the prop affects just the children of the element or also the element itself.

The [official Apple docs](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/accessibilityelementshidden) do not help as it does not have description for this prop. 

In order to resolve this uncertainty I've created a [simple iOS app testing this prop](https://github.com/mdjastrzebski/poc-ios-accessibility-elements-hidden
). This clearly shows that the `accessibilityElementsHidden` prop also affects the elements it's applied to.

https://github.com/user-attachments/assets/ec3fb2a1-0407-4722-bc4e-787910d788de


