### PR TITLE
Renumber screenshots section in publishing guide

### DIFF
--- a/website/versioned_docs/version-0.82/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.82/publishing-to-app-store.md
@@ -63,6 +63,6 @@ Check your Bundle Identifier and make sure it is exactly same as the one you hav
 
 Now fill up the necessary information and in the Build Section, select the build of the app and click on `Save` → `Submit For Review`.
 
-### 4. Screenshots
+### 3. Screenshots
 
 The Apple Store requires you have screenshots for the latest devices. The reference for such devices would be found [here](https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/). Note that screenshots for some display sizes are not required if they are provided for other sizes.


### PR DESCRIPTION
Renumbered the section for screenshots in the publishing guide.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
