### PR TITLE
[docs] Add scrollsChildToFocus prop to ScrollView (Android, 0.85)

### DIFF
--- a/docs/scrollview.md
+++ b/docs/scrollview.md
@@ -608,6 +608,16 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
+### `scrollsChildToFocus` <div className="label android">Android</div>
+
+When `true`, the ScrollView automatically scrolls to bring a focused child into view. Set to `false` to disable this behavior and take manual control of scroll position when focus changes.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.

--- a/website/versioned_docs/version-0.85/scrollview.md
+++ b/website/versioned_docs/version-0.85/scrollview.md
@@ -608,6 +608,16 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
+### `scrollsChildToFocus` <div className="label android">Android</div>
+
+When `true`, the ScrollView automatically scrolls to bring a focused child into view. Set to `false` to disable this behavior and take manual control of scroll position when focus changes.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.

--- a/website/versioned_docs/version-0.86/scrollview.md
+++ b/website/versioned_docs/version-0.86/scrollview.md
@@ -608,6 +608,16 @@ Tag used to log scroll performance on this scroll view. Will force momentum even
 
 ---
 
+### `scrollsChildToFocus` <div className="label android">Android</div>
+
+When `true`, the ScrollView automatically scrolls to bring a focused child into view. Set to `false` to disable this behavior and take manual control of scroll position when focus changes.
+
+| Type | Default |
+| ---- | ------- |
+| bool | `true`  |
+
+---
+
 ### `scrollToOverflowEnabled` <div className="label ios">iOS</div>
 
 When `true`, the scroll view can be programmatically scrolled beyond its content size.


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

PR adds missing documentation for the `scrollsChildToFocus` Android prop on `ScrollView`, introduced in React Native 0.85.                        
                                                                          
  The prop controls whether the ScrollView automatically scrolls to bring  a focused child into view (default: `true`). Setting it to `false` gives  developers manual control over scroll position on focus changes.    
  
You can find this prop mentioned in the v0.85 CHANGELOG.md here: https://github.com/facebook/react-native/blob/main/CHANGELOG.md#android-specific-5
