### PR TITLE
add Releases page with the Docusaurus redirect

### DIFF
--- a/website/src/pages/releases.tsx
+++ b/website/src/pages/releases.tsx
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {Redirect} from '@docusaurus/router';
+
+const Releases = () => {
+  return <Redirect to="/docs/next/releases" />;
+};
+
+export default Releases;


### PR DESCRIPTION
# Why

To make it easier to access new Releases page.

# How

Add Releases stub page with the Docusaurus redirect. 

# Preview

https://deploy-preview-4768--react-native.netlify.app/releases

