### PR TITLE
fix dead URLs plugin, correct some broken links

### DIFF
--- a/docs/animations.md
+++ b/docs/animations.md
@@ -549,7 +549,7 @@ The native driver also works with `Animated.event`. This is especially useful fo
 </Animated.ScrollView>
 ```
 
-You can see the native driver in action by running the [RNTester app](https://github.com/facebook/react-native/blob/main/packages/rn-tester/), then loading the Native Animated Example. You can also take a look at the [source code](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js) to learn how these examples were produced.
+You can see the native driver in action by running the [RNTester app](https://github.com/facebook/react-native/blob/main/packages/rn-tester/), then loading the Native Animated Example. You can also take a look at the [source code](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js) to learn how these examples were produced.
 
 #### Caveats
 

--- a/docs/build-speed.md
+++ b/docs/build-speed.md
@@ -120,7 +120,7 @@ Ccache works by wrapping the C++ compilers, storing the compilation results, and
 if an intermediate compilation result was originally stored.
 
 Ccache is available in the package manager for most operating systems. On macOS, we can install ccache with `brew install ccache`.
-Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md) to install from source.
+Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/install.md) to install from source.
 
 You can then do two clean builds (e.g. on Android you can first run `yarn react-native run-android`, delete the `android/app/build` folder and run the first command once more). You will notice that the second build was way faster than the first one (it should take seconds rather than minutes).
 While building, you can verify that `ccache` works correctly and check the cache hits/miss rate `ccache -s`

--- a/docs/debugging-release-builds.md
+++ b/docs/debugging-release-builds.md
@@ -20,7 +20,7 @@ If a React Native app throws an unhandled exception in a release build, the outp
 
 In the above stack trace, entries like `p@1:132161` are minified function names and bytecode offsets. To debug these calls, we want to translate these into file, line, and function name, e.g. `AwesomeProject/App.js:54:initializeMap`. This is known as **symbolication.**
 
-You can symbolicate minified function names and bytecode like the above by passing the stack trace and a generated source map to [`metro-symbolicate`](http://npmjs.com/package/metro-symbolicate).
+You can symbolicate minified function names and bytecode like the above by passing the stack trace and a generated source map to [`metro-symbolicate`](https://www.npmjs.com/package/metro-symbolicate).
 
 ### Enabling source maps
 

--- a/docs/element-nodes.md
+++ b/docs/element-nodes.md
@@ -84,9 +84,9 @@ From [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element):
     - ℹ️ Returns the value of the `id` or `nativeID` props.
   - [`lastElementChild`](https://developer.mozilla.org/en-US/docs/Web/API/Element/lastElementChild)
   - [`nextElementSibling`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nextElementSibling)
-  - [`nodeName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nodeName)
-  - [`nodeType`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nodeType)
-  - [`nodeValue`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nodeValue)
+  - [`nodeName`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName)
+  - [`nodeType`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
+  - [`nodeValue`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue)
   - [`previousElementSibling`](https://developer.mozilla.org/en-US/docs/Web/API/Element/previousElementSibling)
   - [`scrollHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)
   - [`scrollLeft`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
@@ -96,7 +96,7 @@ From [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element):
   - [`scrollWidth`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth)
   - [`tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName)
     - ℹ️ Returns a normalized native component name prefixed with `RN:`, like `RN:View`.
-  - [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Element/textContent)
+  - [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
 - Methods
   - [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
   - [`hasPointerCapture()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture)

--- a/docs/images.md
+++ b/docs/images.md
@@ -67,7 +67,7 @@ Note that image sources required this way include size (width, height) info for 
 
 ## Static Non-Image Resources
 
-The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [bundler defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
+The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html`, `.pdf` and more. See [bundler defaults](https://github.com/facebook/metro/blob/main/packages/metro-config/src/defaults/defaults.js#L16-L51) for the full list.
 
 You can add support for other types by adding an [`assetExts` resolver option](https://metrobundler.dev/docs/configuration#resolver-options) in your [Metro configuration](https://metrobundler.dev/docs/configuration).
 

--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -245,7 +245,7 @@ Snapshots have several weak points:
 
 Snapshots themselves do not ensure that your component render logic is correct, they are merely good at guarding against unexpected changes and for checking that the components in the React tree under test receive the expected props (styles and etc.).
 
-We recommend that you only use small snapshots (see [`no-large-snapshots` rule](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md)). If you want to test a _change_ between two React component states, use [`snapshot-diff`](https://github.com/jest-community/snapshot-diff). When in doubt, prefer explicit expectations as described in the previous paragraph.
+We recommend that you only use small snapshots (see [`no-large-snapshots` rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-large-snapshots.md)). If you want to test a _change_ between two React component states, use [`snapshot-diff`](https://github.com/jest-community/snapshot-diff). When in doubt, prefer explicit expectations as described in the previous paragraph.
 
 <img src="/docs/assets/p_tests-snapshot.svg" alt=" " />
 

--- a/plugins/remark-lint-no-dead-urls/src/__tests__/index.ts
+++ b/plugins/remark-lint-no-dead-urls/src/__tests__/index.ts
@@ -8,6 +8,7 @@
 import {remark} from 'remark';
 import dedent from 'dedent';
 import {jest, describe, beforeEach, test, expect} from '@jest/globals';
+import {Options} from '../index.ts';
 
 const mockFetch = jest.fn() as jest.MockedFunction<
   (url: string, method: unknown, options?: object) => Promise<number>
@@ -19,7 +20,7 @@ jest.unstable_mockModule('../lib.ts', () => ({
 
 const plugin = (await import('../index.ts')).default;
 
-function processMarkdown(md: string, opts = {}) {
+function processMarkdown(md: string, opts: Options = {}) {
   return remark().use(plugin, opts).process(md);
 }
 

--- a/plugins/remark-lint-no-dead-urls/src/lib.ts
+++ b/plugins/remark-lint-no-dead-urls/src/lib.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import got, {Method} from 'got';
+import got, {type Method} from 'got';
 
 export async function fetch(url: string, method: Method, options = {}) {
   const {statusCode} = await got(url, {

--- a/plugins/remark-lint-no-dead-urls/src/types.d.ts
+++ b/plugins/remark-lint-no-dead-urls/src/types.d.ts
@@ -1,0 +1,1 @@
+export {type Node as MDASTNode} from 'mdast';

--- a/website/versioned_docs/version-0.83/animations.md
+++ b/website/versioned_docs/version-0.83/animations.md
@@ -549,7 +549,7 @@ The native driver also works with `Animated.event`. This is especially useful fo
 </Animated.ScrollView>
 ```
 
-You can see the native driver in action by running the [RNTester app](https://github.com/facebook/react-native/blob/main/packages/rn-tester/), then loading the Native Animated Example. You can also take a look at the [source code](https://github.com/facebook/react-native/blob/master/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js) to learn how these examples were produced.
+You can see the native driver in action by running the [RNTester app](https://github.com/facebook/react-native/blob/main/packages/rn-tester/), then loading the Native Animated Example. You can also take a look at the [source code](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js) to learn how these examples were produced.
 
 #### Caveats
 

--- a/website/versioned_docs/version-0.83/build-speed.md
+++ b/website/versioned_docs/version-0.83/build-speed.md
@@ -120,7 +120,7 @@ Ccache works by wrapping the C++ compilers, storing the compilation results, and
 if an intermediate compilation result was originally stored.
 
 Ccache is available in the package manager for most operating systems. On macOS, we can install ccache with `brew install ccache`.
-Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/INSTALL.md) to install from source.
+Or you can follow the [official installation instructions](https://github.com/ccache/ccache/blob/master/doc/install.md) to install from source.
 
 You can then do two clean builds (e.g. on Android you can first run `yarn react-native run-android`, delete the `android/app/build` folder and run the first command once more). You will notice that the second build was way faster than the first one (it should take seconds rather than minutes).
 While building, you can verify that `ccache` works correctly and check the cache hits/miss rate `ccache -s`

--- a/website/versioned_docs/version-0.83/debugging-release-builds.md
+++ b/website/versioned_docs/version-0.83/debugging-release-builds.md
@@ -20,7 +20,7 @@ If a React Native app throws an unhandled exception in a release build, the outp
 
 In the above stack trace, entries like `p@1:132161` are minified function names and bytecode offsets. To debug these calls, we want to translate these into file, line, and function name, e.g. `AwesomeProject/App.js:54:initializeMap`. This is known as **symbolication.**
 
-You can symbolicate minified function names and bytecode like the above by passing the stack trace and a generated source map to [`metro-symbolicate`](http://npmjs.com/package/metro-symbolicate).
+You can symbolicate minified function names and bytecode like the above by passing the stack trace and a generated source map to [`metro-symbolicate`](https://www.npmjs.com/package/metro-symbolicate).
 
 ### Enabling source maps
 

--- a/website/versioned_docs/version-0.83/element-nodes.md
+++ b/website/versioned_docs/version-0.83/element-nodes.md
@@ -84,9 +84,9 @@ From [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element):
     - ℹ️ Returns the value of the `id` or `nativeID` props.
   - [`lastElementChild`](https://developer.mozilla.org/en-US/docs/Web/API/Element/lastElementChild)
   - [`nextElementSibling`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nextElementSibling)
-  - [`nodeName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nodeName)
-  - [`nodeType`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nodeType)
-  - [`nodeValue`](https://developer.mozilla.org/en-US/docs/Web/API/Element/nodeValue)
+  - [`nodeName`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName)
+  - [`nodeType`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
+  - [`nodeValue`](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue)
   - [`previousElementSibling`](https://developer.mozilla.org/en-US/docs/Web/API/Element/previousElementSibling)
   - [`scrollHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)
   - [`scrollLeft`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)
@@ -96,7 +96,7 @@ From [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element):
   - [`scrollWidth`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth)
   - [`tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName)
     - ℹ️ Returns a normalized native component name prefixed with `RN:`, like `RN:View`.
-  - [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Element/textContent)
+  - [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
 - Methods
   - [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
   - [`hasPointerCapture()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture)

--- a/website/versioned_docs/version-0.83/images.md
+++ b/website/versioned_docs/version-0.83/images.md
@@ -67,7 +67,7 @@ Note that image sources required this way include size (width, height) info for 
 
 ## Static Non-Image Resources
 
-The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [bundler defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
+The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html`, `.pdf` and more. See [bundler defaults](https://github.com/facebook/metro/blob/main/packages/metro-config/src/defaults/defaults.js#L16-L51) for the full list.
 
 You can add support for other types by adding an [`assetExts` resolver option](https://metrobundler.dev/docs/configuration#resolver-options) in your [Metro configuration](https://metrobundler.dev/docs/configuration).
 

--- a/website/versioned_docs/version-0.83/testing-overview.md
+++ b/website/versioned_docs/version-0.83/testing-overview.md
@@ -245,7 +245,7 @@ Snapshots have several weak points:
 
 Snapshots themselves do not ensure that your component render logic is correct, they are merely good at guarding against unexpected changes and for checking that the components in the React tree under test receive the expected props (styles and etc.).
 
-We recommend that you only use small snapshots (see [`no-large-snapshots` rule](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md)). If you want to test a _change_ between two React component states, use [`snapshot-diff`](https://github.com/jest-community/snapshot-diff). When in doubt, prefer explicit expectations as described in the previous paragraph.
+We recommend that you only use small snapshots (see [`no-large-snapshots` rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-large-snapshots.md)). If you want to test a _change_ between two React component states, use [`snapshot-diff`](https://github.com/jest-community/snapshot-diff). When in doubt, prefer explicit expectations as described in the previous paragraph.
 
 <img src="/docs/assets/p_tests-snapshot.svg" alt=" " />
 


### PR DESCRIPTION
# Why

Tried to run broken links check script locally, but find out that Remark cannot parse the plugin file:

<img width="1700" height="558" alt="Screenshot 2026-01-15 205741" src="https://github.com/user-attachments/assets/d0db41a0-b55a-4872-b25c-6444ad764bfc" />

# How

Fix `mdast` type issue by defining declaration file and avoid clash with `Node` type, improve the plugin typings to avoid further parse issues.

Run `lint:markdown:links` script locally, and correct some of reported broken links in next and versioned docs for 0.83. Some warning generated by the plugin seems like false-positives so we need to investigate this further in the near future.

# Preview

<img width="2051" height="710" alt="Screenshot 2026-01-15 210750" src="https://github.com/user-attachments/assets/a5e3c0bc-4625-46e9-ab4c-e4dcfc50f1b0" />
