### PR TITLE
Do not specify package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1"
   },
-  "packageManager": "yarn@4.13.0",
   "resolutions": {
     "serialize-javascript": "^7.0.5",
     "serve-handler/minimatch": "3.1.4"


### PR DESCRIPTION
This breaks internal Meta setup because we run on a different yarn version

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
