### PR TITLE
docs: remove outdated credentials omit warning

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -254,7 +254,6 @@ ws.onclose = e => {
 The following options are currently not working with `fetch`
 
 - `redirect:manual`
-- `credentials:omit`
 
 * Having same name headers on Android will result in only the latest one being present. A temporary solution can be found here: https://github.com/facebook/react-native/issues/18837#issuecomment-398779994.
 * Cookie based authentication is currently unstable. You can view some of the issues raised here: https://github.com/facebook/react-native/issues/23185

--- a/website/versioned_docs/version-0.86/network.md
+++ b/website/versioned_docs/version-0.86/network.md
@@ -254,7 +254,6 @@ ws.onclose = e => {
 The following options are currently not working with `fetch`
 
 - `redirect:manual`
-- `credentials:omit`
 
 * Having same name headers on Android will result in only the latest one being present. A temporary solution can be found here: https://github.com/facebook/react-native/issues/18837#issuecomment-398779994.
 * Cookie based authentication is currently unstable. You can view some of the issues raised here: https://github.com/facebook/react-native/issues/23185


### PR DESCRIPTION
## Summary

- Remove the outdated `credentials: 'omit'` limitation from the current Networking documentation.
- Apply the same correction to the React Native 0.86 documentation.

React Native 0.86.0 was verified on an iOS 26.5 simulator and an Android API 37 emulator. All 10 credential and cookie scenarios described in the linked issue passed independently on both platforms, including direct requests and automatic redirects.

## Test plan

- `yarn lint:website`
- `yarn prettier --check docs/network.md website/versioned_docs/version-0.86/network.md`
- `yarn --cwd website lint:markdown:links`

Closes react/react-native#57786
