### PR TITLE
Extract experimental API warning to a separate file

### DIFF
--- a/docs/_experimental-api-warning.mdx
+++ b/docs/_experimental-api-warning.mdx
@@ -1,0 +1,5 @@
+:::important Experimental 🧪
+
+**This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
+
+:::

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -4,6 +4,8 @@ title: Accessibility
 description: Create mobile apps accessible to assistive technology with React Native's suite of APIs designed to work with Android and iOS.
 ---
 
+import ExperimentalAPIWarning from './\_experimental-api-warning.mdx';
+
 Both Android and iOS provide APIs for integrating apps with assistive technologies like the bundled screen readers VoiceOver (iOS) and TalkBack (Android). React Native has complementary APIs that let your app accommodate all users.
 
 :::info
@@ -339,9 +341,8 @@ Indicates whether a selectable element is currently selected or not.
 
 ### `experimental_accessibilityOrder`
 
-:::important Experimental 🧪
-**This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
-:::
+<ExperimentalAPIWarning />
+
 :::note
 For the sake of brevity, layout is excluded in the following examples even though it dictates the default focus order. Assume the document order matches the layout order.
 :::

--- a/docs/view.md
+++ b/docs/view.md
@@ -3,6 +3,8 @@ id: view
 title: View
 ---
 
+import ExperimentalAPIWarning from './\_experimental-api-warning.mdx';
+
 The most fundamental component for building a UI, `View` is a container that supports layout with [flexbox](flexbox.md), [style](style.md), [some touch handling](handling-touches.md), and [accessibility](accessibility.md) controls. `View` maps directly to the native view equivalent on whatever platform React Native is running on, whether that is a `UIView`, `<div>`, `android.view`, etc.
 
 `View` is designed to be nested inside other views and can have 0 to many children of any type.
@@ -385,9 +387,7 @@ Setting to false prevents direct children of the view from being removed from th
 
 ### `experimental_accessibilityOrder`
 
-:::important Experimental 🧪
-**This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
-:::
+<ExperimentalAPIWarning />
 
 `experimental_accessibilityOrder` indicates the order in which an assistive technology focuses descendants of this `View`. This prop takes an array of strings where each string is a [`nativeID`](view.md#nativeid) of some descendant component whose order is being defined. This prop does not enable accessibility itself, each referenced component still needs to be accessible by setting [`accessible`](view.md#accessible) to true. This prop is both **nestable** and **exhaustive** meaning
 

--- a/docs/virtualview.md
+++ b/docs/virtualview.md
@@ -3,9 +3,9 @@ id: virtualview
 title: VirtualView 🧪
 ---
 
-:::important Experimental 🧪
-**This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
-:::
+import ExperimentalAPIWarning from './\_experimental-api-warning.mdx';
+
+<ExperimentalAPIWarning />
 
 `VirtualView` is a core component that behaves similar to [`View`](view).
 


### PR DESCRIPTION
We'll use this banner more often soon, so extracting prevents copy&pasting.