### PR TITLE
scripts: fix incorrect Releases page link in LLMS.txt

### DIFF
--- a/scripts/src/generate-llms-txt.ts
+++ b/scripts/src/generate-llms-txt.ts
@@ -325,7 +325,7 @@ function generateMarkdown(
   return markdown.replace(/(#+ .*)\n/g, '\n$1\n').replace(/\n(\n)+/g, '\n\n');
 }
 
-function appendPageLink(fullDocPath, prefix, fsPath) {
+function appendPageLink(fullDocPath: string, prefix: string, fsPath: string) {
   const {title, slug} = extractMetadataFromMarkdown(fullDocPath);
   return `- [${title}](${URL_PREFIX}${prefix}/${slug ?? fsPath})\n`;
 }


### PR DESCRIPTION
# Why

Fixes #4871

# How

Handle Docusuaurs link simplification when the root page is named the same as category.  This PR also addresses the incorrect fetch path error printed when generating the file.

# Preview

https://deploy-preview-4872--react-native.netlify.app/llms.txt

<img width="967" height="312" alt="Screenshot 2025-11-10 131208" src="https://github.com/user-attachments/assets/066fdb20-aac4-4904-a565-f0b50a832582" />

