### PR TITLE
docs: Clearify swapLeftAndRightInRTL functionality

### DIFF
--- a/website/versioned_docs/version-0.81/i18nmanager.md
+++ b/website/versioned_docs/version-0.81/i18nmanager.md
@@ -117,6 +117,12 @@ static doLeftAndRightSwapInRTL: boolean;
 
 A boolean value indicating whether left and right style properties should be automatically swapped when in RTL mode. When enabled, left becomes right and right becomes left in RTL layouts.
 
+**Important Notes:**
+
+- doLeftAndRightSwapInRTL is `true` by default. This can be set to `false` with `swapLeftAndRightinRTL()`.
+- Does only affect `marginLeft` / `marginRight` / `paddingLeft` / `paddingRight` / `borderLeftWidth` / `borderRightWidth`
+- Does not affect position (relative/absolute) `left` / `right`
+
 ## Methods
 
 ### `allowRTL()`
@@ -162,4 +168,4 @@ Avoid forcing RTL in production apps as it requires a full app restart to take e
 static swapLeftAndRightInRTL: (swapLeftAndRight: boolean) => void;
 ```
 
-Swap left and right style properties in RTL mode. When enabled, left becomes right and right becomes left in RTL layouts. Does not affect the value of `isRTL`.
+Swap left and right style properties in RTL mode. When enabled, left becomes right and right becomes left in RTL layouts. Does not affect the value of `isRTL`. 

--- a/website/versioned_docs/version-0.81/i18nmanager.md
+++ b/website/versioned_docs/version-0.81/i18nmanager.md
@@ -168,4 +168,4 @@ Avoid forcing RTL in production apps as it requires a full app restart to take e
 static swapLeftAndRightInRTL: (swapLeftAndRight: boolean) => void;
 ```
 
-Swap left and right style properties in RTL mode. When enabled, left becomes right and right becomes left in RTL layouts. Does not affect the value of `isRTL`. 
+Swap left and right style properties in RTL mode. When enabled, left becomes right and right becomes left in RTL layouts. Does not affect the value of `isRTL`.


### PR DESCRIPTION
Current docs don’t clearly explain how swapLeftAndRightInRTL interacts with:
	•	marginLeft / marginRight
	•	paddingLeft / paddingRight
	•	Absolute positioning (left / right)
This leads to confusion, because developers may expect left / right to flip automatically, which it does not.

Also it's not clear what the default state of swapLeftAndRightInRTL is. This PR gives explaination on this behaviour. 
