### PR TITLE
use admonitions instead of blockquote for global pages

### DIFF
--- a/docs/global-AbortController.md
+++ b/docs/global-AbortController.md
@@ -3,6 +3,8 @@ id: global-AbortController
 title: AbortController
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) for more information.
+:::
 
 The global `AbortController` class, as defined in Web specifications.

--- a/docs/global-AbortSignal.md
+++ b/docs/global-AbortSignal.md
@@ -3,6 +3,8 @@ id: global-AbortSignal
 title: AbortSignal
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) for more information.
+:::
 
 The global `AbortSignal` class, as defined in Web specifications.

--- a/docs/global-Blob.md
+++ b/docs/global-Blob.md
@@ -3,6 +3,8 @@ id: global-Blob
 title: Blob
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob) for more information.
+:::
 
 The global `Blob` class, as defined in Web specifications.

--- a/docs/global-File.md
+++ b/docs/global-File.md
@@ -3,6 +3,8 @@ id: global-File
 title: File
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/File) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/File) for more information.
+:::
 
 The global `File` class, as defined in Web specifications.

--- a/docs/global-FileReader.md
+++ b/docs/global-FileReader.md
@@ -3,6 +3,8 @@ id: global-FileReader
 title: FileReader
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) for more information.
+:::
 
 The global `FileReader` class, as defined in Web specifications.

--- a/docs/global-FormData.md
+++ b/docs/global-FormData.md
@@ -3,6 +3,8 @@ id: global-FormData
 title: FormData
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/FormData) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/FormData) for more information.
+:::
 
 The global `FormData` class, as defined in Web specifications.

--- a/docs/global-Headers.md
+++ b/docs/global-Headers.md
@@ -3,6 +3,8 @@ id: global-Headers
 title: Headers
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Headers) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Headers) for more information.
+:::
 
 The global `Headers` class, as defined in Web specifications.

--- a/docs/global-Request.md
+++ b/docs/global-Request.md
@@ -3,6 +3,8 @@ id: global-Request
 title: Request
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Request) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Request) for more information.
+:::
 
 The global `Request` class, as defined in Web specifications.

--- a/docs/global-Response.md
+++ b/docs/global-Response.md
@@ -3,6 +3,8 @@ id: global-Response
 title: Response
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Response) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Response) for more information.
+:::
 
 The global `Response` class, as defined in Web specifications.

--- a/docs/global-URL.md
+++ b/docs/global-URL.md
@@ -3,6 +3,8 @@ id: global-URL
 title: URL
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/URL) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/URL) for more information.
+:::
 
 The global `URL` class, as defined in Web specifications.

--- a/docs/global-URLSearchParams.md
+++ b/docs/global-URLSearchParams.md
@@ -3,6 +3,8 @@ id: global-URLSearchParams
 title: URLSearchParams
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) for more information.\
+:::
 
 The global `URLSearchParams` class, as defined in Web specifications.

--- a/docs/global-WebSocket.md
+++ b/docs/global-WebSocket.md
@@ -3,6 +3,8 @@ id: global-WebSocket
 title: WebSocket
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) for more information.
+:::
 
 The global `WebSocket` class, as defined in Web specifications.

--- a/docs/global-XMLHttpRequest.md
+++ b/docs/global-XMLHttpRequest.md
@@ -3,6 +3,8 @@ id: global-XMLHttpRequest
 title: XMLHttpRequest
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for more information.
+:::
 
 The global `XMLHttpRequest` class, as defined in Web specifications.

--- a/docs/global-alert.md
+++ b/docs/global-alert.md
@@ -3,6 +3,8 @@ id: global-alert
 title: alert
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) for more information.
+:::
 
 The global `alert` function, as defined in Web specifications.

--- a/docs/global-cancelAnimationFrame.md
+++ b/docs/global-cancelAnimationFrame.md
@@ -3,6 +3,8 @@ id: global-cancelAnimationFrame
 title: cancelAnimationFrame
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame) for more information.
+:::
 
 The global `cancelAnimationFrame` function, as defined in Web specifications.

--- a/docs/global-cancelIdleCallback.md
+++ b/docs/global-cancelIdleCallback.md
@@ -3,6 +3,8 @@ id: global-cancelIdleCallback
 title: cancelIdleCallback
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelIdleCallback) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelIdleCallback) for more information.
+:::
 
 The global `cancelIdleCallback` function, as defined in Web specifications.

--- a/docs/global-clearInterval.md
+++ b/docs/global-clearInterval.md
@@ -3,6 +3,8 @@ id: global-clearInterval
 title: clearInterval
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/clearInterval) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/clearInterval) for more information.
+:::
 
 The global `clearInterval` function, as defined in Web specifications.

--- a/docs/global-clearTimeout.md
+++ b/docs/global-clearTimeout.md
@@ -3,6 +3,8 @@ id: global-clearTimeout
 title: clearTimeout
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/clearTimeout) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/clearTimeout) for more information.
+:::
 
 The global `clearTimeout` function, as defined in Web specifications.

--- a/docs/global-console.md
+++ b/docs/global-console.md
@@ -3,6 +3,8 @@ id: global-console
 title: console
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/console) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/console) for more information.
+:::
 
 The global `console` object, as defined in Web specifications.

--- a/docs/global-fetch.md
+++ b/docs/global-fetch.md
@@ -3,6 +3,8 @@ id: global-fetch
 title: fetch
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) for more information.
+:::
 
 The global `fetch` function, as defined in Web specifications.

--- a/docs/global-navigator.md
+++ b/docs/global-navigator.md
@@ -3,6 +3,8 @@ id: global-navigator
 title: navigator
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator) for more information.
+:::
 
 The global `navigator` object, as defined in Web specifications.

--- a/docs/global-performance.md
+++ b/docs/global-performance.md
@@ -3,6 +3,8 @@ id: global-performance
 title: performance
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/performance) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/performance) for more information.
+:::
 
 The global `performance` object, as defined in Web specifications.

--- a/docs/global-process.md
+++ b/docs/global-process.md
@@ -3,6 +3,8 @@ id: global-process
 title: process
 ---
 
-> 🚧 This page is work in progress.
+:::warning
+🚧 This page is work in progress.
+:::
 
 The global `process` object, as defined in Node.js.

--- a/docs/global-queueMicrotask.md
+++ b/docs/global-queueMicrotask.md
@@ -3,6 +3,8 @@ id: global-queueMicrotask
 title: queueMicrotask
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask) for more information.
+:::
 
 The global `queueMicrotask` function, as defined in Web specifications.

--- a/docs/global-requestAnimationFrame.md
+++ b/docs/global-requestAnimationFrame.md
@@ -3,6 +3,8 @@ id: global-requestAnimationFrame
 title: requestAnimationFrame
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame) for more information.
+:::
 
 The global `requestAnimationFrame` function, as defined in Web specifications.

--- a/docs/global-requestIdleCallback.md
+++ b/docs/global-requestIdleCallback.md
@@ -3,6 +3,8 @@ id: global-requestIdleCallback
 title: requestIdleCallback
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) for more information.
+:::
 
 The global `requestIdleCallback` function, as defined in Web specifications.

--- a/docs/global-setInterval.md
+++ b/docs/global-setInterval.md
@@ -3,6 +3,8 @@ id: global-setInterval
 title: setInterval
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval) for more information.
+:::
 
 The global `setInterval` function, as defined in Web specifications.

--- a/docs/global-setTimeout.md
+++ b/docs/global-setTimeout.md
@@ -3,6 +3,8 @@ id: global-setTimeout
 title: setTimeout
 ---
 
-> 🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout) for more information.
+:::warning
+🚧 This page is work in progress, so please refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout) for more information.
+:::
 
 The global `setTimeout` function, as defined in Web specifications.


### PR DESCRIPTION
# Why

Recently, we started an efforts to migrate off re-styled blockquotes, to Docusuaurs admonitions, which were alos updated to match the appearance from react.dev website.

Refs:
* https://github.com/facebook/react-native-website/pull/4725
* https://github.com/facebook/react-native-website/pull/4755
* https://github.com/facebook/react-native-website/pull/4757
* https://github.com/facebook/react-native-website/pull/4784

# How

Use warning admonitions instead of blockquote for newly added global pages.

# Preview

<img width="1700" height="632" alt="Screenshot 2025-09-09 at 20 34 57" src="https://github.com/user-attachments/assets/979b9654-75b6-4517-b4b0-719ed2cbf7fc" />
