### PR TITLE
switch workflows and Netlify setup to use Node 22

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
 
       - name: Check lock for duplications
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
 
       - name: Install dependencies

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,20 +4,11 @@
   command = "yarn && cd website && yarn build"
 
 [context.production.environment]
-  NODE_VERSION = "20"
-  NODE_OPTIONS = "--max_old_space_size=4096"
+  NODE_VERSION = "22"
 
 [context.deploy-preview.environment]
-  NODE_VERSION = "20"
-  NODE_OPTIONS = "--max_old_space_size=4096"
+  NODE_VERSION = "22"
   PREVIEW_DEPLOY = "true"
-
-[[plugins]]
-  package = "netlify-plugin-cache"
-  [plugins.inputs]
-    paths = [
-      "website/node_modules/.cache",
-    ]
 
 [[headers]]
   for = "/movies.json"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "workspaces": [
     "website",
@@ -36,10 +36,9 @@
     "eslint-plugin-yml": "^1.18.0",
     "globals": "^16.4.0",
     "husky": "^9.1.7",
-    "netlify-plugin-cache": "^1.0.3",
     "prettier": "^3.6.2",
     "pretty-quick": "^4.2.2",
     "typescript-eslint": "^8.43.0"
   },
-  "packageManager": "yarn@4.9.2"
+  "packageManager": "yarn@4.10.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15149,13 +15149,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"netlify-plugin-cache@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "netlify-plugin-cache@npm:1.0.3"
-  checksum: 10c0/0f80bdd52a9407e13ad26930435cd28cb1dddfb140c6a9cd3f7e8489ab46e7060bab0bb6ebddc16e542d19435cb21e58688d95a3756fd45051dd220b4b15ff13
-  languageName: node
-  linkType: hard
-
 "nlcst-is-literal@npm:^2.0.0":
   version: 2.1.1
   resolution: "nlcst-is-literal@npm:2.1.1"
@@ -17413,7 +17406,6 @@ __metadata:
     eslint-plugin-yml: "npm:^1.18.0"
     globals: "npm:^16.4.0"
     husky: "npm:^9.1.7"
-    netlify-plugin-cache: "npm:^1.0.3"
     prettier: "npm:^3.6.2"
     pretty-quick: "npm:^4.2.2"
     typescript-eslint: "npm:^8.43.0"


### PR DESCRIPTION
# Why

Refs:
* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
* https://answers.netlify.com/t/new-ubuntu-24-04-noble-numbat-build-image/130497#p-290898-what-about-ubuntu-2004-focal-fossa-4

# How

Switch GitHub workflows and Netlify setup to use Node 22, bump yarn, align Netlify setup to what's used locally, remove cache plugin in favour of in-panel project config.

The Node upgrade and build image switch also speed up a build time quite noticeably:

<img width="2868" height="810" alt="Screenshot 2025-09-22 at 11 28 53" src="https://github.com/user-attachments/assets/1aac59d6-42b3-4250-baf5-6d2ac6b413db" />
