### PR TITLE
ui: small visual adjustment for second nav and dropdown elements

### DIFF
--- a/website/src/components/DocsSecondaryNav/index.tsx
+++ b/website/src/components/DocsSecondaryNav/index.tsx
@@ -243,15 +243,13 @@ export default function DocsSecondaryNav({
           <CopyPageButton
             customStyles={{
               container: {className: styles.copyPageContainer},
-              button: {
-                className: styles.copyPageButton,
-                style: {marginBottom: 0},
-              },
+              button: {className: styles.copyPageButton},
               dropdown: {className: styles.copyPageDropdown},
             }}
           />
         )}
       </div>
+      <div className={styles.secondaryNavDivider} />
     </nav>
   );
 }

--- a/website/src/components/DocsSecondaryNav/styles.module.css
+++ b/website/src/components/DocsSecondaryNav/styles.module.css
@@ -166,7 +166,7 @@ button.copyPageButton {
 
 .copyPageDropdown {
   border-color: var(--ifm-table-border-color) !important;
-  margin-top: -2px;
+  margin-top: -3px;
 
   button[class^="dropdownItem"] {
     border-bottom-color: var(--ifm-table-border-color) !important;

--- a/website/src/components/DocsSecondaryNav/styles.module.css
+++ b/website/src/components/DocsSecondaryNav/styles.module.css
@@ -11,7 +11,7 @@
   justify-content: space-between;
   gap: 1rem;
   height: var(--rn-subnav-height);
-  padding: 0 1.5rem;
+  padding: 6px 1.5rem 0;
 
   /* Pin directly below the main navbar so page content scrolls underneath. */
   position: sticky;
@@ -40,7 +40,7 @@
   content: "";
   position: absolute;
   right: 0.75rem;
-  bottom: 0;
+  bottom: -6px;
   left: 0.75rem;
   height: 1px;
   background-color: var(--ifm-toc-border-color);
@@ -49,7 +49,7 @@
 .start {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
   min-width: 0;
 }
 
@@ -71,6 +71,7 @@
   font-size: 1.5rem;
   font-weight: var(--ifm-heading-font-weight);
   line-height: 1.2;
+  margin-right: 0.5rem;
 }
 
 /* Outlined controls: the section dropdown toggle and the back link share the
@@ -90,9 +91,12 @@
   font-size: 0.9rem;
   color: var(--ifm-font-color-base);
   background: transparent;
-  border: 1px solid var(--ifm-color-emphasis-300);
+  border: 1px solid var(--ifm-color-emphasis-400);
   border-radius: var(--ifm-global-radius);
   text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .dropdownToggle {
@@ -127,7 +131,7 @@
   color: var(--ifm-font-color-base);
   text-decoration: none;
   background-color: var(--ifm-menu-color-background-hover);
-  border-color: var(--ifm-color-gray-400);
+  border-color: var(--ifm-color-gray-500);
 }
 
 /* Docs version dropdown wrapper. The dropdown reuses the theme navbar dropdown;
@@ -137,9 +141,6 @@
 .versionDropdown {
   display: flex;
   align-items: center;
-
-  /* Sit closer to the section dropdown than the .start gap allows. */
-  margin-left: -0.5rem;
 }
 
 /* Copy page button — appearance shared with its former home in DocItem */
@@ -150,59 +151,60 @@
 
 button.copyPageButton {
   border-radius: var(--ifm-global-radius);
-  border-color: var(--ifm-color-gray-500);
-}
+  border-color: var(--ifm-color-gray-400);
 
-button.copyPageButton:hover {
-  background-color: var(--ifm-menu-color-background-hover) !important;
-  border-color: var(--ifm-color-gray-400) !important;
-}
+  &:hover {
+    background-color: var(--ifm-menu-color-background-hover) !important;
+    border-color: var(--ifm-color-gray-500) !important;
+  }
 
-button.copyPageButton svg {
-  opacity: 0.75;
+  svg {
+    opacity: 0.75;
+  }
 }
 
 .copyPageDropdown {
   border-color: var(--ifm-table-border-color) !important;
+
+  button[class^="dropdownItem"] {
+    border-bottom-color: var(--ifm-table-border-color) !important;
+
+    &:hover {
+      background-color: var(--ifm-menu-color-background-hover);
+    }
+  }
+
+  div[class^="itemDescription"] {
+    font-weight: 300;
+    font-size: 12px;
+  }
 }
 
-.copyPageDropdown button[class^="dropdownItem"] {
-  border-bottom-color: var(--ifm-table-border-color) !important;
-}
+[data-theme="dark"] {
+  .dropdownToggle,
+  .backLink,
+  button.copyPageButton {
+    background-color: color-mix(in srgb, var(--light), black 25%) !important;
+    border-color: var(--ifm-hr-border-color) !important;
+  }
 
-.copyPageDropdown button[class^="dropdownItem"]:hover {
-  background-color: var(--ifm-menu-color-background-hover);
-}
+  .dropdownToggle:hover,
+  .backLink:hover,
+  button.copyPageButton:hover {
+    background-color: color-mix(in srgb, var(--light), black 10%) !important;
+    border-color: var(--ifm-color-gray-800) !important;
+  }
 
-.copyPageDropdown div[class^="itemDescription"] {
-  font-weight: 300;
-  font-size: 12px;
-}
+  .copyPageDropdown {
+    background-color: var(--ifm-navbar-background-color);
+    background-color: color-mix(in srgb, var(--light), black 40%) !important;
 
-[data-theme="dark"] .dropdownToggle,
-[data-theme="dark"] .backLink {
-  background-color: var(--light);
-}
+    button[class^="dropdownItem"]:hover {
+      background-color: color-mix(in srgb, var(--light), black 20%);
+    }
 
-[data-theme="dark"] .dropdownToggle:hover,
-[data-theme="dark"] .backLink:hover {
-  background-color: color-mix(in srgb, var(--light), white 10%);
-  border-color: var(--ifm-color-gray-800);
-}
-
-[data-theme="dark"] button.copyPageButton:hover {
-  background-color: var(--dark) !important;
-  border-color: var(--ifm-color-gray-800) !important;
-}
-
-[data-theme="dark"] .copyPageDropdown {
-  background-color: var(--ifm-navbar-background-color);
-}
-
-[data-theme="dark"] .copyPageDropdown button[class^="dropdownItem"]:hover {
-  background-color: var(--dark);
-}
-
-[data-theme="dark"] .copyPageDropdown div[class^="itemDescription"] {
-  color: var(--ifm-color-gray-600) !important;
+    div[class^="itemDescription"] {
+      color: var(--ifm-color-gray-600) !important;
+    }
+  }
 }

--- a/website/src/components/DocsSecondaryNav/styles.module.css
+++ b/website/src/components/DocsSecondaryNav/styles.module.css
@@ -11,7 +11,7 @@
   justify-content: space-between;
   gap: 1rem;
   height: var(--rn-subnav-height);
-  padding: 6px 1.5rem 0;
+  padding: 0 var(--ifm-spacing-horizontal);
 
   /* Pin directly below the main navbar so page content scrolls underneath. */
   position: sticky;
@@ -36,11 +36,10 @@
 
 /* Bottom keyline, inset from both edges so it comes in from the screen edges
    without lining up with the inner elements' padding. */
-.secondaryNav:after {
-  content: "";
+.secondaryNavDivider {
   position: absolute;
   right: 0.75rem;
-  bottom: -6px;
+  bottom: 0;
   left: 0.75rem;
   height: 1px;
   background-color: var(--ifm-toc-border-color);
@@ -152,6 +151,8 @@
 button.copyPageButton {
   border-radius: var(--ifm-global-radius);
   border-color: var(--ifm-color-gray-400);
+  padding: 7px 12px;
+  margin-bottom: 0;
 
   &:hover {
     background-color: var(--ifm-menu-color-background-hover) !important;
@@ -165,6 +166,7 @@ button.copyPageButton {
 
 .copyPageDropdown {
   border-color: var(--ifm-table-border-color) !important;
+  margin-top: -2px;
 
   button[class^="dropdownItem"] {
     border-bottom-color: var(--ifm-table-border-color) !important;

--- a/website/src/css/docs-secondary-nav.scss
+++ b/website/src/css/docs-secondary-nav.scss
@@ -79,32 +79,50 @@ html.plugin-docs {
     line-height: normal;
     color: var(--ifm-font-color-base);
     background: transparent;
-    border: 1px solid var(--ifm-color-emphasis-300);
+    border: 1px solid var(--ifm-color-emphasis-400);
     border-radius: 999px;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
 
     // Match the section dropdown caret: nudged down and dimmed to grey.
     &:after {
       opacity: 0.6;
       transform: translateY(-1px);
+      border-width: 0.3rem 0.3rem 0;
+      margin-left: 0.35rem;
     }
 
     &:hover {
       color: var(--ifm-font-color-base);
       background-color: var(--ifm-menu-color-background-hover);
-      border-color: var(--ifm-color-gray-400);
+      border-color: var(--ifm-color-gray-500);
     }
+  }
+}
+
+[class*="dropdown"] {
+  .dropdown__menu {
+    border: 1px solid var(--ifm-table-border-color);
+  }
+}
+
+[data-theme="dark"] [class*="dropdown"] {
+  .dropdown__menu {
+    background-color: color-mix(in srgb, var(--light), black 40%);
   }
 }
 
 // Placed before the `[data-version-next]` block so the brand-blue "Next" state
 // still wins.
 [data-theme="dark"] [class*="versionDropdown"] .navbar__link {
-  background-color: var(--light);
-}
+  background-color: color-mix(in srgb, var(--light), black 25%);
+  border-color: var(--ifm-hr-border-color);
 
-[data-theme="dark"] [class*="versionDropdown"] .navbar__link:hover {
-  background-color: color-mix(in srgb, var(--light), white 10%);
-  border-color: var(--ifm-color-gray-800);
+  &:hover {
+    background-color: color-mix(in srgb, var(--light), black 10%);
+    border-color: var(--ifm-color-gray-800);
+  }
 }
 
 [class*="versionDropdown"][data-version-next] .navbar__link {

--- a/website/src/css/docs-secondary-nav.scss
+++ b/website/src/css/docs-secondary-nav.scss
@@ -108,7 +108,7 @@ html.plugin-docs {
     overflow: visible;
 
     // Make sure that menu does not close on hover, with dropdown portion detached via transform
-    &::before {
+    &:before {
       content: "";
       position: absolute;
       height: 5px;

--- a/website/src/css/docs-secondary-nav.scss
+++ b/website/src/css/docs-secondary-nav.scss
@@ -104,6 +104,18 @@ html.plugin-docs {
 [class*="dropdown"] {
   .dropdown__menu {
     border: 1px solid var(--ifm-table-border-color);
+    transform: translateY(4px);
+    overflow: visible;
+
+    // Make sure that menu does not close on hover, with dropdown portion detached via transform
+    &::before {
+      content: "";
+      position: absolute;
+      height: 5px;
+      top: -5px;
+      left: 0;
+      right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
# How

Align buttons and dropdown appearance within all the member of new sub nav component, emphasize border a bit more, tweak spacing and chevron sizing.

# Preview

* https://deploy-preview-5193--react-native.netlify.app/

<img width="2124" height="586" alt="Screenshot 2026-07-28 102613" src="https://github.com/user-attachments/assets/12ca69e7-ce29-40b2-8525-69135d178b19" />
<img width="2157" height="782" alt="Screenshot 2026-07-28 102708" src="https://github.com/user-attachments/assets/baa64d9d-b124-4078-96d8-393ed9f68868" />
<img width="2117" height="622" alt="Screenshot 2026-07-28 102602" src="https://github.com/user-attachments/assets/106e26e5-e492-4c46-8fc0-a6cf45c43701" />
<img width="2103" height="769" alt="Screenshot 2026-07-28 102545" src="https://github.com/user-attachments/assets/7dc03d90-75f2-44eb-8be2-59a2ee14a700" />
