### PR TITLE
Add missing background to collapsible menu items

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1268,12 +1268,12 @@ aside[class^="theme-doc-sidebar-container"] {
 
   .menu__list-item-collapsible {
     border-radius: var(--ifm-global-radius);
-    
+
     // Disable background color on hover for collapsible items with direct child anchor without href
     &:has(> a:not([href])):hover {
       background-color: transparent;
     }
-    
+
     .menu__caret {
       padding: 0 6px;
 


### PR DESCRIPTION
Add a hover bg style to the collapsible menu items.

<img width="259" height="224" alt="image" src="https://github.com/user-attachments/assets/08243ba3-e1ff-41a9-a851-26ee4c81e9c1" />
