### PR TITLE
update page status emojis in versioned docs

### DIFF
--- a/website/versioned_docs/version-0.77/alertios.md
+++ b/website/versioned_docs/version-0.77/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: '🚧 AlertIOS'
+title: '❌ AlertIOS'
 ---
 
 > **Removed.** Use [`Alert`](alert) instead.

--- a/website/versioned_docs/version-0.77/asyncstorage.md
+++ b/website/versioned_docs/version-0.77/asyncstorage.md
@@ -1,6 +1,6 @@
 ---
 id: asyncstorage
-title: '🚧 AsyncStorage'
+title: '❌ AsyncStorage'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.

--- a/website/versioned_docs/version-0.77/checkbox.md
+++ b/website/versioned_docs/version-0.77/checkbox.md
@@ -1,6 +1,6 @@
 ---
 id: checkbox
-title: '🚧 CheckBox'
+title: '❌ CheckBox'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.

--- a/website/versioned_docs/version-0.77/clipboard.md
+++ b/website/versioned_docs/version-0.77/clipboard.md
@@ -1,6 +1,6 @@
 ---
 id: clipboard
-title: '🚧 Clipboard'
+title: '❌ Clipboard'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.

--- a/website/versioned_docs/version-0.77/datepickerandroid.md
+++ b/website/versioned_docs/version-0.77/datepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerandroid
-title: '🚧 DatePickerAndroid'
+title: '❌ DatePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.77/datepickerios.md
+++ b/website/versioned_docs/version-0.77/datepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerios
-title: '🚧 DatePickerIOS'
+title: '❌ DatePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.77/imagepickerios.md
+++ b/website/versioned_docs/version-0.77/imagepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: imagepickerios
-title: '🚧 ImagePickerIOS'
+title: '❌ ImagePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.

--- a/website/versioned_docs/version-0.77/progressbarandroid.md
+++ b/website/versioned_docs/version-0.77/progressbarandroid.md
@@ -1,6 +1,6 @@
 ---
 id: progressbarandroid
-title: '🚧 ProgressBarAndroid'
+title: '🗑️ ProgressBarAndroid'
 ---
 
 > **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.

--- a/website/versioned_docs/version-0.77/pushnotificationios.md
+++ b/website/versioned_docs/version-0.77/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: '🚧 PushNotificationIOS'
+title: '🗑️ PushNotificationIOS'
 ---
 
 > **Deprecated.** Use the [community package](https://github.com/react-native-push-notification/ios) instead.

--- a/website/versioned_docs/version-0.77/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.77/segmentedcontrolios.md
@@ -1,6 +1,6 @@
 ---
 id: segmentedcontrolios
-title: '🚧 SegmentedControlIOS'
+title: '❌ SegmentedControlIOS'
 ---
 
 > **Removed from React Native.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.

--- a/website/versioned_docs/version-0.77/statusbarios.md
+++ b/website/versioned_docs/version-0.77/statusbarios.md
@@ -1,6 +1,6 @@
 ---
 id: statusbarios
-title: '🚧 StatusBarIOS'
+title: '❌ StatusBarIOS'
 ---
 
 > **Deleted.** Use [`StatusBar`](statusbar.md) for mutating the status bar.

--- a/website/versioned_docs/version-0.77/timepickerandroid.md
+++ b/website/versioned_docs/version-0.77/timepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: timepickerandroid
-title: '🚧 TimePickerAndroid'
+title: '❌ TimePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.

--- a/website/versioned_docs/version-0.78/alertios.md
+++ b/website/versioned_docs/version-0.78/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: '🚧 AlertIOS'
+title: '❌ AlertIOS'
 ---
 
 > **Removed.** Use [`Alert`](alert) instead.

--- a/website/versioned_docs/version-0.78/asyncstorage.md
+++ b/website/versioned_docs/version-0.78/asyncstorage.md
@@ -1,6 +1,6 @@
 ---
 id: asyncstorage
-title: '🚧 AsyncStorage'
+title: '❌ AsyncStorage'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.

--- a/website/versioned_docs/version-0.78/checkbox.md
+++ b/website/versioned_docs/version-0.78/checkbox.md
@@ -1,6 +1,6 @@
 ---
 id: checkbox
-title: '🚧 CheckBox'
+title: '❌ CheckBox'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.

--- a/website/versioned_docs/version-0.78/clipboard.md
+++ b/website/versioned_docs/version-0.78/clipboard.md
@@ -1,6 +1,6 @@
 ---
 id: clipboard
-title: '🚧 Clipboard'
+title: '❌ Clipboard'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.

--- a/website/versioned_docs/version-0.78/datepickerandroid.md
+++ b/website/versioned_docs/version-0.78/datepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerandroid
-title: '🚧 DatePickerAndroid'
+title: '❌ DatePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.78/datepickerios.md
+++ b/website/versioned_docs/version-0.78/datepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerios
-title: '🚧 DatePickerIOS'
+title: '❌ DatePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.78/imagepickerios.md
+++ b/website/versioned_docs/version-0.78/imagepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: imagepickerios
-title: '🚧 ImagePickerIOS'
+title: '❌ ImagePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.

--- a/website/versioned_docs/version-0.78/progressbarandroid.md
+++ b/website/versioned_docs/version-0.78/progressbarandroid.md
@@ -1,6 +1,6 @@
 ---
 id: progressbarandroid
-title: '🚧 ProgressBarAndroid'
+title: '🗑️ ProgressBarAndroid'
 ---
 
 > **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.

--- a/website/versioned_docs/version-0.78/pushnotificationios.md
+++ b/website/versioned_docs/version-0.78/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: '🚧 PushNotificationIOS'
+title: '🗑️ PushNotificationIOS'
 ---
 
 > **Deprecated.** Use the [community package](https://github.com/react-native-push-notification/ios) instead.

--- a/website/versioned_docs/version-0.78/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.78/segmentedcontrolios.md
@@ -1,6 +1,6 @@
 ---
 id: segmentedcontrolios
-title: '🚧 SegmentedControlIOS'
+title: '❌ SegmentedControlIOS'
 ---
 
 > **Removed from React Native.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.

--- a/website/versioned_docs/version-0.78/statusbarios.md
+++ b/website/versioned_docs/version-0.78/statusbarios.md
@@ -1,6 +1,6 @@
 ---
 id: statusbarios
-title: '🚧 StatusBarIOS'
+title: '❌ StatusBarIOS'
 ---
 
 > **Deleted.** Use [`StatusBar`](statusbar.md) for mutating the status bar.

--- a/website/versioned_docs/version-0.78/timepickerandroid.md
+++ b/website/versioned_docs/version-0.78/timepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: timepickerandroid
-title: '🚧 TimePickerAndroid'
+title: '❌ TimePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.

--- a/website/versioned_docs/version-0.79/alertios.md
+++ b/website/versioned_docs/version-0.79/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: '🚧 AlertIOS'
+title: '❌ AlertIOS'
 ---
 
 > **Removed.** Use [`Alert`](alert) instead.

--- a/website/versioned_docs/version-0.79/asyncstorage.md
+++ b/website/versioned_docs/version-0.79/asyncstorage.md
@@ -1,6 +1,6 @@
 ---
 id: asyncstorage
-title: '🚧 AsyncStorage'
+title: '❌ AsyncStorage'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.

--- a/website/versioned_docs/version-0.79/checkbox.md
+++ b/website/versioned_docs/version-0.79/checkbox.md
@@ -1,6 +1,6 @@
 ---
 id: checkbox
-title: '🚧 CheckBox'
+title: '❌ CheckBox'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.

--- a/website/versioned_docs/version-0.79/clipboard.md
+++ b/website/versioned_docs/version-0.79/clipboard.md
@@ -1,6 +1,6 @@
 ---
 id: clipboard
-title: '🚧 Clipboard'
+title: '❌ Clipboard'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.

--- a/website/versioned_docs/version-0.79/datepickerandroid.md
+++ b/website/versioned_docs/version-0.79/datepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerandroid
-title: '🚧 DatePickerAndroid'
+title: '❌ DatePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.79/datepickerios.md
+++ b/website/versioned_docs/version-0.79/datepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerios
-title: '🚧 DatePickerIOS'
+title: '❌ DatePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.79/imagepickerios.md
+++ b/website/versioned_docs/version-0.79/imagepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: imagepickerios
-title: '🚧 ImagePickerIOS'
+title: '❌ ImagePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.

--- a/website/versioned_docs/version-0.79/progressbarandroid.md
+++ b/website/versioned_docs/version-0.79/progressbarandroid.md
@@ -1,6 +1,6 @@
 ---
 id: progressbarandroid
-title: '🚧 ProgressBarAndroid'
+title: '🗑️ ProgressBarAndroid'
 ---
 
 > **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.

--- a/website/versioned_docs/version-0.79/pushnotificationios.md
+++ b/website/versioned_docs/version-0.79/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: '🚧 PushNotificationIOS'
+title: '🗑️ PushNotificationIOS'
 ---
 
 > **Deprecated.** Use the [community package](https://github.com/react-native-push-notification/ios) instead.

--- a/website/versioned_docs/version-0.79/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.79/segmentedcontrolios.md
@@ -1,6 +1,6 @@
 ---
 id: segmentedcontrolios
-title: '🚧 SegmentedControlIOS'
+title: '❌ SegmentedControlIOS'
 ---
 
 > **Removed from React Native.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.

--- a/website/versioned_docs/version-0.79/statusbarios.md
+++ b/website/versioned_docs/version-0.79/statusbarios.md
@@ -1,6 +1,6 @@
 ---
 id: statusbarios
-title: '🚧 StatusBarIOS'
+title: '❌ StatusBarIOS'
 ---
 
 > **Deleted.** Use [`StatusBar`](statusbar.md) for mutating the status bar.

--- a/website/versioned_docs/version-0.79/timepickerandroid.md
+++ b/website/versioned_docs/version-0.79/timepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: timepickerandroid
-title: '🚧 TimePickerAndroid'
+title: '❌ TimePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.

--- a/website/versioned_docs/version-0.80/alertios.md
+++ b/website/versioned_docs/version-0.80/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: '🚧 AlertIOS'
+title: '❌ AlertIOS'
 ---
 
 > **Removed.** Use [`Alert`](alert) instead.

--- a/website/versioned_docs/version-0.80/asyncstorage.md
+++ b/website/versioned_docs/version-0.80/asyncstorage.md
@@ -1,6 +1,6 @@
 ---
 id: asyncstorage
-title: '🚧 AsyncStorage'
+title: '❌ AsyncStorage'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.

--- a/website/versioned_docs/version-0.80/checkbox.md
+++ b/website/versioned_docs/version-0.80/checkbox.md
@@ -1,6 +1,6 @@
 ---
 id: checkbox
-title: '🚧 CheckBox'
+title: '❌ CheckBox'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.

--- a/website/versioned_docs/version-0.80/clipboard.md
+++ b/website/versioned_docs/version-0.80/clipboard.md
@@ -1,6 +1,6 @@
 ---
 id: clipboard
-title: '🚧 Clipboard'
+title: '❌ Clipboard'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.

--- a/website/versioned_docs/version-0.80/datepickerandroid.md
+++ b/website/versioned_docs/version-0.80/datepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerandroid
-title: '🚧 DatePickerAndroid'
+title: '❌ DatePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.80/datepickerios.md
+++ b/website/versioned_docs/version-0.80/datepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerios
-title: '🚧 DatePickerIOS'
+title: '❌ DatePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.80/imagepickerios.md
+++ b/website/versioned_docs/version-0.80/imagepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: imagepickerios
-title: '🚧 ImagePickerIOS'
+title: '❌ ImagePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.

--- a/website/versioned_docs/version-0.80/progressbarandroid.md
+++ b/website/versioned_docs/version-0.80/progressbarandroid.md
@@ -1,6 +1,6 @@
 ---
 id: progressbarandroid
-title: '🚧 ProgressBarAndroid'
+title: '🗑️ ProgressBarAndroid'
 ---
 
 > **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.

--- a/website/versioned_docs/version-0.80/pushnotificationios.md
+++ b/website/versioned_docs/version-0.80/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: '🚧 PushNotificationIOS'
+title: '🗑️ PushNotificationIOS'
 ---
 
 > **Deprecated.** Use the [community package](https://github.com/react-native-push-notification/ios) instead.

--- a/website/versioned_docs/version-0.80/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.80/segmentedcontrolios.md
@@ -1,6 +1,6 @@
 ---
 id: segmentedcontrolios
-title: '🚧 SegmentedControlIOS'
+title: '❌ SegmentedControlIOS'
 ---
 
 > **Removed from React Native.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.

--- a/website/versioned_docs/version-0.80/statusbarios.md
+++ b/website/versioned_docs/version-0.80/statusbarios.md
@@ -1,6 +1,6 @@
 ---
 id: statusbarios
-title: '🚧 StatusBarIOS'
+title: '❌ StatusBarIOS'
 ---
 
 > **Deleted.** Use [`StatusBar`](statusbar.md) for mutating the status bar.

--- a/website/versioned_docs/version-0.80/timepickerandroid.md
+++ b/website/versioned_docs/version-0.80/timepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: timepickerandroid
-title: '🚧 TimePickerAndroid'
+title: '❌ TimePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.

--- a/website/versioned_docs/version-0.81/alertios.md
+++ b/website/versioned_docs/version-0.81/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: '🚧 AlertIOS'
+title: '❌️ AlertIOS'
 ---
 
 > **Removed.** Use [`Alert`](alert) instead.

--- a/website/versioned_docs/version-0.81/asyncstorage.md
+++ b/website/versioned_docs/version-0.81/asyncstorage.md
@@ -1,6 +1,6 @@
 ---
 id: asyncstorage
-title: '🚧 AsyncStorage'
+title: '❌ AsyncStorage'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=storage) instead.

--- a/website/versioned_docs/version-0.81/checkbox.md
+++ b/website/versioned_docs/version-0.81/checkbox.md
@@ -1,6 +1,6 @@
 ---
 id: checkbox
-title: '🚧 CheckBox'
+title: '❌ CheckBox'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=checkbox) instead.

--- a/website/versioned_docs/version-0.81/clipboard.md
+++ b/website/versioned_docs/version-0.81/clipboard.md
@@ -1,6 +1,6 @@
 ---
 id: clipboard
-title: '🚧 Clipboard'
+title: '❌ Clipboard'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=clipboard) instead.

--- a/website/versioned_docs/version-0.81/datepickerandroid.md
+++ b/website/versioned_docs/version-0.81/datepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerandroid
-title: '🚧 DatePickerAndroid'
+title: '❌ DatePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.81/datepickerios.md
+++ b/website/versioned_docs/version-0.81/datepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: datepickerios
-title: '🚧 DatePickerIOS'
+title: '❌ DatePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=datepicker) instead.

--- a/website/versioned_docs/version-0.81/imagepickerios.md
+++ b/website/versioned_docs/version-0.81/imagepickerios.md
@@ -1,6 +1,6 @@
 ---
 id: imagepickerios
-title: '🚧 ImagePickerIOS'
+title: '❌ ImagePickerIOS'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=image+picker) instead.

--- a/website/versioned_docs/version-0.81/progressbarandroid.md
+++ b/website/versioned_docs/version-0.81/progressbarandroid.md
@@ -1,6 +1,6 @@
 ---
 id: progressbarandroid
-title: '🚧 ProgressBarAndroid'
+title: '🗑️ ProgressBarAndroid'
 ---
 
 > **Deprecated.** Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.

--- a/website/versioned_docs/version-0.81/pushnotificationios.md
+++ b/website/versioned_docs/version-0.81/pushnotificationios.md
@@ -1,6 +1,6 @@
 ---
 id: pushnotificationios
-title: '🚧 PushNotificationIOS'
+title: '🗑️ PushNotificationIOS'
 ---
 
 > **Deprecated.** Use the [community package](https://github.com/react-native-push-notification/ios) instead.

--- a/website/versioned_docs/version-0.81/segmentedcontrolios.md
+++ b/website/versioned_docs/version-0.81/segmentedcontrolios.md
@@ -1,6 +1,6 @@
 ---
 id: segmentedcontrolios
-title: '🚧 SegmentedControlIOS'
+title: '❌ SegmentedControlIOS'
 ---
 
 > **Removed from React Native.** Use one of the [community packages](https://reactnative.directory/?search=segmentedcontrol) instead.

--- a/website/versioned_docs/version-0.81/statusbarios.md
+++ b/website/versioned_docs/version-0.81/statusbarios.md
@@ -1,6 +1,6 @@
 ---
 id: statusbarios
-title: '🚧 StatusBarIOS'
+title: '❌ StatusBarIOS'
 ---
 
 > **Deleted.** Use [`StatusBar`](statusbar.md) for mutating the status bar.

--- a/website/versioned_docs/version-0.81/timepickerandroid.md
+++ b/website/versioned_docs/version-0.81/timepickerandroid.md
@@ -1,6 +1,6 @@
 ---
 id: timepickerandroid
-title: '🚧 TimePickerAndroid'
+title: '❌ TimePickerAndroid'
 ---
 
 > **Removed.** Use one of the [community packages](https://reactnative.directory/?search=timepicker) instead.


### PR DESCRIPTION
# Why

Follow up to the recent unversioned docs changes:
* https://github.com/facebook/react-native-website/pull/4786
* https://github.com/facebook/react-native-website/pull/4757

# How

Replace "🚧" emojis with "🗑️" and "❌" based on the component/API status for the versioned pages.
