### PR TITLE
Add 'xml' format support for Android images

### DIFF
--- a/website/versioned_docs/version-0.83/image.md
+++ b/website/versioned_docs/version-0.83/image.md
@@ -402,7 +402,7 @@ The image source (either a remote URL or a local file resource).
 
 This prop can also contain several remote URLs, specified together with their width and height and potentially with scale/other URI arguments. The native side will then choose the best `uri` to display based on the measured size of the image container. A `cache` property can be added to control how networked request interacts with the local cache. (For more information see [Cache Control for Images](images#cache-control)).
 
-The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, `psd` (iOS only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
+The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, `psd` (iOS only), `xml` (Android only). In addition, iOS supports several RAW image formats. Refer to Apple's documentation for the current list of supported camera models (for iOS 12, see https://support.apple.com/en-ca/HT208967).
 
 Please note that the `webp` format is supported on iOS **only** when bundled with the JavaScript code.
 


### PR DESCRIPTION
In 0.78 xml was added for Android as a supported image extension type.

See: https://reactnative.dev/blog/2025/02/19/react-native-0.78#added-support-for-android-xml-drawables

Haven't been able to find an xml mention from 0.78 docs onwards - https://reactnative.dev/docs/0.78/image

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
