### PR TITLE
docs(text-style-props): clarify `textAlign` behavior under RTL

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -855,6 +855,8 @@ Specifies text alignment. On Android, the value 'justify' is only supported on O
 | ------------------------------------------------------------ | -------- |
 | enum(`'auto'`, `'left'`, `'right'`, `'center'`, `'justify'`) | `'auto'` |
 
+The default `'auto'` follows the resolved text direction. The physical values `'left'` and `'right'` are mirrored under a right-to-left layout direction — `'left'` is rendered on the visual right and `'right'` on the visual left, so `'left'` acts as the start edge in RTL. `'center'` and `'justify'` are not mirrored. (Dedicated `'start'`/`'end'` values are not yet supported; see [react-native#45255](https://github.com/facebook/react-native/issues/45255).)
+
 ---
 
 ### `textAlignVertical` <div className="label android">Android</div>


### PR DESCRIPTION
## Summary

The `textAlign` entry only lists the enum values with no explanation of how they behave under a right-to-left layout direction. This is a recurring source of confusion (e.g. developers expecting `textAlign: 'right'` to render visually right in RTL).

This adds a short note clarifying that:
- the physical values `'left'`/`'right'` are **mirrored** under RTL (`'left'` renders on the visual right, so it acts as the start edge),
- `'center'`/`'justify'` are not mirrored,
- there is no `'start'`/`'end'` value yet (links the tracking issue #45255).

Docs only — no behavior change.

## Context

Motivated by RTL `textAlign` confusion reported in [expo/expo#39752](https://github.com/expo/expo/issues/39752) — see [this comment](https://github.com/expo/expo/issues/39752#issuecomment-4762160953) for the full root-cause breakdown of how `textAlign` behaves under an RTL layout direction.