### PR TITLE
ui: hide "Copy page" menu AI tools entries descriptions

### DIFF
--- a/website/src/theme/DocItem/Layout/styles.module.css
+++ b/website/src/theme/DocItem/Layout/styles.module.css
@@ -47,6 +47,16 @@ div[class^="copyPageDropdown"] {
     &:hover {
       background-color: var(--ifm-menu-color-background-hover);
     }
+
+    &:not([data-copy-page-action="copy"], [data-copy-page-action="view"]) {
+      div[class^="itemTitle"] {
+        margin-bottom: 0;
+      }
+
+      div[class^="itemDescription"] {
+        display: none;
+      }
+    }
   }
 
   div[class^="itemDescription"] {


### PR DESCRIPTION
# Why

The description on every "Copy page" menu AI tool entry is the same and does not add much value. Besides that descriptions unnecessary increases the height of dropdown menu.

# How

Hide "Copy page" menu AI tools entries descriptions. Leave descriptions visible for copy page and raw Markdown entries.

# Preview

<img width="689" height="623" alt="Screenshot 2026-06-25 205243" src="https://github.com/user-attachments/assets/d2b9e038-3448-4b0f-b9b4-31b30b1fc199" />

