### PR TITLE
Fix non-compiling Java snippet in Android Fabric Native Component guide

### DIFF
--- a/docs/fabric-native-components-android.md
+++ b/docs/fabric-native-components-android.md
@@ -38,6 +38,7 @@ package com.webview;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -46,6 +47,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.EventDispatcher;
 
 public class ReactWebView extends WebView {
   public ReactWebView(Context context) {
@@ -64,7 +66,8 @@ public class ReactWebView extends WebView {
   }
 
   private void configureComponent() {
-    this.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+    this.getSettings().setJavaScriptEnabled(true);
+    this.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
     this.setWebViewClient(new WebViewClient() {
       @Override
       public void onPageFinished(WebView view, String url) {
@@ -74,7 +77,7 @@ public class ReactWebView extends WebView {
   }
 
   public void emitOnScriptLoaded(OnScriptLoadedEventResult result) {
-    ReactContext reactContext = (ReactContext) context;
+    ReactContext reactContext = (ReactContext) getContext();
     int surfaceId = UIManagerHelper.getSurfaceId(reactContext);
     EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
     WritableMap payload = Arguments.createMap();
@@ -142,6 +145,7 @@ class ReactWebView: WebView {
   }
 
   private fun configureComponent() {
+    this.settings.javaScriptEnabled = true
     this.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
     this.webViewClient = object : WebViewClient() {
       override fun onPageFinished(view: WebView, url: String) {
@@ -186,6 +190,8 @@ class ReactWebView: WebView {
 The `ReactWebView` extends the Android `WebView` so you can reuse all the properties already defined by the platform with ease.
 
 The class defines the three Android constructors but defers their actual implementation to the private `configureComponent` function. This function takes care of initializing all the components specific properties: in this case you are setting the layout of the `WebView` and you are defining the `WebClient` that you use to customize the behavior of the `WebView`. In this code, the `ReactWebView` emits an event when the page finishes loading, by implementing the `WebClient`'s `onPageFinished` method.
+
+`configureComponent` also enables JavaScript. The Android `WebView` [disables it by default](<https://developer.android.com/reference/android/webkit/WebSettings#setJavaScriptEnabled(boolean)>). The `WKWebView` used on iOS enables it. Without this line, the same component would run web content differently on the two platforms. Only enable JavaScript for content you trust.
 
 The code then defines a helper function to actually emit an event. To emit an event, you have to:
 


### PR DESCRIPTION
## 1. The Java snippet does not compile

```
error: no suitable constructor found for LayoutParams(int,int)
    this.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
      constructor android.widget.AbsoluteLayout.LayoutParams.LayoutParams(Context,AttributeSet) is not applicable
      constructor android.widget.AbsoluteLayout.LayoutParams.LayoutParams(ViewGroup.LayoutParams) is not applicable
      constructor android.widget.AbsoluteLayout.LayoutParams.LayoutParams(int,int,int,int) is not applicable
error: cannot find symbol
    ReactContext reactContext = (ReactContext) context;
      symbol: variable context
error: cannot find symbol
    EventDispatcher eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, getId());
      symbol: class EventDispatcher
```

- `WebView extends AbsoluteLayout`, so the simple name `LayoutParams` resolves to `AbsoluteLayout.LayoutParams`, which has no `(int, int)` constructor → qualified as `ViewGroup.LayoutParams` + import.
- No `context` variable is in scope → `getContext()`.
- `EventDispatcher` is used as a declared type but never imported. Missing from every version of this page.

Same failure on `compileSdk` 35, 36 and 37 — name/overload resolution, independent of AGP and React Native version. Present since #4288. The Kotlin tab is unaffected: Kotlin resolves `LayoutParams(...)` to `ViewGroup.LayoutParams(int, int)` and infers the `EventDispatcher` type.

## 2. JavaScript is enabled on iOS, disabled on Android

The iOS page uses `_webView = [WKWebView new];` — `WKWebpagePreferences.allowsContentJavaScript` defaults to `true`. The Android `WebView` [defaults to `false`](https://developer.android.com/reference/android/webkit/WebSettings#setJavaScriptEnabled(boolean)) and the guide never sets it, so the same component runs web content differently per platform. Not fatal for the tutorial's own URL, which renders server-side, but it silently breaks JS-dependent pages.

Added the call to both language tabs and a paragraph naming the asymmetry.

## Test plan

Both snippets were copied out of the updated page into an Android library module of a React Native 0.86 app.

- Java: `compileDebugJavaWithJavac` reports the three errors above before the change, `BUILD SUCCESSFUL` after.
- Kotlin: `compileDebugKotlin` succeeds before and after — only the JavaScript line differs.
- JavaScript, on an emulator, with `sourceURL` set to `data:text/html,<body><h1>no-js</h1><script>document.body.textContent='js-ran'</script>`: the component as documented today renders `no-js`, with the added line it renders `js-ran`.

The same three Java errors are in `website/versioned_docs/version-0.77` … `version-0.87`. README says not to edit the generated versioned docs, so this PR leaves them alone; #4673 backported an equivalent fix as a separate PR, happy to do the same here.
