### PR TITLE
fix CocoaPods capitalization in the latest blog post

### DIFF
--- a/website/blog/2026-08-11-react-native-0.87.mdx
+++ b/website/blog/2026-08-11-react-native-0.87.mdx
@@ -156,7 +156,7 @@ See [RFC #0994](https://github.com/react-native-community/discussions-and-propos
 
 #### Headers Breaking Changes
 
-To properly support SwiftPM integration with React Native, we had to rethink how we ship the precompiled binaries of React Native itself. This is needed because SwiftPM is much stricter than Cocoapods when it comes to XCFramework structure and headers location.
+To properly support SwiftPM integration with React Native, we had to rethink how we ship the precompiled binaries of React Native itself. This is needed because SwiftPM is much stricter than CocoaPods when it comes to XCFramework structure and headers location.
 
 You might notice a couple of new XCFrameworks:
 


### PR DESCRIPTION
# Why

<img width="1342" height="374" alt="Screenshot 2026-08-13 171950" src="https://github.com/user-attachments/assets/5e731f5d-46f9-46ba-b243-50b666a8655d" />

# How

Fix CocoaPods capitalization in the latest blog post, this was caught by Alex checks on CI.