### PR TITLE
docs: add helper for creating versioned core repo links

### DIFF
--- a/docs/the-new-architecture/pure-cxx-modules.md
+++ b/docs/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 
@@ -228,7 +229,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:

--- a/website/src/getCoreBranchNameForCurrentVersion.ts
+++ b/website/src/getCoreBranchNameForCurrentVersion.ts
@@ -1,0 +1,6 @@
+import {useActiveVersion} from '@docusaurus/plugin-content-docs/client';
+
+export function getCoreBranchNameForCurrentVersion() {
+  const version = useActiveVersion(undefined);
+  return version.label === 'Next' ? 'main' : `v${version.label}.0`;
+}

--- a/website/versioned_docs/version-0.77/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.77/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -227,7 +228,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:

--- a/website/versioned_docs/version-0.78/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.78/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -227,7 +228,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:

--- a/website/versioned_docs/version-0.79/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.79/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -227,7 +228,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:

--- a/website/versioned_docs/version-0.80/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.80/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -227,7 +228,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:

--- a/website/versioned_docs/version-0.81/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.81/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -227,7 +228,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:

--- a/website/versioned_docs/version-0.82/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.82/the-new-architecture/pure-cxx-modules.md
@@ -1,3 +1,4 @@
+import {getCoreBranchNameForCurrentVersion} from '@site/src/getCoreBranchNameForCurrentVersion';
 import {getCurrentVersion} from '@site/src/getCurrentVersion';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
@@ -227,7 +228,7 @@ The final step is to register the new C++ Turbo Native Module in the runtime, so
 1. From the folder `SampleApp/android/app/src/main/jni`, run the following command:
 
 <CodeBlock language="sh" title="shell">
-{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCurrentVersion() === 'latest' ? '' : 'v'}${getCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
+{`curl -O https://raw.githubusercontent.com/facebook/react-native/${getCoreBranchNameForCurrentVersion()}/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp`}
 </CodeBlock>
 
 2. Then, modify this file as follows:


### PR DESCRIPTION
# Why

Fixes #4909

# How

Add dedicated helper for creating core repo versioned link based on currently active docs version (similar to one which we have for template repo).

Previous approach resulted in lacking trailing `.0` in the tag, which lead to 404 link reference.

# Test plan

https://deploy-preview-4910--react-native.netlify.app/docs/the-new-architecture/pure-cxx-modules#3-register-the-new-turbo-native-module