### PR TITLE
Remove outdated Objective-C splash screen setup instructions

### DIFF
--- a/docs/publishing-to-app-store.md
+++ b/docs/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell

--- a/website/versioned_docs/version-0.77/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.77/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell

--- a/website/versioned_docs/version-0.78/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.78/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell

--- a/website/versioned_docs/version-0.79/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.79/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell

--- a/website/versioned_docs/version-0.80/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.80/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell

--- a/website/versioned_docs/version-0.81/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.81/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell

--- a/website/versioned_docs/version-0.82/publishing-to-app-store.md
+++ b/website/versioned_docs/version-0.82/publishing-to-app-store.md
@@ -19,15 +19,6 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 #### Pro Tips
 
-As your App Bundle grows in size, you may start to see a blank screen flash between your splash screen and the display of your root application view. If this is the case, you can add the following code to `AppDelegate.m` in order to keep your splash screen displayed during the transition.
-
-```objectivec
-  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
-  UIViewController *vc = [sb instantiateInitialViewController];
-  rootView.loadingView = vc.view;
-```
-
 The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding the following to your shell script in the Xcode Build Phase `Bundle React Native code and images`:
 
 ```shell


### PR DESCRIPTION
## Summary

- Removes the outdated Objective-C code snippet from the "Pro Tips" section of the "Publishing to Apple App Store" documentation
- Updates all versioned docs (0.77-0.82) and the main docs

## Motivation

Since React Native 0.71+, new projects generate `AppDelegate.swift` by default. The existing Objective-C code referencing `AppDelegate.m` and `[self.window makeKeyAndVisible]` is incompatible with Swift-based AppDelegate files and causes confusion for developers.

The `LaunchScreen.storyboard` handles splash screens automatically for most use cases. Developers experiencing the white flash issue can use community libraries like [react-native-bootsplash](https://github.com/zoontek/react-native-bootsplash) which have proper Swift support.

## Test plan

- [x] Verified all 7 files were updated consistently
- [ ] Verify docs build successfully

Fixes #4770