### PR TITLE
Enhance visibility of toc active link style with underline

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1493,6 +1493,7 @@ div[class^="tableOfContents"] {
 
     &:hover {
       color: var(--home-button-primary) !important;
+      text-decoration: underline;
 
       code {
         color: var(--home-button-primary) !important;


### PR DESCRIPTION
Improve the visual style of the table of contents links by adding an underline to active links for better user experience.

before

https://github.com/user-attachments/assets/534721df-4b02-453d-8819-5f3fe24df713

after


https://github.com/user-attachments/assets/85f95f8a-bf44-455e-b3a5-476b2c04f99e



