### PR TITLE
Fix `important` admonition syntax

### DIFF
--- a/docs/_experimental-api-warning.mdx
+++ b/docs/_experimental-api-warning.mdx
@@ -1,4 +1,4 @@
-:::important Experimental 🧪
+:::important[Experimental 🧪]
 
 **This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
 

--- a/website/versioned_docs/version-0.82/_experimental-api-warning.mdx
+++ b/website/versioned_docs/version-0.82/_experimental-api-warning.mdx
@@ -1,4 +1,4 @@
-:::important Experimental 🧪
+:::important[Experimental 🧪]
 
 **This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
 

--- a/website/versioned_docs/version-0.83/_experimental-api-warning.mdx
+++ b/website/versioned_docs/version-0.83/_experimental-api-warning.mdx
@@ -1,4 +1,4 @@
-:::important Experimental 🧪
+:::important[Experimental 🧪]
 
 **This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
 

--- a/website/versioned_docs/version-0.84/_experimental-api-warning.mdx
+++ b/website/versioned_docs/version-0.84/_experimental-api-warning.mdx
@@ -1,4 +1,4 @@
-:::important Experimental 🧪
+:::important[Experimental 🧪]
 
 **This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
 

--- a/website/versioned_docs/version-0.85/_experimental-api-warning.mdx
+++ b/website/versioned_docs/version-0.85/_experimental-api-warning.mdx
@@ -1,4 +1,4 @@
-:::important Experimental 🧪
+:::important[Experimental 🧪]
 
 **This API is experimental.** Experimental APIs may contain bugs and are likely to change in a future version of React Native. Don't use them in production.
 


### PR DESCRIPTION

`important` admonition with title has incorrect syntax, see docs: https://docusaurus.io/docs/markdown-features/admonitions#specifying-title

- Issue: https://github.com/facebook/react-native-website/issues/5062
- Preview: https://deploy-preview-5063--react-native.netlify.app/docs/virtualview



Before:

<img width="1500" height="663" alt="Screenshot 2026-04-27 at 11 30 15" src="https://github.com/user-attachments/assets/f4beac6f-24d9-4a39-ad2b-e3bcb1bb45a5" />



After:

<img width="1439" height="664" alt="Screenshot 2026-04-27 at 12 00 09" src="https://github.com/user-attachments/assets/e30d38bc-e216-4286-9245-087a8ff1e304" />

