### PR TITLE
fix(copy-page): right-align Copy page button on pages without a TOC

### DIFF
--- a/website/src/theme/DocItem/Layout/styles.module.css
+++ b/website/src/theme/DocItem/Layout/styles.module.css
@@ -24,6 +24,13 @@ div[class^="copyPageArticleAction"] {
   margin-bottom: 0;
 }
 
+/* Keep the in-article button right-aligned even when DocVersionBadge renders
+ * nothing (current release), so .docHeaderContainer's space-between doesn't
+ * pin the lone child to the left. */
+.copyPageArticleAction {
+  margin-left: auto;
+}
+
 button[class^="copyPageButton"] {
   border-radius: var(--ifm-global-radius);
   border-color: var(--ifm-color-gray-500);

--- a/website/src/theme/DocItem/Layout/styles.module.css
+++ b/website/src/theme/DocItem/Layout/styles.module.css
@@ -24,9 +24,6 @@ div[class^="copyPageArticleAction"] {
   margin-bottom: 0;
 }
 
-/* Keep the in-article button right-aligned even when DocVersionBadge renders
- * nothing (current release), so .docHeaderContainer's space-between doesn't
- * pin the lone child to the left. */
 .copyPageArticleAction {
   margin-left: auto;
 }


### PR DESCRIPTION
Fixes #5160.

## Summary

On doc pages without a table of contents (e.g. `hide_table_of_contents: true`), the **"Copy page"** button appeared at the top-**left** (above the title) instead of the top-right.

The in-article button is rendered in `.docHeaderContainer` — a flex row with `justify-content: space-between` — next to `<DocVersionBadge />`. On the current/latest release the stock `DocVersionBadge` renders nothing, so the container is left with a single flex child, which `space-between` pins to flex-start (the left). In addition, `.copyPageArticleAction` was referenced via `styles.copyPageArticleAction` in the component but never defined in `styles.module.css`, so in the no-TOC case the wrapper had no class to right-align it.

## Fix

Define the class with `margin-left: auto`:

```css
.copyPageArticleAction {
  margin-left: auto;
}
```

`margin-left: auto` pushes the button to the right edge whether it is the only child (no version badge) or sharing the row with the badge (badge stays left, button right). When a TOC is present the article button is `display: none` on desktop and the aside button is used instead, so that path is unaffected.

## Test plan

- `prettier --check` passes on the changed file.
- Visual before/after below.

## Screenshots

Before:
<img width="1108" height="228" alt="Image" src="https://github.com/user-attachments/assets/56272bc6-5cfe-4f5d-a60d-d3750ba41afb" />

After:

<img width="1141" height="225" alt="Image" src="https://github.com/user-attachments/assets/88e37eed-ef7f-438c-aa38-3435cf9c7fe4" />
