### PR TITLE
Fix typos in modal.md, timers.md, colors.md

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -198,7 +198,7 @@ A ref setter that will be assigned an [element node](element-nodes) when mounted
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.77/colors.md
+++ b/website/versioned_docs/version-0.77/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.77/modal.md
+++ b/website/versioned_docs/version-0.77/modal.md
@@ -179,7 +179,7 @@ The `onOrientationChange` callback is called when the orientation changes while 
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.77/timers.md
+++ b/website/versioned_docs/version-0.77/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - setImmediate, clearImmediate
 - requestAnimationFrame, cancelAnimationFrame
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.78/colors.md
+++ b/website/versioned_docs/version-0.78/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.78/modal.md
+++ b/website/versioned_docs/version-0.78/modal.md
@@ -179,7 +179,7 @@ The `onOrientationChange` callback is called when the orientation changes while 
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.78/timers.md
+++ b/website/versioned_docs/version-0.78/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - setImmediate, clearImmediate
 - requestAnimationFrame, cancelAnimationFrame
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.79/colors.md
+++ b/website/versioned_docs/version-0.79/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.79/modal.md
+++ b/website/versioned_docs/version-0.79/modal.md
@@ -179,7 +179,7 @@ The `onOrientationChange` callback is called when the orientation changes while 
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.79/timers.md
+++ b/website/versioned_docs/version-0.79/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - setImmediate, clearImmediate
 - requestAnimationFrame, cancelAnimationFrame
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.80/colors.md
+++ b/website/versioned_docs/version-0.80/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.80/modal.md
+++ b/website/versioned_docs/version-0.80/modal.md
@@ -179,7 +179,7 @@ The `onOrientationChange` callback is called when the orientation changes while 
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.80/timers.md
+++ b/website/versioned_docs/version-0.80/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.81/colors.md
+++ b/website/versioned_docs/version-0.81/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.81/modal.md
+++ b/website/versioned_docs/version-0.81/modal.md
@@ -190,7 +190,7 @@ This requires you to implement the `onRequestClose` prop to handle the dismissal
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.81/timers.md
+++ b/website/versioned_docs/version-0.81/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.82/colors.md
+++ b/website/versioned_docs/version-0.82/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.82/modal.md
+++ b/website/versioned_docs/version-0.82/modal.md
@@ -198,7 +198,7 @@ A ref setter that will be assigned an [element node](element-nodes) when mounted
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.82/timers.md
+++ b/website/versioned_docs/version-0.82/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.83/colors.md
+++ b/website/versioned_docs/version-0.83/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.83/modal.md
+++ b/website/versioned_docs/version-0.83/modal.md
@@ -198,7 +198,7 @@ A ref setter that will be assigned an [element node](element-nodes) when mounted
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.83/timers.md
+++ b/website/versioned_docs/version-0.83/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.84/colors.md
+++ b/website/versioned_docs/version-0.84/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.84/modal.md
+++ b/website/versioned_docs/version-0.84/modal.md
@@ -198,7 +198,7 @@ A ref setter that will be assigned an [element node](element-nodes) when mounted
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.84/timers.md
+++ b/website/versioned_docs/version-0.84/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.85/colors.md
+++ b/website/versioned_docs/version-0.85/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.85/modal.md
+++ b/website/versioned_docs/version-0.85/modal.md
@@ -198,7 +198,7 @@ A ref setter that will be assigned an [element node](element-nodes) when mounted
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.85/timers.md
+++ b/website/versioned_docs/version-0.85/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 

--- a/website/versioned_docs/version-0.86/colors.md
+++ b/website/versioned_docs/version-0.86/colors.md
@@ -68,7 +68,7 @@ React Native only supports lowercase color names. Uppercase color names are not 
 
 #### `transparent`
 
-This is a shortcut for `rgba(0,0,0,0)`, same like in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
+This is a shortcut for `rgba(0,0,0,0)`, same as in [CSS3](https://www.w3.org/TR/css-color-3/#transparent).
 
 #### Color keywords
 

--- a/website/versioned_docs/version-0.86/modal.md
+++ b/website/versioned_docs/version-0.86/modal.md
@@ -198,7 +198,7 @@ A ref setter that will be assigned an [element node](element-nodes) when mounted
 ### `onRequestClose`
 
 The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV. Because of this required prop, be aware that `BackHandler` events will not be emitted as long as the modal is open.
-On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet or formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
+On iOS, this callback is called when a Modal is being dismissed using a drag gesture when `presentationStyle` is `pageSheet` or `formSheet`. When `allowSwipeDismissal` is enabled this callback will be called after dismissing the modal.
 
 | Type                                                                                                                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-0.86/timers.md
+++ b/website/versioned_docs/version-0.86/timers.md
@@ -12,7 +12,7 @@ Timers are an important part of an application and React Native implements the [
 - `setImmediate` and `clearImmediate`
 - `requestAnimationFrame` and `cancelAnimationFrame`
 
-`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on a iPhone 5S).
+`requestAnimationFrame(fn)` is not the same as `setTimeout(fn, 0)` - the former will fire after all the frames have flushed, whereas the latter will fire as quickly as possible (over 1000x per second on an iPhone 5S).
 
 `setImmediate` is executed at the end of the current JavaScript execution block, right before sending the batched response back to native. Note that if you call `setImmediate` within a `setImmediate` callback, it will be executed right away, it won't yield back to native in between.
 


### PR DESCRIPTION
## Summary

Fixes three documentation typos:

- **modal.md**: Missing closing backtick on `\`pageSheet\` or \`formSheet\`
- **timers.md**: Wrong article — "a iPhone" → "an iPhone"
- **colors.md**: Non-idiomatic phrase — "same like" → "same as"

All changes are minor grammar/markdown fixes only.