### PR TITLE
[docs] Replace useRef with useAnimatedValue in Animated example

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -18,7 +18,14 @@ The following example contains a `View` which will fade in and fade out based on
 ```SnackPlayer name=Animated%20Example
 import React from 'react';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
-import {Animated, Text, View, StyleSheet, Button, useAnimatedValue} from 'react-native';
+import {
+  Animated,
+  Text,
+  View,
+  StyleSheet,
+  Button,
+  useAnimatedValue,
+} from 'react-native';
 
 const App = () => {
   // fadeAnim will be used as the value for opacity. Initial Value: 0


### PR DESCRIPTION
## Summary

- The `Animated` docs example was reading `ref.current` during render (`useRef(new Animated.Value(0)).current`), which violates React's rules for refs
- Replaced with `useAnimatedValue(0)`, which is the hook React Native provides for this use case and is already referenced elsewhere in the same doc

## Test plan

- Validated the example code doesn't trigger any Flow errors