### PR TITLE
Use trash can emoji for deprecated APIs

### DIFF
--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -1,6 +1,6 @@
 ---
 id: progressbarandroid
-title: '🚧 ProgressBarAndroid'
+title: '🗑️ ProgressBarAndroid'
 ---
 
 :::warning Deprecated

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: '🚧 PushNotificationIOS'
+title: '🗑️ PushNotificationIOS'
 ---
 
 :::warning Deprecated

--- a/docs/safeareaview.md
+++ b/docs/safeareaview.md
@@ -1,6 +1,6 @@
 ---
 id: safeareaview
-title: '🚧 SafeAreaView'
+title: '🗑️ SafeAreaView'
 ---
 
 :::warning Deprecated


### PR DESCRIPTION
Deprecated APIs are currently being marked with the construction sign emoji (🚧) which is most often used to indicate "work in progress" instead. The use of the waste basket emoji (🗑️) is more often use for this use case, as seen in MDN, for example:

<img width="170" height="58" alt="Screenshot 2025-09-09 at 18 30 14" src="https://github.com/user-attachments/assets/879d6758-b696-4665-8e88-e9ee2a50c35f" />

<img width="180" height="108" alt="Screenshot 2025-09-09 at 18 28 19" src="https://github.com/user-attachments/assets/efbf1ef3-d844-4cf5-8f2c-593c9001ad93" />
