### PR TITLE
docs: fix guide on enabling source map generation for iOS

### DIFF
--- a/docs/debugging-release-builds.md
+++ b/docs/debugging-release-builds.md
@@ -61,7 +61,7 @@ To enable source map generation:
 - Above the other exports, add a `SOURCEMAP_FILE` entry with the desired output path.
 
 ```diff
-+ SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
++ export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"
   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 ```
 

--- a/website/versioned_docs/version-0.77/debugging-release-builds.md
+++ b/website/versioned_docs/version-0.77/debugging-release-builds.md
@@ -61,7 +61,7 @@ To enable source map generation:
 - Above the other exports, add a `SOURCEMAP_FILE` entry with the desired output path.
 
 ```diff
-+ SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
++ export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"
   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 ```
 

--- a/website/versioned_docs/version-0.78/debugging-release-builds.md
+++ b/website/versioned_docs/version-0.78/debugging-release-builds.md
@@ -61,7 +61,7 @@ To enable source map generation:
 - Above the other exports, add a `SOURCEMAP_FILE` entry with the desired output path.
 
 ```diff
-+ SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
++ export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"
   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 ```
 

--- a/website/versioned_docs/version-0.79/debugging-release-builds.md
+++ b/website/versioned_docs/version-0.79/debugging-release-builds.md
@@ -61,7 +61,7 @@ To enable source map generation:
 - Above the other exports, add a `SOURCEMAP_FILE` entry with the desired output path.
 
 ```diff
-+ SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
++ export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"
   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 ```
 

--- a/website/versioned_docs/version-0.80/debugging-release-builds.md
+++ b/website/versioned_docs/version-0.80/debugging-release-builds.md
@@ -61,7 +61,7 @@ To enable source map generation:
 - Above the other exports, add a `SOURCEMAP_FILE` entry with the desired output path.
 
 ```diff
-+ SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
++ export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"
   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 ```
 

--- a/website/versioned_docs/version-0.81/debugging-release-builds.md
+++ b/website/versioned_docs/version-0.81/debugging-release-builds.md
@@ -61,7 +61,7 @@ To enable source map generation:
 - Above the other exports, add a `SOURCEMAP_FILE` entry with the desired output path.
 
 ```diff
-+ SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
++ export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"
   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 ```
 


### PR DESCRIPTION
This PR fixes the guide for generating source maps during iOS builds.

Following the current guide as-is does not generate a source map file.
This diff adds `export` to the environment variable declaration so that child processes can read the `SOURCEMAP_FILE` variable.


If child processes can't read the `SOURCEMAP_FILE`, react-native-xcode.sh script will not recognize it, and `-output-source-map` option will not be added when executing hermesc.
As a result, the source map file is not generated.



https://github.com/user-attachments/assets/449d94a7-1805-4385-882e-2ec542066d34

