### PR TITLE
docs: note that TextInput textAlign does not flip in RTL unlike Text

### DIFF
--- a/docs/text-style-props.md
+++ b/docs/text-style-props.md
@@ -84,6 +84,8 @@ Specifies font weight. The values 'normal' and 'bold' are supported for most fon
 
 Specifies text alignment. The value 'justify' is only supported on iOS and fallbacks to `left` on Android.
 
+> **_Note:_** Unlike [`<Text>`](text.md), `TextInput` treats `left` and `right` as physical values that do not flip in RTL mode. On `<Text>`, `textAlign: 'left'` behaves as logical `start` (aligns right in RTL), but on `TextInput` it always aligns left. For direction-aware alignment on `TextInput`, use `I18nManager.isRTL ? 'right' : 'left'`. See [#45255](https://github.com/facebook/react-native/issues/45255) for background.
+
 | Type                                               | Required |
 | -------------------------------------------------- | -------- |
 | enum('auto', 'left', 'right', 'center', 'justify') | No       |


### PR DESCRIPTION
## Summary

The shared `textAlign` docs in [`text-style-props.md`](docs/text-style-props.md) (used by both `<Text>` and `<TextInput>`) did not mention that its behavior diverges between the two components in RTL mode.

- On `<Text>`: `textAlign: 'left'` behaves as logical `start` (aligns right in RTL)
- On `<TextInput>`: `textAlign: 'left'` is physical (stays left in RTL) — on both iOS and Android

This PR adds a note to the `textAlign` section documenting the difference, showing the direction-aware workaround (`I18nManager.isRTL ? 'right' : 'left'`), and linking to [#45255](https://github.com/facebook/react-native/issues/45255).

## Why docs-only?

PRs [#57007](https://github.com/facebook/react-native/pull/57007) and [#57201](https://github.com/facebook/react-native/pull/57201) attempted to add `textAlign: 'start'/'end'` support — both were closed without merge. Documenting the existing behavior is the pragmatic outcome.

## Note on placement

`textAlign` is not documented directly in `textinput.md` (that page only has a `style` section linking out to the shared text style props), so the canonical `textAlign` section in `text-style-props.md` is where this note belongs.