### PR TITLE
Update memoryWarning event description to mention it is iOS only

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.77/appstate.md
+++ b/website/versioned_docs/version-0.77/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.78/appstate.md
+++ b/website/versioned_docs/version-0.78/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.79/appstate.md
+++ b/website/versioned_docs/version-0.79/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.80/appstate.md
+++ b/website/versioned_docs/version-0.80/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.81/appstate.md
+++ b/website/versioned_docs/version-0.81/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.82/appstate.md
+++ b/website/versioned_docs/version-0.82/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 

--- a/website/versioned_docs/version-0.83/appstate.md
+++ b/website/versioned_docs/version-0.83/appstate.md
@@ -82,7 +82,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 This event is received when the app state has changed. The listener is called with one of [the current app state values](appstate#app-states).
 
-### `memoryWarning`  <div className="label ios">iOS</div>
+### `memoryWarning` <div className="label ios">iOS</div>
 
 Fires when the app receives a memory warning from the operating system.
 


### PR DESCRIPTION
This event is iOS only, and the current documentation does not mention that fact. Also, it incorrectly states that the event fires when when a memory warning is "thrown or released". In fact, there is no event when memory pressure is released.

See https://github.com/facebook/react-native/issues/36426 and https://github.com/facebook/react-native/issues/47951

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
