### PR TITLE
Optimizing FlatList: wording tweak, backport default value change

### DIFF
--- a/docs/optimizing-flatlist-configuration.md
+++ b/docs/optimizing-flatlist-configuration.md
@@ -27,7 +27,7 @@ Here are a list of props that can help to improve `FlatList` performance:
 | ------- | ------------------------------------ |
 | Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 

--- a/website/versioned_docs/version-0.77/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.77/optimizing-flatlist-configuration.md
@@ -23,11 +23,11 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 ### removeClippedSubviews
 
-| Type    | Default |
-| ------- | ------- |
-| Boolean | False   |
+| Type    | Default                              |
+| ------- | ------------------------------------ |
+| Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 

--- a/website/versioned_docs/version-0.78/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.78/optimizing-flatlist-configuration.md
@@ -23,11 +23,11 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 ### removeClippedSubviews
 
-| Type    | Default |
-| ------- | ------- |
-| Boolean | False   |
+| Type    | Default                              |
+| ------- | ------------------------------------ |
+| Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 

--- a/website/versioned_docs/version-0.79/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.79/optimizing-flatlist-configuration.md
@@ -23,11 +23,11 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 ### removeClippedSubviews
 
-| Type    | Default |
-| ------- | ------- |
-| Boolean | False   |
+| Type    | Default                              |
+| ------- | ------------------------------------ |
+| Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 

--- a/website/versioned_docs/version-0.80/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.80/optimizing-flatlist-configuration.md
@@ -23,11 +23,11 @@ Here are a list of props that can help to improve `FlatList` performance:
 
 ### removeClippedSubviews
 
-| Type    | Default |
-| ------- | ------- |
-| Boolean | False   |
+| Type    | Default                              |
+| ------- | ------------------------------------ |
+| Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 

--- a/website/versioned_docs/version-0.81/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.81/optimizing-flatlist-configuration.md
@@ -27,7 +27,7 @@ Here are a list of props that can help to improve `FlatList` performance:
 | ------- | ------------------------------------ |
 | Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 

--- a/website/versioned_docs/version-0.82/optimizing-flatlist-configuration.md
+++ b/website/versioned_docs/version-0.82/optimizing-flatlist-configuration.md
@@ -27,7 +27,7 @@ Here are a list of props that can help to improve `FlatList` performance:
 | ------- | ------------------------------------ |
 | Boolean | `true` on Android, otherwise `false` |
 
-If `true`, views that are outside of the viewport are detached from the native view hierarchy.
+If `true`, views that are outside of the viewport are automatically detached from the native view hierarchy.
 
 **Pros:** This reduces time spent on the main thread, and thus reduces the risk of dropped frames, by excluding views outside of the viewport from the native rendering and drawing traversals.
 


### PR DESCRIPTION
# Why

Supersedes:
* #4399

# How

Mention automatic detach on pages where default value for FlatList's `removeClippedSubviews` prop has been already updated, backport the changes to all versions where old value has been present.

# Preview

<img width="1312" height="450" alt="Screenshot 2025-10-11 234634" src="https://github.com/user-attachments/assets/a5c2b9d4-b9b9-4f5d-aa69-03bfa660ad62" />
