### PR TITLE
docs: initial docs for console.timeStamp

### DIFF
--- a/docs/global-console.md
+++ b/docs/global-console.md
@@ -8,3 +8,48 @@ title: console
 :::
 
 The global `console` object, as defined in Web specifications.
+
+---
+
+## Methods
+
+### `timeStamp()`
+
+```tsx
+console.timeStamp(
+  label: string,
+  start?: string | number,
+  end?: string | number,
+  trackName?: string,
+  trackGroup?: string,
+  color?: DevToolsColor
+): void;
+```
+
+The `console.timeStamp` API allows you to add custom timing entries in the Performance panel timeline.
+
+**Parameters:**
+
+| Name       | Type               | Required | Description                                                                                                                                                                                                                                                                                                   |
+| ---------- | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| label      | `string`           | Yes      | The label for the timing entry.                                                                                                                                                                                                                                                                               |
+| start      | `string \| number` | No       | <ul><li>If string, the name of a previously recorded timestamp with `console.timeStamp`.</li><li>If number, the [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp). For example, from `performance.now()`.</li><li>If undefined, the current time is used.</li></ul> |
+| end        | `string \| number` | No       | <ul><li>If string, the name of a previously recorded timestamp with `console.timeStamp`.</li><li>If number, the [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp). For example, from `performance.now()`.</li><li>If undefined, the current time is used.</li></ul> |
+| trackName  | `string`           | No       | The name of the custom track.                                                                                                                                                                                                                                                                                 |
+| trackGroup | `string`           | No       | The name of the track group.                                                                                                                                                                                                                                                                                  |
+| color      | `DevToolsColor`    | No       | The color of the entry.                                                                                                                                                                                                                                                                                       |
+
+```tsx
+type DevToolsColor =
+  | 'primary'
+  | 'primary-light'
+  | 'primary-dark'
+  | 'secondary'
+  | 'secondary-light'
+  | 'secondary-dark'
+  | 'tertiary'
+  | 'tertiary-light'
+  | 'tertiary-dark'
+  | 'warning'
+  | 'error';
+```


### PR DESCRIPTION
Mostly just an outline of the API spec.

Looks a bit weird, since we don't list any other console methods here, but `console.timeStamp` is special, because it is non-standard.