### PR TITLE
Remove React Conf announcement bar from config

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -371,14 +371,6 @@ const config: Config = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
-    announcementBar: {
-      id: 'react-conf',
-      content:
-        'Join us for React Conf on Oct 7-8. <a target="_blank" rel="noopener noreferrer" href="https://conf.react.dev">Learn more</a>.',
-      backgroundColor: '#20232a',
-      textColor: '#fff',
-      isCloseable: false,
-    },
     prism: {
       defaultLanguage: 'tsx',
       theme: prismTheme,


### PR DESCRIPTION
The React Conf 2025 was over two months ago, there's no point in keeping the announcement bar with an invitation.