### PR TITLE
docs: Add matrix transform documentation and example (#1899)

### DIFF
--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -220,13 +220,25 @@ The matrix is specified in column-major order:
   transform: [
     {
       matrix: [
-        scaleX, skewY, 0, 0,
-        skewX, scaleY, 0, 0,
-        0, 0, 1, 0,
-        translateX, translateY, 0, 1
-      ]
-    }
-  ]
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
 }
 ```
 
@@ -236,14 +248,16 @@ For example, to apply a combination of scale and skew:
 {
   transform: [
     {
-      matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
-    }
-  ]
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
 }
 ```
 
 :::note
-Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For simple transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
 :::
 
 | Type                                                                                                                                                                                                                                                                                                          | Required |

--- a/website/versioned_docs/version-0.77/transforms.md
+++ b/website/versioned_docs/version-0.77/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -195,6 +209,57 @@ The skew transformations require a string so that the transform may be expressed
 }
 ```
 
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
+
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | array of objects: `{matrix: number[]}`, `{perspective: number}`, `{rotate: string}`, `{rotateX: string}`, `{rotateY: string}`, `{rotateZ: string}`, `{scale: number}`, `{scaleX: number}`, `{scaleY: number}`, `{translateX: number}`, `{translateY: number}`, `{skewX: string}`, `{skewY: string}` or string | No       |
@@ -203,7 +268,9 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](transforms#transform) prop instead.
+:::warning Deprecated
+Use the [`transform`](transforms#transform) prop instead.
+:::
 
 ## Transform Origin
 
@@ -211,14 +278,9 @@ The `transformOrigin` property sets the origin for a view's transformations. The
 
 # Example
 
-```SnackPlayer name=TransformOrigin%20Example&supportedPlatforms=ios,android
+```SnackPlayer name=TransformOrigin%20Example
 import React, {useEffect, useRef} from 'react';
-import {
-  Animated,
-  View,
-  StyleSheet,
-  Easing,
-} from 'react-native';
+import {Animated, View, StyleSheet, Easing} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {

--- a/website/versioned_docs/version-0.78/transforms.md
+++ b/website/versioned_docs/version-0.78/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -195,6 +209,57 @@ The skew transformations require a string so that the transform may be expressed
 }
 ```
 
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
+
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | array of objects: `{matrix: number[]}`, `{perspective: number}`, `{rotate: string}`, `{rotateX: string}`, `{rotateY: string}`, `{rotateZ: string}`, `{scale: number}`, `{scaleX: number}`, `{scaleY: number}`, `{translateX: number}`, `{translateY: number}`, `{skewX: string}`, `{skewY: string}` or string | No       |
@@ -203,7 +268,9 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](transforms#transform) prop instead.
+:::warning Deprecated
+Use the [`transform`](transforms#transform) prop instead.
+:::
 
 ## Transform Origin
 
@@ -211,14 +278,9 @@ The `transformOrigin` property sets the origin for a view's transformations. The
 
 # Example
 
-```SnackPlayer name=TransformOrigin%20Example&supportedPlatforms=ios,android
+```SnackPlayer name=TransformOrigin%20Example
 import React, {useEffect, useRef} from 'react';
-import {
-  Animated,
-  View,
-  StyleSheet,
-  Easing,
-} from 'react-native';
+import {Animated, View, StyleSheet, Easing} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {

--- a/website/versioned_docs/version-0.79/transforms.md
+++ b/website/versioned_docs/version-0.79/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -195,6 +209,57 @@ The skew transformations require a string so that the transform may be expressed
 }
 ```
 
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
+
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | array of objects: `{matrix: number[]}`, `{perspective: number}`, `{rotate: string}`, `{rotateX: string}`, `{rotateY: string}`, `{rotateZ: string}`, `{scale: number}`, `{scaleX: number}`, `{scaleY: number}`, `{translateX: number}`, `{translateY: number}`, `{skewX: string}`, `{skewY: string}` or string | No       |
@@ -203,7 +268,9 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](transforms#transform) prop instead.
+:::warning Deprecated
+Use the [`transform`](transforms#transform) prop instead.
+:::
 
 ## Transform Origin
 
@@ -211,14 +278,9 @@ The `transformOrigin` property sets the origin for a view's transformations. The
 
 # Example
 
-```SnackPlayer name=TransformOrigin%20Example&supportedPlatforms=ios,android
+```SnackPlayer name=TransformOrigin%20Example
 import React, {useEffect, useRef} from 'react';
-import {
-  Animated,
-  View,
-  StyleSheet,
-  Easing,
-} from 'react-native';
+import {Animated, View, StyleSheet, Easing} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {

--- a/website/versioned_docs/version-0.80/transforms.md
+++ b/website/versioned_docs/version-0.80/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -195,6 +209,57 @@ The skew transformations require a string so that the transform may be expressed
 }
 ```
 
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
+
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | array of objects: `{matrix: number[]}`, `{perspective: number}`, `{rotate: string}`, `{rotateX: string}`, `{rotateY: string}`, `{rotateZ: string}`, `{scale: number}`, `{scaleX: number}`, `{scaleY: number}`, `{translateX: number}`, `{translateY: number}`, `{skewX: string}`, `{skewY: string}` or string | No       |
@@ -203,7 +268,9 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](transforms#transform) prop instead.
+:::warning Deprecated
+Use the [`transform`](transforms#transform) prop instead.
+:::
 
 ## Transform Origin
 
@@ -211,14 +278,9 @@ The `transformOrigin` property sets the origin for a view's transformations. The
 
 # Example
 
-```SnackPlayer name=TransformOrigin%20Example&supportedPlatforms=ios,android
+```SnackPlayer name=TransformOrigin%20Example
 import React, {useEffect, useRef} from 'react';
-import {
-  Animated,
-  View,
-  StyleSheet,
-  Easing,
-} from 'react-native';
+import {Animated, View, StyleSheet, Easing} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {

--- a/website/versioned_docs/version-0.81/transforms.md
+++ b/website/versioned_docs/version-0.81/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -195,6 +209,57 @@ The skew transformations require a string so that the transform may be expressed
 }
 ```
 
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
+
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | array of objects: `{matrix: number[]}`, `{perspective: number}`, `{rotate: string}`, `{rotateX: string}`, `{rotateY: string}`, `{rotateZ: string}`, `{scale: number}`, `{scaleX: number}`, `{scaleY: number}`, `{translateX: number}`, `{translateY: number}`, `{skewX: string}`, `{skewY: string}` or string | No       |
@@ -203,7 +268,9 @@ The skew transformations require a string so that the transform may be expressed
 
 ### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-> **Deprecated.** Use the [`transform`](transforms#transform) prop instead.
+:::warning Deprecated
+Use the [`transform`](transforms#transform) prop instead.
+:::
 
 ## Transform Origin
 
@@ -213,12 +280,7 @@ The `transformOrigin` property sets the origin for a view's transformations. The
 
 ```SnackPlayer name=TransformOrigin%20Example
 import React, {useEffect, useRef} from 'react';
-import {
-  Animated,
-  View,
-  StyleSheet,
-  Easing,
-} from 'react-native';
+import {Animated, View, StyleSheet, Easing} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {

--- a/website/versioned_docs/version-0.82/transforms.md
+++ b/website/versioned_docs/version-0.82/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -194,6 +208,57 @@ The skew transformations require a string so that the transform may be expressed
   transform: [{skewX: '45deg'}],
 }
 ```
+
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
 
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |

--- a/website/versioned_docs/version-0.83/transforms.md
+++ b/website/versioned_docs/version-0.83/transforms.md
@@ -129,6 +129,20 @@ const App = () => (
           ]}>
           <Text style={styles.text}>TranslateY by 50 </Text>
         </View>
+
+        <View
+          style={[
+            styles.box,
+            {
+              transform: [
+                {
+                  matrix: [1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+              ],
+            },
+          ]}>
+          <Text style={styles.text}>Matrix Transform</Text>
+        </View>
       </ScrollView>
     </SafeAreaView>
   </SafeAreaProvider>
@@ -194,6 +208,57 @@ The skew transformations require a string so that the transform may be expressed
   transform: [{skewX: '45deg'}],
 }
 ```
+
+### Matrix Transform
+
+The `matrix` transform accepts a 4x4 transformation matrix as an array of 16 numbers. This allows you to apply complex transformations that combine translation, rotation, scaling, and skewing in a single operation.
+
+The matrix is specified in column-major order:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        scaleX,
+        skewY,
+        0,
+        0,
+        skewX,
+        scaleY,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        translateX,
+        translateY,
+        0,
+        1,
+      ],
+    },
+  ];
+}
+```
+
+For example, to apply a combination of scale and skew:
+
+```js
+{
+  transform: [
+    {
+      matrix: [
+        1, 0.5, 0, 0, 0.5, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+      ],
+    },
+  ];
+}
+```
+
+:::note
+Matrix transforms are useful when you need to apply pre-calculated transformation matrices, such as those from animation libraries or when building UI editor applications. For basic transformations, it's recommended to use the individual transform properties (scale, rotate, translate, etc.) as they are more readable.
+:::
 
 | Type                                                                                                                                                                                                                                                                                                          | Required |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |


### PR DESCRIPTION
## Summary
Fixes #1899

This PR adds comprehensive documentation for the `matrix` transform property, which was previously undocumented despite being supported in React Native since the deprecation of `transformMatrix`.

## Changes
- ✅ Added matrix transform example in the interactive demo
- ✅ Documented the 4x4 matrix structure in column-major order
- ✅ Provided practical code examples
- ✅ Added guidance on when to use matrix vs individual transforms
- ✅ Clarified use cases (UI editors, pre-calculated transforms)

## Context
The `matrix` transform property has been supported but undocumented, causing confusion for developers who need to work with transformation matrices (especially in UI editor applications). This PR addresses that gap.

## Test Plan
- Verified documentation renders correctly
- Confirmed matrix example displays properly in the interactive demo
- Tested that the matrix syntax is accurate
