### PR TITLE
Update releases table

### DIFF
--- a/website/src/components/releases/_releases-table.md
+++ b/website/src/components/releases/_releases-table.md
@@ -5,10 +5,10 @@
 | `0.87.x` | 2026-07-06      | 2026-08-10   | Future       |                                               |
 | `0.86.x` | 2026-05-04      | 2026-06-08   | Future       |                                               |
 | `0.85.x` | 2026-03-02      | 2026-04-06   | Future       |                                               |
-| `0.84.x` | 2026-01-05      | 2026-02-09   | Future       |                                               |
+| `0.84.x` | 2026-01-05      | 2026-02-09   | Active       | [Details](/blog/2026/02/11/react-native-0.84) |
 | `0.83.x` | 2025-11-03      | 2025-12-10   | Active       | [Details](/blog/2025/12/10/react-native-0.83) |
-| `0.82.x` | 2025-09-01      | 2025-10-06   | Active       | [Details](/blog/2025/10/08/react-native-0.82) |
-| `0.81.x` | 2025-07-10      | 2025-08-12   | End of Cycle | [Details](/blog/2025/08/12/react-native-0.81) |
+| `0.82.x` | 2025-09-01      | 2025-10-06   | End of Cycle | [Details](/blog/2025/10/08/react-native-0.82) |
+| `0.81.x` | 2025-07-10      | 2025-08-12   | Unsupported  | [Details](/blog/2025/08/12/react-native-0.81) |
 | `0.80.x` | 2025-05-07      | 2025-06-12   | Unsupported  | [Details](/blog/2025/06/12/react-native-0.80) |
 | `0.79.x` | 2025-03-04      | 2025-04-08   | Unsupported  | [Details](/blog/2025/04/08/react-native-0.79) |
 | `0.78.x` | 2025-01-15      | 2025-02-19   | Unsupported  | [Details](/blog/2025/02/19/react-native-0.78) |


### PR DESCRIPTION
Updated the status of version 0.84.x to 'Active' and changed 0.81.x to 'Unsupported'.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
