### PR TITLE
docs: update out-of-tree Fabric wording

### DIFF
--- a/docs/out-of-tree-platforms.md
+++ b/docs/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.77/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.77/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.78/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.78/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.79/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.79/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.80/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.80/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.81/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.81/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.82/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.82/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.83/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.83/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.84/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.84/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.85/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.85/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 

--- a/website/versioned_docs/version-0.86/out-of-tree-platforms.md
+++ b/website/versioned_docs/version-0.86/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native is not only for Android and iOS devices - our partners and the comm
 
 ## Creating your own React Native platform
 
-Right now the process of creating a React Native platform from scratch is not very well documented - one of the goals of the upcoming re-architecture ([Fabric](/blog/2018/06/14/state-of-react-native-2018)) is to make maintaining a platform easier.
+The process of creating a React Native platform from scratch is still not very well documented - one of the goals of the New Architecture and [Fabric](/architecture/fabric-renderer) is to make maintaining a platform easier.
 
 ### Bundling
 


### PR DESCRIPTION
## Summary
- Replace stale “upcoming re-architecture” wording in Out-of-Tree Platforms docs
- Update current and versioned docs so supported docs versions no longer refer to Fabric as upcoming

Fixes #5094

## Test Plan
- `git diff --check`