### PR TITLE
fix: Fix old broken Margelo link

### DIFF
--- a/website/blog/2022-01-19-version-067.mdx
+++ b/website/blog/2022-01-19-version-067.mdx
@@ -34,7 +34,7 @@ This release includes [379 commits with 74 contributors](https://github.com/face
 
 We wanted to also thank the release testers who helped us make sure that 0.67.0 could reach your codebases without any massive regression. Specifically, we wanted to thank:
 
-- Marc Rousavy ([@mrousavy](https://github.com/mrousavy)) from [Margelo](https://margelo.io/), that surfaced a [regression for Hermes 0.10](https://github.com/facebook/hermes/issues/649) (that would have never been caught on CI testing) which will be fixed in Hermes 0.11 in the 0.68 release of React Native.
+- Marc Rousavy ([@mrousavy](https://github.com/mrousavy)) from [Margelo](https://margelo.com/), that surfaced a [regression for Hermes 0.10](https://github.com/facebook/hermes/issues/649) (that would have never been caught on CI testing) which will be fixed in Hermes 0.11 in the 0.68 release of React Native.
 - The Reanimated team for quickly preparing a [0.67 compatible version](https://github.com/software-mansion/react-native-reanimated/releases/tag/2.2.4) of their lib early in the 0.67 RC phase.
 - Elias Nahum ([@enahum](https://github.com/enahum)) from [Mattermost](https://mattermost.com/)
 - Mike Hardy ([@mikeHardy](https://github.com/mikeHardy)) working with [Invertase](https://invertase.io/)


### PR DESCRIPTION
I know this is an old article, but the website margelo.io is gone since a few years and we are now on margelo.com.

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
