### PR TITLE
[docs] Add API docs for PerformanceResourceTiming

### DIFF
--- a/docs/global-PerformanceObserver.md
+++ b/docs/global-PerformanceObserver.md
@@ -45,7 +45,7 @@ See [documentation in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Perf
 
 See [documentation in MDN](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/supportedEntryTypes).
 
-Returns `['mark', 'measure', 'event', 'longtask']`.
+Returns `['mark', 'measure', 'event', 'longtask', 'resource']`.
 
 ## Instance methods
 

--- a/docs/global-PerformanceResourceTiming.md
+++ b/docs/global-PerformanceResourceTiming.md
@@ -1,0 +1,23 @@
+---
+id: global-PerformanceResourceTiming
+title: PerformanceResourceTiming
+---
+
+The global [`PerformanceResourceTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) class, as defined in Web specifications.
+
+:::warning Partial support
+
+React Native implements the following `PerformanceResourceTiming` properties only:
+
+- `fetchStart`
+- `requestStart`
+- `connectStart`
+- `connectEnd`
+- `responseStart`
+- `responseEnd`
+- `responseStatus`
+- `contentType`
+- `encodedBodySize`
+- `decodedBodySize`
+
+:::

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -258,6 +258,7 @@ export default {
           'global-PerformanceMeasure',
           'global-PerformanceObserver',
           'global-PerformanceObserverEntryList',
+          'global-PerformanceResourceTiming',
           'global-process',
           'global-queueMicrotask',
           'global-Request',

--- a/website/versioned_docs/version-0.83/global-PerformanceResourceTiming.md
+++ b/website/versioned_docs/version-0.83/global-PerformanceResourceTiming.md
@@ -1,0 +1,23 @@
+---
+id: global-PerformanceResourceTiming
+title: PerformanceResourceTiming
+---
+
+The global [`PerformanceResourceTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) class, as defined in Web specifications.
+
+:::warning Partial support
+
+React Native implements the following `PerformanceResourceTiming` properties only:
+
+- `fetchStart`
+- `requestStart`
+- `connectStart`
+- `connectEnd`
+- `responseStart`
+- `responseEnd`
+- `responseStatus`
+- `contentType`
+- `encodedBodySize`
+- `decodedBodySize`
+
+:::

--- a/website/versioned_sidebars/version-0.83-sidebars.json
+++ b/website/versioned_sidebars/version-0.83-sidebars.json
@@ -267,6 +267,7 @@
           "global-PerformanceMeasure",
           "global-PerformanceObserver",
           "global-PerformanceObserverEntryList",
+          "global-PerformanceResourceTiming",
           "global-process",
           "global-queueMicrotask",
           "global-Request",


### PR DESCRIPTION
Covers new `'resource'` support in `PerformanceObserver` from 0.83 onwards.