### PR TITLE
[docs] Update Appearance.setColorScheme keys (0.87)

### DIFF
--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -59,13 +59,13 @@ Although the color scheme is available immediately, this may change when not ove
 
 ### App-level overriding
 
-`setColorScheme()` overrides the color scheme at the application level — it does not affect the system setting or other applications. Passing `'unspecified'` removes any override, restoring the system preference.
+`setColorScheme()` overrides the color scheme at the application level — it does not affect the system setting or other applications. Passing `'auto'` removes any override, restoring the system preference.
 
 ```mermaid
 flowchart TD
     USC["useColorScheme()"] --> GCS["getColorScheme()"]
     GCS --> DEC{App override?}
-    DEC -- "NO / reset via setColorScheme('unspecified')" --> SYS["System preference\n'light' or 'dark'"]
+    DEC -- "NO / reset via setColorScheme('auto')" --> SYS["System preference\n'light' or 'dark'"]
     DEC -- "YES — setColorScheme('light' | 'dark')" --> OVR["'light' or 'dark' (static)"]
 
     classDef fn fill:#dce8f8,stroke:#4a90d9,color:#1a1a1a
@@ -101,7 +101,7 @@ See also: [`useColorScheme`](usecolorscheme) (hook).
 ### `setColorScheme()`
 
 ```tsx
-static setColorScheme('light' | 'dark' | 'unspecified'): void;
+static setColorScheme('light' | 'dark' | 'auto' | 'unspecified'): void;
 ```
 
 Forces the application to always adopt a light or dark interface style. The change applies to the application and all native elements within it (Alerts, Pickers, etc.).
@@ -112,7 +112,8 @@ Supported values:
 
 - `'light'`: Apply light color scheme.
 - `'dark'`: Apply dark color scheme.
-- `'unspecified'`: Follow the system color scheme (removes any override).
+- `'auto'`: Follow the system color scheme (removes any override).
+- `'unspecified'` (**deprecated**): Follow the system color scheme (removes any override).
 
 ---
 


### PR DESCRIPTION
Final recent docs update to the `Appearance` API, given https://github.com/facebook/react-native/pull/56696 was accepted.

> [!Note]
> Let's not land this one until the 0.86 version of the docs is cut.
>
> **Sidenote**: It would be great if we could cut a docs version in sync with the RN repo, but not publish it (`0.86-stable` was cut yesterday in facebook/react-native) 😅