### PR TITLE
Update the required Node.js version to 20.19.4 for React Native v0.81 and later

### DIFF
--- a/docs/_getting-started-linux-android.md
+++ b/docs/_getting-started-linux-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node</h3>
 
-Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 18.18 or newer.
+Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 20.19.4 or newer.
 
 <h3>Java Development Kit</h3>
 

--- a/docs/_getting-started-macos-android.md
+++ b/docs/_getting-started-macos-android.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18.18 or newer.
+If you have already installed Node on your system, make sure it is Node 20.19.4 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/docs/_getting-started-macos-ios.md
+++ b/docs/_getting-started-macos-ios.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18.18 or newer.
+If you have already installed Node on your system, make sure it is Node 20.19.4 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/website/versioned_docs/version-0.81/_getting-started-linux-android.md
+++ b/website/versioned_docs/version-0.81/_getting-started-linux-android.md
@@ -6,7 +6,7 @@ While you can use any editor of your choice to develop your app, you will need t
 
 <h3>Node</h3>
 
-Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 18.18 or newer.
+Follow the [installation instructions for your Linux distribution](https://nodejs.org/en/download/package-manager/) to install Node 20.19.4 or newer.
 
 <h3>Java Development Kit</h3>
 

--- a/website/versioned_docs/version-0.81/_getting-started-macos-android.md
+++ b/website/versioned_docs/version-0.81/_getting-started-macos-android.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18.18 or newer.
+If you have already installed Node on your system, make sure it is Node 20.19.4 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 

--- a/website/versioned_docs/version-0.81/_getting-started-macos-ios.md
+++ b/website/versioned_docs/version-0.81/_getting-started-macos-ios.md
@@ -13,7 +13,7 @@ brew install node
 brew install watchman
 ```
 
-If you have already installed Node on your system, make sure it is Node 18.18 or newer.
+If you have already installed Node on your system, make sure it is Node 20.19.4 or newer.
 
 [Watchman](https://facebook.github.io/watchman) is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance.
 


### PR DESCRIPTION
### Summary

This PR updates the recommended Node.js version in the "Set Up Your Environment" documentation to align with the requirements of React Native 0.81.

### Background

The official blog post for the [React Native 0.81 release](https://reactnative.dev/blog/2025/08/12/react-native-0.81#minimum-nodejs-bumped-to-20) states that the minimum Node.js version has been bumped to **20.19.4** or higher.

However, the ["Set Up Your Environment" guide](https://reactnative.dev/docs/set-up-your-environment) currently still recommends **Node 18.18** or higher. This discrepancy can be confusing for developers.

This change updates the setup guide to reflect the new requirement, ensuring the documentation is consistent with the latest release.