### PR TITLE
add keynote videos, highlight the latest one via announcement bar

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -407,6 +407,14 @@ const config: Config = {
         },
       ],
     },
+    announcementBar: {
+      id: 'watch_keynote',
+      content:
+        'Re-watch the latest <a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/watch?v=NiYwlvXsBKw">React Native Keynote</a> from React Conf 2025',
+      backgroundColor: '#20232a',
+      textColor: '#fff',
+      isCloseable: false,
+    },
     navbar: {
       title: 'React Native',
       logo: {

--- a/website/src/components/Home/Watch/index.tsx
+++ b/website/src/components/Home/Watch/index.tsx
@@ -12,6 +12,13 @@ import SectionTitle from '../SectionTitle';
 
 import styles from './styles.module.css';
 
+enum VideoId {
+  Why = 'wUDeLT6WXnQ',
+  Keynote2025 = 'NiYwlvXsBKw',
+  Keynote2024 = 'Q5SMmKb7qVI',
+  FB2019 = 'NCAY0HIfrwc',
+}
+
 function Watch() {
   const [playingId, setPlayingId] = useState<string | null>(null);
 
@@ -38,47 +45,17 @@ function Watch() {
       <div className={styles.videos}>
         <div
           role="button"
-          aria-label="Play: FB 2019: Mobile innovation with React Native"
-          className={[
-            styles.videoContainer,
-            playingId === 'fb2019'
-              ? styles.videoContainerPlaying
-              : styles.videoContainerHover,
-          ].join(' ')}
-          onClick={() => setPlayingId('fb2019')}>
-          {playingId === 'fb2019' ? (
-            <iframe
-              src="https://www.youtube.com/embed/NCAY0HIfrwc?autoplay=1"
-              title="Mobile Innovation with React Native, ComponentKit, and Litho"
-              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
-              className={styles.video}
-            />
-          ) : (
-            <img
-              src="https://img.youtube.com/vi/NCAY0HIfrwc/maxresdefault.jpg"
-              alt="Mobile Innovation with React Native, ComponentKit, and Litho"
-              className={styles.video}
-            />
-          )}
-          <div className={styles.videoInfo}>
-            <h4>FB 2019: Mobile innovation with React Native</h4>
-            <p>45:29</p>
-          </div>
-        </div>
-        <div
-          role="button"
           aria-label="Play: Why React Native?"
           className={[
             styles.videoContainer,
-            playingId === 'why'
+            playingId === VideoId.Why
               ? styles.videoContainerPlaying
               : styles.videoContainerHover,
           ].join(' ')}
-          onClick={() => setPlayingId('why')}>
-          {playingId === 'why' ? (
+          onClick={() => setPlayingId(VideoId.Why)}>
+          {playingId === VideoId.Why ? (
             <iframe
-              src="https://www.youtube.com/embed/wUDeLT6WXnQ?autoplay=1"
+              src={`https://www.youtube.com/embed/${VideoId.Why}?autoplay=1`}
               title="Explain Like I'm 5: React Native"
               allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
@@ -86,7 +63,7 @@ function Watch() {
             />
           ) : (
             <img
-              src="https://img.youtube.com/vi/wUDeLT6WXnQ/maxresdefault.jpg"
+              src={`https://img.youtube.com/vi/${VideoId.Why}/maxresdefault.jpg`}
               alt="Explain Like I'm 5: React Native"
               className={styles.video}
             />
@@ -94,6 +71,108 @@ function Watch() {
           <div className={styles.videoInfo}>
             <h4>Why React Native?</h4>
             <p>1:42</p>
+          </div>
+        </div>
+        <div
+          role="button"
+          aria-label="Play: React Conf 2025 React Native Keynote"
+          className={[
+            styles.videoContainer,
+            playingId === VideoId.Keynote2025
+              ? styles.videoContainerPlaying
+              : styles.videoContainerHover,
+          ].join(' ')}
+          onClick={() => setPlayingId(VideoId.Keynote2025)}>
+          {playingId === VideoId.Keynote2025 ? (
+            <iframe
+              src={`https://www.youtube.com/embed/${VideoId.Keynote2025}?autoplay=1`}
+              title="React Conf 2025 React Native Keynote"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className={styles.video}
+            />
+          ) : (
+            <img
+              src={`https://img.youtube.com/vi/${VideoId.Keynote2025}/maxresdefault.jpg`}
+              alt="React Conf 2025 React Native Keynote"
+              className={styles.video}
+            />
+          )}
+          <div className={styles.videoInfo}>
+            <h4>
+              React Conf 2025
+              <br />
+              React Native Keynote
+            </h4>
+            <p>55:13</p>
+          </div>
+        </div>
+        <div
+          role="button"
+          aria-label="Play: React Conf 2024 React Native Keynote"
+          className={[
+            styles.videoContainer,
+            playingId === VideoId.Keynote2024
+              ? styles.videoContainerPlaying
+              : styles.videoContainerHover,
+          ].join(' ')}
+          onClick={() => setPlayingId(VideoId.Keynote2024)}>
+          {playingId === VideoId.Keynote2024 ? (
+            <iframe
+              src={`https://www.youtube.com/embed/${VideoId.Keynote2024}?autoplay=1`}
+              title="React Conf 2024 React Native Keynote"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className={styles.video}
+            />
+          ) : (
+            <img
+              src={`https://img.youtube.com/vi/${VideoId.Keynote2024}/maxresdefault.jpg`}
+              alt="React Conf 2024 React Native Keynote"
+              className={styles.video}
+            />
+          )}
+          <div className={styles.videoInfo}>
+            <h4>
+              React Conf 2024
+              <br />
+              React Native Keynote
+            </h4>
+            <p>55:14</p>
+          </div>
+        </div>
+        <div
+          role="button"
+          aria-label="Play: FB 2019: Mobile innovation with React Native"
+          className={[
+            styles.videoContainer,
+            playingId === VideoId.FB2019
+              ? styles.videoContainerPlaying
+              : styles.videoContainerHover,
+          ].join(' ')}
+          onClick={() => setPlayingId(VideoId.FB2019)}>
+          {playingId === VideoId.FB2019 ? (
+            <iframe
+              src={`https://www.youtube.com/embed/${VideoId.FB2019}?autoplay=1`}
+              title="Mobile Innovation with React Native, ComponentKit, and Litho"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className={styles.video}
+            />
+          ) : (
+            <img
+              src={`https://img.youtube.com/vi/${VideoId.FB2019}/maxresdefault.jpg`}
+              alt="Mobile Innovation with React Native, ComponentKit, and Litho"
+              className={styles.video}
+            />
+          )}
+          <div className={styles.videoInfo}>
+            <h4>
+              FB 2019
+              <br />
+              Mobile innovation with React Native
+            </h4>
+            <p>45:29</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Why

We want to promote a bit more latest content form the official React conference.

# How

Add 2025 and 2024 keynote videos to the Watch section on the Home page, also highlight the latest one via announcement bar.

# Preview

<img width="1682" height="1424" alt="Screenshot 2026-01-08 173404" src="https://github.com/user-attachments/assets/d0f9a0a7-b8b1-4c95-a340-cf32f40afde0" />

<img width="2425" height="790" alt="Screenshot 2026-01-08 174217" src="https://github.com/user-attachments/assets/1fbe26f2-9601-46d4-a67b-3f85068fd67f" />
