### PR TITLE
mixBlendMode is Android 10+

### DIFF
--- a/docs/view-style-props.md
+++ b/docs/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.77/view-style-props.md
+++ b/website/versioned_docs/version-0.77/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.78/view-style-props.md
+++ b/website/versioned_docs/version-0.78/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.79/view-style-props.md
+++ b/website/versioned_docs/version-0.79/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.80/view-style-props.md
+++ b/website/versioned_docs/version-0.80/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.81/view-style-props.md
+++ b/website/versioned_docs/version-0.81/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.82/view-style-props.md
+++ b/website/versioned_docs/version-0.82/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.83/view-style-props.md
+++ b/website/versioned_docs/version-0.83/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.

--- a/website/versioned_docs/version-0.84/view-style-props.md
+++ b/website/versioned_docs/version-0.84/view-style-props.md
@@ -392,7 +392,7 @@ The following filter functions work on Android only:
 ### `mixBlendMode`
 
 :::note
-`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page)
+`mixBlendMode` is only available on the [New Architecture](/architecture/landing-page) and **Android 10+**
 :::
 
 Controls how the `View` blends its colors with the other elements in its **stacking context**. Check out the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) for a full overview of each blending function.


### PR DESCRIPTION
`mixBlendMode` uses [android.graphics.BlendMode](https://github.com/bigcupcoffee/react-native/blob/185a6130ddc566ef67d04f83721f41d13651dbd0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt#L10), which [was added in API LEVEL 29+ (Android 10)](https://developer.android.com/reference/android/graphics/BlendMode), react-native kinda [guards it](https://github.com/facebook/react-native/blob/185a6130ddc566ef67d04f83721f41d13651dbd0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java#L311)