### PR TITLE
feat: Extends default admonitions with a custom `important`

### DIFF
--- a/docs/_experimental-channel-api-warning.mdx
+++ b/docs/_experimental-channel-api-warning.mdx
@@ -1,4 +1,4 @@
-:::tip[Experimental Feature 🧪]
+:::important[Experimental Feature 🧪]
 
 **This API is currently only available in React Native’s Experimental channels.**
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -30,6 +30,7 @@ export type EditUrlButton = {
 };
 
 const commonDocsOptions: PluginContentDocs.Options = {
+  admonitions: {keywords: ['important'], extendDefaults: true},
   breadcrumbs: false,
   showLastUpdateAuthor: false,
   showLastUpdateTime: true,

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -664,6 +664,13 @@ html[data-theme="dark"] article .badge {
   --ifm-alert-background-color-highlight: rgba(225, 227, 230, 0.7);
 }
 
+.alert--important {
+  --ifm-alert-background-color: #8250df2a;
+  --ifm-alert-background-color-highlight: #e0cfff;
+  --ifm-alert-foreground-color: #281846;
+  --ifm-alert-border-color: #e0cfff;
+}
+
 html[data-theme="dark"] {
   span[class^="admonitionIcon"] svg {
     fill: hsl(from var(--ifm-alert-border-color) h calc(s + 10) calc(l + 10));
@@ -678,6 +685,11 @@ html[data-theme="dark"] {
       --ifm-color-secondary-contrast-background
     );
     --ifm-alert-background-color-highlight: rgba(225, 227, 230, 0.15);
+  }
+  .alert--important {
+    --ifm-alert-background-color-highlight: #442f6b;
+    --ifm-alert-foreground-color: #c0b1dc;
+    --ifm-alert-border-color: #8250df;
   }
 }
 

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -673,11 +673,11 @@ html[data-theme="dark"] article .badge {
 
 html[data-theme="dark"] {
   span[class^="admonitionIcon"] svg {
-    fill: hsl(from var(--ifm-alert-border-color) h calc(s + 10) calc(l + 10));
+    fill: hsl(from var(--ifm-alert-border-color) h calc(s - 10) calc(l + 10));
   }
 
   div[class^="admonitionHeading"] {
-    color: hsl(from var(--ifm-alert-border-color) h calc(s + 10) calc(l + 10));
+    color: hsl(from var(--ifm-alert-border-color) h calc(s - 10) calc(l + 10));
   }
 
   .alert--secondary {

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -693,6 +693,20 @@ html[data-theme="dark"] {
   }
 }
 
+html[data-theme="light"] {
+  .alert--success {
+    span[class^="admonitionIcon"] svg {
+      fill: hsl(from var(--ifm-alert-border-color) h calc(s + 20) calc(l - 10));
+    }
+
+    div[class^="admonitionHeading"] {
+      color: hsl(
+        from var(--ifm-alert-border-color) h calc(s + 20) calc(l - 10)
+      );
+    }
+  }
+}
+
 /* Home page */
 
 .homepage {

--- a/website/src/theme/Admonition/Types.js
+++ b/website/src/theme/Admonition/Types.js
@@ -4,15 +4,15 @@ import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
 
 const {info: Info} = DefaultAdmonitionTypes;
 
-function MyCustomAdmonition(props) {
+function ImportantAdmonition({ className, ...rest }) {
   return (
-    <Info className={clsx(props.className, 'alert--important')} {...props} />
+    <Info className={clsx(className, 'alert--important')} {...rest} />
   );
 }
 
 const AdmonitionTypes = {
   ...DefaultAdmonitionTypes,
-  important: MyCustomAdmonition,
+  important: ImportantAdmonition,
 };
 
 export default AdmonitionTypes;

--- a/website/src/theme/Admonition/Types.js
+++ b/website/src/theme/Admonition/Types.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import clsx from 'clsx';
+import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
+
+const {info: Info} = DefaultAdmonitionTypes;
+
+function MyCustomAdmonition(props) {
+  return (
+    <Info className={clsx(props.className, 'alert--important')} {...props} />
+  );
+}
+
+const AdmonitionTypes = {
+  ...DefaultAdmonitionTypes,
+  important: MyCustomAdmonition,
+};
+
+export default AdmonitionTypes;

--- a/website/src/theme/Admonition/Types.tsx
+++ b/website/src/theme/Admonition/Types.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import clsx from 'clsx';
 import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
+import type {Props} from '@theme/Admonition';
 
 const {info: Info} = DefaultAdmonitionTypes;
 
-function ImportantAdmonition({ className, ...rest }) {
-  return (
-    <Info className={clsx(className, 'alert--important')} {...rest} />
-  );
+function ImportantAdmonition({className, ...rest}: Props) {
+  return <Info className={clsx(className, 'alert--important')} {...rest} />;
 }
 
 const AdmonitionTypes = {

--- a/website/versioned_docs/version-0.82/_experimental-channel-api-warning.mdx
+++ b/website/versioned_docs/version-0.82/_experimental-channel-api-warning.mdx
@@ -1,4 +1,4 @@
-:::tip[Experimental Feature 🧪]
+:::important[Experimental Feature 🧪]
 
 **This API is currently only available in React Native’s Experimental channels.**
 

--- a/website/versioned_docs/version-0.83/_experimental-channel-api-warning.mdx
+++ b/website/versioned_docs/version-0.83/_experimental-channel-api-warning.mdx
@@ -1,4 +1,4 @@
-:::tip[Experimental Feature 🧪]
+:::important[Experimental Feature 🧪]
 
 **This API is currently only available in React Native’s Experimental channels.**
 

--- a/website/versioned_docs/version-0.84/_experimental-channel-api-warning.mdx
+++ b/website/versioned_docs/version-0.84/_experimental-channel-api-warning.mdx
@@ -1,4 +1,4 @@
-:::tip[Experimental Feature 🧪]
+:::important[Experimental Feature 🧪]
 
 **This API is currently only available in React Native’s Experimental channels.**
 

--- a/website/versioned_docs/version-0.85/_experimental-channel-api-warning.mdx
+++ b/website/versioned_docs/version-0.85/_experimental-channel-api-warning.mdx
@@ -1,4 +1,4 @@
-:::tip[Experimental Feature 🧪]
+:::important[Experimental Feature 🧪]
 
 **This API is currently only available in React Native’s Experimental channels.**
 


### PR DESCRIPTION
 `important` by default uses info variant: https://github.com/facebook/docusaurus/blob/094248992c5b5e99c8dc8ab3f77d564192736a29/packages/docusaurus-theme-classic/src/theme/Admonition/Types.tsx#L30

see: https://github.com/facebook/react-native-website/issues/5062#issuecomment-4327123821


---

AFTER (Dark, Light):

<img width="1236" height="517" alt="Screenshot 2026-04-27 at 18 33 44" src="https://github.com/user-attachments/assets/ca9e3eda-ffc0-4a4e-bac1-5340b496da68" />

<img width="1303" height="528" alt="Screenshot 2026-04-27 at 18 33 49" src="https://github.com/user-attachments/assets/d10e53e6-afd9-4bfd-a89f-506b0f5143b4" />

