### PR TITLE
Add border radius to content images

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -404,6 +404,18 @@ hr {
     font-weight: 600;
   }
 
+  img {
+    border-radius: var(--ifm-global-radius);
+    &.center {
+      width: 100%;
+      justify-content: center;
+    }
+    &.half-size {
+      max-height: 50vh;
+      object-fit: contain;
+    }
+  }
+
   table {
     display: table;
     width: 100%;
@@ -2359,17 +2371,6 @@ figcaption > p:last-child {
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
-}
-
-img {
-  &.center {
-    width: 100%;
-    justify-content: center;
-  }
-  &.half-size {
-    max-height: 50vh;
-    object-fit: contain;
-  }
 }
 
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
## Summary

This is a small theme tweak to add rounded corners to Markdown images, matching other content such as code blocks and admonitions.

## Test plan

Visit any blog or docs article.

✅ Rounded corners are set on content images
✅ Homepage and blog author images are _**NOT**_ changed

<img width="883" height="195" alt="image" src="https://github.com/user-attachments/assets/6e04c3ba-82f5-4d38-abb4-f8f6cae3af8d" />

<img width="873" height="292" alt="image" src="https://github.com/user-attachments/assets/3e42eb2d-b633-43a1-a10a-5326eb624d8f" />

