### PR TITLE
Add additional type hint for fadingEdgeLength

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -285,9 +285,9 @@ Fades out the edges of the scroll content.
 
 If the value is greater than `0`, the fading edges will be set accordingly to the current scroll direction and position, indicating if there is more content to show.
 
-| Type   | Default |
-| ------ | ------- |
-| number | `0`     |
+| Type                                               | Default |
+| -------------------------------------------------- | ------- |
+| number<hr />object: `{start: number, end: number}` | `0`     |
 
 ---
 

--- a/website/versioned_docs/version-0.81/scrollview.md
+++ b/website/versioned_docs/version-0.81/scrollview.md
@@ -285,9 +285,9 @@ Fades out the edges of the scroll content.
 
 If the value is greater than `0`, the fading edges will be set accordingly to the current scroll direction and position, indicating if there is more content to show.
 
-| Type   | Default |
-| ------ | ------- |
-| number | `0`     |
+| Type                                               | Default |
+| -------------------------------------------------- | ------- |
+| number<hr />object: `{start: number, end: number}` | `0`     |
 
 ---
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Support for a custom object type on the `fadingEdgeLength` prop to represent non-uniform fades was added in v81 in [this commit](https://github.com/facebook/react-native/commit/a21a4b87c337f3f2d998a30841430f587c066580). This updates both v81 and current docs to include the additional type
