### PR TITLE
docs: mark `InteractionManager` as deprecated

### DIFF
--- a/docs/interactionmanager.md
+++ b/docs/interactionmanager.md
@@ -1,9 +1,13 @@
 ---
 id: interactionmanager
-title: InteractionManager
+title: 🗑️ InteractionManager
 ---
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
+:::warning Deprecated
+Use the [`setImmediate`](timers) instead.
+:::
 
 InteractionManager allows long-running work to be scheduled after any interactions/animations have completed. In particular, this allows JavaScript animations to run smoothly.
 

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -7,10 +7,10 @@ Timers are an important part of an application and React Native implements the [
 
 ## Timers
 
-- setTimeout, clearTimeout
-- setInterval, clearInterval
-- setImmediate, clearImmediate
-- requestAnimationFrame, cancelAnimationFrame
+- `setTimeout` and `clearTimeout`
+- `setInterval` and `clearInterval`
+- `setImmediate` and `clearImmediate`
+- `requestAnimationFrame` and `cancelAnimationFrame`
 
 `requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
 
@@ -24,6 +24,10 @@ Please correct this by running ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"`` on 
 :::
 
 ## InteractionManager
+
+:::warning Deprecated
+The `InteractionManager` behavior has been changed to be the same as `setImmediate`, which should be used instead.
+:::
 
 One reason why well-built native apps feel so smooth is by avoiding expensive operations during interactions and animations. In React Native, we currently have a limitation that there is only a single JS execution thread, but you can use `InteractionManager` to make sure long-running work is scheduled to start after any interactions/animations have completed.
 
@@ -43,7 +47,7 @@ Compare this to other scheduling alternatives:
 
 The touch handling system considers one or more active touches to be an 'interaction' and will delay `runAfterInteractions()` callbacks until all touches have ended or been cancelled.
 
-InteractionManager also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
+`InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
 ```tsx
 const handle = InteractionManager.createInteractionHandle();

--- a/website/versioned_docs/version-0.80/interactionmanager.md
+++ b/website/versioned_docs/version-0.80/interactionmanager.md
@@ -1,9 +1,13 @@
 ---
 id: interactionmanager
-title: InteractionManager
+title: 🗑️ InteractionManager
 ---
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
+:::warning Deprecated
+Use the [`setImmediate`](timers) instead.
+:::
 
 InteractionManager allows long-running work to be scheduled after any interactions/animations have completed. In particular, this allows JavaScript animations to run smoothly.
 

--- a/website/versioned_docs/version-0.80/timers.md
+++ b/website/versioned_docs/version-0.80/timers.md
@@ -7,10 +7,10 @@ Timers are an important part of an application and React Native implements the [
 
 ## Timers
 
-- setTimeout, clearTimeout
-- setInterval, clearInterval
-- setImmediate, clearImmediate
-- requestAnimationFrame, cancelAnimationFrame
+- `setTimeout` and `clearTimeout`
+- `setInterval` and `clearInterval`
+- `setImmediate` and `clearImmediate`
+- `requestAnimationFrame` and `cancelAnimationFrame`
 
 `requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
 
@@ -24,6 +24,10 @@ Please correct this by running ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"`` on 
 :::
 
 ## InteractionManager
+
+:::warning Deprecated
+The `InteractionManager` behavior has been changed to be the same as `setImmediate`, which should be used instead.
+:::
 
 One reason why well-built native apps feel so smooth is by avoiding expensive operations during interactions and animations. In React Native, we currently have a limitation that there is only a single JS execution thread, but you can use `InteractionManager` to make sure long-running work is scheduled to start after any interactions/animations have completed.
 
@@ -43,7 +47,7 @@ Compare this to other scheduling alternatives:
 
 The touch handling system considers one or more active touches to be an 'interaction' and will delay `runAfterInteractions()` callbacks until all touches have ended or been cancelled.
 
-InteractionManager also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
+`InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
 ```tsx
 const handle = InteractionManager.createInteractionHandle();

--- a/website/versioned_docs/version-0.81/interactionmanager.md
+++ b/website/versioned_docs/version-0.81/interactionmanager.md
@@ -1,9 +1,13 @@
 ---
 id: interactionmanager
-title: InteractionManager
+title: 🗑️ InteractionManager
 ---
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
+
+:::warning Deprecated
+Use the [`setImmediate`](timers) instead.
+:::
 
 InteractionManager allows long-running work to be scheduled after any interactions/animations have completed. In particular, this allows JavaScript animations to run smoothly.
 

--- a/website/versioned_docs/version-0.81/timers.md
+++ b/website/versioned_docs/version-0.81/timers.md
@@ -7,10 +7,10 @@ Timers are an important part of an application and React Native implements the [
 
 ## Timers
 
-- setTimeout, clearTimeout
-- setInterval, clearInterval
-- setImmediate, clearImmediate
-- requestAnimationFrame, cancelAnimationFrame
+- `setTimeout` and `clearTimeout`
+- `setInterval` and `clearInterval`
+- `setImmediate` and `clearImmediate`
+- `requestAnimationFrame` and `cancelAnimationFrame`
 
 `requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
 
@@ -24,6 +24,10 @@ Please correct this by running ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"`` on 
 :::
 
 ## InteractionManager
+
+:::warning Deprecated
+The `InteractionManager` behavior has been changed to be the same as `setImmediate`, which should be used instead.
+:::
 
 One reason why well-built native apps feel so smooth is by avoiding expensive operations during interactions and animations. In React Native, we currently have a limitation that there is only a single JS execution thread, but you can use `InteractionManager` to make sure long-running work is scheduled to start after any interactions/animations have completed.
 
@@ -43,7 +47,7 @@ Compare this to other scheduling alternatives:
 
 The touch handling system considers one or more active touches to be an 'interaction' and will delay `runAfterInteractions()` callbacks until all touches have ended or been cancelled.
 
-InteractionManager also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
+`InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
 ```tsx
 const handle = InteractionManager.createInteractionHandle();


### PR DESCRIPTION
# Why

Fixes:
* #4808

# How

Add deprecation note and and indicator to the `InteractionManager` docs page, and highlight the fact again on the Timers page. The changes have been applied to the docs for 0.80, 0.81 and unversioned ones.

# Preview

<img width="2946" height="1092" alt="Screenshot 2025-09-22 at 10 43 20" src="https://github.com/user-attachments/assets/0af8e5bd-c52e-4db1-89b7-4f69077ba6b6" />

