### PR TITLE
run all packages/plugins checks from the workspace

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -36,18 +36,6 @@ jobs:
       - name: Run plugins lint
         run: yarn lint:plugins
 
-      - name: Run remark-codeblock-language-as-title plugin checks
-        working-directory: plugins/remark-codeblock-language-as-title
-        run: yarn tsc
-
-      - name: Run remark-lint-no-dead-urls plugin checks
-        working-directory: plugins/remark-lint-no-dead-urls
-        run: yarn tsc && yarn test
-
-      - name: Run remark-snackplayer plugin checks
-        working-directory: plugins/remark-snackplayer
-        run: yarn tsc && yarn test
-
   lint-website:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "serve": "yarn --cwd website serve",
     "prepare": "husky",
     "lint": "eslint .",
-    "lint:packages": "eslint ./packages",
-    "lint:plugins": "eslint ./plugins",
+    "lint:packages": "yarn workspaces foreach --from \"packages/*\" -p -R run lint",
+    "lint:plugins": "yarn workspaces foreach --from \"plugins/*\" -p -R run lint && yarn workspaces foreach --from \"plugins/*\" -p -R run test",
     "lint:website": "eslint ./website ./docs",
     "update-lock": "yarn dedupe",
     "check-dependencies": "manypkg check"


### PR DESCRIPTION
# Why

Suggested by previous PR by Nico, ref:
* https://github.com/facebook/react-native-website/pull/4962#discussion_r2685774157

# How

An attempt to simplify checks workflow and introduce one root level script to run them.
