### PR TITLE
apply Swift linking example correction to all docs

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -87,7 +87,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -95,7 +95,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.81/linking.md
+++ b/website/versioned_docs/version-0.81/linking.md
@@ -84,7 +84,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -92,7 +92,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.82/linking.md
+++ b/website/versioned_docs/version-0.82/linking.md
@@ -87,7 +87,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -95,7 +95,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.83/linking.md
+++ b/website/versioned_docs/version-0.83/linking.md
@@ -87,7 +87,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -95,7 +95,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.84/linking.md
+++ b/website/versioned_docs/version-0.84/linking.md
@@ -87,7 +87,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -95,7 +95,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.85/linking.md
+++ b/website/versioned_docs/version-0.85/linking.md
@@ -87,7 +87,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -95,7 +95,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/website/versioned_docs/version-0.86/linking.md
+++ b/website/versioned_docs/version-0.86/linking.md
@@ -87,7 +87,7 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
 <TabItem value="swift">
 
 ```swift title="AppDelegate.swift"
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
   return RCTLinkingManager.application(app, open: url, options: options)
 }
 ```
@@ -95,7 +95,7 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 If your app is using [Universal Links](https://developer.apple.com/ios/universal-links/), you'll need to add the following code as well:
 
 ```swift title="AppDelegate.swift"
-override func application(
+func application(
   _ application: UIApplication,
   continue userActivity: NSUserActivity,
   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {


### PR DESCRIPTION
# Why

Follow up to:
* #4684

# How

Apply Swift linking example correction to all docs (base + newest versioned ones).