### PR TITLE
Clarify Android AppState background for autofill credential pickers

### DIFF
--- a/docs/appstate.md
+++ b/docs/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.77/appstate.md
+++ b/website/versioned_docs/version-0.77/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.78/appstate.md
+++ b/website/versioned_docs/version-0.78/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.79/appstate.md
+++ b/website/versioned_docs/version-0.79/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.80/appstate.md
+++ b/website/versioned_docs/version-0.80/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.81/appstate.md
+++ b/website/versioned_docs/version-0.81/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.82/appstate.md
+++ b/website/versioned_docs/version-0.82/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.83/appstate.md
+++ b/website/versioned_docs/version-0.83/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.84/appstate.md
+++ b/website/versioned_docs/version-0.84/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.85/appstate.md
+++ b/website/versioned_docs/version-0.85/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)

--- a/website/versioned_docs/version-0.86/appstate.md
+++ b/website/versioned_docs/version-0.86/appstate.md
@@ -13,7 +13,8 @@ AppState is frequently used to determine the intent and proper behavior when han
 - `background` - The app is running in the background. The user is either:
   - in another app
   - on the home screen
-  - [Android] on another `Activity` (even if it was launched by your app)
+  - [Android] on another `Activity`, including temporary system activities such
+    as autofill credential pickers (even if launched by your app or the system)
 - [iOS] `inactive` - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
 
 For more information, see [Apple's documentation](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)


### PR DESCRIPTION
## Summary

Clarifies that Android AppState `background` can be emitted when another `Activity` takes focus, including temporary system activities such as autofill credential pickers.

## Context

The AppState docs already mention that Android may report `background` when the user is on another `Activity`. This adds a concrete system-flow example where that distinction matters in practice, without changing the documented API behavior.

Related: facebook/react-native#36420