### PR TITLE
fix: update link to useEffectEvent in React docs

### DIFF
--- a/website/blog/2025-12-10-react-native-0.83.md
+++ b/website/blog/2025-12-10-react-native-0.83.md
@@ -66,7 +66,7 @@ To solve this, most users disable the lint rule and exclude the dependency. But 
 
 With `useEffectEvent`, you can split the "event" part of this logic out of the Effect that emits it.
 
-You can read more about `useEffectEvent` in the [React docs](https://react.dev/reference/react/Activity).
+You can read more about `useEffectEvent` in the [React docs](https://react.dev/reference/react/useEffectEvent).
 
 ## New DevTools features
 


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
