### PR TITLE
docs: fix TS API deprecated types link

### DIFF
--- a/docs/strict-typescript-api.md
+++ b/docs/strict-typescript-api.md
@@ -3,6 +3,8 @@ id: strict-typescript-api
 title: Strict TypeScript API (opt in)
 ---
 
+import RNRepoLink from '@site/core/RNRepoLink';
+
 The Strict TypeScript API is a preview of our future, stable JavaScript API for React Native.
 
 Specifically, this is a new set of TypeScript types for the `react-native` npm package, available from 0.80 onwards. These provide stronger and more futureproof type accuracy, and will allow us to confidently evolve React Native's API into a stable shape. Opting in to the Strict TypeScript API brings some structural type differences, and is therefore a one-time breaking change.
@@ -178,7 +180,7 @@ In the new types, every optional prop will be typed as `type | undefined`.
 
 ### Removal of some deprecated types
 
-All types listed in [`DeprecatedPropertiesAlias.d.ts`](https://github.com/facebook/react-native/blob/0.80-stable/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts) are inaccessible under the Strict API.
+All types listed in <RNRepoLink href="/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts">`DeprecatedPropertiesAlias.d.ts`</RNRepoLink> are inaccessible under the Strict API.
 
 ### Removal of leftover component props
 

--- a/website/core/RNRepoLink.tsx
+++ b/website/core/RNRepoLink.tsx
@@ -1,0 +1,15 @@
+import A from '@theme/MDXComponents/A';
+import type {ComponentProps} from 'react';
+import {getTemplateBranchNameForCurrentVersion} from '../src/getTemplateBranchNameForCurrentVersion';
+
+type Props = ComponentProps<'a'>;
+
+export default function RNRepoLink({href, children, ...rest}: Props) {
+  return (
+    <A
+      href={`https://github.com/facebook/react-native/blob/${getTemplateBranchNameForCurrentVersion()}/${href.startsWith('/') ? href.slice(1) : href}`}
+      {...rest}>
+      {children}
+    </A>
+  );
+}

--- a/website/versioned_docs/version-0.80/strict-typescript-api.md
+++ b/website/versioned_docs/version-0.80/strict-typescript-api.md
@@ -3,6 +3,8 @@ id: strict-typescript-api
 title: Strict TypeScript API (opt in)
 ---
 
+import RNRepoLink from '@site/core/RNRepoLink';
+
 The Strict TypeScript API is a preview of our future, stable JavaScript API for React Native.
 
 Specifically, this is a new set of TypeScript types for the `react-native` npm package, available from 0.80 onwards. These provide stronger and more futureproof type accuracy, and will allow us to confidently evolve React Native's API into a stable shape. Opting in to the Strict TypeScript API brings some structural type differences, and is therefore a one-time breaking change.
@@ -178,7 +180,7 @@ In the new types, every optional prop will be typed as `type | undefined`.
 
 ### Removal of some deprecated types
 
-All types listed in [`DeprecatedPropertiesAlias.d.ts`](https://github.com/facebook/react-native/blob/0.80-stable/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts) are inaccessible under the Strict API.
+All types listed in <RNRepoLink href="/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts">`DeprecatedPropertiesAlias.d.ts`</RNRepoLink> are inaccessible under the Strict API.
 
 ### Removal of leftover component props
 

--- a/website/versioned_docs/version-0.81/strict-typescript-api.md
+++ b/website/versioned_docs/version-0.81/strict-typescript-api.md
@@ -3,6 +3,8 @@ id: strict-typescript-api
 title: Strict TypeScript API (opt in)
 ---
 
+import RNRepoLink from '@site/core/RNRepoLink';
+
 The Strict TypeScript API is a preview of our future, stable JavaScript API for React Native.
 
 Specifically, this is a new set of TypeScript types for the `react-native` npm package, available from 0.80 onwards. These provide stronger and more futureproof type accuracy, and will allow us to confidently evolve React Native's API into a stable shape. Opting in to the Strict TypeScript API brings some structural type differences, and is therefore a one-time breaking change.
@@ -178,7 +180,7 @@ In the new types, every optional prop will be typed as `type | undefined`.
 
 ### Removal of some deprecated types
 
-All types listed in [`DeprecatedPropertiesAlias.d.ts`](https://github.com/facebook/react-native/blob/0.80-stable/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts) are inaccessible under the Strict API.
+All types listed in <RNRepoLink href="/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts">`DeprecatedPropertiesAlias.d.ts`</RNRepoLink> are inaccessible under the Strict API.
 
 ### Removal of leftover component props
 

--- a/website/versioned_docs/version-0.82/strict-typescript-api.md
+++ b/website/versioned_docs/version-0.82/strict-typescript-api.md
@@ -3,6 +3,8 @@ id: strict-typescript-api
 title: Strict TypeScript API (opt in)
 ---
 
+import RNRepoLink from '@site/core/RNRepoLink';
+
 The Strict TypeScript API is a preview of our future, stable JavaScript API for React Native.
 
 Specifically, this is a new set of TypeScript types for the `react-native` npm package, available from 0.80 onwards. These provide stronger and more futureproof type accuracy, and will allow us to confidently evolve React Native's API into a stable shape. Opting in to the Strict TypeScript API brings some structural type differences, and is therefore a one-time breaking change.
@@ -178,7 +180,7 @@ In the new types, every optional prop will be typed as `type | undefined`.
 
 ### Removal of some deprecated types
 
-All types listed in [`DeprecatedPropertiesAlias.d.ts`](https://github.com/facebook/react-native/blob/0.80-stable/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts) are inaccessible under the Strict API.
+All types listed in <RNRepoLink href="/packages/react-native/types/public/DeprecatedPropertiesAlias.d.ts">`DeprecatedPropertiesAlias.d.ts`</RNRepoLink> are inaccessible under the Strict API.
 
 ### Removal of leftover component props
 


### PR DESCRIPTION
# Why

While reviewing other PR I have spotted that we have one more link with hardcoded version in docs.

# How

Add `RNRepoLink` component, similar to one we already have for the template repo, update TS API deprecated types reference.

# Preview

<img width="1815" height="1262" alt="Screenshot 2025-11-13 093642" src="https://github.com/user-attachments/assets/4c0d4ab5-5e73-4ac4-b7fe-e1db64c4c215" />

