### PR TITLE
Update Netlify.toml for Docusaurus deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,14 @@
 [build]
   base    = ""
   publish = "website/build"
-  command = "yarn && cd website && yarn build"
-
+  command = "git backfill & yarn & wait && cd website && yarn build"
+  
 [context.production.environment]
-  NODE_VERSION = "22"
+  NODE_VERSION = "24"
+  DOCUSAURUS_PERF_LOGGER = "true"
 
 [context.deploy-preview.environment]
-  NODE_VERSION = "22"
+  NODE_VERSION = "24"
   PREVIEW_DEPLOY = "true"
 
 [[headers]]


### PR DESCRIPTION

You can use Node 24 now

DOCUSAURUS_PERF_LOGGER=true gives additional logs on Netlify to see which Docusaurus step takes the most time

`git backfill` can be run in parallel to `yarn`, and I've recently noticed it improves build times on Netlify, which uses "blobless" clones by default, but we need those blobs for the "last updated at" feature so it's faster to fetch them eagerly than lazily/on-demand. See also https://github.com/facebook/docusaurus/pull/11553 (I plan to document this officially later). Also related to our new VCS Git Eager strategy, that RNW now uses: https://docusaurus.io/blog/releases/3.10#vcs

cc @Simek 