### PR TITLE
ScrollView: add missing `onScroll` event properties

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -440,7 +440,7 @@ Called when the momentum scroll ends (scroll which occurs as the ScrollView glid
 
 ### `onScroll`
 
-Fires at most once per frame during scrolling. The event has the following shape (all values are numbers):
+Fires at most once per frame during scrolling. The event has the following shape (all values with unspecified type are numbers):
 
 ```js
 {
@@ -449,7 +449,11 @@ Fires at most once per frame during scrolling. The event has the following shape
     contentOffset: {x, y},
     contentSize: {height, width},
     layoutMeasurement: {height, width},
-    zoomScale
+    velocity: {x, y},
+    responderIgnoreScroll: boolean,
+    zoomScale,
+    // iOS only
+    targetContentOffset: {x, y}
   }
 }
 ```

--- a/website/versioned_docs/version-0.77/scrollview.md
+++ b/website/versioned_docs/version-0.77/scrollview.md
@@ -440,7 +440,7 @@ Called when the momentum scroll ends (scroll which occurs as the ScrollView glid
 
 ### `onScroll`
 
-Fires at most once per frame during scrolling. The event has the following shape (all values are numbers):
+Fires at most once per frame during scrolling. The event has the following shape (all values with unspecified type are numbers):
 
 ```js
 {
@@ -449,7 +449,11 @@ Fires at most once per frame during scrolling. The event has the following shape
     contentOffset: {x, y},
     contentSize: {height, width},
     layoutMeasurement: {height, width},
-    zoomScale
+    velocity: {x, y},
+    responderIgnoreScroll: boolean,
+    zoomScale,
+    // iOS only
+    targetContentOffset: {x, y}
   }
 }
 ```

--- a/website/versioned_docs/version-0.78/scrollview.md
+++ b/website/versioned_docs/version-0.78/scrollview.md
@@ -440,7 +440,7 @@ Called when the momentum scroll ends (scroll which occurs as the ScrollView glid
 
 ### `onScroll`
 
-Fires at most once per frame during scrolling. The event has the following shape (all values are numbers):
+Fires at most once per frame during scrolling. The event has the following shape (all values with unspecified type are numbers):
 
 ```js
 {
@@ -449,7 +449,11 @@ Fires at most once per frame during scrolling. The event has the following shape
     contentOffset: {x, y},
     contentSize: {height, width},
     layoutMeasurement: {height, width},
-    zoomScale
+    velocity: {x, y},
+    responderIgnoreScroll: boolean,
+    zoomScale,
+    // iOS only
+    targetContentOffset: {x, y}
   }
 }
 ```

--- a/website/versioned_docs/version-0.79/scrollview.md
+++ b/website/versioned_docs/version-0.79/scrollview.md
@@ -440,7 +440,7 @@ Called when the momentum scroll ends (scroll which occurs as the ScrollView glid
 
 ### `onScroll`
 
-Fires at most once per frame during scrolling. The event has the following shape (all values are numbers):
+Fires at most once per frame during scrolling. The event has the following shape (all values with unspecified type are numbers):
 
 ```js
 {
@@ -449,7 +449,11 @@ Fires at most once per frame during scrolling. The event has the following shape
     contentOffset: {x, y},
     contentSize: {height, width},
     layoutMeasurement: {height, width},
-    zoomScale
+    velocity: {x, y},
+    responderIgnoreScroll: boolean,
+    zoomScale,
+    // iOS only
+    targetContentOffset: {x, y}
   }
 }
 ```

--- a/website/versioned_docs/version-0.80/scrollview.md
+++ b/website/versioned_docs/version-0.80/scrollview.md
@@ -440,7 +440,7 @@ Called when the momentum scroll ends (scroll which occurs as the ScrollView glid
 
 ### `onScroll`
 
-Fires at most once per frame during scrolling. The event has the following shape (all values are numbers):
+Fires at most once per frame during scrolling. The event has the following shape (all values with unspecified type are numbers):
 
 ```js
 {
@@ -449,7 +449,11 @@ Fires at most once per frame during scrolling. The event has the following shape
     contentOffset: {x, y},
     contentSize: {height, width},
     layoutMeasurement: {height, width},
-    zoomScale
+    velocity: {x, y},
+    responderIgnoreScroll: boolean,
+    zoomScale,
+    // iOS only
+    targetContentOffset: {x, y}
   }
 }
 ```

--- a/website/versioned_docs/version-0.81/scrollview.md
+++ b/website/versioned_docs/version-0.81/scrollview.md
@@ -440,7 +440,7 @@ Called when the momentum scroll ends (scroll which occurs as the ScrollView glid
 
 ### `onScroll`
 
-Fires at most once per frame during scrolling. The event has the following shape (all values are numbers):
+Fires at most once per frame during scrolling. The event has the following shape (all values with unspecified type are numbers):
 
 ```js
 {
@@ -449,7 +449,11 @@ Fires at most once per frame during scrolling. The event has the following shape
     contentOffset: {x, y},
     contentSize: {height, width},
     layoutMeasurement: {height, width},
-    zoomScale
+    velocity: {x, y},
+    responderIgnoreScroll: boolean,
+    zoomScale,
+    // iOS only
+    targetContentOffset: {x, y}
   }
 }
 ```


### PR DESCRIPTION
# Why

Supersedes:
* #2953

Refs:
* https://github.com/facebook/react-native/blob/ee811a82ec009cf5b5e77dcfcfab1907b99f6fe9/packages/react-native/Libraries/Types/CoreEventTypes.js#L291-L303

# How

Add missing `onScroll` event properties to the ScrollView component docs.

# Preview

<img width="1714" height="1068" alt="Screenshot 2025-09-23 at 11 00 37" src="https://github.com/user-attachments/assets/0742e680-120a-447c-b106-7f20bb1c45c6" />
