### PR TITLE
Fix minor issues in the Turbo Modules iOS doc

### DIFF
--- a/docs/turbo-native-modules-ios.md
+++ b/docs/turbo-native-modules-ios.md
@@ -60,6 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTNativeLocalStorage : NSObject <NativeLocalStorageSpec>
 
 @end
+
+NS_ASSUME_NONNULL_END
 ```
 
 Then update our implementation to use `NSUserDefaults` with a custom [suite name](https://developer.apple.com/documentation/foundation/nsuserdefaults/1409957-initwithsuitename).
@@ -136,7 +138,7 @@ Modify the `package.json` as it follows:
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {
-       "javaPackageName": "com.sampleapp.specs"
+       "javaPackageName": "com.nativelocalstorage"
      },
      // highlight-add-start
      "ios": {
@@ -155,7 +157,7 @@ At this point, you need to re-install the pods to make sure that codegen runs ag
 ```bash
 # from the ios folder
 bundle exec pod install
-open SampleApp.xcworkspace
+open TurboModuleExample.xcworkspace
 ```
 
 If you now build your application from Xcode, you should be able to build successfully.


### PR DESCRIPTION
Hi there,

Main issue was that instead of `open TurboModuleExample.xcworkspace`, `open SampleApp.xcworkspace` was used.

NS_ASSUME_NONNULL_END should already be existing in the file, but I made the mistake of clicking the copy button at the top when viewing the docs, and pasting directly into the file. Given that it is just one more line, it wouldn't hurt to have it in the diff.

And, I have a question, I see some copies of this in the `website/versioned_docs/**/*` as well, should I update those as well, or is there a script/automation that does this?