### PR TITLE
backport native modules note addition to versioned docs

### DIFF
--- a/website/versioned_docs/version-0.78/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.78/turbo-native-modules.md
@@ -45,6 +45,10 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/appendix.md) documentation.
 :::
 
+:::info
+If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. `NativeStorage` or `NativeUsersDefault`).
+:::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>

--- a/website/versioned_docs/version-0.79/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.79/turbo-native-modules.md
@@ -45,6 +45,10 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/appendix.md) documentation.
 :::
 
+:::info
+If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. `NativeStorage` or `NativeUsersDefault`).
+:::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>

--- a/website/versioned_docs/version-0.80/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.80/turbo-native-modules.md
@@ -45,6 +45,10 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/appendix.md) documentation.
 :::
 
+:::info
+If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. `NativeStorage` or `NativeUsersDefault`).
+:::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>

--- a/website/versioned_docs/version-0.81/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.81/turbo-native-modules.md
@@ -49,6 +49,10 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/appendix.md) documentation.
 :::
 
+:::info
+If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. `NativeStorage` or `NativeUsersDefault`).
+:::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>

--- a/website/versioned_docs/version-0.82/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.82/turbo-native-modules.md
@@ -49,6 +49,10 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/docs/appendix) documentation.
 :::
 
+:::info
+If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. `NativeStorage` or `NativeUsersDefault`).
+:::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>

--- a/website/versioned_docs/version-0.83/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.83/turbo-native-modules.md
@@ -49,6 +49,10 @@ To create a specs file:
 You can see all of the types you can use in your specification and the native types that are generated in the [Appendix](/docs/appendix) documentation.
 :::
 
+:::info
+If you want to change the name of your module and the related specs file, make sure to always use 'Native' as prefix (e.g. `NativeStorage` or `NativeUsersDefault`).
+:::
+
 Here is an implementation of the `localStorage` specification:
 
 <Tabs groupId="language" queryString defaultValue={constants.defaultJavaScriptSpecLanguage} values={constants.javaScriptSpecLanguages}>


### PR DESCRIPTION
# Why

Follow up to:
* #4465

# How

Port the added native modules note to versioned docs for 0.78 to 0.83.
