### PR TITLE
lint-examples: fix false-positive errors on Windows

### DIFF
--- a/packages/lint-examples/.prettierrc.json
+++ b/packages/lint-examples/.prettierrc.json
@@ -3,5 +3,6 @@
   "bracketSameLine": true,
   "bracketSpacing": false,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
# Why

When running lint examples on Windows Prettier reported a bunch of false-positive warnings due to EOL character mismatch.

# How

Add `"endOfLine": "auto"` option to the Prettier config ([just like we do in monorepo root](https://github.com/facebook/react-native-website/blob/main/.prettierrc.json#L12)), to avoid forcing platform-specific EOL characters.

# Test plan

Run the check after the changes on Windows and all passed without any warnings.