### PR TITLE
add Releases page redirect

### DIFF
--- a/website/src/pages/releases.tsx
+++ b/website/src/pages/releases.tsx
@@ -4,9 +4,19 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import Layout from '@theme/Layout';
+import React, {useEffect} from 'react';
 
 const Releases = () => {
-  location.href = '/docs/next/releases';
+  useEffect(() => {
+    location.href = '/docs/next/releases';
+  }, []);
+
+  return (
+    <Layout title="Releases" wrapperClassName="versions-page">
+      <div style={{textAlign: 'center'}}>Redirecting...</div>
+    </Layout>
+  );
 };
 
 export default Releases;

--- a/website/src/pages/releases.tsx
+++ b/website/src/pages/releases.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const Releases = () => {
+  location.href = '/docs/next/releases';
+};
+
+export default Releases;

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -14,7 +14,8 @@
 
 /contributing/how-to-contribute     /contributing/overview
 /contributing/how-to-file-an-issue  /contributing/how-to-report-a-bug
-/releases/release-candidate-minor   /releases/release-branch-cut-and-rc0
+
+/releases                           /docs/next/releases
 
 # Redirect New Architecture docs of all versions
 # Note: We had to delete the older versions to get redirects to work
@@ -115,9 +116,6 @@ https://reactnative.dev/docs/0.74/ram-bundles-inline-requires            /docs/o
 
 # Rework of the community
 /help         /community/overview
-
-# Releases
-/docs/next/releases       /releases
 
 # Latest version might be linked to directly and should redirect
 /docs/$LATEST_VERSION$/*  /docs/:splat

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -116,5 +116,8 @@ https://reactnative.dev/docs/0.74/ram-bundles-inline-requires            /docs/o
 # Rework of the community
 /help         /community/overview
 
+# Releases
+/docs/next/releases       /releases
+
 # Latest version might be linked to directly and should redirect
 /docs/$LATEST_VERSION$/*  /docs/:splat

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -15,8 +15,6 @@
 /contributing/how-to-contribute     /contributing/overview
 /contributing/how-to-file-an-issue  /contributing/how-to-report-a-bug
 
-/releases                           /docs/next/releases
-
 # Redirect New Architecture docs of all versions
 # Note: We had to delete the older versions to get redirects to work
 /docs/the-new-architecture/why                             /architecture/landing-page


### PR DESCRIPTION
# Why

To make it easier to access new Releases page.

# How

Update Netlify redirects file.
