### PR TITLE
small visual tweaks for the copy button

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -133,6 +133,7 @@
 
 body {
   font-family: var(--ifm-font-family-base);
+  scrollbar-gutter: stable;
 }
 
 html[data-theme="light"] {
@@ -140,6 +141,10 @@ html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
+  body {
+    scrollbar-color: var(--subtle) var(--ifm-background-color);
+  }
+
   --subtle: #858993;
 
   --navbar-background: #20232aee;

--- a/website/src/theme/DocItem/Layout/index.tsx
+++ b/website/src/theme/DocItem/Layout/index.tsx
@@ -76,14 +76,16 @@ export default function DocItemLayout({children}: Props): ReactNode {
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
-            <DocVersionBadge />
+            <div className={styles.docHeaderContainer}>
+              <DocVersionBadge />
+              <DocItemCopyPageButton
+                className={clsx(
+                  styles.copyPageArticleAction,
+                  docTOC.canRender && styles.copyPageArticleActionWithToc
+                )}
+              />
+            </div>
             {docTOC.mobile}
-            <DocItemCopyPageButton
-              className={clsx(
-                styles.copyPageArticleAction,
-                docTOC.canRender && styles.copyPageArticleActionWithToc
-              )}
-            />
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
           </article>

--- a/website/src/theme/DocItem/Layout/styles.module.css
+++ b/website/src/theme/DocItem/Layout/styles.module.css
@@ -10,31 +10,68 @@
   margin-top: 0;
 }
 
-.copyPageAction {
+.docHeaderContainer {
   display: flex;
-}
-
-.copyPageArticleAction {
-  justify-content: flex-end;
-  min-height: 37px;
-  margin-bottom: 1rem;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .copyPageAsideAction {
-  display: none;
   margin-bottom: 1rem;
 }
 
-.copyPageButtonContainer {
-  display: inline-block;
+div[class^="copyPageArticleAction"] {
+  margin-bottom: 0;
 }
 
-.copyPageButton {
-  font-family: var(--ifm-font-family-base);
+button[class^="copyPageButton"] {
+  border-radius: var(--ifm-global-radius);
+  border-color: var(--ifm-color-gray-500);
+
+  &:hover {
+    background-color: var(--ifm-menu-color-background-hover) !important;
+    border-color: var(--ifm-color-gray-400) !important;
+  }
+
+  svg {
+    opacity: 0.75;
+  }
 }
 
-.copyPageDropdown {
-  font-family: var(--ifm-font-family-base);
+div[class^="copyPageDropdown"] {
+  border-color: var(--ifm-table-border-color) !important;
+
+  button[class^="dropdownItem"] {
+    border-bottom-color: var(--ifm-table-border-color) !important;
+
+    &:hover {
+      background-color: var(--ifm-menu-color-background-hover);
+    }
+  }
+
+  div[class^="itemDescription"] {
+    font-weight: 300;
+    font-size: 12px;
+  }
+}
+
+[data-theme="dark"] {
+  button[class^="copyPageButton"] {
+    &:hover {
+      background-color: var(--dark) !important;
+      border-color: var(--ifm-color-gray-800) !important;
+    }
+  }
+
+  button[class^="dropdownItem"] {
+    &:hover {
+      background-color: var(--dark);
+    }
+  }
+
+  div[class^="copyPageDropdown"] {
+    background-color: var(--ifm-navbar-background-color);
+  }
 }
 
 @media (min-width: 997px) {
@@ -44,11 +81,5 @@
 
   .copyPageArticleActionWithToc {
     display: none;
-  }
-
-  .copyPageAsideAction {
-    display: flex;
-    justify-content: flex-start;
-    min-height: 37px;
   }
 }


### PR DESCRIPTION
# Why

Follow up to:
* #5085
 
# How

Small visual tweaks for the Copy button to align it more with the website style, adjust button position on pages without a ToC, adjust scrollbar stack color in dark mode.

# Preview

<img width="2169" height="647" alt="Screenshot 2026-05-25 112224" src="https://github.com/user-attachments/assets/5a09f540-692b-408f-ada8-e3f984d1d2d3" />

<img width="610" height="718" alt="Screenshot 2026-05-25 112202" src="https://github.com/user-attachments/assets/ef58631d-53a1-4e95-a970-3b8ed93e3f19" />
