### PR TITLE
docs: fix versioning policy redirect link in contribution guide

### DIFF
--- a/website/contributing/contributing-overview.md
+++ b/website/contributing/contributing-overview.md
@@ -22,7 +22,7 @@ As a reminder, all contributors are expected to adhere to the [Code of Conduct](
 
 ## Versioning Policy
 
-In order to fully understand the versioning of React Native, we recommend you to check out the [Versioning Policy](/contributing/versioning-policy) page.
+In order to fully understand the versioning of React Native, we recommend you to check out the [Versioning Policy](/docs/releases/versioning-policy) page.
 In that page we describe which versions of React Native are supported, how often they're released and which one you should use based on your circumstances.
 
 ## Ways to Contribute


### PR DESCRIPTION
Versioning policy link was broken in the latest docs website version

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
