### PR TITLE
apply formatting for code block names, reduce variations

### DIFF
--- a/docs/debugging-native-code.md
+++ b/docs/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -199,7 +199,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -225,7 +225,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/plugins/remark-codeblock-language-as-title/src/index.ts
+++ b/plugins/remark-codeblock-language-as-title/src/index.ts
@@ -7,18 +7,44 @@
 
 import {Root} from 'mdast';
 
+const LANGUAGES_MAP: Record<string, string> = {
+  js: 'JavaScript',
+  javascript: 'JavaScript',
+  ts: 'TypeScript',
+  typescript: 'TypeScript',
+  jsx: 'React JSX',
+  tsx: 'React TSX',
+  json: 'JSON',
+  objc: 'Objective-C',
+  objectivec: 'Objective-C',
+  xml: 'XML',
+  css: 'CSS',
+  cpp: 'C++',
+};
+
+const HIDDEN_TITLES = ['zsh', 'sh', 'shell', 'bash', 'powershell'];
+
+function capitalizeFirstLetter(str: string | null) {
+  if (!str) {
+    return str;
+  }
+  return str[0].toUpperCase() + str.slice(1);
+}
+
 export default function codeblockLanguageAsTitleRemarkPlugin() {
   return async (root: Root) => {
     const {visit} = await import('unist-util-visit');
     visit(root, 'code', node => {
-      if (node.lang && !['shell', 'bash'].includes(node.lang)) {
+      if (node.lang && !HIDDEN_TITLES.includes(node.lang)) {
+        const formattedTitle =
+          LANGUAGES_MAP[node.lang] ?? capitalizeFirstLetter(node.lang);
         if (node.meta) {
           if (node.meta.includes('title=')) {
             return;
           }
-          node.meta = `title="${node.lang}" ${node.meta}`;
+          node.meta = `title="${formattedTitle}" ${node.meta}`;
         } else {
-          node.meta = `title="${node.lang}"`;
+          node.meta = `title="${formattedTitle}"`;
         }
       }
     });

--- a/website/architecture/bundled-hermes.md
+++ b/website/architecture/bundled-hermes.md
@@ -119,9 +119,9 @@ To implement this on Android, we've added a new build inside the `/ReactAndroid/
 You can now trigger a build of Hermes engine by invoking:
 
 ```bash
-// Build a debug version of Hermes
+# Build a debug version of Hermes
 ./gradlew :ReactAndroid:hermes-engine:assembleDebug
-// Build a release version of Hermes
+# Build a release version of Hermes
 ./gradlew :ReactAndroid:hermes-engine:assembleRelease
 ```
 
@@ -133,7 +133,7 @@ On the Gradle consumer side, we also shipped a small improvement on the consumer
 
 However, this made this line necessary in the template:
 
-```
+```groovy
 exclude group:'com.facebook.fbjni'
 ```
 

--- a/website/versioned_docs/version-0.77/debugging-native-code.md
+++ b/website/versioned_docs/version-0.77/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.77/network.md
+++ b/website/versioned_docs/version-0.77/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -189,7 +189,7 @@ export default App;
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -213,7 +213,7 @@ request.send();
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.77/the-new-architecture/custom-cxx-types.md
+++ b/website/versioned_docs/version-0.77/the-new-architecture/custom-cxx-types.md
@@ -336,7 +336,7 @@ Now, we need to implement the `validateAddress` function in C++. First, we need 
 
 2. Open the `shared/NativeSampleModule.cpp` file and add the function implementation
 
-```c++ title="NativeSampleModule.cpp (validateAddress implementation)"
+```cpp title="NativeSampleModule.cpp (validateAddress implementation)"
 bool NativeSampleModule::validateAddress(jsi::Runtime &rt, jsi::Object input) {
   std::string street = input.getProperty(rt, "street").asString(rt).utf8(rt);
   int32_t number = input.getProperty(rt, "num").asNumber();

--- a/website/versioned_docs/version-0.77/timers.md
+++ b/website/versioned_docs/version-0.77/timers.md
@@ -29,7 +29,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -45,7 +45,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 InteractionManager also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.78/debugging-native-code.md
+++ b/website/versioned_docs/version-0.78/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.78/network.md
+++ b/website/versioned_docs/version-0.78/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -189,7 +189,7 @@ export default App;
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -213,7 +213,7 @@ request.send();
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.78/the-new-architecture/custom-cxx-types.md
+++ b/website/versioned_docs/version-0.78/the-new-architecture/custom-cxx-types.md
@@ -336,7 +336,7 @@ Now, we need to implement the `validateAddress` function in C++. First, we need 
 
 2. Open the `shared/NativeSampleModule.cpp` file and add the function implementation
 
-```c++ title="NativeSampleModule.cpp (validateAddress implementation)"
+```cpp title="NativeSampleModule.cpp (validateAddress implementation)"
 bool NativeSampleModule::validateAddress(jsi::Runtime &rt, jsi::Object input) {
   std::string street = input.getProperty(rt, "street").asString(rt).utf8(rt);
   int32_t number = input.getProperty(rt, "num").asNumber();

--- a/website/versioned_docs/version-0.78/timers.md
+++ b/website/versioned_docs/version-0.78/timers.md
@@ -29,7 +29,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -45,7 +45,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 InteractionManager also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.79/debugging-native-code.md
+++ b/website/versioned_docs/version-0.79/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.79/network.md
+++ b/website/versioned_docs/version-0.79/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -189,7 +189,7 @@ export default App;
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -213,7 +213,7 @@ request.send();
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.79/the-new-architecture/custom-cxx-types.md
+++ b/website/versioned_docs/version-0.79/the-new-architecture/custom-cxx-types.md
@@ -336,7 +336,7 @@ Now, we need to implement the `validateAddress` function in C++. First, we need 
 
 2. Open the `shared/NativeSampleModule.cpp` file and add the function implementation
 
-```c++ title="NativeSampleModule.cpp (validateAddress implementation)"
+```cpp title="NativeSampleModule.cpp (validateAddress implementation)"
 bool NativeSampleModule::validateAddress(jsi::Runtime &rt, jsi::Object input) {
   std::string street = input.getProperty(rt, "street").asString(rt).utf8(rt);
   int32_t number = input.getProperty(rt, "num").asNumber();

--- a/website/versioned_docs/version-0.79/timers.md
+++ b/website/versioned_docs/version-0.79/timers.md
@@ -29,7 +29,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -45,7 +45,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 InteractionManager also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.80/debugging-native-code.md
+++ b/website/versioned_docs/version-0.80/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.80/network.md
+++ b/website/versioned_docs/version-0.80/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -189,7 +189,7 @@ export default App;
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -213,7 +213,7 @@ request.send();
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.80/the-new-architecture/custom-cxx-types.md
+++ b/website/versioned_docs/version-0.80/the-new-architecture/custom-cxx-types.md
@@ -336,7 +336,7 @@ Now, we need to implement the `validateAddress` function in C++. First, we need 
 
 2. Open the `shared/NativeSampleModule.cpp` file and add the function implementation
 
-```c++ title="NativeSampleModule.cpp (validateAddress implementation)"
+```cpp title="NativeSampleModule.cpp (validateAddress implementation)"
 bool NativeSampleModule::validateAddress(jsi::Runtime &rt, jsi::Object input) {
   std::string street = input.getProperty(rt, "street").asString(rt).utf8(rt);
   int32_t number = input.getProperty(rt, "num").asNumber();

--- a/website/versioned_docs/version-0.80/timers.md
+++ b/website/versioned_docs/version-0.80/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.81/debugging-native-code.md
+++ b/website/versioned_docs/version-0.81/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.81/network.md
+++ b/website/versioned_docs/version-0.81/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -193,7 +193,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -219,7 +219,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.81/the-new-architecture/custom-cxx-types.md
+++ b/website/versioned_docs/version-0.81/the-new-architecture/custom-cxx-types.md
@@ -336,7 +336,7 @@ Now, we need to implement the `validateAddress` function in C++. First, we need 
 
 2. Open the `shared/NativeSampleModule.cpp` file and add the function implementation
 
-```c++ title="NativeSampleModule.cpp (validateAddress implementation)"
+```cpp title="NativeSampleModule.cpp (validateAddress implementation)"
 bool NativeSampleModule::validateAddress(jsi::Runtime &rt, jsi::Object input) {
   std::string street = input.getProperty(rt, "street").asString(rt).utf8(rt);
   int32_t number = input.getProperty(rt, "num").asNumber();

--- a/website/versioned_docs/version-0.81/timers.md
+++ b/website/versioned_docs/version-0.81/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.82/debugging-native-code.md
+++ b/website/versioned_docs/version-0.82/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.82/network.md
+++ b/website/versioned_docs/version-0.82/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -193,7 +193,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -219,7 +219,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.82/timers.md
+++ b/website/versioned_docs/version-0.82/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.83/debugging-native-code.md
+++ b/website/versioned_docs/version-0.83/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.83/network.md
+++ b/website/versioned_docs/version-0.83/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -199,7 +199,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -225,7 +225,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.83/timers.md
+++ b/website/versioned_docs/version-0.83/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.84/debugging-native-code.md
+++ b/website/versioned_docs/version-0.84/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.84/network.md
+++ b/website/versioned_docs/version-0.84/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -199,7 +199,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -225,7 +225,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.84/timers.md
+++ b/website/versioned_docs/version-0.84/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.85/debugging-native-code.md
+++ b/website/versioned_docs/version-0.85/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.85/network.md
+++ b/website/versioned_docs/version-0.85/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -199,7 +199,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -225,7 +225,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.85/timers.md
+++ b/website/versioned_docs/version-0.85/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/website/versioned_docs/version-0.86/debugging-native-code.md
+++ b/website/versioned_docs/version-0.86/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 In your native module, use `NSLog` for custom logs:
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/website/versioned_docs/version-0.86/network.md
+++ b/website/versioned_docs/version-0.86/network.md
@@ -15,13 +15,13 @@ React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/W
 
 In order to fetch content from an arbitrary URL, you can pass the URL to fetch:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/mydata.json');
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
-```tsx
+```ts
 fetch('https://mywebsite.com/endpoint/', {
   method: 'POST',
   headers: {
@@ -43,7 +43,7 @@ The above examples show how you can make a request. In many cases, you will want
 
 Networking is an inherently asynchronous operation. Fetch method will return a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that makes it straightforward to write code that works in an asynchronous manner:
 
-```tsx
+```ts
 const getMoviesFromApi = () => {
   return fetch('https://reactnative.dev/movies.json')
     .then(response => response.json())
@@ -58,7 +58,7 @@ const getMoviesFromApi = () => {
 
 You can also use the `async` / `await` syntax in a React Native app:
 
-```tsx
+```ts
 const getMoviesFromApiAsync = async () => {
   try {
     const response = await fetch(
@@ -199,7 +199,7 @@ On Android, as of API Level 28, clear text traffic is also blocked by default. T
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built into React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/axios/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
 
-```tsx
+```ts
 const request = new XMLHttpRequest();
 request.onreadystatechange = e => {
   if (request.readyState !== 4) {
@@ -225,7 +225,7 @@ The security model for XMLHttpRequest is different than on web as there is no co
 
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-```tsx
+```ts
 const ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {

--- a/website/versioned_docs/version-0.86/timers.md
+++ b/website/versioned_docs/version-0.86/timers.md
@@ -33,7 +33,7 @@ One reason why well-built native apps feel so smooth is by avoiding expensive op
 
 Applications can schedule tasks to run after interactions with the following:
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ The touch handling system considers one or more active touches to be an 'interac
 
 `InteractionManager` also allows applications to register animations by creating an interaction 'handle' on animation start, and clearing it upon completion:
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:


### PR DESCRIPTION
# Why

Supersedes:
* #4425

# How

Apply formatting for code block language names, limit to map to actually used languages, hide title from few more shell languages, reduce variations.

When working on the changes I have constructed the set of all languages present/used in the docs, added global capitalize rule and listed in map only the cases needing custom formatting.

# Preview

<img width="1328" height="746" alt="Screenshot 2026-05-25 165644" src="https://github.com/user-attachments/assets/3bf0b385-7356-4255-a5b3-ee479e51d70a" />

<img width="1280" height="1080" alt="Screenshot 2026-05-25 165451" src="https://github.com/user-attachments/assets/711427fc-7c42-4e8d-a233-3c6325fc722b" />

<img width="1286" height="595" alt="Screenshot 2026-05-25 165717" src="https://github.com/user-attachments/assets/865b656c-add7-4c5e-b441-fa88e5f1906a" />
