### PR TITLE
add missing deprecation markings for few pages and headers

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -234,7 +234,7 @@ Query whether reduce motion and prefer cross-fade transitions settings are curre
 
 ---
 
-### `setAccessibilityFocus()`
+### 🗑️ `setAccessibilityFocus()`
 
 :::warning Deprecated
 Prefer using `sendAccessibilityEvent` with eventType `focus` instead.

--- a/docs/building-for-tv.md
+++ b/docs/building-for-tv.md
@@ -1,6 +1,6 @@
 ---
 id: building-for-tv
-title: Building For TV Devices
+title: 🗑️ Building For TV Devices
 hide_table_of_contents: true
 ---
 

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -104,7 +104,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### `animated`
+### 🗑️ `animated`
 
 :::warning Deprecated
 Use the [`animationType`](modal.md#animationtype) prop instead.

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -236,7 +236,7 @@ If `true`, focuses the input. The default value is `false`.
 
 ---
 
-### `blurOnSubmit`
+### 🗑️ `blurOnSubmit`
 
 :::warning Deprecated
 Note that `submitBehavior` now takes the place of `blurOnSubmit` and will override any behavior defined by `blurOnSubmit`. See [submitBehavior](textinput#submitbehavior).

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -266,7 +266,7 @@ Matrix transforms are useful when you need to apply pre-calculated transformatio
 
 ---
 
-### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
+### 🗑️ `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
 :::warning Deprecated
 Use the [`transform`](transforms#transform) prop instead.

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -298,7 +298,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 ---
 
-### `disableVirtualization`
+### 🗑️ `disableVirtualization`
 
 :::warning Deprecated
 Virtualization provides significant performance and memory optimizations, but fully unmounts react instances that are outside of the render window. You should only need to disable this for debugging purposes.

--- a/website/versioned_docs/version-0.83/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.83/accessibilityinfo.md
@@ -234,7 +234,7 @@ Query whether reduce motion and prefer cross-fade transitions settings are curre
 
 ---
 
-### `setAccessibilityFocus()`
+### 🗑️ `setAccessibilityFocus()`
 
 :::warning Deprecated
 Prefer using `sendAccessibilityEvent` with eventType `focus` instead.

--- a/website/versioned_docs/version-0.83/building-for-tv.md
+++ b/website/versioned_docs/version-0.83/building-for-tv.md
@@ -1,6 +1,6 @@
 ---
 id: building-for-tv
-title: Building For TV Devices
+title: 🗑️ Building For TV Devices
 hide_table_of_contents: true
 ---
 

--- a/website/versioned_docs/version-0.83/modal.md
+++ b/website/versioned_docs/version-0.83/modal.md
@@ -104,7 +104,7 @@ Inherits [View Props](view.md#props).
 
 ---
 
-### `animated`
+### 🗑️ `animated`
 
 :::warning Deprecated
 Use the [`animationType`](modal.md#animationtype) prop instead.

--- a/website/versioned_docs/version-0.83/textinput.md
+++ b/website/versioned_docs/version-0.83/textinput.md
@@ -236,7 +236,7 @@ If `true`, focuses the input. The default value is `false`.
 
 ---
 
-### `blurOnSubmit`
+### 🗑️ `blurOnSubmit`
 
 :::warning Deprecated
 Note that `submitBehavior` now takes the place of `blurOnSubmit` and will override any behavior defined by `blurOnSubmit`. See [submitBehavior](textinput#submitbehavior).

--- a/website/versioned_docs/version-0.83/transforms.md
+++ b/website/versioned_docs/version-0.83/transforms.md
@@ -266,7 +266,7 @@ Matrix transforms are useful when you need to apply pre-calculated transformatio
 
 ---
 
-### `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
+### 🗑️ `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
 :::warning Deprecated
 Use the [`transform`](transforms#transform) prop instead.

--- a/website/versioned_docs/version-0.83/virtualizedlist.md
+++ b/website/versioned_docs/version-0.83/virtualizedlist.md
@@ -298,7 +298,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 ---
 
-### `disableVirtualization`
+### 🗑️ `disableVirtualization`
 
 :::warning Deprecated
 Virtualization provides significant performance and memory optimizations, but fully unmounts react instances that are outside of the render window. You should only need to disable this for debugging purposes.


### PR DESCRIPTION
# Why

While verifying if `setAccessibilityFocus` has the deprecation note on the website side already, I have spotted that some headers and pages miss the 🗑 emoji, which we started recently to use, to indicate the deprecated parts.

# How

Add 🗑 emoji to few headers and pages, backport changes to 0.83 docs.

# Preview

<img width="2242" height="1446" alt="Screenshot 2026-01-06 094613" src="https://github.com/user-attachments/assets/679fd841-8851-42dc-a03b-5f320cb8d28d" />
