### PR TITLE
fix(docs): use bracket syntax for admonition titles

### DIFF
--- a/docs/accessibilityinfo.md
+++ b/docs/accessibilityinfo.md
@@ -256,7 +256,7 @@ Query whether reduce motion and prefer cross-fade transitions settings are curre
 
 ### 🗑️ `setAccessibilityFocus()`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Prefer using `sendAccessibilityEvent` with eventType `focus` instead.
 :::
 

--- a/docs/backhandler.md
+++ b/docs/backhandler.md
@@ -10,7 +10,7 @@ The event subscriptions are called in reverse order (i.e. the last registered su
 - **If one subscription returns true,** then subscriptions registered earlier will not be called.
 - **If no subscription returns true or none are registered,** it programmatically invokes the default back button functionality to exit the app.
 
-:::warning Warning for modal users
+:::warning[Warning for modal users]
 If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](modal#onrequestclose)).
 :::
 

--- a/docs/building-for-tv.md
+++ b/docs/building-for-tv.md
@@ -6,6 +6,6 @@ hide_table_of_contents: true
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-:::warning Deprecated
+:::warning[Deprecated]
 TV support has moved to the [React Native for TV](https://github.com/react-native-tvos/react-native-tvos#readme) repository. Please see the **README** there for information on projects for Apple TV or Android TV.
 :::

--- a/docs/global-PerformanceEventTiming.md
+++ b/docs/global-PerformanceEventTiming.md
@@ -5,6 +5,6 @@ title: PerformanceEventTiming
 
 The global [`PerformanceEventTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming) class, as defined in Web specifications.
 
-:::warning Partial support
+:::warning[Partial support]
 The `cancelable` and `target` properties are not supported yet.
 :::

--- a/docs/global-PerformanceLongTaskTiming.md
+++ b/docs/global-PerformanceLongTaskTiming.md
@@ -5,6 +5,6 @@ title: PerformanceLongTaskTiming
 
 The global [`PerformanceLongTaskTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming) class, as defined in Web specifications.
 
-:::warning Partial support
+:::warning[Partial support]
 The value for the `attribution` property is always an empty array.
 :::

--- a/docs/global-PerformanceResourceTiming.md
+++ b/docs/global-PerformanceResourceTiming.md
@@ -5,7 +5,7 @@ title: PerformanceResourceTiming
 
 The global [`PerformanceResourceTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) class, as defined in Web specifications.
 
-:::warning Partial support
+:::warning[Partial support]
 
 React Native implements the following `PerformanceResourceTiming` properties only:
 

--- a/docs/global-intersectionobserver.md
+++ b/docs/global-intersectionobserver.md
@@ -61,7 +61,7 @@ An offset rectangle applied to the root's bounding box when calculating intersec
 
 ### `rnRootThresholds` ⚠️
 
-:::warning Non-standard
+:::warning[Non-standard]
 This is a React Native specific extension.
 :::
 

--- a/docs/global-intersectionobserverentry.md
+++ b/docs/global-intersectionobserverentry.md
@@ -43,7 +43,7 @@ A Boolean value which is `true` if the target element intersects with the inters
 
 ### `rnRootIntersectionRatio` ⚠️
 
-:::warning Non-standard
+:::warning[Non-standard]
 This is a React Native specific extension.
 :::
 

--- a/docs/global-performance.md
+++ b/docs/global-performance.md
@@ -21,7 +21,7 @@ See [documentation in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Perf
 
 ### `rnStartupTiming` ⚠️
 
-:::warning Non-standard
+:::warning[Non-standard]
 This is a React Native specific extension.
 :::
 
@@ -41,7 +41,7 @@ The `ReactNativeStartupTiming` interface provides the following fields:
 
 ### `timeOrigin`
 
-:::warning Partial support
+:::warning[Partial support]
 Provides the number of milliseconds from the UNIX epoch until system boot, instead of the number of milliseconds from the UNIX epoch until app startup.
 :::
 
@@ -79,7 +79,7 @@ See [documentation in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Perf
 
 ### `now()`
 
-:::warning Partial support
+:::warning[Partial support]
 Provides the number of milliseconds from system boot, instead of the number of milliseconds from app startup.
 :::
 

--- a/docs/integration-with-android-fragment.md
+++ b/docs/integration-with-android-fragment.md
@@ -33,7 +33,7 @@ This is required by React Native to handle the back button press event.
 
 Go into your host activity and make sure it implements the `DefaultHardwareBackBtnHandler` interface:
 
-:::warning Deprecated
+:::warning[Deprecated]
 `Activity.onBackPressed()` has been [deprecated](<https://developer.android.com/reference/android/app/Activity#onBackPressed()>) since API level 33. Android 16 devices with apps targeting API level 36 this will [no longer be called](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back) and [OnBackPressedDispatcher](https://developer.android.com/reference/androidx/activity/OnBackPressedDispatcher) should be used instead.
 :::
 

--- a/docs/interactionmanager.md
+++ b/docs/interactionmanager.md
@@ -5,7 +5,7 @@ title: 🗑️ InteractionManager
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-:::warning Deprecated
+:::warning[Deprecated]
 Avoid long-running work and use [`requestIdleCallback`](global-requestIdleCallback) instead.
 :::
 

--- a/docs/modal.md
+++ b/docs/modal.md
@@ -106,7 +106,7 @@ Inherits [View Props](view.md#props).
 
 ### 🗑️ `animated`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use the [`animationType`](modal.md#animationtype) prop instead.
 :::
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -217,7 +217,7 @@ request.open('GET', 'https://mywebsite.com/endpoint/');
 request.send();
 ```
 
-:::warning Caution
+:::warning[Caution]
 The security model for XMLHttpRequest is different than on web as there is no concept of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) in native apps.
 :::
 

--- a/docs/other-debugging-methods.md
+++ b/docs/other-debugging-methods.md
@@ -27,7 +27,7 @@ Every time the app is reloaded, a new JSContext is created. Choosing "Automatica
 
 ## Remote JavaScript Debugging (removed)
 
-:::warning Important
+:::warning[Important]
 Remote JavaScript Debugging has been removed as of React Native 0.79. See the original [deprecation announcement](https://github.com/react-native-community/discussions-and-proposals/discussions/734).
 
 If you are on an older version of React Native, please go to the docs [for your version](/versions).

--- a/docs/progressbarandroid.md
+++ b/docs/progressbarandroid.md
@@ -3,7 +3,7 @@ id: progressbarandroid
 title: '🗑️ ProgressBarAndroid'
 ---
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.
 :::
 

--- a/docs/pushnotificationios.md
+++ b/docs/pushnotificationios.md
@@ -3,7 +3,7 @@ id: pushnotificationios
 title: '🗑️ PushNotificationIOS'
 ---
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use one of the [community packages](https://reactnative.directory/?search=notification) instead.
 :::
 

--- a/docs/safeareaview.md
+++ b/docs/safeareaview.md
@@ -3,7 +3,7 @@ id: safeareaview
 title: '🗑️ SafeAreaView'
 ---
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use [react-native-safe-area-context](https://github.com/AppAndFlow/react-native-safe-area-context) instead.
 :::
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -68,7 +68,7 @@ In order to use iOS Keychain services or Android Secure Shared Preferences, you 
 - [expo-secure-store](https://docs.expo.dev/versions/latest/sdk/securestore/)
 - [react-native-keychain](https://github.com/oblador/react-native-keychain)
 
-:::warning Caution
+:::warning[Caution]
 **Be mindful of unintentionally storing or exposing sensitive info.** This could happen accidentally, for example saving sensitive form data in redux state and persisting the whole state tree in Async Storage. Or sending user tokens and personal info to an application monitoring service such as Sentry or Crashlytics.
 :::
 
@@ -127,7 +127,7 @@ Using https endpoints could still leave your data vulnerable to interception. Wi
 
 **SSL pinning** is a technique that can be used on the client side to avoid this attack. It works by embedding (or pinning) a list of trusted certificates to the client during development, so that only the requests signed with one of the trusted certificates will be accepted, and any self-signed certificates will not be.
 
-:::warning Caution
+:::warning[Caution]
 When using SSL pinning, you should be mindful of certificate expiry. Certificates expire every 1-2 years and when one does, it’ll need to be updated in the app as well as on the server. As soon as the certificate on the server has been updated, any apps with the old certificate embedded in them will cease to work.
 :::
 

--- a/docs/statusbar.md
+++ b/docs/statusbar.md
@@ -440,7 +440,7 @@ Show or hide the status bar.
 
 ### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
-:::warning Deprecated
+:::warning[Deprecated]
 The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
 :::
 

--- a/docs/stylesheet.md
+++ b/docs/stylesheet.md
@@ -171,7 +171,7 @@ export default App;
 
 ### `setStyleAttributePreprocessor()`
 
-:::warning Experimental
+:::warning[Experimental]
 Breaking changes will probably happen a lot and will not be reliably announced. The whole thing might be deleted, who knows? Use at your own risk.
 :::
 

--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -238,7 +238,7 @@ If `true`, focuses the input. The default value is `false`.
 
 ### 🗑️ `blurOnSubmit`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Note that `submitBehavior` now takes the place of `blurOnSubmit` and will override any behavior defined by `blurOnSubmit`. See [submitBehavior](textinput#submitbehavior).
 :::
 

--- a/docs/timers.md
+++ b/docs/timers.md
@@ -25,7 +25,7 @@ Please correct this by running ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"`` on 
 
 ## InteractionManager
 
-:::warning Deprecated
+:::warning[Deprecated]
 The `InteractionManager` behavior has been changed to be the same as `setImmediate`, which should be used instead.
 :::
 

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -267,7 +267,7 @@ Matrix transforms are useful when you need to apply pre-calculated transformatio
 
 ### 🗑️ `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use the [`transform`](transforms#transform) prop instead.
 :::
 

--- a/docs/virtualizedlist.md
+++ b/docs/virtualizedlist.md
@@ -298,7 +298,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 ### 🗑️ `disableVirtualization`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Virtualization provides significant performance and memory optimizations, but fully unmounts react instances that are outside of the render window. You should only need to disable this for debugging purposes.
 :::
 

--- a/website/versioned_docs/version-0.86/accessibilityinfo.md
+++ b/website/versioned_docs/version-0.86/accessibilityinfo.md
@@ -256,7 +256,7 @@ Query whether reduce motion and prefer cross-fade transitions settings are curre
 
 ### 🗑️ `setAccessibilityFocus()`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Prefer using `sendAccessibilityEvent` with eventType `focus` instead.
 :::
 

--- a/website/versioned_docs/version-0.86/backhandler.md
+++ b/website/versioned_docs/version-0.86/backhandler.md
@@ -10,7 +10,7 @@ The event subscriptions are called in reverse order (i.e. the last registered su
 - **If one subscription returns true,** then subscriptions registered earlier will not be called.
 - **If no subscription returns true or none are registered,** it programmatically invokes the default back button functionality to exit the app.
 
-:::warning Warning for modal users
+:::warning[Warning for modal users]
 If your app shows an opened `Modal`, `BackHandler` will not publish any events ([see `Modal` docs](modal#onrequestclose)).
 :::
 

--- a/website/versioned_docs/version-0.86/building-for-tv.md
+++ b/website/versioned_docs/version-0.86/building-for-tv.md
@@ -6,6 +6,6 @@ hide_table_of_contents: true
 
 TV devices support has been implemented with the intention of making existing React Native applications work on Apple TV and Android TV, with few or no changes needed in the JavaScript code for the applications.
 
-:::warning Deprecated
+:::warning[Deprecated]
 TV support has moved to the [React Native for TV](https://github.com/react-native-tvos/react-native-tvos#readme) repository. Please see the **README** there for information on projects for Apple TV or Android TV.
 :::

--- a/website/versioned_docs/version-0.86/global-PerformanceEventTiming.md
+++ b/website/versioned_docs/version-0.86/global-PerformanceEventTiming.md
@@ -5,6 +5,6 @@ title: PerformanceEventTiming
 
 The global [`PerformanceEventTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming) class, as defined in Web specifications.
 
-:::warning Partial support
+:::warning[Partial support]
 The `cancelable` and `target` properties are not supported yet.
 :::

--- a/website/versioned_docs/version-0.86/global-PerformanceLongTaskTiming.md
+++ b/website/versioned_docs/version-0.86/global-PerformanceLongTaskTiming.md
@@ -5,6 +5,6 @@ title: PerformanceLongTaskTiming
 
 The global [`PerformanceLongTaskTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming) class, as defined in Web specifications.
 
-:::warning Partial support
+:::warning[Partial support]
 The value for the `attribution` property is always an empty array.
 :::

--- a/website/versioned_docs/version-0.86/global-PerformanceResourceTiming.md
+++ b/website/versioned_docs/version-0.86/global-PerformanceResourceTiming.md
@@ -5,7 +5,7 @@ title: PerformanceResourceTiming
 
 The global [`PerformanceResourceTiming`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) class, as defined in Web specifications.
 
-:::warning Partial support
+:::warning[Partial support]
 
 React Native implements the following `PerformanceResourceTiming` properties only:
 

--- a/website/versioned_docs/version-0.86/global-intersectionobserver.md
+++ b/website/versioned_docs/version-0.86/global-intersectionobserver.md
@@ -61,7 +61,7 @@ An offset rectangle applied to the root's bounding box when calculating intersec
 
 ### `rnRootThresholds` ⚠️
 
-:::warning Non-standard
+:::warning[Non-standard]
 This is a React Native specific extension.
 :::
 

--- a/website/versioned_docs/version-0.86/global-intersectionobserverentry.md
+++ b/website/versioned_docs/version-0.86/global-intersectionobserverentry.md
@@ -43,7 +43,7 @@ A Boolean value which is `true` if the target element intersects with the inters
 
 ### `rnRootIntersectionRatio` ⚠️
 
-:::warning Non-standard
+:::warning[Non-standard]
 This is a React Native specific extension.
 :::
 

--- a/website/versioned_docs/version-0.86/global-performance.md
+++ b/website/versioned_docs/version-0.86/global-performance.md
@@ -21,7 +21,7 @@ See [documentation in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Perf
 
 ### `rnStartupTiming` ⚠️
 
-:::warning Non-standard
+:::warning[Non-standard]
 This is a React Native specific extension.
 :::
 
@@ -41,7 +41,7 @@ The `ReactNativeStartupTiming` interface provides the following fields:
 
 ### `timeOrigin`
 
-:::warning Partial support
+:::warning[Partial support]
 Provides the number of milliseconds from the UNIX epoch until system boot, instead of the number of milliseconds from the UNIX epoch until app startup.
 :::
 
@@ -79,7 +79,7 @@ See [documentation in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Perf
 
 ### `now()`
 
-:::warning Partial support
+:::warning[Partial support]
 Provides the number of milliseconds from system boot, instead of the number of milliseconds from app startup.
 :::
 

--- a/website/versioned_docs/version-0.86/integration-with-android-fragment.md
+++ b/website/versioned_docs/version-0.86/integration-with-android-fragment.md
@@ -33,7 +33,7 @@ This is required by React Native to handle the back button press event.
 
 Go into your host activity and make sure it implements the `DefaultHardwareBackBtnHandler` interface:
 
-:::warning Deprecated
+:::warning[Deprecated]
 `Activity.onBackPressed()` has been [deprecated](<https://developer.android.com/reference/android/app/Activity#onBackPressed()>) since API level 33. Android 16 devices with apps targeting API level 36 this will [no longer be called](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back) and [OnBackPressedDispatcher](https://developer.android.com/reference/androidx/activity/OnBackPressedDispatcher) should be used instead.
 :::
 

--- a/website/versioned_docs/version-0.86/interactionmanager.md
+++ b/website/versioned_docs/version-0.86/interactionmanager.md
@@ -5,7 +5,7 @@ title: 🗑️ InteractionManager
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem'; import constants from '@site/core/TabsConstants';
 
-:::warning Deprecated
+:::warning[Deprecated]
 Avoid long-running work and use [`requestIdleCallback`](global-requestIdleCallback) instead.
 :::
 

--- a/website/versioned_docs/version-0.86/modal.md
+++ b/website/versioned_docs/version-0.86/modal.md
@@ -106,7 +106,7 @@ Inherits [View Props](view.md#props).
 
 ### 🗑️ `animated`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use the [`animationType`](modal.md#animationtype) prop instead.
 :::
 

--- a/website/versioned_docs/version-0.86/network.md
+++ b/website/versioned_docs/version-0.86/network.md
@@ -217,7 +217,7 @@ request.open('GET', 'https://mywebsite.com/endpoint/');
 request.send();
 ```
 
-:::warning Caution
+:::warning[Caution]
 The security model for XMLHttpRequest is different than on web as there is no concept of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) in native apps.
 :::
 

--- a/website/versioned_docs/version-0.86/other-debugging-methods.md
+++ b/website/versioned_docs/version-0.86/other-debugging-methods.md
@@ -27,7 +27,7 @@ Every time the app is reloaded, a new JSContext is created. Choosing "Automatica
 
 ## Remote JavaScript Debugging (removed)
 
-:::warning Important
+:::warning[Important]
 Remote JavaScript Debugging has been removed as of React Native 0.79. See the original [deprecation announcement](https://github.com/react-native-community/discussions-and-proposals/discussions/734).
 
 If you are on an older version of React Native, please go to the docs [for your version](/versions).

--- a/website/versioned_docs/version-0.86/progressbarandroid.md
+++ b/website/versioned_docs/version-0.86/progressbarandroid.md
@@ -3,7 +3,7 @@ id: progressbarandroid
 title: '🗑️ ProgressBarAndroid'
 ---
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use one of the [community packages](https://reactnative.directory/?search=progressbar) instead.
 :::
 

--- a/website/versioned_docs/version-0.86/pushnotificationios.md
+++ b/website/versioned_docs/version-0.86/pushnotificationios.md
@@ -3,7 +3,7 @@ id: pushnotificationios
 title: '🗑️ PushNotificationIOS'
 ---
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use one of the [community packages](https://reactnative.directory/?search=notification) instead.
 :::
 

--- a/website/versioned_docs/version-0.86/safeareaview.md
+++ b/website/versioned_docs/version-0.86/safeareaview.md
@@ -3,7 +3,7 @@ id: safeareaview
 title: '🗑️ SafeAreaView'
 ---
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use [react-native-safe-area-context](https://github.com/AppAndFlow/react-native-safe-area-context) instead.
 :::
 

--- a/website/versioned_docs/version-0.86/security.md
+++ b/website/versioned_docs/version-0.86/security.md
@@ -68,7 +68,7 @@ In order to use iOS Keychain services or Android Secure Shared Preferences, you 
 - [expo-secure-store](https://docs.expo.dev/versions/latest/sdk/securestore/)
 - [react-native-keychain](https://github.com/oblador/react-native-keychain)
 
-:::warning Caution
+:::warning[Caution]
 **Be mindful of unintentionally storing or exposing sensitive info.** This could happen accidentally, for example saving sensitive form data in redux state and persisting the whole state tree in Async Storage. Or sending user tokens and personal info to an application monitoring service such as Sentry or Crashlytics.
 :::
 
@@ -127,7 +127,7 @@ Using https endpoints could still leave your data vulnerable to interception. Wi
 
 **SSL pinning** is a technique that can be used on the client side to avoid this attack. It works by embedding (or pinning) a list of trusted certificates to the client during development, so that only the requests signed with one of the trusted certificates will be accepted, and any self-signed certificates will not be.
 
-:::warning Caution
+:::warning[Caution]
 When using SSL pinning, you should be mindful of certificate expiry. Certificates expire every 1-2 years and when one does, it’ll need to be updated in the app as well as on the server. As soon as the certificate on the server has been updated, any apps with the old certificate embedded in them will cease to work.
 :::
 

--- a/website/versioned_docs/version-0.86/statusbar.md
+++ b/website/versioned_docs/version-0.86/statusbar.md
@@ -440,7 +440,7 @@ Show or hide the status bar.
 
 ### 🗑️ `setNetworkActivityIndicatorVisible()` <div className="label ios">iOS</div>
 
-:::warning Deprecated
+:::warning[Deprecated]
 The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
 :::
 

--- a/website/versioned_docs/version-0.86/stylesheet.md
+++ b/website/versioned_docs/version-0.86/stylesheet.md
@@ -171,7 +171,7 @@ export default App;
 
 ### `setStyleAttributePreprocessor()`
 
-:::warning Experimental
+:::warning[Experimental]
 Breaking changes will probably happen a lot and will not be reliably announced. The whole thing might be deleted, who knows? Use at your own risk.
 :::
 

--- a/website/versioned_docs/version-0.86/textinput.md
+++ b/website/versioned_docs/version-0.86/textinput.md
@@ -238,7 +238,7 @@ If `true`, focuses the input. The default value is `false`.
 
 ### 🗑️ `blurOnSubmit`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Note that `submitBehavior` now takes the place of `blurOnSubmit` and will override any behavior defined by `blurOnSubmit`. See [submitBehavior](textinput#submitbehavior).
 :::
 

--- a/website/versioned_docs/version-0.86/timers.md
+++ b/website/versioned_docs/version-0.86/timers.md
@@ -25,7 +25,7 @@ Please correct this by running ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"`` on 
 
 ## InteractionManager
 
-:::warning Deprecated
+:::warning[Deprecated]
 The `InteractionManager` behavior has been changed to be the same as `setImmediate`, which should be used instead.
 :::
 

--- a/website/versioned_docs/version-0.86/transforms.md
+++ b/website/versioned_docs/version-0.86/transforms.md
@@ -267,7 +267,7 @@ Matrix transforms are useful when you need to apply pre-calculated transformatio
 
 ### 🗑️ `decomposedMatrix`, `rotation`, `scaleX`, `scaleY`, `transformMatrix`, `translateX`, `translateY`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Use the [`transform`](transforms#transform) prop instead.
 :::
 

--- a/website/versioned_docs/version-0.86/virtualizedlist.md
+++ b/website/versioned_docs/version-0.86/virtualizedlist.md
@@ -298,7 +298,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 ### 🗑️ `disableVirtualization`
 
-:::warning Deprecated
+:::warning[Deprecated]
 Virtualization provides significant performance and memory optimizations, but fully unmounts react instances that are outside of the render window. You should only need to disable this for debugging purposes.
 :::
 


### PR DESCRIPTION
Fixes #5158.

## Summary

Convert legacy space-separated admonition titles (`:::warning Deprecated`) to the MDX directive bracket form (`:::warning[Deprecated]`).

Docusaurus 3 / MDX 3 (with the `future.v4` flag enabled in `docusaurus.config.ts`) no longer parse the space-title form, so `remark-directive` leaves the block as a plain paragraph and the `:::` fences render as **literal text** (e.g. on [Building For TV](https://reactnative.dev/docs/building-for-tv)). Inline markdown inside the block still renders, which is why only the `:::` markers looked broken.

The bracket form is already the convention across the rest of the docs (e.g. `:::danger[Removed from React Native]`, `:::note[Hint]`); this migrates the remaining stragglers.

Before:
<img width="892" height="207" alt="Screenshot 2026-06-28 at 8 17 28 PM" src="https://github.com/user-attachments/assets/b4ffff86-028b-477d-bcf6-3369bd7c463d" />

After:
<img width="1133" height="340" alt="Screenshot 2026-06-28 at 8 35 12 PM" src="https://github.com/user-attachments/assets/9abdfdb2-3846-47e9-bbe7-2dcfa76f1212" />

## Changes

- 54 occurrences across 48 files — current `docs/` and their `website/versioned_docs/version-0.86/` copies.
- CRLF line endings in the versioned files are preserved (only the admonition line changes; no whole-file churn).

## Test plan

- `yarn prettier --check` passes on all 48 changed files (the `endOfLine: auto` config leaves the CRLF files intact, label on a single line).
- Verified the fix against the live site: every page using `:::type <Title>` (space) currently renders literal `:::`, while pages using the bracket form `:::type[Title]` render correctly — so the converted pages now match the working syntax.