### PR TITLE
chore: change AppSpecs to NativeLocalStorageSpec

### DIFF
--- a/docs/turbo-native-modules-ios.md
+++ b/docs/turbo-native-modules-ios.md
@@ -132,7 +132,7 @@ Modify the `package.json` as it follows:
      "test": "jest"
    },
    "codegenConfig": {
-     "name": "AppSpecs",
+     "name": "NativeLocalStorageSpec",
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {

--- a/website/versioned_docs/version-0.79/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.79/turbo-native-modules-ios.md
@@ -132,7 +132,7 @@ Modify the `package.json` as it follows:
      "test": "jest"
    },
    "codegenConfig": {
-     "name": "AppSpecs",
+     "name": "NativeLocalStorageSpec",
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {

--- a/website/versioned_docs/version-0.80/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.80/turbo-native-modules-ios.md
@@ -132,7 +132,7 @@ Modify the `package.json` as it follows:
      "test": "jest"
    },
    "codegenConfig": {
-     "name": "AppSpecs",
+     "name": "NativeLocalStorageSpec",
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {

--- a/website/versioned_docs/version-0.81/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.81/turbo-native-modules-ios.md
@@ -132,7 +132,7 @@ Modify the `package.json` as it follows:
      "test": "jest"
    },
    "codegenConfig": {
-     "name": "AppSpecs",
+     "name": "NativeLocalStorageSpec",
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {

--- a/website/versioned_docs/version-0.82/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.82/turbo-native-modules-ios.md
@@ -132,7 +132,7 @@ Modify the `package.json` as it follows:
      "test": "jest"
    },
    "codegenConfig": {
-     "name": "AppSpecs",
+     "name": "NativeLocalStorageSpec",
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {

--- a/website/versioned_docs/version-0.83/turbo-native-modules-ios.md
+++ b/website/versioned_docs/version-0.83/turbo-native-modules-ios.md
@@ -132,7 +132,7 @@ Modify the `package.json` as it follows:
      "test": "jest"
    },
    "codegenConfig": {
-     "name": "AppSpecs",
+     "name": "NativeLocalStorageSpec",
      "type": "modules",
      "jsSrcsDir": "specs",
      "android": {


### PR DESCRIPTION
Fix the content in the [Native Modules](https://reactnative.dev/docs/next/turbo-native-modules-introduction?platforms=ios) by changing `AppSpecs` to `NativeLocalStorageSpec`
