### PR TITLE
fix: turbo modules with swift @objc annotation

### DIFF
--- a/docs/the-new-architecture/turbo-modules-with-swift.md
+++ b/docs/the-new-architecture/turbo-modules-with-swift.md
@@ -33,23 +33,22 @@ To achieve that, please follow these steps:
 ```swift title="NativeLocalStorage.swift"
 import Foundation
 
-@objc public class NativeLocalStorage: NSObject {
+@objcMembers public class NativeLocalStorage: NSObject {
   let userDefaults = UserDefaults(suiteName: "local-storage");
 
-
-  @objc public func getItem(for key: String) -> String? {
+  public func getItem(for key: String) -> String? {
     return userDefaults?.string(forKey: key)
   }
 
-  @objc public func setItem(for key: String, value: String) {
+  public func setItem(for key: String, value: String) {
     userDefaults?.set(value, forKey: key)
   }
 
-  @objc public func removeItem(for key: String) {
+  public func removeItem(for key: String) {
     userDefaults?.removeObject(forKey: key)
   }
 
-  @objc public  func clear() {
+  public func clear() {
     userDefaults?.dictionaryRepresentation().keys.forEach { removeItem(for: $0) }
   }
 }

--- a/website/versioned_docs/version-0.79/the-new-architecture/turbo-modules-with-swift.md
+++ b/website/versioned_docs/version-0.79/the-new-architecture/turbo-modules-with-swift.md
@@ -33,23 +33,22 @@ To achieve that, please follow these steps:
 ```swift title="NativeLocalStorage.swift"
 import Foundation
 
-@objc public class NativeLocalStorage: NSObject {
+@objcMembers public class NativeLocalStorage: NSObject {
   let userDefaults = UserDefaults(suiteName: "local-storage");
 
-
-  @objc public func getItem(for key: String) -> String? {
+  public func getItem(for key: String) -> String? {
     return userDefaults?.string(forKey: key)
   }
 
-  @objc public func setItem(for key: String, value: String) {
+  public func setItem(for key: String, value: String) {
     userDefaults?.set(value, forKey: key)
   }
 
-  @objc public func removeItem(for key: String) {
+  public func removeItem(for key: String) {
     userDefaults?.removeObject(forKey: key)
   }
 
-  @objc public  func clear() {
+  public func clear() {
     userDefaults?.dictionaryRepresentation().keys.forEach { removeItem(for: $0) }
   }
 }

--- a/website/versioned_docs/version-0.80/the-new-architecture/turbo-modules-with-swift.md
+++ b/website/versioned_docs/version-0.80/the-new-architecture/turbo-modules-with-swift.md
@@ -33,23 +33,22 @@ To achieve that, please follow these steps:
 ```swift title="NativeLocalStorage.swift"
 import Foundation
 
-@objc public class NativeLocalStorage: NSObject {
+@objcMembers public class NativeLocalStorage: NSObject {
   let userDefaults = UserDefaults(suiteName: "local-storage");
 
-
-  @objc public func getItem(for key: String) -> String? {
+  public func getItem(for key: String) -> String? {
     return userDefaults?.string(forKey: key)
   }
 
-  @objc public func setItem(for key: String, value: String) {
+  public func setItem(for key: String, value: String) {
     userDefaults?.set(value, forKey: key)
   }
 
-  @objc public func removeItem(for key: String) {
+  public func removeItem(for key: String) {
     userDefaults?.removeObject(forKey: key)
   }
 
-  @objc public  func clear() {
+  public func clear() {
     userDefaults?.dictionaryRepresentation().keys.forEach { removeItem(for: $0) }
   }
 }

--- a/website/versioned_docs/version-0.81/the-new-architecture/turbo-modules-with-swift.md
+++ b/website/versioned_docs/version-0.81/the-new-architecture/turbo-modules-with-swift.md
@@ -33,23 +33,22 @@ To achieve that, please follow these steps:
 ```swift title="NativeLocalStorage.swift"
 import Foundation
 
-@objc public class NativeLocalStorage: NSObject {
+@objcMembers public class NativeLocalStorage: NSObject {
   let userDefaults = UserDefaults(suiteName: "local-storage");
 
-
-  @objc public func getItem(for key: String) -> String? {
+  public func getItem(for key: String) -> String? {
     return userDefaults?.string(forKey: key)
   }
 
-  @objc public func setItem(for key: String, value: String) {
+  public func setItem(for key: String, value: String) {
     userDefaults?.set(value, forKey: key)
   }
 
-  @objc public func removeItem(for key: String) {
+  public func removeItem(for key: String) {
     userDefaults?.removeObject(forKey: key)
   }
 
-  @objc public  func clear() {
+  public func clear() {
     userDefaults?.dictionaryRepresentation().keys.forEach { removeItem(for: $0) }
   }
 }

--- a/website/versioned_docs/version-0.82/the-new-architecture/turbo-modules-with-swift.md
+++ b/website/versioned_docs/version-0.82/the-new-architecture/turbo-modules-with-swift.md
@@ -33,23 +33,22 @@ To achieve that, please follow these steps:
 ```swift title="NativeLocalStorage.swift"
 import Foundation
 
-@objc public class NativeLocalStorage: NSObject {
+@objcMembers public class NativeLocalStorage: NSObject {
   let userDefaults = UserDefaults(suiteName: "local-storage");
 
-
-  @objc public func getItem(for key: String) -> String? {
+  public func getItem(for key: String) -> String? {
     return userDefaults?.string(forKey: key)
   }
 
-  @objc public func setItem(for key: String, value: String) {
+  public func setItem(for key: String, value: String) {
     userDefaults?.set(value, forKey: key)
   }
 
-  @objc public func removeItem(for key: String) {
+  public func removeItem(for key: String) {
     userDefaults?.removeObject(forKey: key)
   }
 
-  @objc public  func clear() {
+  public func clear() {
     userDefaults?.dictionaryRepresentation().keys.forEach { removeItem(for: $0) }
   }
 }


### PR DESCRIPTION
This PR removes the redundant @objc annotation and replaces it with `@objcMembers` which exposes all members to Objective-C.
