### PR TITLE
fix Snack player re-initializer on custom pages

### DIFF
--- a/website/modules/snackPlayerInitializer.ts
+++ b/website/modules/snackPlayerInitializer.ts
@@ -74,10 +74,14 @@ export default (() => {
       }
     });
 
-    observer.observe(document.querySelector('.container'), {
-      childList: true,
-      subtree: true,
-    });
+    // Homepage or Showcase pages does not use MDX content, so `.container` node is not present there
+    const mdxContentContainer = document.body.querySelector('.container');
+    if (mdxContentContainer) {
+      observer.observe(mdxContentContainer, {
+        childList: true,
+        subtree: true,
+      });
+    }
   };
 
   // Need to set the theme before the snack script (deferred) initialize


### PR DESCRIPTION
# Why

Fixes an error visible in browser logs and responsible for throwing during local development related to recently introduced Snack player re-initializer.

Refs:
* https://github.com/facebook/react-native-website/pull/4870#issuecomment-3519055791

# How

Verify if `.container` node exist before starting to observe. It could be not present on custom pages, which are not based on MDX content.