### PR TITLE
StatusBar: mention network indicator method deprecation

### DIFF
--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -1504,6 +1504,7 @@ div[class^="tableOfContents"] {
     color: var(--home-button-primary) !important;
 
     code {
+      word-break: break-all;
       font-weight: 700;
       color: var(--home-button-primary) !important;
     }

--- a/website/versioned_docs/version-0.77/statusbar.md
+++ b/website/versioned_docs/version-0.77/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/versioned_docs/version-0.78/statusbar.md
+++ b/website/versioned_docs/version-0.78/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/versioned_docs/version-0.79/statusbar.md
+++ b/website/versioned_docs/version-0.79/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/versioned_docs/version-0.80/statusbar.md
+++ b/website/versioned_docs/version-0.80/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/versioned_docs/version-0.81/statusbar.md
+++ b/website/versioned_docs/version-0.81/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/versioned_docs/version-0.82/statusbar.md
+++ b/website/versioned_docs/version-0.82/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);

--- a/website/versioned_docs/version-0.83/statusbar.md
+++ b/website/versioned_docs/version-0.83/statusbar.md
@@ -438,7 +438,11 @@ Show or hide the status bar.
 
 ---
 
-### `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
+
+:::warning Deprecated
+The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
+:::
 
 ```tsx
 static setNetworkActivityIndicatorVisible(visible: boolean);


### PR DESCRIPTION
# Why

When looking through the core repository code I have spotted that we miss deprecation note for StatusBar `setNetworkActivityIndicatorVisible()` method, which has been introduced in 0.76 release, ref:
* https://github.com/facebook/react-native/commit/8a390ba9b8c1b8889dd0933fe1477083a24ff71d

Also refs:
* #4913

# How

Add depreciation note to the `setNetworkActivityIndicatorVisible()` entry and backport it to all currently existing versioned docs.

I have also made a CSS tweak to make sure that an additional emoji in header does not cause wrapping issues in API Table of Content.

# Preview

<img width="2866" height="1420" alt="Screenshot 2026-01-09 at 16 31 38" src="https://github.com/user-attachments/assets/25c2efa3-b028-4252-a602-4a2ae8ec13a8" />
