### PR TITLE
Fix duplicate Highlights anchor in 0.86 release post

### DIFF
--- a/website/blog/2026-06-11-react-native-0.86.mdx
+++ b/website/blog/2026-06-11-react-native-0.86.mdx
@@ -13,15 +13,13 @@ This release includes comprehensive edge-to-edge support on Android 15+ and impr
 
 Following 0.83, this is the second React Native release with no user-facing breaking changes, reflecting our continued commitment to making upgrades more predictable and seamless.
 
-### Highlights
+## Highlights
 
 - [A New Home for React Native](/blog/2026/06/11/react-native-0.86#a-new-home-for-react-native)
 - [Edge-to-Edge on Android](/blog/2026/06/11/react-native-0.86#edge-to-edge-on-android)
 - [React Native DevTools Improvements](/blog/2026/06/11/react-native-0.86#react-native-devtools-improvements)
 
 {/* truncate */}
-
-## Highlights
 
 ### A New Home for React Native
 


### PR DESCRIPTION
## Summary

The 0.86 release post showed two "Highlights" links in the sidebar table of contents, pointing to `#highlights` and `#highlights-1`.

The cause is two headings that both slug to `highlights`:
- the pre-truncate teaser `### Highlights`
- the `## Highlights` section heading after the truncate marker

Docusaurus deduped the second anchor to `#highlights-1`. In 0.86 the teaser only lists "Highlights", so the two entries sit adjacent in the sidebar and the duplication is obvious.

## Fix

Promote the teaser to `## Highlights` and drop the now-redundant `## Highlights` section heading after the truncate marker. The highlight subsections (`###`) then nest under the single Highlights heading.

```diff
-### Highlights
+## Highlights

 - [A New Home for React Native](...)
 - [Edge-to-Edge on Android](...)
 - [React Native DevTools Improvements](...)

 {/* truncate */}

-## Highlights
-
 ### A New Home for React Native
```

## Test plan

Verified against a local `yarn build`:
- only one `id=highlights` anchor is generated (no `highlights-1`)
- the sidebar shows a single Highlights with A New Home for React Native, Edge-to-Edge on Android, and React Native DevTools Improvements nested underneath it
- the teaser links (`#a-new-home-for-react-native`, `#edge-to-edge-on-android`, `#react-native-devtools-improvements`) all resolve
