### PR TITLE
Promote Web Performance APIs as stable

### DIFF
--- a/docs/global-EventCounts.md
+++ b/docs/global-EventCounts.md
@@ -1,10 +1,6 @@
 ---
 id: global-EventCounts
-title: EventCounts 🧪
+title: EventCounts
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`EventCounts`](https://developer.mozilla.org/en-US/docs/Web/API/EventCounts) class, as defined in Web specifications.

--- a/docs/global-PerformanceEntry.md
+++ b/docs/global-PerformanceEntry.md
@@ -1,10 +1,6 @@
 ---
 id: global-PerformanceEntry
-title: PerformanceEntry 🧪
+title: PerformanceEntry
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceEntry`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry) class, as defined in Web specifications.

--- a/docs/global-PerformanceEventTiming.md
+++ b/docs/global-PerformanceEventTiming.md
@@ -1,11 +1,7 @@
 ---
 id: global-PerformanceEventTiming
-title: PerformanceEventTiming 🧪
+title: PerformanceEventTiming
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceEventTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming) class, as defined in Web specifications.
 

--- a/docs/global-PerformanceLongTaskTiming.md
+++ b/docs/global-PerformanceLongTaskTiming.md
@@ -1,11 +1,7 @@
 ---
 id: global-PerformanceLongTaskTiming
-title: PerformanceLongTaskTiming 🧪
+title: PerformanceLongTaskTiming
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceLongTaskTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming) class, as defined in Web specifications.
 

--- a/docs/global-PerformanceMark.md
+++ b/docs/global-PerformanceMark.md
@@ -1,10 +1,6 @@
 ---
 id: global-PerformanceMark
-title: PerformanceMark 🧪
+title: PerformanceMark
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceMark`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark) class, as defined in Web specifications.

--- a/docs/global-PerformanceMeasure.md
+++ b/docs/global-PerformanceMeasure.md
@@ -1,10 +1,6 @@
 ---
 id: global-PerformanceMeasure
-title: PerformanceMeasure 🧪
+title: PerformanceMeasure
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceMeasure`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure) class, as defined in Web specifications.

--- a/docs/global-PerformanceObserver.md
+++ b/docs/global-PerformanceObserver.md
@@ -1,11 +1,7 @@
 ---
 id: global-PerformanceObserver
-title: PerformanceObserver 🧪
+title: PerformanceObserver
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceObserver`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver) class, as defined in Web specifications.
 

--- a/docs/global-PerformanceObserverEntryList.md
+++ b/docs/global-PerformanceObserverEntryList.md
@@ -1,10 +1,6 @@
 ---
 id: global-PerformanceObserverEntryList
-title: PerformanceObserverEntryList 🧪
+title: PerformanceObserverEntryList
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`PerformanceObserverEntryList`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserverEntryList) class, as defined in Web specifications.

--- a/docs/global-performance.md
+++ b/docs/global-performance.md
@@ -1,11 +1,7 @@
 ---
 id: global-performance
-title: performance 🧪
+title: performance
 ---
-
-import CanaryAPIWarning from './\_canary-channel-api-warning.mdx';
-
-<CanaryAPIWarning />
 
 The global [`performance`](https://developer.mozilla.org/en-US/docs/Web/API/Window/performance) object, as defined in Web specifications.
 


### PR DESCRIPTION
This promotes the Web Performance APIs as stable in RN, as done recently in https://github.com/facebook/react-native/pull/54324
