### PR TITLE
Fix Accessibility Contrast Issue for Learn more Buttons

### DIFF
--- a/website/src/css/showcase.scss
+++ b/website/src/css/showcase.scss
@@ -174,7 +174,7 @@ html[data-theme="dark"] {
   }
 
   .articleButton {
-    color: var(--ifm-color-emphasis-800);
+    color: var(--ifm-color-emphasis-700);
     font-weight: 500;
     font-size: 15px;
     padding: 6px 12px;


### PR DESCRIPTION
### Issue Description

This PR fixes an accessibility violation reported by automated a11y checks.
When running [IBM Accessibility Checker](https://github.com/IBMa/equal-access) (Version 4.0.9) on the [showcase page](https://reactnative.dev/showcase), I find some accessibility violations as below.

<img width="2560" height="918" alt="image" src="https://github.com/user-attachments/assets/bcbaee1e-099f-430e-960e-78b2b1f2eb54" />

The "Learn more" buttons in the showcase section have insufficient color contrast, failing to meet WCAG AA accessibility requirements. As shown in the accessibility checker:

```
Current contrast ratio: 3.06:1
Required contrast ratio: 4.5:1 (WCAG AA standard for text size 15px and weight 500)
```

This affects users with low vision or color blindness who rely on adequate contrast to read text content.

### Fix Description

Updated the button text color from `--ifm-color-emphasis-600` to `--ifm-color-emphasis-800` in `website/src/css/showcase.scss`.
This change increases the contrast ratio to meet WCAG AA requirements while maintaining the design's visual hierarchy.

Generated Patch of A11YRepair:
```
diff --git a/website/src/css/showcase.scss b/website/src/css/showcase.scss
index 49f15912..2999191a 100644
--- a/website/src/css/showcase.scss
+++ b/website/src/css/showcase.scss
@@ -174,7 +174,7 @@ html[data-theme="dark"] {
   }
 
   .articleButton {
-    color: var(--ifm-color-emphasis-600);
+    color: var(--ifm-color-emphasis-800);
     font-weight: 500;
     font-size: 15px;
     padding: 6px 12px;
```

Note: The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission, which ensures proper contrast in both light mode and dark mode, providing consistent accessibility across all theme variations.

**Fix Before:**
<img width="258" height="267" alt="image" src="https://github.com/user-attachments/assets/7717e6c3-67bb-42a1-9dc8-b4049cf3fada" />

**Fix After:**
<img width="267" height="267" alt="image" src="https://github.com/user-attachments/assets/38d57830-86a8-4964-9d10-2e1caae33b3b" />

