### PR TITLE
rename deprecated meta tag, fix PWA assets paths

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -282,7 +282,7 @@ const config: Config = {
           },
           {
             tagName: 'meta',
-            name: 'apple-mobile-web-app-capable',
+            name: 'mobile-web-app-capable',
             content: 'yes',
           },
           {
@@ -599,7 +599,7 @@ const config: Config = {
         content: 'https://reactnative.dev/img/logo-share.png',
       },
       {name: 'twitter:site', content: '@reactnative'},
-      {name: 'apple-mobile-web-app-capable', content: 'yes'},
+      {name: 'mobile-web-app-capable', content: 'yes'},
     ],
   } satisfies Preset.ThemeConfig,
 };

--- a/website/static/manifest.json
+++ b/website/static/manifest.json
@@ -43,25 +43,25 @@
   ],
   "icons": [
     {
-      "src": "static/img/pwa/manifest-icon-192.png",
+      "src": "img/pwa/manifest-icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "static/img/pwa/manifest-icon-192.maskable.png",
+      "src": "img/pwa/manifest-icon-192.maskable.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "static/img/pwa/manifest-icon-512.png",
+      "src": "img/pwa/manifest-icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "static/img/pwa/manifest-icon-512.maskable.png",
+      "src": "img/pwa/manifest-icon-512.maskable.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
# Why

There are few warning popping out in the browser console, when visiting the docs homepage.

<img width="1540" height="152" alt="Screenshot 2026-01-05 171028" src="https://github.com/user-attachments/assets/cbc9b1f0-4180-4675-9829-c3bbda868c7c" />

# How

Rename `apple-mobile-web-app-capable` meta tag as advised, correct few asset path in PWA manifest.

# Preview

Warnings are resolved in PR preview deployment:
* https://deploy-preview-4951--react-native.netlify.app/

PWA app uses the correct icon asset after the changes:
<img width="728" height="310" alt="Screenshot 2026-01-05 171647" src="https://github.com/user-attachments/assets/27379f02-3ca8-4933-a51d-de367ec763a1" />
<img width="192" height="199" alt="Screenshot 2026-01-05 171715" src="https://github.com/user-attachments/assets/1e3cdfb7-913a-4b99-80b2-2a73b38002b0" />
